### PR TITLE
use largenumberhitstopdocscollector for matchalldocsquery

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -568,7 +568,6 @@ public class LuceneServer {
                 IndexState indexState = globalState.getIndex(searchRequest.getIndexName());
                 SearchHandler searchHandler = new SearchHandler(searchThreadPoolExecutor);
                 SearchResponse reply = searchHandler.handle(indexState, searchRequest);
-                logger.debug(String.format("SearchHandler returned results %s", reply.toString()));
                 searchResponseStreamObserver.onNext(reply);
                 searchResponseStreamObserver.onCompleted();
             } catch (IOException e) {

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
@@ -113,8 +113,14 @@ public class LuceneServerClient {
      */
     LuceneServerClient(ManagedChannel channel) {
         this.channel = channel;
-        blockingStub = LuceneServerGrpc.newBlockingStub(channel);
-        asyncStub = LuceneServerGrpc.newStub(channel);
+        blockingStub = LuceneServerGrpc
+                .newBlockingStub(channel)
+                .withMaxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
+                .withMaxOutboundMessageSize(MAX_MESSAGE_BYTES_SIZE);
+        asyncStub = LuceneServerGrpc
+                .newStub(channel)
+                .withMaxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
+                .withMaxOutboundMessageSize(MAX_MESSAGE_BYTES_SIZE);
     }
 
     public void shutdown() throws InterruptedException {

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClient.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClient.java
@@ -68,8 +68,14 @@ public class ReplicationServerClient implements Closeable {
      */
     ReplicationServerClient(ManagedChannel channel, String host, int port) {
         this.channel = channel;
-        blockingStub = ReplicationServerGrpc.newBlockingStub(channel);
-        asyncStub = ReplicationServerGrpc.newStub(channel);
+        blockingStub = ReplicationServerGrpc
+                .newBlockingStub(channel)
+                .withMaxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
+                .withMaxOutboundMessageSize(MAX_MESSAGE_BYTES_SIZE);
+        asyncStub = ReplicationServerGrpc
+                .newStub(channel)
+                .withMaxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
+                .withMaxOutboundMessageSize(MAX_MESSAGE_BYTES_SIZE);
         this.host = host;
         this.port = port;
     }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/LargeNumHitsTopDocsCollectorManagerCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/LargeNumHitsTopDocsCollectorManagerCreator.java
@@ -1,0 +1,36 @@
+package com.yelp.nrtsearch.server.luceneserver;
+
+import org.apache.lucene.search.CollectorManager;
+import org.apache.lucene.search.LargeNumHitsTopDocsCollector;
+import org.apache.lucene.search.TopDocs;
+
+import java.io.IOException;
+import java.util.Collection;
+
+public class LargeNumHitsTopDocsCollectorManagerCreator {
+    /**
+     * Create a CollectorManager of LargeNumHitsTopDocsCollectors to facilitate parallel segment search on
+     * LargeNumHitsTopDocsCollector
+     */
+    public static CollectorManager<LargeNumHitsTopDocsCollector, TopDocs> createSharedManager(int numHits) {
+        return new CollectorManager<LargeNumHitsTopDocsCollector, TopDocs>() {
+
+            @Override
+            public LargeNumHitsTopDocsCollector newCollector() throws IOException {
+                return new LargeNumHitsTopDocsCollector(numHits);
+            }
+
+            @Override
+            public TopDocs reduce(Collection<LargeNumHitsTopDocsCollector> collectors) throws IOException {
+                final TopDocs[] topDocs = new TopDocs[collectors.size()];
+                int i = 0;
+                for (LargeNumHitsTopDocsCollector collector : collectors) {
+                    topDocs[i++] = collector.topDocs();
+                }
+                return TopDocs.merge(numHits, topDocs);
+            }
+
+        };
+    }
+
+}


### PR DESCRIPTION
Trying to retrieve all "ids" from nrtsearch causes OOM error. Sample query:  curl -XPOST localhost:20445/v1/search -d '{"indexName": "talk_v1", "topHits": "25000000", "retrieveFields":["id"]}

```
Exception in thread "GrpcLuceneServerExecutor-4-thread-1" java.lang.OutOfMemoryError: Java heap space
        at org.apache.lucene.util.PriorityQueue.<init>(PriorityQueue.java:100)
        at org.apache.lucene.search.HitQueue.<init>(HitQueue.java:63)
        at org.apache.lucene.search.TopScoreDocCollector.<init>(TopScoreDocCollector.java:279)
        at org.apache.lucene.search.TopScoreDocCollector$SimpleTopScoreDocCollector.<init>(TopScoreDocCollector.java:55)
        at org.apache.lucene.search.TopScoreDocCollector.create(TopScoreDocCollector.java:235)
        at org.apache.lucene.search.TopScoreDocCollector$1.newCollector(TopScoreDocCollector.java:254)
        at org.apache.lucene.search.TopScoreDocCollector$1.newCollector(TopScoreDocCollector.java:247)
        at org.apache.lucene.search.IndexSearcher.search(IndexSearcher.java:580)
        at com.yelp.nrtsearch.server.luceneserver.SearchHandler.handle(SearchHandler.java:325)
        at com.yelp.nrtsearch.server.grpc.LuceneServer$LuceneServerImpl.search(LuceneServer.java:570)
        at com.yelp.nrtsearch.server.grpc.LuceneServerGrpc$MethodHandlers.invoke(LuceneServerGrpc.java:2372)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:172)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:331)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:820)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
        at java.base/java.lang.Thread.run(Thread.java:832)
```