### PR TITLE
enable parallel segment search, use it by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ targetCompatibility = 1.12
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def luceneVersion = '8.2.0'
+def luceneVersion = '8.4.0'
 def slf4jVersion = '2.0.0-alpha0'
 def gsonVersion = '2.8.5'
 def snakeYamlVersion = '1.25'

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ dependencies {
 
     //lucene deps
     implementation "org.apache.lucene:lucene-core:${luceneVersion}"
+    implementation "org.apache.lucene:lucene-codecs:${luceneVersion}"
+    implementation "org.apache.lucene:lucene-backward-codecs:${luceneVersion}"
     implementation "org.apache.lucene:lucene-queries:${luceneVersion}"
     implementation "org.apache.lucene:lucene-facet:${luceneVersion}"
     implementation "org.apache.lucene:lucene-replicator:${luceneVersion}"

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ServerCodec.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ServerCodec.java
@@ -22,16 +22,16 @@ package com.yelp.nrtsearch.server.luceneserver;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.PostingsFormat;
-import org.apache.lucene.codecs.lucene80.Lucene80Codec;
+import org.apache.lucene.codecs.lucene84.Lucene84Codec;
 
 
 /**
  * Implements per-index {@link Codec}.
  */
 
-public class ServerCodec extends Lucene80Codec {
+public class ServerCodec extends Lucene84Codec {
 
-    public final static String DEFAULT_POSTINGS_FORMAT = "Lucene50";
+    public final static String DEFAULT_POSTINGS_FORMAT = "Lucene84";
     public final static String DEFAULT_DOC_VALUES_FORMAT = "Lucene80";
 
     private final IndexState state;

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/StatsRequestHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/StatsRequestHandler.java
@@ -60,14 +60,16 @@ public class StatsRequestHandler implements Handler<StatsRequest, StatsResponse>
         for (Map.Entry<Integer, ShardState> entry : indexState.shards.entrySet()) {
             ShardState shardState = entry.getValue();
             statsResponseBuilder.setOrd(entry.getKey());
-            IndexWriter.DocStats docStats = shardState.writer.getDocStats();
+            if (shardState.writer != null) { //replica
+                IndexWriter.DocStats docStats = shardState.writer.getDocStats();
+                statsResponseBuilder.setMaxDoc(docStats.maxDoc);
+                statsResponseBuilder.setNumDocs(docStats.numDocs);
+            }
             String[] fNames = shardState.indexDir.listAll();
             long dirSize = 0;
             for (int i = 0; i < fNames.length; i++) {
                 dirSize += shardState.indexDir.fileLength(fNames[i]);
             }
-            statsResponseBuilder.setMaxDoc(docStats.maxDoc);
-            statsResponseBuilder.setNumDocs(docStats.numDocs);
             statsResponseBuilder.setDirSize(dirSize);
             // TODO: snapshots
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/StatsRequestHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/StatsRequestHandler.java
@@ -60,7 +60,7 @@ public class StatsRequestHandler implements Handler<StatsRequest, StatsResponse>
         for (Map.Entry<Integer, ShardState> entry : indexState.shards.entrySet()) {
             ShardState shardState = entry.getValue();
             statsResponseBuilder.setOrd(entry.getKey());
-            if (shardState.writer != null) { //replica
+            if (shardState.writer != null) { // primary and standalone mode
                 IndexWriter.DocStats docStats = shardState.writer.getDocStats();
                 statsResponseBuilder.setMaxDoc(docStats.maxDoc);
                 statsResponseBuilder.setNumDocs(docStats.numDocs);


### PR DESCRIPTION
Lucene enabled parallel segment search in this PR: https://issues.apache.org/jira/browse/LUCENE-6294
Another fix for Early termination when numHits is met was backported to 8.3: https://issues.apache.org/jira/browse/LUCENE-8939

This functionality is currently missing from our ES deployments since elasticsearch (at least the version we have in production) does not support it.

Being able to search over segments in parallel should be a crucial performance win (w.r.t latency).

Note: The  "leaves"/"segments" are divided into "leafSlices" in lucene. Each LeafSlice is then searched upon by a thread.  Better Segment To Thread Mapping Algorithm was merged in lucene 9.0 (master): https://issues.apache.org/jira/browse/LUCENE-8757. I am borrowing some of that code here so we can more easily customize how we slice the leaves for individual threads.

Fixes #86 #87 