### PR TITLE
increase max message size on channel

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
@@ -75,6 +75,7 @@ import static com.yelp.nrtsearch.server.cli.StartIndexCommand.START_INDEX;
 import static com.yelp.nrtsearch.server.cli.StatusCommand.STATUS;
 import static com.yelp.nrtsearch.server.cli.StopIndexCommand.STOP_INDEX;
 import static com.yelp.nrtsearch.server.cli.WriteNRTPointCommand.WRITE_NRT_POINT;
+import static com.yelp.nrtsearch.server.grpc.ReplicationServerClient.MAX_MESSAGE_BYTES_SIZE;
 
 /**
  * A simple client that requests a greeting from the {@link LuceneServer}.
@@ -103,6 +104,7 @@ public class LuceneServerClient {
                 // Channels are secure by default (via SSL/TLS). For the example we disable TLS to avoid
                 // needing certificates.
                 .usePlaintext()
+                .maxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
                 .build());
     }
 

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClient.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClient.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 public class ReplicationServerClient implements Closeable {
     public final static int BINARY_MAGIC = 0x3414f5c;
+    public static final int MAX_MESSAGE_BYTES_SIZE = 10 * 1024 * 1024 * 1024;
     Logger logger = LoggerFactory.getLogger(ReplicationServerClient.class);
     private final String host;
     private final int port;
@@ -58,6 +59,7 @@ public class ReplicationServerClient implements Closeable {
                 // Channels are secure by default (via SSL/TLS). For the example we disable TLS to avoid
                 // needing certificates.
                 .usePlaintext()
+                .maxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
                 .build(), host, port);
     }
 

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClient.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClient.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 public class ReplicationServerClient implements Closeable {
     public final static int BINARY_MAGIC = 0x3414f5c;
-    public static final int MAX_MESSAGE_BYTES_SIZE = 10 * 1024 * 1024 * 1024;
+    public static final int MAX_MESSAGE_BYTES_SIZE = 2 * 1024 * 1024 * 1024;
     Logger logger = LoggerFactory.getLogger(ReplicationServerClient.class);
     private final String host;
     private final int port;

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClient.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClient.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 public class ReplicationServerClient implements Closeable {
     public final static int BINARY_MAGIC = 0x3414f5c;
-    public static final int MAX_MESSAGE_BYTES_SIZE = 2 * 1024 * 1024 * 1024;
+    public static final int MAX_MESSAGE_BYTES_SIZE = 1 * 1024 * 1024 * 1024;
     Logger logger = LoggerFactory.getLogger(ReplicationServerClient.class);
     private final String host;
     private final int port;


### PR DESCRIPTION
We need to increase grpc max message length as mentioned here https://github.com/tensorflow/serving/issues/1382 in order to avoid getting the below error on larger responses:

{"error":"grpc: received message larger than max (7750076 vs. 4194304)","code":8,"message":"grpc: received message larger than max (7750076 vs. 4194304)"}