### PR TITLE
Add dependencies to published poms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,6 +201,15 @@ publishing {
                     url = 'https://github.com/Yelp/nrtsearch'
                 }
             }
+            pom.withXml {
+                def dependenciesNode = asNode().appendNode('dependencies')
+                configurations.implementation.allDependencies.each {
+                    def dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', it.group)
+                    dependencyNode.appendNode('artifactId', it.name)
+                    dependencyNode.appendNode('version', it.version)
+                }
+            }
         }
     }
     repositories {

--- a/clientlib/build.gradle
+++ b/clientlib/build.gradle
@@ -138,6 +138,15 @@ publishing {
                     url = 'https://github.com/Yelp/nrtsearch'
                 }
             }
+            pom.withXml {
+                def dependenciesNode = asNode().appendNode('dependencies')
+                configurations.implementation.allDependencies.each {
+                    def dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', it.group)
+                    dependencyNode.appendNode('artifactId', it.name)
+                    dependencyNode.appendNode('version', it.version)
+                }
+            }
         }
     }
     repositories {


### PR DESCRIPTION
The current published artifacts do no have any dependencies listed in their pom files. This adds the projects implementation dependencies.