### PR TITLE
use default similarity with IndexSearcher for fields not explicitly defined

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
@@ -38,9 +38,7 @@ import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.util.FilesystemResourceLoader;
 import org.apache.lucene.expressions.Bindings;
 import org.apache.lucene.facet.FacetsConfig;
-import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager;
 import org.apache.lucene.index.ConcurrentMergeScheduler;
-import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
@@ -395,10 +393,11 @@ public class IndexState implements Closeable, Restorable {
 
         @Override
         public Similarity get(String name) {
-            if (internalFacetFieldNames.contains(name)) {
+            if(fields.containsKey(name)) {
+                return getField(name).sim;
+            } else {
                 return defaultSim;
             }
-            return getField(name).sim;
         }
     };
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/RegisterFieldsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/RegisterFieldsHandler.java
@@ -20,6 +20,10 @@
 package com.yelp.nrtsearch.server.luceneserver;
 
 import com.google.common.collect.Maps;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
 import com.yelp.nrtsearch.server.grpc.FacetType;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
@@ -27,12 +31,6 @@ import com.yelp.nrtsearch.server.grpc.FieldDefResponse;
 import com.yelp.nrtsearch.server.grpc.FieldType;
 import com.yelp.nrtsearch.server.grpc.TermVectors;
 import com.yelp.nrtsearch.server.luceneserver.analysis.AnalyzerCreator;
-
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.util.JsonFormat;
-
 import com.yelp.nrtsearch.server.luceneserver.script.ScoreScript;
 import com.yelp.nrtsearch.server.luceneserver.script.ScriptParamsTransformer;
 import com.yelp.nrtsearch.server.luceneserver.script.ScriptService;


### PR DESCRIPTION
We set customSimilarity for our IndexSearch (in all modes Primary, Replica, Standalone)
[searcher.setSimilarity(indexState.sim);](https://github.com/Yelp/nrtsearch/search?q=searcher.setSimilarity&unscoped_q=searcher.setSimilarity). The primary reason to do this is that we could have a custom similarity perField which we define [here](https://github.com/Yelp/nrtsearch/blob/614f6fef6aef77936f903e4a8606dde6c950ed0e/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java#L393)

When the replica is finishing up a copy job
[ReplicaNode. finishNRTCopy](https://github.com/apache/lucene-solr/blob/8867f465dc629c8fe898c7a8c49c82db26349d82/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/ReplicaNode.java#L433)  it logs some internal counts. This causes our custom `PerFieldSimilarityWrapper` to be invoked. 

In status quo we threw error for any unknown field. I now return the default `BM25Similarity` for fields external to the ones defined in the mapping