### PR TITLE
Use generalized config reader

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/LuceneServerModule.java
+++ b/src/main/java/com/yelp/nrtsearch/LuceneServerModule.java
@@ -42,15 +42,12 @@ import com.google.inject.Inject;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 
-import org.yaml.snakeyaml.Yaml;
-
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import io.prometheus.client.CollectorRegistry;
-import org.yaml.snakeyaml.constructor.Constructor;
 
 public class LuceneServerModule extends AbstractModule {
     private final String[] args;
@@ -113,9 +110,9 @@ public class LuceneServerModule extends AbstractModule {
         LuceneServerConfiguration luceneServerConfiguration;
         if (args.length == 0) {
             Path filePath = Paths.get("src", "main", "resources", "lucene_server_default_configuration.yaml");
-            luceneServerConfiguration = new Yaml(new Constructor(LuceneServerConfiguration.class)).load(new FileInputStream(filePath.toFile()));
+            luceneServerConfiguration = new LuceneServerConfiguration(new FileInputStream(filePath.toFile()));
         } else {
-            luceneServerConfiguration = new Yaml(new Constructor(LuceneServerConfiguration.class)).load(new FileInputStream(args[0]));
+            luceneServerConfiguration = new LuceneServerConfiguration(new FileInputStream(args[0]));
         }
         return luceneServerConfiguration;
     }

--- a/src/main/java/com/yelp/nrtsearch/server/config/ConfigKeyNotFoundException.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/ConfigKeyNotFoundException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yelp.nrtsearch.server.config;
+
+/**
+ * Exception thrown by {@link YamlConfigReader} functions when any component of the config key lookup path
+ * does not exist.
+ */
+public class ConfigKeyNotFoundException extends Exception {
+    ConfigKeyNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/config/ConfigReadException.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/ConfigReadException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yelp.nrtsearch.server.config;
+
+/**
+ * Exception thrown by {@link YamlConfigReader} functions when there is an unexpected problem. This exception
+ * indicates malformed config, such as a component of the key lookup path not being a hash or a value not being
+ * parsable into the desired type.
+ */
+public class ConfigReadException extends RuntimeException {
+    ConfigReadException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -21,9 +21,11 @@ package com.yelp.nrtsearch.server.config;
 
 import com.google.inject.Inject;
 
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public class LuceneServerConfiguration {
     public final static Path DEFAULT_USER_DIR = Paths.get(System.getProperty("user.home"), "lucene", "server");
@@ -39,37 +41,63 @@ public class LuceneServerConfiguration {
     //buckets represent number of requests completed in "less than" seconds
     private static final double[] DEFAULT_METRICS_BUCKETS = new double[]{.005, .01, .025, .05, .075, .1, .25, .5, .75, 1, 2.5, 5, 7.5, 10};
     private static final int DEFAULT_INTERVAL_MS = 1000 * 10;
-    private static final String[] DEFAULT_PLUGINS = new String[]{};
+    private static final List<String> DEFAULT_PLUGINS = Collections.emptyList();
     private static final Path DEFAULT_PLUGIN_SEARCH_PATH = Paths.get(DEFAULT_USER_DIR.toString(), "plugins");
     private static final String DEFAULT_SERVICE_NAME = "nrtsearch-generic";
 
-    private int port = DEFAULT_PORT;
-    private int replicationPort = DEFAULT_REPLICATION_PORT;
-    private int replicaReplicationPortPingInterval = DEFAULT_INTERVAL_MS;
-    private String nodeName = DEFAULT_NODE_NAME;
-    private String hostName = DEFAULT_HOSTNAME;
-    private String stateDir = DEFAULT_STATE_DIR.toString();
-    private String indexDir = DEFAULT_INDEX_DIR.toString();
-    private String archiveDirectory = DEFAULT_ARCHIVER_DIR.toString();
-    private String botoCfgPath = DEFAULT_BOTO_CFG_PATH.toString();
-    private String bucketName = DEFAULT_BUCKET_NAME;
-    private double[] metricsBuckets = DEFAULT_METRICS_BUCKETS;
-    private String[] plugins = DEFAULT_PLUGINS;
-    private String pluginSearchPath = DEFAULT_PLUGIN_SEARCH_PATH.toString();
-    private String serviceName = DEFAULT_SERVICE_NAME;
-    private boolean restoreState = false;
-    private ThreadPoolConfiguration threadPoolConfiguration = new ThreadPoolConfiguration();
+    private final int port;
+    private final int replicationPort;
+    private final int replicaReplicationPortPingInterval;
+    private final String nodeName;
+    private final String hostName;
+    private final String stateDir;
+    private final String indexDir;
+    private final String archiveDirectory;
+    private final String botoCfgPath;
+    private final String bucketName;
+    private final double[] metricsBuckets;
+    private final String[] plugins;
+    private final String pluginSearchPath;
+    private final String serviceName;
+    private final boolean restoreState;
+    private final ThreadPoolConfiguration threadPoolConfiguration;
+
+    private final YamlConfigReader configReader;
 
     @Inject
-    public LuceneServerConfiguration() {
+    public LuceneServerConfiguration(InputStream yamlStream) {
+        configReader = new YamlConfigReader(yamlStream);
+
+        port = configReader.getInteger("port", DEFAULT_PORT);
+        replicationPort = configReader.getInteger("replicationPort", DEFAULT_REPLICATION_PORT);
+        replicaReplicationPortPingInterval = configReader.getInteger("replicaReplicationPortPingInterval", DEFAULT_INTERVAL_MS);
+        nodeName = configReader.getString("nodeName", DEFAULT_NODE_NAME);
+        hostName = configReader.getString("hostName", DEFAULT_HOSTNAME);
+        stateDir = configReader.getString("stateDir", DEFAULT_STATE_DIR.toString());
+        indexDir = configReader.getString("indexDir", DEFAULT_INDEX_DIR.toString());
+        archiveDirectory = configReader.getString("archiveDirectory", DEFAULT_ARCHIVER_DIR.toString());
+        botoCfgPath = configReader.getString("botoCfgPath", DEFAULT_BOTO_CFG_PATH.toString());
+        bucketName = configReader.getString("bucketName", DEFAULT_BUCKET_NAME);
+        double[] metricsBuckets;
+        try {
+            List<Double> bucketList = configReader.getDoubleList("metricsBuckets");
+            metricsBuckets = new double[bucketList.size()];
+            for (int i = 0; i < bucketList.size(); ++i) {
+                metricsBuckets[i] = bucketList.get(i);
+            }
+        } catch (ConfigKeyNotFoundException e) {
+            metricsBuckets = DEFAULT_METRICS_BUCKETS;
+        }
+        this.metricsBuckets = metricsBuckets;
+        plugins = configReader.getStringList("plugins", DEFAULT_PLUGINS).toArray(new String[0]);
+        pluginSearchPath = configReader.getString("pluginSearchPath", DEFAULT_PLUGIN_SEARCH_PATH.toString());
+        serviceName = configReader.getString("serviceName", DEFAULT_SERVICE_NAME);
+        restoreState = configReader.getBoolean("restoreState", false);
+        threadPoolConfiguration = new ThreadPoolConfiguration(configReader);
     }
 
     public ThreadPoolConfiguration getThreadPoolConfiguration() {
         return threadPoolConfiguration;
-    }
-
-    public void setThreadPoolConfiguration(ThreadPoolConfiguration threadPoolConfiguration) {
-        this.threadPoolConfiguration = threadPoolConfiguration;
     }
 
     public int getPort() {
@@ -100,57 +128,16 @@ public class LuceneServerConfiguration {
         return hostName;
     }
 
-    public void setPort(int port) {
-        this.port = port;
-    }
-
-    public void setServiceName(String serviceName) {
-        this.serviceName = serviceName;
-    }
-
-    public void setReplicationPort(int replicationPort) {
-        this.replicationPort = replicationPort;
-    }
-
-    public void setNodeName(String nodeName) {
-        this.nodeName = nodeName;
-    }
-
-    public void setStateDir(String stateDir) {
-        this.stateDir = stateDir;
-    }
-
-    public void setIndexDir(String indexDir) {
-        this.indexDir = indexDir;
-    }
-
-    public void setHostName(String hostName) {
-        this.hostName = hostName;
-    }
-
-
     public String getBotoCfgPath() {
         return botoCfgPath;
-    }
-
-    public void setBotoCfgPath(String botoCfgPath) {
-        this.botoCfgPath = botoCfgPath;
     }
 
     public String getBucketName() {
         return bucketName;
     }
 
-    public void setBucketName(String bucketName) {
-        this.bucketName = bucketName;
-    }
-
     public String getArchiveDirectory() {
         return archiveDirectory;
-    }
-
-    public void setArchiveDirectory(String archiveDirectory) {
-        this.archiveDirectory = archiveDirectory;
     }
 
     public double[] getMetricsBuckets() {
@@ -161,161 +148,20 @@ public class LuceneServerConfiguration {
         return replicaReplicationPortPingInterval;
     }
 
-    public void setReplicaReplicationPortPingInterval(int replicaReplicationPortPingInterval) {
-        this.replicaReplicationPortPingInterval = replicaReplicationPortPingInterval;
-    }
-
     public String[] getPlugins() {
         return this.plugins;
-    }
-
-    public void setPlugins(String[] plugins) {
-        this.plugins = plugins;
     }
 
     public String getPluginSearchPath() {
         return this.pluginSearchPath;
     }
 
-    public void setPluginSearchPath(String pluginSearchPath) {
-        this.pluginSearchPath = pluginSearchPath;
-    }
-
     public boolean getRestoreState() {
         return restoreState;
     }
 
-    public void setRestoreState(boolean restoreState) {
-        this.restoreState = restoreState;
+    public YamlConfigReader getConfigReader() {
+        return configReader;
     }
-
-    public static class Builder {
-        private final double[] metricsBuckets;
-        private String hostName;
-        private int replicationPort;
-        private int port;
-        private int replicaReplicationPortPingInterval;
-        private String nodeName;
-        private Path stateDir;
-        private Path indexDir;
-        private String archiveDirectory;
-        private String botoCfgPath;
-        private String bucketName;
-        private String[] plugins;
-        private String pluginSearchPath;
-        private String serviceName;
-        private boolean restoreState;
-
-        public Builder() {
-            //set default values
-            this.nodeName = DEFAULT_NODE_NAME;
-            this.hostName = DEFAULT_HOSTNAME;
-            this.stateDir = DEFAULT_STATE_DIR;
-            this.indexDir = DEFAULT_INDEX_DIR;
-            this.port = DEFAULT_PORT;
-            this.serviceName = DEFAULT_SERVICE_NAME;
-            this.replicationPort = DEFAULT_REPLICATION_PORT;
-            this.archiveDirectory = DEFAULT_ARCHIVER_DIR.toString();
-            this.botoCfgPath = DEFAULT_BOTO_CFG_PATH.toString();
-            this.bucketName = DEFAULT_BUCKET_NAME;
-            this.metricsBuckets = DEFAULT_METRICS_BUCKETS;
-            this.replicaReplicationPortPingInterval = DEFAULT_INTERVAL_MS;
-            this.plugins = DEFAULT_PLUGINS;
-            this.pluginSearchPath = DEFAULT_PLUGIN_SEARCH_PATH.toString();
-            this.restoreState = false;
-        }
-
-        public Builder withStateDir(String tempStateDir) {
-            this.stateDir = Paths.get(tempStateDir);
-            return this;
-        }
-
-        public Builder withIndexDir(String tempIndexDir) {
-            this.indexDir = Paths.get(tempIndexDir);
-            return this;
-        }
-
-        public Builder withNodeName(String nodeName) {
-            this.nodeName = nodeName;
-            return this;
-        }
-
-        public Builder withPort(int port) {
-            this.port = port;
-            return this;
-        }
-
-        public Builder withServiceName(String serviceName) {
-            this.serviceName = serviceName;
-            return this;
-        }
-
-        public Builder withRestoreState(boolean restoreState) {
-            this.restoreState = restoreState;
-            return this;
-        }
-
-        public Builder withReplicationPort(int replicationPort) {
-            this.replicationPort = replicationPort;
-            return this;
-        }
-
-        public Builder withReplicaReplicationPortPingInterval(int replicaReplicationPortPingInterval) {
-            this.replicaReplicationPortPingInterval = replicaReplicationPortPingInterval;
-            return this;
-        }
-
-        public Builder withHostName(String hostName) {
-            this.hostName = hostName;
-            return this;
-        }
-
-        public Builder withArchiveDirectory(String archiveDirectory) {
-            this.archiveDirectory = archiveDirectory;
-            return this;
-        }
-
-        public Builder withBotoCfgPath(String botoCfgPath) {
-            this.botoCfgPath = botoCfgPath;
-            return this;
-        }
-
-        public Builder withBucketName(String bucketName) {
-            this.bucketName = bucketName;
-            return this;
-        }
-
-        public Builder withPlugins(String[] plugins) {
-            this.plugins = plugins;
-            return this;
-        }
-
-        public Builder withPluginSearchPath(String pluginSearchPath) {
-            this.pluginSearchPath = pluginSearchPath;
-            return this;
-        }
-
-        public LuceneServerConfiguration build() {
-            LuceneServerConfiguration luceneServerConfiguration = new LuceneServerConfiguration();
-            luceneServerConfiguration.nodeName = this.nodeName;
-            luceneServerConfiguration.stateDir = this.stateDir.toString();
-            luceneServerConfiguration.indexDir = this.indexDir.toString();
-            luceneServerConfiguration.port = this.port;
-            luceneServerConfiguration.hostName = this.hostName;
-            luceneServerConfiguration.replicationPort = this.replicationPort;
-            luceneServerConfiguration.archiveDirectory = this.archiveDirectory;
-            luceneServerConfiguration.botoCfgPath = this.botoCfgPath;
-            luceneServerConfiguration.bucketName = this.bucketName;
-            luceneServerConfiguration.metricsBuckets = this.metricsBuckets;
-            luceneServerConfiguration.replicaReplicationPortPingInterval = this.replicaReplicationPortPingInterval;
-            luceneServerConfiguration.plugins = this.plugins;
-            luceneServerConfiguration.pluginSearchPath = this.pluginSearchPath;
-            luceneServerConfiguration.serviceName = this.serviceName;
-            luceneServerConfiguration.restoreState = this.restoreState;
-            return luceneServerConfiguration;
-        }
-
-    }
-
 
 }

--- a/src/main/java/com/yelp/nrtsearch/server/config/NumberReaderFunc.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/NumberReaderFunc.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yelp.nrtsearch.server.config;
+
+import java.util.function.Function;
+
+/**
+ * Helper Function to convert a yaml read Object that is expected to be a String or Number. Used as a generic
+ * way to read types that extend Number, though this is not a strict requirement.
+ * @param <T> type to convert the config object into
+ */
+public class NumberReaderFunc<T> implements Function<Object, T> {
+    private final Function<Number, T> numberConverter;
+    private final Function<String, T> stringConverter;
+    private final Class<T> clazz;
+
+    NumberReaderFunc(Class<T> clazz, Function<Number, T> numberConverter, Function<String, T> stringConverter) {
+        this.numberConverter = numberConverter;
+        this.stringConverter = stringConverter;
+        this.clazz = clazz;
+    }
+
+    @Override
+    public T apply(Object o) {
+        if (o instanceof String) {
+            return stringConverter.apply((String) o);
+        }
+        if (o instanceof Number) {
+            Number num = (Number) o;
+            if (clazz.isInstance(num)) {
+                return clazz.cast(num);
+            }
+            return numberConverter.apply(num);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java
@@ -11,85 +11,79 @@ public class ThreadPoolConfiguration {
     private static final int DEFAULT_MAX_INDEXING_THREADS = Runtime.getRuntime().availableProcessors() + 1;
     private static final int DEFAULT_MAX_INDEXING_BUFFERED_ITEMS = Math.max(200, 2 * DEFAULT_MAX_INDEXING_THREADS);
 
-    private final static int DEFAULT_MAX_GRPC_LUCENESERVER_THREADS = DEFAULT_MAX_INDEXING_THREADS;
+    private static final int DEFAULT_MAX_GRPC_LUCENESERVER_THREADS = DEFAULT_MAX_INDEXING_THREADS;
     private static final int DEFAULT_MAX_GRPC_LUCENESERVER_BUFFERED_ITEMS = DEFAULT_MAX_INDEXING_BUFFERED_ITEMS;
 
-    private final static int DEFAULT_MAX_GRPC_REPLICATIONSERVER_THREADS = DEFAULT_MAX_INDEXING_THREADS;
+    private static final int DEFAULT_MAX_GRPC_REPLICATIONSERVER_THREADS = DEFAULT_MAX_INDEXING_THREADS;
     private static final int DEFAULT_MAX_GRPC_REPLICATIONSERVER_BUFFERED_ITEMS = DEFAULT_MAX_INDEXING_BUFFERED_ITEMS;
 
-    private int maxSearchingThreads = DEFAULT_MAX_SEARCHING_THREADS;
-    private int maxSearchBufferedItems = DEFAULT_MAX_SEARCH_BUFFERED_ITEMS;
+    private final int maxSearchingThreads;
+    private final int maxSearchBufferedItems;
 
-    private int maxIndexingThreads = DEFAULT_MAX_INDEXING_THREADS;
-    private int maxIndexingBufferedItems = DEFAULT_MAX_INDEXING_BUFFERED_ITEMS;
+    private final int maxIndexingThreads;
+    private final int maxIndexingBufferedItems;
 
-    private int maxGrpcLuceneserverThreads = DEFAULT_MAX_GRPC_LUCENESERVER_THREADS;
-    private int maxGrpcLuceneserverBufferedItems = DEFAULT_MAX_GRPC_LUCENESERVER_BUFFERED_ITEMS;
+    private final int maxGrpcLuceneserverThreads;
+    private final int maxGrpcLuceneserverBufferedItems;
 
-    private int maxGrpcReplicationserverThreads = DEFAULT_MAX_GRPC_REPLICATIONSERVER_THREADS;
-    private int maxGrpcReplicationserverBufferedItems = DEFAULT_MAX_GRPC_REPLICATIONSERVER_BUFFERED_ITEMS;
+    private final int maxGrpcReplicationserverThreads;
+    private final int maxGrpcReplicationserverBufferedItems;
+
+    public ThreadPoolConfiguration(YamlConfigReader configReader) {
+        maxSearchingThreads = configReader.getInteger(
+                "threadPoolConfiguration.maxSearchingThreads", DEFAULT_MAX_SEARCHING_THREADS);
+        maxSearchBufferedItems = configReader.getInteger(
+                "threadPoolConfiguration.maxSearchBufferedItems", DEFAULT_MAX_SEARCH_BUFFERED_ITEMS);
+
+        maxIndexingThreads = configReader.getInteger(
+                "threadPoolConfiguration.maxIndexingThreads", DEFAULT_MAX_INDEXING_THREADS);
+        maxIndexingBufferedItems = configReader.getInteger(
+                "threadPoolConfiguration.maxIndexingBufferedItems", DEFAULT_MAX_INDEXING_BUFFERED_ITEMS);
+
+        maxGrpcLuceneserverThreads = configReader.getInteger(
+                "threadPoolConfiguration.maxGrpcLuceneserverThreads", DEFAULT_MAX_GRPC_LUCENESERVER_THREADS);
+        maxGrpcLuceneserverBufferedItems = configReader.getInteger(
+                "threadPoolConfiguration.maxGrpcLuceneserverBufferedItems",
+                DEFAULT_MAX_GRPC_LUCENESERVER_BUFFERED_ITEMS);
+
+        maxGrpcReplicationserverThreads = configReader.getInteger(
+                "threadPoolConfiguration.maxGrpcReplicationserverThreads",
+                DEFAULT_MAX_GRPC_REPLICATIONSERVER_THREADS);
+        maxGrpcReplicationserverBufferedItems = configReader.getInteger(
+                "threadPoolConfiguration.maxGrpcReplicationserverBufferedItems",
+                DEFAULT_MAX_GRPC_REPLICATIONSERVER_BUFFERED_ITEMS);
+    }
 
     public int getMaxSearchingThreads() {
         return maxSearchingThreads;
-    }
-
-    public void setMaxSearchingThreads(int maxSearchingThreads) {
-        this.maxSearchingThreads = maxSearchingThreads;
     }
 
     public int getMaxSearchBufferedItems() {
         return maxSearchBufferedItems;
     }
 
-    public void setMaxSearchBufferedItems(int maxSearchBufferedItems) {
-        this.maxSearchBufferedItems = maxSearchBufferedItems;
-    }
-
     public int getMaxIndexingThreads() {
         return maxIndexingThreads;
-    }
-
-    public void setMaxIndexingThreads(int maxIndexingThreads) {
-        this.maxIndexingThreads = maxIndexingThreads;
     }
 
     public int getMaxIndexingBufferedItems() {
         return maxIndexingBufferedItems;
     }
 
-    public void setMaxIndexingBufferedItems(int maxIndexingBufferedItems) {
-        this.maxIndexingBufferedItems = maxIndexingBufferedItems;
-    }
-
     public int getMaxGrpcLuceneserverThreads() {
         return maxGrpcLuceneserverThreads;
-    }
-
-    public void setMaxGrpcLuceneserverThreads(int maxGrpcLuceneserverThreads) {
-        this.maxGrpcLuceneserverThreads = maxGrpcLuceneserverThreads;
     }
 
     public int getMaxGrpcReplicationserverThreads() {
         return maxGrpcReplicationserverThreads;
     }
 
-    public void setMaxGrpcReplicationserverThreads(int maxGrpcReplicationserverThreads) {
-        this.maxGrpcReplicationserverThreads = maxGrpcReplicationserverThreads;
-    }
-
     public int getMaxGrpcLuceneserverBufferedItems() {
         return maxGrpcLuceneserverBufferedItems;
-    }
-
-    public void setMaxGrpcLuceneserverBufferedItems(int maxGrpcLuceneserverBufferedItems) {
-        this.maxGrpcLuceneserverBufferedItems = maxGrpcLuceneserverBufferedItems;
     }
 
     public int getMaxGrpcReplicationserverBufferedItems() {
         return maxGrpcReplicationserverBufferedItems;
     }
 
-    public void setMaxGrpcReplicationserverBufferedItems(int maxGrpcReplicationserverBufferedItems) {
-        this.maxGrpcReplicationserverBufferedItems = maxGrpcReplicationserverBufferedItems;
-    }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/config/YamlConfigReader.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/YamlConfigReader.java
@@ -1,0 +1,506 @@
+/*
+ * Copyright 2019 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yelp.nrtsearch.server.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * General purpose Yaml config file reader that allows value lookup by providing dot separated key paths.
+ * The path represents the traversal through yaml hashes. The input file is expected to contain a single document
+ * that is a hash. For example:
+ * <pre>
+ *     a1:
+ *       a2:
+ *         key1: val1
+ *       a3:
+ *         key2: val2
+ *     a2:
+ *       key3: val3
+ *     ...
+ * </pre>
+ * The key "a1.a3.key2" would have the value "val2".
+ *
+ * Reading lists and getting the list of a hash's keys are also supported.
+ *
+ * Some helper functions are include for the reading of basic types, and extension is possible by using
+ * the generic versions of the lookup functions.
+ *
+ * All lookup functions throw {@link NullPointerException} if the provided path or reader function is null.
+ *
+ * Lookup functions without default values will throw a checked {@link ConfigKeyNotFoundException} if any
+ * component of the lookup path does not exist in the config.
+ *
+ * Lookup functions can throw an unchecked {@link ConfigReadException} if the config is malformed for the given
+ * key path. This will occur if a component of the key path is not a hash, such as "key3" in path "a2.key3.a4"
+ * in the example above. This will also occur if the key value is not parsable into the desired type.
+ */
+public class YamlConfigReader {
+    private static final Logger logger = LoggerFactory.getLogger(YamlConfigReader.class.getName());
+
+    private static Function<Object, String> STR_READER = (node) -> {
+        if (!(node instanceof Collection) && !(node instanceof Map)) {
+            return node.toString();
+        }
+        return null;
+    };
+    private static Function<Object, Boolean> BOOL_READER = (node) -> {
+        if (node instanceof Boolean) {
+            return (Boolean) node;
+        }
+
+        if (node instanceof String) {
+            return Boolean.parseBoolean((String)node);
+        }
+        return null;
+    };
+    private static Function<Object, Integer> INT_READER = new NumberReaderFunc<>(Integer.class, Number::intValue, Integer::parseInt);
+    private static Function<Object, Long> LONG_READER = new NumberReaderFunc<>(Long.class, Number::longValue, Long::parseLong);
+    private static Function<Object, Float> FLOAT_READER = new NumberReaderFunc<>(Float.class, Number::floatValue, Float::parseFloat);
+    private static Function<Object, Double> DOUBLE_READER = new NumberReaderFunc<>(Double.class, Number::doubleValue, Double::parseDouble);
+
+    private static String SPLIT_REGEX = "[.]";
+
+    private final Map<?,?> configRoot;
+
+    public YamlConfigReader(InputStream fileStream) {
+        Yaml yaml = new Yaml();
+        Object configObject = yaml.load(fileStream);
+        if (!(configObject instanceof Map)) {
+            throw new IllegalArgumentException("Loaded yaml file must be a hash.");
+        }
+        configRoot = (Map<?,?>) configObject;
+    }
+
+    /**
+     * Read String config value. Must not be array or hash.
+     * @param path dot separated key path
+     * @return the .toString() value of config entry
+     * @throws ConfigKeyNotFoundException if any path component does not exist
+     */
+    public String getString(String path) throws ConfigKeyNotFoundException {
+        return get(path, STR_READER);
+    }
+
+    /**
+     * Read String config value, or default if not found. Must not be array or hash.
+     * @param path dot separated key path
+     * @param def default value
+     * @return the .toString() value of config entry, or default if not found
+     */
+    public String getString(String path, String def) {
+        return get(path, STR_READER, def);
+    }
+
+    /**
+     * Read array of String values.
+     * @param path dot separated key path
+     * @return list of .toString() values of items in specified array
+     * @throws ConfigKeyNotFoundException if any path component does not exist
+     */
+    public List<String> getStringList(String path) throws ConfigKeyNotFoundException {
+        return getList(path, STR_READER);
+    }
+
+    /**
+     * Read array of String values, or default if not found.
+     * @param path dot separated key path
+     * @param def default value
+     * @return list of .toString() values of items in specified array, or default if not found
+     */
+    public List<String> getStringList(String path, List<String> def) {
+        return getList(path, STR_READER, def);
+    }
+
+    /**
+     * Read Boolean config value. Must be a boolean or a string parsable with Boolean::parseBoolean().
+     * @param path dot separated key path
+     * @return Boolean value of config key
+     * @throws ConfigKeyNotFoundException if any path component does not exist
+     */
+    public Boolean getBoolean(String path) throws ConfigKeyNotFoundException {
+        return get(path, BOOL_READER);
+    }
+
+    /**
+     * Read Boolean config value, of default if not found.
+     * Must be a boolean or a string parsable with Boolean::parseBoolean().
+     * @param path dot separated key path
+     * @param def default value
+     * @return Boolean value of config key, of default if not found
+     */
+    public Boolean getBoolean(String path, Boolean def) {
+        return get(path, BOOL_READER, def);
+    }
+
+    /**
+     * Read array of Boolean config values. Items must be a boolean or a string parsable with Boolean::parseBoolean().
+     * @param path dot separated key path
+     * @return list of Boolean values for config key
+     * @throws ConfigKeyNotFoundException if any path component does not exist
+     */
+    public List<Boolean> getBooleanList(String path) throws ConfigKeyNotFoundException {
+        return getList(path, BOOL_READER);
+    }
+
+    /**
+     * Read array of Boolean config values, or default if not found.
+     * Items must be a boolean or a string parsable with Boolean::parseBoolean().
+     * @param path dot separated key path
+     * @return list of Boolean values for config key, or default if not found
+     */
+    public List<Boolean> getBooleanList(String path, List<Boolean> def) {
+        return getList(path, BOOL_READER, def);
+    }
+
+    /**
+     * Read Integer config value. Must be a {@link Number} or a string parsable with Integer::parseInteger().
+     * @param path dot separated key path
+     * @return Integer value of config key
+     * @throws ConfigKeyNotFoundException if any path component does not exist
+     */
+    public Integer getInteger(String path) throws ConfigKeyNotFoundException {
+        return get(path, INT_READER);
+    }
+
+    /**
+     * Read Integer config value, or default if not found.
+     * Must be a {@link Number} or a string parsable with Integer::parseInteger().
+     * @param path dot separated key path
+     * @param def default value
+     * @return Integer value of config key, or default if not found
+     */
+    public Integer getInteger(String path, Integer def) {
+        return get(path, INT_READER, def);
+    }
+
+    /**
+     * Read array of Integer config values.
+     * Items must be a {@link Number} or a string parsable with Integer::parseInteger().
+     * @param path dot separated key path
+     * @return list of Integer values for config key
+     * @throws ConfigKeyNotFoundException if any path component does not exist
+     */
+    public List<Integer> getIntegerList(String path) throws ConfigKeyNotFoundException {
+        return getList(path, INT_READER);
+    }
+
+    /**
+     * Read array of Integer config values, or default if not found.
+     * Items must be a {@link Number} or a string parsable with Integer::parseInteger().
+     * @param path dot separated key path
+     * @param def default value
+     * @return list of Integer values for config key, or default if not found
+     */
+    public List<Integer> getIntegerList(String path, List<Integer> def) {
+        return getList(path, INT_READER, def);
+    }
+
+    /**
+     * Read Long config value. Must be a {@link Number} or a string parsable with Long::parseLong().
+     * @param path dot separated key path
+     * @return Long value of config key
+     * @throws ConfigKeyNotFoundException if any path component does not exist
+     */
+    public Long getLong(String path) throws ConfigKeyNotFoundException {
+        return get(path, LONG_READER);
+    }
+
+    /**
+     * Read Long config value, or default if not found.
+     * Must be a {@link Number} or a string parsable with Long::parseLong().
+     * @param path dot separated key path
+     * @param def default value
+     * @return Long value of config key, or default if not found
+     */
+    public Long getLong(String path, Long def) {
+        return get(path, LONG_READER, def);
+    }
+
+    /**
+     * Read array of Long config values.
+     * Items must be a {@link Number} or a string parsable with Long::parseLong().
+     * @param path dot separated key path
+     * @return list of Long values for config key
+     * @throws ConfigKeyNotFoundException if any path component does not exist
+     */
+    public List<Long> getLongList(String path) throws ConfigKeyNotFoundException {
+        return getList(path, LONG_READER);
+    }
+
+    /**
+     * Read array of Long config values, or default if not found.
+     * Items must be a {@link Number} or a string parsable with Long::parseLong().
+     * @param path dot separated key path
+     * @param def default value
+     * @return list of Long values for config key, or default if not found
+     */
+    public List<Long> getLongList(String path, List<Long> def) {
+        return getList(path, LONG_READER, def);
+    }
+
+    /**
+     * Read Float config value. Must be a {@link Number} or a string parsable with Float::parseFloat().
+     * @param path dot separated key path
+     * @return Float value of config key
+     * @throws ConfigKeyNotFoundException if any path component does not exist
+     */
+    public Float getFloat(String path) throws ConfigKeyNotFoundException {
+        return get(path, FLOAT_READER);
+    }
+
+    /**
+     * Read Float config value, or default if not found.
+     * Must be a {@link Number} or a string parsable with Float::parseFloat().
+     * @param path dot separated key path
+     * @param def default value
+     * @return Float value of config key, or default if not found
+     */
+    public Float getFloat(String path, Float def) {
+        return get(path, FLOAT_READER, def);
+    }
+
+    /**
+     * Read array of Float config values.
+     * Items must be a {@link Number} or a string parsable with Float::parseFloat().
+     * @param path dot separated key path
+     * @return list of Float values for config key
+     * @throws ConfigKeyNotFoundException if any path component does not exist
+     */
+    public List<Float> getFloatList(String path) throws ConfigKeyNotFoundException {
+        return getList(path, FLOAT_READER);
+    }
+
+    /**
+     * Read array of Float config values, or default if not found.
+     * Items must be a {@link Number} or a string parsable with Float::parseFloat().
+     * @param path dot separated key path
+     * @param def default value
+     * @return list of Float values for config key, or default if not found
+     */
+    public List<Float> getFloatList(String path, List<Float> def) {
+        return getList(path, FLOAT_READER, def);
+    }
+
+    /**
+     * Read Double config value. Must be a {@link Number} or a string parsable with Double::parseDouble().
+     * @param path dot separated key path
+     * @return Double value of config key
+     * @throws ConfigKeyNotFoundException if any path component does not exist
+     */
+    public Double getDouble(String path) throws ConfigKeyNotFoundException {
+        return get(path, DOUBLE_READER);
+    }
+
+    /**
+     * Read Double config value, or default if not found.
+     * Must be a {@link Number} or a string parsable with Double::parseDouble().
+     * @param path dot separated key path
+     * @param def default value
+     * @return Double value of config key, or default if not found
+     */
+    public Double getDouble(String path, Double def) {
+        return get(path, DOUBLE_READER, def);
+    }
+
+    /**
+     * Read array of Double config values.
+     * Items must be a {@link Number} or a string parsable with Double::parseDouble().
+     * @param path dot separated key path
+     * @return list of Double values for config key
+     * @throws ConfigKeyNotFoundException if any path component does not exist
+     */
+    public List<Double> getDoubleList(String path) throws ConfigKeyNotFoundException {
+        return getList(path, DOUBLE_READER);
+    }
+
+    /**
+     * Read array of Double config values, or default if not found.
+     * Items must be a {@link Number} or a string parsable with Double::parseDouble().
+     * @param path dot separated key path
+     * @param def default value
+     * @return list of Double values for config key, or default if not found
+     */
+    public List<Double> getDoubleList(String path, List<Double> def) {
+        return getList(path, DOUBLE_READER, def);
+    }
+
+    /**
+     * Get a value from the config given a dot separated key path and providing a default value.
+     * If any component of the key path does not exist, the default value is returned.
+     * @param path dot separated key path
+     * @param readerFunc function to convert config Object into the desired type
+     * @param def default value to return if any component of the key path is not found
+     * @param <T> type to read config value as
+     * @return value of the given key, or default if not found
+     */
+    public <T> T get(String path, Function<Object, T> readerFunc, T def) {
+        try {
+            return get(path, readerFunc);
+        } catch (ConfigKeyNotFoundException e) {
+            logger.debug(path + ": " + def + " (default)");
+            return def;
+        }
+    }
+
+    /**
+     * Get a value from the config given a dot separated key path. The desired entry is located by
+     * traversing the hashes in the path. The provided function converts the entry into the
+     * desired type.
+     * @param path dot separated key path
+     * @param readerFunc function to convert config Object into the desired type
+     * @param <T> type to read config value as
+     * @return value of the given config key
+     * @throws ConfigKeyNotFoundException if any component of the key path does not exist
+     */
+    public <T> T get(String path, Function<Object, T> readerFunc) throws ConfigKeyNotFoundException {
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(readerFunc);
+
+        Object node = getObject(path);
+        T readValue = readerFunc.apply(node);
+        if (readValue == null) {
+            throw new ConfigReadException("Unable to parse config entry: " + node + ", path: " + path);
+        }
+        logger.debug(path + ": " + readValue);
+        return readValue;
+    }
+
+    /**
+     * Get a list (yaml array) from the config given a dot separated key path and providing a default value.
+     * If any component of the key path does not exist, the default value is returned.
+     * @param path dot separated key path
+     * @param readerFunc function to convert config array entries into the desired type
+     * @param def default value to return if any component of the key path is not found
+     * @param <T> type to read array values as
+     * @return list value for the given config array, or default if not found
+     */
+    public <T> List<T> getList(String path, Function<Object, T> readerFunc, List<T> def) {
+        try {
+            return getList(path, readerFunc);
+        } catch (ConfigKeyNotFoundException e) {
+            logger.debug(path + ": " + def + " (default)");
+            return def;
+        }
+    }
+
+    /**
+     * Get a list (yaml array) from the config given a dot separated key path. The desired entry is located by
+     * traversing the hashes in the path. The provided function converts the list entries into the
+     * desired type.
+     * @param path dot separated key path
+     * @param readerFunc function to convert config array entries into the desired type
+     * @param <T> type to read array values as
+     * @return list value for the given config array
+     * @throws ConfigKeyNotFoundException if any component of the key path does not exist
+     */
+    public <T> List<T> getList(String path, Function<Object, T> readerFunc) throws ConfigKeyNotFoundException {
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(readerFunc);
+
+        Object node = getObject(path);
+        if (!(node instanceof Iterable)) {
+            throw new ConfigReadException("Not instance of array, path: " + path);
+        }
+        List<T> readList = new ArrayList<>();
+        for (Object item : (Iterable<?>)node) {
+            T readItem = readerFunc.apply(item);
+            if (readItem == null) {
+                throw new ConfigReadException("Unable to parse array entry: " + item + ", path: " + path);
+            }
+            readList.add(readItem);
+        }
+        logger.debug(path + ": " + readList);
+        return readList;
+    }
+
+    /**
+     * Get the keys present in the hash specified by the dot separated key path. These keys must
+     * be Strings.
+     * @param path dot separated key path
+     * @return list of keys present in the specified config hash
+     * @throws ConfigKeyNotFoundException if any component of the key path does not exist
+     */
+    public List<String> getKeys(String path) throws ConfigKeyNotFoundException {
+        Objects.requireNonNull(path);
+
+        Object node = getObject(path);
+        if (!(node instanceof Map)) {
+            throw new ConfigReadException("Not instance of Map, path: " + path);
+        }
+        List<String> keys = new ArrayList<>();
+        for (Object mapKey : ((Map)node).keySet()) {
+            if (!(mapKey instanceof String)) {
+                throw new ConfigReadException("Map contain non String key: " + mapKey + ", path: " + path);
+            }
+            keys.add((String)mapKey);
+        }
+        logger.debug(path + ": " + keys + " (keys)");
+        return keys;
+    }
+
+    /**
+     * Get the keys present in the hash specified by the dot separated key path, or an empty list if any
+     * of the path components do not exist.
+     * @param path dot separated key path
+     * @return list of keys present in the specified config hash, or empty list if not found
+     */
+    public List<String> getKeysOrEmpty(String path) {
+        try {
+            return getKeys(path);
+        } catch (ConfigKeyNotFoundException e) {
+            logger.debug(path + ": [] (keys, not found)");
+            return Collections.emptyList();
+        }
+    }
+
+    private List<String> getPathComponents(String path) {
+        String[] splits = path.split(SPLIT_REGEX);
+        List<String> componentList = Arrays.asList(splits);
+        if (path.endsWith(".")) {
+            componentList = new ArrayList<>(componentList);
+            componentList.add("");
+        }
+        return componentList;
+    }
+
+    private Object getObject(String path) throws ConfigKeyNotFoundException {
+        List<String> pathComponents = getPathComponents(path);
+        Object currentNode = configRoot;
+        for (String pathComponent : pathComponents) {
+            if (!(currentNode instanceof Map)) {
+                throw new ConfigReadException("Path components must be hashes for path: " + path);
+            }
+            currentNode = ((Map<?,?>)currentNode).get(pathComponent);
+            if(currentNode == null) {
+                throw new ConfigKeyNotFoundException(pathComponent + " not found for path: " + path);
+            }
+        }
+        return currentNode;
+    }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -127,7 +127,7 @@ public class LuceneServer {
                         .withCollectorRegistry(collectorRegistry));
         /* The port on which the server should run */
         server = ServerBuilder.forPort(luceneServerConfiguration.getPort())
-                .addService(ServerInterceptors.intercept(new LuceneServerImpl(globalState, archiver, collectorRegistry, plugins), monitoringInterceptor))
+                .addService(ServerInterceptors.intercept(new LuceneServerImpl(globalState, luceneServerConfiguration, archiver, collectorRegistry, plugins), monitoringInterceptor))
                 .executor(ThreadPoolExecutorFactory.getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.LUCENESERVER,
                         luceneServerConfiguration.getThreadPoolConfiguration()))
                 .build()
@@ -201,19 +201,25 @@ public class LuceneServer {
         private final CollectorRegistry collectorRegistry;
         private final ThreadPoolExecutor searchThreadPoolExecutor;
 
-        LuceneServerImpl(GlobalState globalState, Archiver archiver, CollectorRegistry collectorRegistry, List<Plugin> plugins) {
+        LuceneServerImpl(
+                GlobalState globalState,
+                LuceneServerConfiguration configuration,
+                Archiver archiver,
+                CollectorRegistry collectorRegistry,
+                List<Plugin> plugins
+        ) {
             this.globalState = globalState;
             this.archiver = archiver;
             this.collectorRegistry = collectorRegistry;
             this.searchThreadPoolExecutor = ThreadPoolExecutorFactory.getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.SEARCH,
                     globalState.getThreadPoolConfiguration());
 
-            registerPlugins(plugins);
+            initExtendableComponents(configuration, plugins);
         }
 
-        private void registerPlugins(List<Plugin> plugins) {
-            AnalyzerCreator.initialize(plugins);
-            ScriptService.initialize(plugins);
+        private void initExtendableComponents(LuceneServerConfiguration configuration, List<Plugin> plugins) {
+            AnalyzerCreator.initialize(configuration, plugins);
+            ScriptService.initialize(configuration, plugins);
         }
 
         @Override

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/analysis/AnalyzerCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/analysis/AnalyzerCreator.java
@@ -17,6 +17,7 @@
 
 package com.yelp.nrtsearch.server.luceneserver.analysis;
 
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.ConditionalTokenFilter;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.NameAndParams;
@@ -46,7 +47,7 @@ public class AnalyzerCreator {
 
     private final Map<String, AnalysisProvider<? extends Analyzer>> analyzerMap = new HashMap<>();
 
-    public AnalyzerCreator() {
+    public AnalyzerCreator(LuceneServerConfiguration configuration) {
         register(STANDARD, name -> new StandardAnalyzer());
         register(CLASSIC, name -> new ClassicAnalyzer());
     }
@@ -85,8 +86,8 @@ public class AnalyzerCreator {
         analyzerMap.put(name, provider);
     }
 
-    public static void initialize(Iterable<Plugin> plugins) {
-        instance = new AnalyzerCreator();
+    public static void initialize(LuceneServerConfiguration configuration, Iterable<Plugin> plugins) {
+        instance = new AnalyzerCreator(configuration);
         for (Plugin plugin : plugins) {
             if (plugin instanceof AnalysisPlugin) {
                 AnalysisPlugin analysisPlugin = (AnalysisPlugin) plugin;

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/script/ScriptService.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/script/ScriptService.java
@@ -20,6 +20,7 @@ package com.yelp.nrtsearch.server.luceneserver.script;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.Script;
 import com.yelp.nrtsearch.server.luceneserver.script.js.JsScriptEngine;
 import com.yelp.nrtsearch.server.plugins.Plugin;
@@ -46,7 +47,7 @@ public class ScriptService {
     private final Map<String, ScriptEngine> scriptEngineMap = new HashMap<>();
     private final LoadingCache<ScriptCacheKey, Object> scriptCache;
 
-    private ScriptService() {
+    private ScriptService(LuceneServerConfiguration configuration) {
         // add provided javascript engine
         scriptEngineMap.put("js", new JsScriptEngine());
 
@@ -98,10 +99,11 @@ public class ScriptService {
 
     /**
      * Initialize the script service. Registers any {@link ScriptEngine} provided by the given {@link Plugin}.
+     * @param configuration server configuration
      * @param plugins loaded plugins
      */
-    public static void initialize(Iterable<Plugin> plugins) {
-        instance = new ScriptService();
+    public static void initialize(LuceneServerConfiguration configuration, Iterable<Plugin> plugins) {
+        instance = new ScriptService(configuration);
         for (Plugin plugin : plugins) {
             if (plugin instanceof ScriptPlugin) {
                 ScriptPlugin scriptPlugin = (ScriptPlugin) plugin;

--- a/src/test/java/com/yelp/nrtsearch/server/LuceneServerTestConfigurationFactory.java
+++ b/src/test/java/com/yelp/nrtsearch/server/LuceneServerTestConfigurationFactory.java
@@ -25,6 +25,7 @@ package com.yelp.nrtsearch.server;
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.Mode;
 
+import java.io.ByteArrayInputStream;
 import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -35,34 +36,36 @@ public class LuceneServerTestConfigurationFactory {
 
     public static LuceneServerConfiguration getConfig(Mode mode) {
         String dirNum = String.valueOf(atomicLong.addAndGet(1));
-        LuceneServerConfiguration.Builder builder = new LuceneServerConfiguration.Builder();
         if (mode.equals(Mode.STANDALONE)) {
             String stateDir = Paths.get(DEFAULT_USER_DIR.toString(), "standalone", dirNum, "state").toString();
             String indexDir = Paths.get(DEFAULT_USER_DIR.toString(), "standalone", dirNum, "index").toString();
-            return builder.withNodeName("standalone")
-                    .withStateDir(stateDir)
-                    .withIndexDir(indexDir)
-                    .withPort(9000)
-                    .withReplicationPort(9000)
-                    .build();
+            String config = String.join("\n",
+                    "nodeName: standalone",
+                    "stateDir: " + stateDir,
+                    "indexDir: " + indexDir,
+                    "port: " + 9000,
+                    "replicationPort: " + 9000);
+            return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
         } else if (mode.equals(Mode.PRIMARY)) {
             String stateDir = Paths.get(DEFAULT_USER_DIR.toString(), "primary", dirNum, "state").toString();
             String indexDir = Paths.get(DEFAULT_USER_DIR.toString(), "primary", dirNum, "index").toString();
-            return builder.withNodeName("primary")
-                    .withStateDir(stateDir)
-                    .withIndexDir(indexDir)
-                    .withPort(9900)
-                    .withReplicationPort(9001)
-                    .build();
+            String config = String.join("\n",
+                    "nodeName: primary",
+                    "stateDir: " + stateDir,
+                    "indexDir: " + indexDir,
+                    "port: " + 9900,
+                    "replicationPort: " + 9001);
+            return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
         } else if (mode.equals(Mode.REPLICA)) {
             String stateDir = Paths.get(DEFAULT_USER_DIR.toString(), "replica", dirNum, "state").toString();
             String indexDir = Paths.get(DEFAULT_USER_DIR.toString(), "replica", dirNum, "index").toString();
-            return builder.withNodeName("replica")
-                    .withStateDir(stateDir)
-                    .withIndexDir(indexDir)
-                    .withPort(9902)
-                    .withReplicationPort(9003)
-                    .build();
+            String config = String.join("\n",
+                    "nodeName: replica",
+                    "stateDir: " + stateDir,
+                    "indexDir: " + indexDir,
+                    "port: " + 9902,
+                    "replicationPort: " + 9003);
+            return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
         }
         throw new RuntimeException("Invalid mode %s, cannot build config" + mode);
     }

--- a/src/test/java/com/yelp/nrtsearch/server/YelpReviewsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/YelpReviewsTest.java
@@ -53,8 +53,6 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import org.apache.lucene.util.NamedThreadFactory;
 import org.junit.Test;
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.Constructor;
 import picocli.CommandLine;
 
 import java.io.File;
@@ -458,7 +456,7 @@ public class YelpReviewsTest {
         }
 
         HostPort(String confiFileName) throws FileNotFoundException {
-            LuceneServerConfiguration luceneServerConfiguration = new Yaml(new Constructor(LuceneServerConfiguration.class)).load(new FileInputStream(confiFileName));
+            LuceneServerConfiguration luceneServerConfiguration = new LuceneServerConfiguration(new FileInputStream(confiFileName));
             this.hostName = luceneServerConfiguration.getHostName();
             this.port = luceneServerConfiguration.getPort();
             this.replicationPort = luceneServerConfiguration.getReplicationPort();

--- a/src/test/java/com/yelp/nrtsearch/server/config/ThreadPoolConfigurationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/ThreadPoolConfigurationTest.java
@@ -1,8 +1,6 @@
 package com.yelp.nrtsearch.server.config;
 
 import org.junit.Test;
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.Constructor;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -15,7 +13,7 @@ public class ThreadPoolConfigurationTest {
     @Test
     public void testConfiguration() throws FileNotFoundException {
         String config = Paths.get("src", "test", "resources", "config.yaml").toAbsolutePath().toString();
-        LuceneServerConfiguration luceneServerConfiguration = new Yaml(new Constructor(LuceneServerConfiguration.class)).load(new FileInputStream(config));
+        LuceneServerConfiguration luceneServerConfiguration = new LuceneServerConfiguration(new FileInputStream(config));
         assertEquals("lucene_server_foo", luceneServerConfiguration.getNodeName());
         assertEquals("foohost", luceneServerConfiguration.getHostName());
         assertEquals(luceneServerConfiguration.getThreadPoolConfiguration().getMaxSearchingThreads(), 16);

--- a/src/test/java/com/yelp/nrtsearch/server/config/YamlConfigReaderTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/YamlConfigReaderTest.java
@@ -1,0 +1,739 @@
+package com.yelp.nrtsearch.server.config;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.ByteArrayInputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(JUnit4.class)
+public class YamlConfigReaderTest {
+
+    private YamlConfigReader getForConfig(String config) {
+        return new YamlConfigReader(new ByteArrayInputStream(config.getBytes()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEmptyConfig() {
+        YamlConfigReader reader = getForConfig("");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testArrayConfig() {
+        String config = String.join("\n",
+                "- val1",
+                "- val2",
+                "- val3");
+        YamlConfigReader reader = getForConfig(config);
+    }
+
+    @Test
+    public void testHash() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "key1: val1",
+                "key2: 'val2'",
+                "key3: value 3");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals("val1", reader.getString("key1"));
+        assertEquals("val2", reader.getString("key2"));
+        assertEquals("value 3", reader.getString("key3"));
+    }
+
+    @Test
+    public void testNestedHash() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l11:",
+                "  l21:",
+                "    l31: val1",
+                "    l32:",
+                "      l41: val2",
+                "      l42: val3",
+                "  l22:",
+                "    l33: val4",
+                "    l34: val5",
+                "l12: val6");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals("val1", reader.getString("l11.l21.l31"));
+        assertEquals("val2", reader.getString("l11.l21.l32.l41"));
+        assertEquals("val3", reader.getString("l11.l21.l32.l42"));
+        assertEquals("val4", reader.getString("l11.l22.l33"));
+        assertEquals("val5", reader.getString("l11.l22.l34"));
+        assertEquals("val6", reader.getString("l12"));
+    }
+
+    @Test(expected = ConfigKeyNotFoundException.class)
+    public void testKeyNotFound() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l11:",
+                "  l21: val1");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getString("l11.not_exist");
+    }
+
+    @Test(expected = ConfigKeyNotFoundException.class)
+    public void testRootNotFound() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l11:",
+                "  l21: val1");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getString("not_exist");
+    }
+
+    @Test(expected = ConfigKeyNotFoundException.class)
+    public void testPathNotFound() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l11:",
+                "  l21: val1");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getString("l11.not_exist.l31");
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testValueInPath() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l11:",
+                "  l21: val1");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getString("l11.l21.l31");
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testArrayInPath() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l11:",
+                "  l21:",
+                "    - val1",
+                "    - val2");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getString("l11.l21.l31");
+    }
+
+    @Test
+    public void testArray() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l11:",
+                "l12:",
+                "  - val1",
+                "  - val2");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(Arrays.asList("val1", "val2"), reader.getStringList("l12"));
+    }
+
+    @Test
+    public void testArrayInNestedHash() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l11:",
+                "  l21:",
+                "    - val1",
+                "    - val2");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(Arrays.asList("val1", "val2"), reader.getStringList("l11.l21"));
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testHashNotArray() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l11:",
+                "  l21:",
+                "    - val1",
+                "    - val2");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(Arrays.asList("val1", "val2"), reader.getStringList("l11"));
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testValueNotArray() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l11:",
+                "  l21: val1");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(Arrays.asList("val1", "val2"), reader.getStringList("l11.l21"));
+    }
+
+    @Test
+    public void testEmptyPath() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l11: val1",
+                "\"\": val2");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals("val2", reader.getString(""));
+    }
+
+    @Test
+    public void testEmptyStrInPath() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l11:",
+                "  \"\":",
+                "    l31: val1");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals("val1", reader.getString("l11..l31"));
+    }
+
+    @Test
+    public void testEmptyStrEndOfPath() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l11:",
+                "  l21:",
+                "    \"\": val1");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals("val1", reader.getString("l11.l21."));
+    }
+
+    @Test
+    public void testReadStr() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "key1: 10",
+                "key2: some value",
+                "key3: 'val1'",
+                "key4: 100.1");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals("10", reader.getString("key1"));
+        assertEquals("some value", reader.getString("key2"));
+        assertEquals("val1", reader.getString("key3"));
+        assertEquals("100.1", reader.getString("key4"));
+    }
+
+    @Test
+    public void testReadStrList() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l1:",
+                "  - 10",
+                "  - some value",
+                "  - 'val1'",
+                "  - 100.1");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(
+                Arrays.asList("10", "some value", "val1", "100.1"),
+                reader.getStringList("l1")
+        );
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testInvalidStr() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "key1:",
+                "  key2: val1");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getString("key1");
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testInvalidStrList() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l1:",
+                "  - 10",
+                "  - false",
+                "  - l2: val1");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getStringList("l1");
+    }
+
+    @Test
+    public void testDefaultStr() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals("default_value", reader.getString("key2", "default_value"));
+    }
+
+    @Test
+    public void testDefaultStrList() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(
+                Arrays.asList("val1", "val2"),
+                reader.getStringList("key2", Arrays.asList("val1", "val2"))
+        );
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testDefaultStrException() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getString("key1.key2", "default_value");
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testDefaultStrListException() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getStringList("key1.key2", Arrays.asList("val1", "val2"));
+    }
+
+    @Test
+    public void testReadBool() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "key1: true",
+                "key2: false",
+                "key3: 'true'",
+                "key4: 'TRUE'",
+                "key5: 'false'",
+                "key6: 'not_true'");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(Boolean.TRUE, reader.getBoolean("key1"));
+        assertEquals(Boolean.FALSE, reader.getBoolean("key2"));
+        assertEquals(Boolean.TRUE, reader.getBoolean("key3"));
+        assertEquals(Boolean.TRUE, reader.getBoolean("key4"));
+        assertEquals(Boolean.FALSE, reader.getBoolean("key5"));
+        assertEquals(Boolean.FALSE, reader.getBoolean("key6"));
+    }
+
+    @Test
+    public void testReadBoolList() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l1:",
+                "  - true",
+                "  - false",
+                "  - 'true'",
+                "  - 'TRUE'",
+                "  - 'false'",
+                "  - 'not_true'");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(
+                Arrays.asList(Boolean.TRUE, Boolean.FALSE,Boolean.TRUE, Boolean.TRUE, Boolean.FALSE, Boolean.FALSE),
+                reader.getBooleanList("l1")
+        );
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testInvalidBool() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getBoolean("key1");
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testInvalidBoolList() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l1:",
+                "  - true",
+                "  - false",
+                "  - 100");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getBooleanList("l1");
+    }
+
+    @Test
+    public void testDefaultBool() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(Boolean.FALSE, reader.getBoolean("key2", Boolean.FALSE));
+    }
+
+    @Test
+    public void testDefaultBoolList() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(
+                Arrays.asList(Boolean.FALSE, Boolean.TRUE),
+                reader.getBooleanList("key2", Arrays.asList(Boolean.FALSE, Boolean.TRUE))
+        );
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testDefaultBoolException() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getBoolean("key1.key2", Boolean.FALSE);
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testDefaultBoolListException() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getBooleanList("key1.key2", Arrays.asList(Boolean.FALSE, Boolean.TRUE));
+    }
+
+    @Test
+    public void testReadInt() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "key1: 10",
+                "key2: '100'");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(Integer.valueOf(10), reader.getInteger("key1"));
+        assertEquals(Integer.valueOf(100), reader.getInteger("key2"));
+    }
+
+    @Test
+    public void testReadIntList() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l1:",
+                "  - 10",
+                "  - 15.1",
+                "  - '100'");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(
+                Arrays.asList(10, 15, 100),
+                reader.getIntegerList("l1")
+        );
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testInvalidInt() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "key1: true");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getInteger("key1");
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testInvalidIntList() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l1:",
+                "  - 10",
+                "  - false",
+                "  - 100");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getIntegerList("l1");
+    }
+
+    @Test
+    public void testDefaultInt() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(Integer.valueOf(10), reader.getInteger("key2", 10));
+    }
+
+    @Test
+    public void testDefaultIntList() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(
+                Arrays.asList(10, 1000),
+                reader.getIntegerList("key2", Arrays.asList(10, 1000))
+        );
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testDefaultIntException() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getInteger("key1.key2", 10);
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testDefaultIntListException() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getIntegerList("key1.key2", Arrays.asList(10, 1000));
+    }
+
+    @Test
+    public void testReadLong() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "key1: 10",
+                "key2: '100'");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(Long.valueOf(10), reader.getLong("key1"));
+        assertEquals(Long.valueOf(100), reader.getLong("key2"));
+    }
+
+    @Test
+    public void testReadLongList() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l1:",
+                "  - 10",
+                "  - 15.1",
+                "  - '100'");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(
+                Arrays.asList(10L, 15L, 100L),
+                reader.getLongList("l1")
+        );
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testInvalidLong() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "key1: true");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getLong("key1");
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testInvalidLongList() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l1:",
+                "  - 10",
+                "  - false",
+                "  - 100");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getLongList("l1");
+    }
+
+    @Test
+    public void testDefaultLong() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(Long.valueOf(10), reader.getLong("key2", 10L));
+    }
+
+    @Test
+    public void testDefaultLongList() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(
+                Arrays.asList(10L, 1000L),
+                reader.getLongList("key2", Arrays.asList(10L, 1000L))
+        );
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testDefaultLongException() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getLong("key1.key2", 10L);
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testDefaultLongListException() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getLongList("key1.key2", Arrays.asList(10L, 1000L));
+    }
+
+    @Test
+    public void testReadFloat() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "key1: 10.2",
+                "key2: '100.5'");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(10.2F, reader.getFloat("key1"), Math.ulp(10.2F));
+        assertEquals(100.5F, reader.getFloat("key2"), Math.ulp(10.2F));
+    }
+
+    @Test
+    public void testReadFloatList() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l1:",
+                "  - 10",
+                "  - 15.1",
+                "  - '100.5'");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(
+                Arrays.asList(10.0F, 15.1F, 100.5F),
+                reader.getFloatList("l1")
+        );
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testInvalidFloat() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "key1: true");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getFloat("key1");
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testInvalidFloatList() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l1:",
+                "  - 10",
+                "  - false",
+                "  - 100.5");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getFloatList("l1");
+    }
+
+    @Test
+    public void testDefaultFloat() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(10.5F, reader.getFloat("key2", 10.5F), Math.ulp(10.5F));
+    }
+
+    @Test
+    public void testDefaultFloatList() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(
+                Arrays.asList(10.5F, 1000F),
+                reader.getFloatList("key2", Arrays.asList(10.5F, 1000F))
+        );
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testDefaultFloatException() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getFloat("key1.key2", 10.1F);
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testDefaultFloatListException() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getFloatList("key1.key2", Arrays.asList(10.1F, 1000F));
+    }
+
+    @Test
+    public void testReadDouble() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "key1: 10.2",
+                "key2: '100.5'");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(10.2, reader.getDouble("key1"), Math.ulp(10.2));
+        assertEquals(100.5, reader.getDouble("key2"), Math.ulp(10.2));
+    }
+
+    @Test
+    public void testReadDoubleList() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l1:",
+                "  - 10",
+                "  - 15.1",
+                "  - '100.5'");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(
+                Arrays.asList(10.0, 15.1, 100.5),
+                reader.getDoubleList("l1")
+        );
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testInvalidDouble() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "key1: true");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getDouble("key1");
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testInvalidDoubleList() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l1:",
+                "  - 10",
+                "  - false",
+                "  - 100.5");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getDoubleList("l1");
+    }
+
+    @Test
+    public void testDefaultDouble() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(10.5, reader.getDouble("key2", 10.5), Math.ulp(10.5));
+    }
+
+    @Test
+    public void testDefaultDoubleList() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(
+                Arrays.asList(10.5, 1000D),
+                reader.getDoubleList("key2", Arrays.asList(10.5, 1000D))
+        );
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testDefaultDoubleException() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getDouble("key1.key2", 10.1);
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testDefaultDoubleListException() {
+        String config = String.join("\n",
+                "key1: 100");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getDoubleList("key1.key2", Arrays.asList(10.1, 1000D));
+    }
+
+    @Test
+    public void testGetKeys() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l1:",
+                "  key1: val1",
+                "  key2: val2",
+                "  key3: val3");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(Set.of("key1", "key2", "key3"), Set.copyOf(reader.getKeys("l1")));
+    }
+
+    @Test
+    public void testGetKeysNestedHash() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l11:",
+                "  l21:",
+                "    l31:",
+                "      key1: val1",
+                "      key2: val2",
+                "    key3: val3",
+                "  key4: val4");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(Set.of("l21", "key4"), Set.copyOf(reader.getKeys("l11")));
+        assertEquals(Set.of("l31", "key3"), Set.copyOf(reader.getKeys("l11.l21")));
+        assertEquals(Set.of("key1", "key2"), Set.copyOf(reader.getKeys("l11.l21.l31")));
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testGetKeysInvalid() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l11:",
+                "  l21: val1");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getKeys("l11.l21.l31");
+    }
+
+    @Test(expected = ConfigKeyNotFoundException.class)
+    public void testGetKeysNotFound() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l11:",
+                "  l21: val1");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getKeys("l11.l22");
+    }
+
+    @Test
+    public void testGetKeysOrEmpty() {
+        String config = String.join("\n",
+                "l1:",
+                "  key1: val1",
+                "  key2: val2",
+                "  key3: val3");
+        YamlConfigReader reader = getForConfig(config);
+        assertEquals(Set.of("key1", "key2", "key3"), Set.copyOf(reader.getKeysOrEmpty("l1")));
+        assertEquals(Collections.emptyList(), reader.getKeysOrEmpty("l1.l2"));
+    }
+
+    @Test(expected = ConfigReadException.class)
+    public void testGetKeysInvalidType() throws ConfigKeyNotFoundException {
+        String config = String.join("\n",
+                "l1:",
+                "  key1: val1",
+                "  ~: val2",
+                "  key3: val3");
+        YamlConfigReader reader = getForConfig(config);
+        reader.getKeys("l1");
+    }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/BackupRestoreIndexRequestHandlerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/BackupRestoreIndexRequestHandlerTest.java
@@ -93,7 +93,7 @@ public class BackupRestoreIndexRequestHandlerTest {
     private GrpcServer setUpGrpcServer() throws IOException {
         LuceneServerConfiguration luceneServerConfiguration = LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE);
         GlobalState globalState = new GlobalState(luceneServerConfiguration);
-        return new GrpcServer(grpcCleanup, folder, false, globalState,
+        return new GrpcServer(grpcCleanup, luceneServerConfiguration, folder, false, globalState,
                 luceneServerConfiguration.getIndexDir(), "test_index", globalState.getPort(), archiver);
     }
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -81,7 +81,7 @@ public class LuceneServerTest {
         LuceneServerConfiguration luceneServerConfiguration = LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE);
         GlobalState globalState = new GlobalState(luceneServerConfiguration);
         return new GrpcServer(
-                collectorRegistry, grpcCleanup, folder, false, globalState, luceneServerConfiguration.getIndexDir(), testIndex, globalState.getPort(), null, Collections.emptyList()
+                collectorRegistry, grpcCleanup, luceneServerConfiguration, folder, false, globalState, luceneServerConfiguration.getIndexDir(), testIndex, globalState.getPort(), null, Collections.emptyList()
         );
     }
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
@@ -75,7 +75,7 @@ public class QueryTest {
         String testIndex = "test_index";
         LuceneServerConfiguration luceneServerConfiguration = LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE);
         GlobalState globalState = new GlobalState(luceneServerConfiguration);
