### PR TITLE
dont use default grpc thread pool executor

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -63,6 +63,7 @@ import com.yelp.nrtsearch.server.luceneserver.analysis.AnalyzerCreator;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.plugins.PluginsService;
 import com.yelp.nrtsearch.server.utils.Archiver;
+import com.yelp.nrtsearch.server.utils.ThreadPoolExecutorFactory;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptors;
@@ -125,6 +126,7 @@ public class LuceneServer {
         /* The port on which the server should run */
         server = ServerBuilder.forPort(luceneServerConfiguration.getPort())
                 .addService(ServerInterceptors.intercept(new LuceneServerImpl(globalState, archiver, collectorRegistry, plugins), monitoringInterceptor))
+                .executor(ThreadPoolExecutorFactory.getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.LUCENESERVER))
                 .build()
                 .start();
         logger.info("Server started, listening on " + luceneServerConfiguration.getPort() + " for messages");
@@ -132,6 +134,7 @@ public class LuceneServer {
         /* The port on which the replication server should run */
         replicationServer = ServerBuilder.forPort(luceneServerConfiguration.getReplicationPort())
                 .addService(new ReplicationServerImpl(globalState))
+                .executor(ThreadPoolExecutorFactory.getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.REPLICATIONSERVER))
                 .build()
                 .start();
         logger.info("Server started, listening on " + luceneServerConfiguration.getReplicationPort() + " for replication messages");
@@ -1095,4 +1098,8 @@ public class LuceneServer {
         }
 
     }
+
+
+
+
 }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/GlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/GlobalState.java
@@ -25,9 +25,9 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.utils.ThreadPoolExecutorFactory;
 import org.apache.lucene.search.TimeLimitingCollector;
 import org.apache.lucene.util.IOUtils;
