### PR TITLE
set max grpc message size on server

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -89,6 +89,8 @@ import org.apache.lucene.store.IndexInput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.yelp.nrtsearch.server.grpc.ReplicationServerClient.MAX_MESSAGE_BYTES_SIZE;
+
 /** Server that manages startup/shutdown of a {@code LuceneServer} server. */
 public class LuceneServer {
   private static final Logger logger = LoggerFactory.getLogger(LuceneServer.class.getName());
@@ -137,6 +139,7 @@ public class LuceneServer {
                 ThreadPoolExecutorFactory.getThreadPoolExecutor(
                     ThreadPoolExecutorFactory.ExecutorType.LUCENESERVER,
                     luceneServerConfiguration.getThreadPoolConfiguration()))
+                .maxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
             .build()
             .start();
     logger.info(
@@ -150,6 +153,7 @@ public class LuceneServer {
                 ThreadPoolExecutorFactory.getThreadPoolExecutor(
                     ThreadPoolExecutorFactory.ExecutorType.REPLICATIONSERVER,
                     luceneServerConfiguration.getThreadPoolConfiguration()))
+                .maxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
             .build()
             .start();
     logger.info(

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -15,6 +15,8 @@
  */
 package com.yelp.nrtsearch.server.grpc;
 
+import static com.yelp.nrtsearch.server.grpc.ReplicationServerClient.MAX_MESSAGE_BYTES_SIZE;
+
 import com.google.api.HttpBody;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -89,8 +91,6 @@ import org.apache.lucene.store.IndexInput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.yelp.nrtsearch.server.grpc.ReplicationServerClient.MAX_MESSAGE_BYTES_SIZE;
-
 /** Server that manages startup/shutdown of a {@code LuceneServer} server. */
 public class LuceneServer {
   private static final Logger logger = LoggerFactory.getLogger(LuceneServer.class.getName());
@@ -139,7 +139,7 @@ public class LuceneServer {
                 ThreadPoolExecutorFactory.getThreadPoolExecutor(
                     ThreadPoolExecutorFactory.ExecutorType.LUCENESERVER,
                     luceneServerConfiguration.getThreadPoolConfiguration()))
-                .maxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
+            .maxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
             .build()
             .start();
     logger.info(
@@ -153,7 +153,7 @@ public class LuceneServer {
                 ThreadPoolExecutorFactory.getThreadPoolExecutor(
                     ThreadPoolExecutorFactory.ExecutorType.REPLICATIONSERVER,
                     luceneServerConfiguration.getThreadPoolConfiguration()))
-                .maxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
+            .maxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
             .build()
             .start();
     logger.info(


### PR DESCRIPTION
In #125 we increase message size limit on the channel(client) side but seems like we also need to do it on the server side as per 
https://github.com/grpc/grpc-java/search?q=defaults+to+4+MiB&unscoped_q=defaults+to+4+MiB
and https://github.com/grpc/grpc/issues/7927#issuecomment-244993104