-        return new GrpcServer(grpcCleanup, folder, false, globalState, luceneServerConfiguration.getIndexDir(), testIndex, globalState.getPort());
+        return new GrpcServer(grpcCleanup, luceneServerConfiguration, folder, false, globalState, luceneServerConfiguration.getIndexDir(), testIndex, globalState.getPort());
     }
 
     @Test

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
@@ -83,17 +83,17 @@ public class ReplicationServerTest {
         String testIndex = "test_index";
         LuceneServerConfiguration luceneServerPrimaryConfiguration = LuceneServerTestConfigurationFactory.getConfig(Mode.PRIMARY);
         GlobalState globalStatePrimary = new GlobalState(luceneServerPrimaryConfiguration);
-        luceneServerPrimary = new GrpcServer(grpcCleanup, folder, false, globalStatePrimary,
+        luceneServerPrimary = new GrpcServer(grpcCleanup, luceneServerPrimaryConfiguration, folder, false, globalStatePrimary,
                 luceneServerPrimaryConfiguration.getIndexDir(), testIndex, globalStatePrimary.getPort(), archiver);
-        replicationServerPrimary = new GrpcServer(grpcCleanup, folder, true, globalStatePrimary,
+        replicationServerPrimary = new GrpcServer(grpcCleanup, luceneServerPrimaryConfiguration, folder, true, globalStatePrimary,
                 luceneServerPrimaryConfiguration.getIndexDir(), testIndex, luceneServerPrimaryConfiguration.getReplicationPort(), archiver);
         //set up secondary servers
         LuceneServerConfiguration luceneServerSecondaryConfiguration = LuceneServerTestConfigurationFactory.getConfig(Mode.REPLICA);
         GlobalState globalStateSecondary = new GlobalState(luceneServerSecondaryConfiguration);
 
-        luceneServerSecondary = new GrpcServer(grpcCleanup, folder, false, globalStateSecondary,
+        luceneServerSecondary = new GrpcServer(grpcCleanup, luceneServerSecondaryConfiguration, folder, false, globalStateSecondary,
                 luceneServerSecondaryConfiguration.getIndexDir(), testIndex, globalStateSecondary.getPort(), archiver);
-        replicationServerSecondary = new GrpcServer(grpcCleanup, folder, true, globalStateSecondary,
+        replicationServerSecondary = new GrpcServer(grpcCleanup, luceneServerSecondaryConfiguration, folder, true, globalStateSecondary,
                 luceneServerSecondaryConfiguration.getIndexDir(), testIndex, globalStateSecondary.getReplicationPort(), archiver);
 
     }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationTestFailureScenarios.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationTestFailureScenarios.java
@@ -85,9 +85,9 @@ public class ReplicationTestFailureScenarios {
     public void startPrimaryServer() throws IOException {
         LuceneServerConfiguration luceneServerPrimaryConfiguration = LuceneServerTestConfigurationFactory.getConfig(Mode.PRIMARY);
         GlobalState globalStatePrimary = new GlobalState(luceneServerPrimaryConfiguration);
-        luceneServerPrimary = new GrpcServer(grpcCleanup, folder, false, globalStatePrimary,
+        luceneServerPrimary = new GrpcServer(grpcCleanup, luceneServerPrimaryConfiguration, folder, false, globalStatePrimary,
                 luceneServerPrimaryConfiguration.getIndexDir(), TEST_INDEX, globalStatePrimary.getPort(), archiver);
-        replicationServerPrimary = new GrpcServer(grpcCleanup, folder, true, globalStatePrimary,
+        replicationServerPrimary = new GrpcServer(grpcCleanup, luceneServerPrimaryConfiguration, folder, true, globalStatePrimary,
                 luceneServerPrimaryConfiguration.getIndexDir(), TEST_INDEX, 9001, archiver);
 
     }
@@ -96,9 +96,9 @@ public class ReplicationTestFailureScenarios {
         LuceneServerConfiguration luceneSecondaryConfiguration = LuceneServerTestConfigurationFactory.getConfig(Mode.REPLICA);
         GlobalState globalStateSecondary = new GlobalState(luceneSecondaryConfiguration);
 
-        luceneServerSecondary = new GrpcServer(grpcCleanup, folder, false, globalStateSecondary,
+        luceneServerSecondary = new GrpcServer(grpcCleanup, luceneSecondaryConfiguration, folder, false, globalStateSecondary,
                 luceneSecondaryConfiguration.getIndexDir(), TEST_INDEX, globalStateSecondary.getPort(), archiver);
-        replicationServerSecondary = new GrpcServer(grpcCleanup, folder, true, globalStateSecondary,
+        replicationServerSecondary = new GrpcServer(grpcCleanup, luceneSecondaryConfiguration, folder, true, globalStateSecondary,
                 luceneSecondaryConfiguration.getIndexDir(), TEST_INDEX, globalStateSecondary.getReplicationPort(), archiver);
     }
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/SuggestTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/SuggestTest.java
@@ -89,7 +89,7 @@ public class SuggestTest {
     public void setUp() throws IOException {
         LuceneServerConfiguration luceneServerConfiguration = LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE);
         GlobalState globalState = new GlobalState(luceneServerConfiguration);
-        grpcServer = new GrpcServer(grpcCleanup, folder, false, globalState,
+        grpcServer = new GrpcServer(grpcCleanup, luceneServerConfiguration, folder, false, globalState,
                 luceneServerConfiguration.getIndexDir(), "test_index", globalState.getPort());
         Path tempDir = folder.newFolder("TestSuggest").toPath();
         tempFile = tempDir.resolve("suggest.in");

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/analysis/AnalyzerCreatorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/analysis/AnalyzerCreatorTest.java
@@ -17,6 +17,7 @@
 
 package com.yelp.nrtsearch.server.luceneserver.analysis;
 
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.IntObject;
 import com.yelp.nrtsearch.server.grpc.NameAndParams;
@@ -49,6 +50,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -76,7 +78,12 @@ public class AnalyzerCreatorTest {
     }
 
     private void init(List<Plugin> plugins) {
-        AnalyzerCreator.initialize(plugins);
+        AnalyzerCreator.initialize(getEmptyConfig(), plugins);
+    }
+
+    private LuceneServerConfiguration getEmptyConfig() {
+        String config = "nodeName: \"lucene_server_foo\"";
+        return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
     }
 
     // Tests for predefined analyzers

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
@@ -105,7 +105,7 @@ public class ScoreScriptTest {
         LuceneServerConfiguration luceneServerConfiguration = LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE);
         GlobalState globalState = new GlobalState(luceneServerConfiguration);
         return new GrpcServer(
-                collectorRegistry, grpcCleanup, folder, false, globalState, luceneServerConfiguration.getIndexDir(),
+                collectorRegistry, grpcCleanup, luceneServerConfiguration, folder, false, globalState, luceneServerConfiguration.getIndexDir(),
                 testIndex, globalState.getPort(), null, Collections.singletonList(new ScoreScriptTestPlugin())
         );
     }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScriptServiceTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScriptServiceTest.java
@@ -18,12 +18,14 @@
 package com.yelp.nrtsearch.server.luceneserver.script;
 
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.Script;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.plugins.ScriptPlugin;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,7 +44,12 @@ public class ScriptServiceTest {
     }
 
     private void init(List<Plugin> plugins) {
-        ScriptService.initialize(plugins);
+        ScriptService.initialize(getEmptyConfig(), plugins);
+    }
+
+    private LuceneServerConfiguration getEmptyConfig() {
+        String config = "nodeName: \"lucene_server_foo\"";
+        return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
     }
 
     static class TestScriptPlugin extends Plugin implements ScriptPlugin {

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/js/JsScriptEngineTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/js/JsScriptEngineTest.java
@@ -88,7 +88,7 @@ public class JsScriptEngineTest {
         LuceneServerConfiguration luceneServerConfiguration = LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE);
         GlobalState globalState = new GlobalState(luceneServerConfiguration);
         return new GrpcServer(
-                collectorRegistry, grpcCleanup, folder, false, globalState, luceneServerConfiguration.getIndexDir(),
+                collectorRegistry, grpcCleanup, luceneServerConfiguration, folder, false, globalState, luceneServerConfiguration.getIndexDir(),
                 testIndex, globalState.getPort(), null, Collections.emptyList()
         );
     }


### PR DESCRIPTION
Adds a YamlConfigReader to allow lookups into configuration by providing a dot separated key path. Accessor are provided for simple types (bool,int,long,float,double,str) and lists of simple types. The generic accessors allow for extensibility (and could perhaps be combined with an ObjectMapper).

This will allow config reading to move outside the main LuceneServerConfiguration class, which will make configuring different core services easier and allow plugins to lookup custom config.