-import org.apache.lucene.util.NamedThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,21 +45,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 public class GlobalState implements Closeable, Restorable {
-    // TODO: make these controllable
-    // nocommit allow controlling per CSV/json bulk import max concurrency sent into IW?
-    private final static int MAX_INDEXING_THREADS = Runtime.getRuntime().availableProcessors();
     public static final String NULL = "NULL";
     private final String hostName;
     private final int port;
@@ -74,18 +67,6 @@ public class GlobalState implements Closeable, Restorable {
     public final String nodeName;
 
     public final List<RemoteNodeConnection> remoteNodes = new CopyOnWriteArrayList<>();
-
-    private final static int MAX_BUFFERED_ITEMS = Math.max(100, 2 * MAX_INDEXING_THREADS);
-
-    // Seems to be substantially faster than ArrayBlockingQueue at high throughput:
-    final BlockingQueue<Runnable> docsToIndex = new LinkedBlockingQueue<Runnable>(MAX_BUFFERED_ITEMS);
-
-    //same as Executors.newFixedThreadPool except we want a NamedThreadFactory instead of defaultFactory
-    private final ExecutorService indexService = new ThreadPoolExecutor(MAX_INDEXING_THREADS,
-            MAX_INDEXING_THREADS,
-            0, TimeUnit.SECONDS,
-            docsToIndex,
-            new NamedThreadFactory("LuceneIndexing"));
 
 
     /**
@@ -105,9 +86,9 @@ public class GlobalState implements Closeable, Restorable {
      * This is persisted so on restart we know about all previously created indices.
      */
     private final JsonObject indexNames = new JsonObject();
+    private final ExecutorService indexService;
 
     public GlobalState(LuceneServerConfiguration luceneServerConfiguration) throws IOException {
-        logger.info("MAX INDEXING THREADS " + MAX_INDEXING_THREADS);
         this.nodeName = luceneServerConfiguration.getNodeName();
         this.stateDir = Paths.get(luceneServerConfiguration.getStateDir());
         this.indexDirBase = Paths.get(luceneServerConfiguration.getIndexDir());
@@ -118,6 +99,7 @@ public class GlobalState implements Closeable, Restorable {
         if (Files.exists(stateDir) == false) {
             Files.createDirectories(stateDir);
         }
+        this.indexService = ThreadPoolExecutorFactory.getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.INDEX);
         //TODO: figure if we need SearchQueue when we get searching
         //searchQueue = new SearchQueue(this);
         loadIndexNames();

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/MyIndexSearcher.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/MyIndexSearcher.java
@@ -19,23 +19,24 @@
 
 package com.yelp.nrtsearch.server.luceneserver;
 
+import com.yelp.nrtsearch.server.utils.ThreadPoolExecutorFactory;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.search.*;
+import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.CollectionTerminatedException;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Bits;
-import org.apache.lucene.util.NamedThreadFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 /**
  * This is sadly necessary because for ToParentBlockJoinQuery we must invoke .scorer not .bulkScorer, yet for DrillSideways we must do
@@ -51,21 +52,8 @@ public class MyIndexSearcher extends IndexSearcher {
     private static final int MAX_DOCS_PER_SLICE = 250_000;
     private static final int MAX_SEGMENTS_PER_SLICE = 5;
 
-    private static Executor getSearchExecutor() {
-        int MAX_SEARCHING_THREADS = Runtime.getRuntime().availableProcessors();
-        int MAX_BUFFERED_ITEMS = Math.max(100, 2 * MAX_SEARCHING_THREADS);
-        // Seems to be substantially faster than ArrayBlockingQueue at high throughput:
-        final BlockingQueue<Runnable> docsToIndex = new LinkedBlockingQueue<Runnable>(MAX_BUFFERED_ITEMS);
-        //same as Executors.newFixedThreadPool except we want a NamedThreadFactory instead of defaultFactory
-        return new ThreadPoolExecutor(MAX_SEARCHING_THREADS,
-                MAX_SEARCHING_THREADS,
-                0, TimeUnit.SECONDS,
-                docsToIndex,
-                new NamedThreadFactory("LuceneSearchExecutor"));
-    }
-
     public MyIndexSearcher(IndexReader reader) {
-        super(reader, getSearchExecutor());
+        super(reader, ThreadPoolExecutorFactory.getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.SEARCH));
     }
 
     /*** start segment to thread mapping **/

--- a/src/main/java/com/yelp/nrtsearch/server/utils/ThreadPoolExecutorFactory.java
+++ b/src/main/java/com/yelp/nrtsearch/server/utils/ThreadPoolExecutorFactory.java
@@ -1,0 +1,66 @@
+package com.yelp.nrtsearch.server.utils;
+
+import com.yelp.nrtsearch.server.grpc.LuceneServer;
+import org.apache.lucene.util.NamedThreadFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class ThreadPoolExecutorFactory {
+    public enum ExecutorType {
+        SEARCH,
+        INDEX,
+        LUCENESERVER,
+        REPLICATIONSERVER
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(ThreadPoolExecutorFactory.class.getName());
+    private static final int MAX_SEARCHING_THREADS = Runtime.getRuntime().availableProcessors();
+    private static final int MAX_BUFFERED_ITEMS = Math.max(100, 2 * MAX_SEARCHING_THREADS);
+    // Seems to be substantially faster than ArrayBlockingQueue at high throughput:
+    private static final BlockingQueue<Runnable> docsToIndex = new LinkedBlockingQueue<Runnable>(MAX_BUFFERED_ITEMS);
+    private final static int MAX_INDEXING_THREADS = MAX_SEARCHING_THREADS;
+    private final static int MAX_GRPC_LUCENESERVER_THREADS = MAX_SEARCHING_THREADS;
+    private final static int MAX_GRPC_REPLICATIONSERVER_THREADS = MAX_SEARCHING_THREADS;
+
+    public static ThreadPoolExecutor getThreadPoolExecutor(ExecutorType executorType) {
+        if (executorType.equals(ExecutorType.SEARCH)) {
+            logger.info("Creating LuceneSearchExecutor of size " + MAX_SEARCHING_THREADS);
+            //same as Executors.newFixedThreadPool except we want a NamedThreadFactory instead of defaultFactory
+            return new ThreadPoolExecutor(MAX_SEARCHING_THREADS,
+                    MAX_SEARCHING_THREADS,
+                    0, TimeUnit.SECONDS,
+                    docsToIndex,
+                    new NamedThreadFactory("LuceneSearchExecutor"));
+
+        } else if (executorType.equals(ExecutorType.INDEX)) {
+            logger.info("Creating LuceneIndexingExecutor of size " + MAX_INDEXING_THREADS);
+            return new ThreadPoolExecutor(MAX_INDEXING_THREADS,
+                    MAX_INDEXING_THREADS,
+                    0, TimeUnit.SECONDS,
+                    docsToIndex,
+                    new NamedThreadFactory("LuceneIndexingExecutor"));
+        } else if (executorType.equals(ExecutorType.LUCENESERVER)) {
+            logger.info("Creating GrpcLuceneServerExecutor of size " + MAX_GRPC_LUCENESERVER_THREADS);
+            return new ThreadPoolExecutor(MAX_GRPC_LUCENESERVER_THREADS,
+                    MAX_GRPC_LUCENESERVER_THREADS,
+                    0, TimeUnit.SECONDS,
+                    docsToIndex,
+                    new NamedThreadFactory("GrpcLuceneServerExecutor"));
+        } else if (executorType.equals(ExecutorType.REPLICATIONSERVER)) {
+            logger.info("Creating GrpcReplicationServerExecutor of size " + MAX_GRPC_REPLICATIONSERVER_THREADS);
+            return new ThreadPoolExecutor(MAX_GRPC_REPLICATIONSERVER_THREADS,
+                    MAX_GRPC_REPLICATIONSERVER_THREADS,
+                    0, TimeUnit.SECONDS,
+                    docsToIndex,
+                    new NamedThreadFactory("GrpcReplicationServerExecutor"));
+        } else {
+            throw new RuntimeException("Invalid executor type provided " + executorType.toString());
+        }
+    }
+}


### PR DESCRIPTION
We were having latency issues for p99s. Upon jprofiling we found that we have a large number of threads and this number keeps growing with time. Most of these come from the grpc-default-executor pool which in turn uses [cachedThreadPool](https://github.com/grpc/grpc-java/blob/d667a67d1586002743c031cb84b115f69b63a5a2/core/src/main/java/io/grpc/internal/GrpcUtil.java#L521). 

The settings used imply we have a max of Integer.MAX_VALUE threads as cachedThreadPool would keep adding new threads when rest are busy

