### PR TITLE
Define script compile contract

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/script/ScriptContext.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/script/ScriptContext.java
@@ -15,18 +15,145 @@
  */
 package com.yelp.nrtsearch.server.luceneserver.script;
 
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
- * Context that holds type information needed to compile a script. Provides the factory class
- * required by the script type.
+ * Context that holds type information needed to compile a script. Provides classes conforming with
+ * the script compile contract:
+ *
+ * <p>The factory Class must be an interface containing one of two methods:
+ *
+ * <pre>
+ *     public interface Factory {
+ *         Script newInstance(a, b);
+ *     }
+ *
+ *     public interface Factory {
+ *         StatefulFactory newFactory(a, b);
+ *     }
+ * </pre>
+ *
+ * The stateful factory must be an interface, or Class with an abstract newInstance method. If using
+ * an abstract Class, it must contain a constructor with the same parameters as newFactory.
+ *
+ * <pre>
+ *     public interface StatefulFactory {
+ *         Script newInstance(c, d);
+ *     }
+ *
+ *     public abstract class StatefulFactory {
+ *         public StatefulFactory(a, b) {}
+ *         public abstract Script newInstance(c, d);
+ *     }
+ * </pre>
+ *
+ * The script instance Class must contain an abstract execute method. The method may contain
+ * parameters. There must be a static String[] called PARAMETERS defined in the class which lists
+ * the label for each parameter (for potentially binding within a script).
+ *
+ * <p>There must be a constructor with the same parameters as newInstance (if not using stateful
+ * factory), or with the concatenation of parameters from newFactory and newInstance (if using
+ * stateful factory).
+ *
+ * <pre>
+ *     public abstract class Script {
+ *         public static final String[] PARAMETERS = new String[]{"e"};
+ *         public Script(a, b, c, d) {}
+ *         public abstract T execute(e);
+ *     }
+ * </pre>
+ *
+ * Though a stateful factory Class (if required) and instance Class must be provided, it is not
+ * required that they be used by the {@link ScriptEngine}. For example, the {@link
+ * com.yelp.nrtsearch.server.luceneserver.script.js.JsScriptEngine} compiles to a Factory that
+ * produces a {@link org.apache.lucene.search.DoubleValuesSource} directly. This stateful factory
+ * Class will not conform with the stateful factory contract. Instead, the abstract {@link
+ * com.yelp.nrtsearch.server.luceneserver.script.ScoreScript.SegmentFactory} is provided as a {@link
+ * org.apache.lucene.search.DoubleValuesSource} which does conform. The same is true for the {@link
+ * ScoreScript}, which is also a {@link org.apache.lucene.search.DoubleValues}.
  *
  * @param <T> factory class type
  */
 public class ScriptContext<T> {
   public final String name;
   public final Class<T> factoryClazz;
+  public final Class<?> statefulFactoryClazz;
+  public final Class<?> instanceClazz;
 
+  /**
+   * Create a script compile context with the given factory Class. Uses reflection to determine the
+   * stateful factory and instance Classes. This constructor can only be used if the interface
+   * Classes all conform with the script compile contract.
+   *
+   * @param name context name
+   * @param factoryClazz factory class scripts of this type will compile to
+   * @throws IllegalArgumentException if neither getInstance or getFactory are defined, if both
+   *     getInstance and getFactory are defined, or if multiple getInstance or getFactory methods
+   *     are defined
+   */
   public ScriptContext(String name, Class<T> factoryClazz) {
     this.name = name;
     this.factoryClazz = factoryClazz;
+
+    Method instanceMethod = getMethod(factoryClazz, "newInstance");
+    Method factoryMethod = getMethod(factoryClazz, "newFactory");
+
+    if (instanceMethod == null && factoryMethod == null) {
+      throw new IllegalArgumentException(
+          "Factory interface must define a newInstance or newFactory method");
+    }
+    if (instanceMethod != null && factoryMethod != null) {
+      throw new IllegalArgumentException(
+          "Factory interface cannot define both newInstance and newFactory methods");
+    }
+
+    if (instanceMethod != null) {
+      statefulFactoryClazz = null;
+      instanceClazz = instanceMethod.getReturnType();
+    } else {
+      statefulFactoryClazz = factoryMethod.getReturnType();
+      Method statefulInstanceMethod = getMethod(statefulFactoryClazz, "newInstance");
+      if (statefulInstanceMethod == null) {
+        throw new IllegalArgumentException("Stateful factory must include newInstance method");
+      }
+      instanceClazz = statefulInstanceMethod.getReturnType();
+    }
+  }
+
+  /**
+   * Create a script compile context with the given type information. This constructor is used if
+   * the types returned from the factory methods do not directly conform to the script compile
+   * contract. Instead, subclasses which do conform must be provided.
+   *
+   * @param name context name
+   * @param factoryClazz factory class scripts of this type will compile to
+   * @param statefulFactoryClazz stateful factory that conforms with script compile contract, or
+   *     null if stateful factory is not used
+   * @param instanceClazz script instance that conforms with the script compile contract
+   */
+  public ScriptContext(
+      String name, Class<T> factoryClazz, Class<?> statefulFactoryClazz, Class<?> instanceClazz) {
+    this.name = name;
+    this.factoryClazz = factoryClazz;
+    this.statefulFactoryClazz = statefulFactoryClazz;
+    this.instanceClazz = instanceClazz;
+  }
+
+  private Method getMethod(Class<?> clazz, String methodName) {
+    List<Method> methods =
+        Arrays.stream(clazz.getMethods())
+            .filter(method -> method.getName().equals(methodName))
+            .collect(Collectors.toList());
+    if (methods.isEmpty()) {
+      return null;
+    }
+    if (methods.size() != 1) {
+      throw new IllegalArgumentException(
+          "Expected at most 1 method named " + methodName + ", found " + methods.size());
+    }
+    return methods.get(0);
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
@@ -38,7 +38,6 @@ import com.yelp.nrtsearch.server.grpc.VirtualField;
 import com.yelp.nrtsearch.server.luceneserver.GlobalState;
 import com.yelp.nrtsearch.server.luceneserver.doc.DocLookup;
 import com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues;
-import com.yelp.nrtsearch.server.luceneserver.doc.SegmentDocLookup;
 import com.yelp.nrtsearch.server.luceneserver.geo.GeoPoint;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.plugins.ScriptPlugin;
@@ -146,12 +145,12 @@ public class ScoreScriptTest {
     }
 
     @Override
-    public boolean needsScores() {
+    public boolean needs_score() {
       return true;
     }
 
     @Override
-    public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores) throws IOException {
+    public DoubleValues newInstance(LeafReaderContext ctx, DoubleValues scores) {
       switch (scriptId) {
         case "verify_doc_values":
           return new VerifyDocValuesScript(params, docLookup, ctx, scores);
@@ -184,9 +183,9 @@ public class ScoreScriptTest {
     }
 
     @Override
-    public double doubleValue() throws IOException {
+    public double execute() {
       try {
-        LoadedDocValues<?> idDocValues = doc().get("doc_id");
+        LoadedDocValues<?> idDocValues = getDoc().get("doc_id");
         assertEquals("doc_id size", 1, idDocValues.size());
         assertEquals("doc_id class", LoadedDocValues.SingleString.class, idDocValues.getClass());
         String id = ((LoadedDocValues.SingleString) idDocValues).get(0);
@@ -252,79 +251,83 @@ public class ScoreScriptTest {
             LoadedDocValues.SortedIntegers.class,
             Integer.class,
             expectedLicenseNo,
-            doc());
+            getDoc());
         assertDocValue(
-            "count", LoadedDocValues.SingleInteger.class, Integer.class, expectedCount, doc());
+            "count", LoadedDocValues.SingleInteger.class, Integer.class, expectedCount, getDoc());
         assertDocValue(
             "vendor_name",
             LoadedDocValues.SortedStrings.class,
             String.class,
             expectedVendorName,
-            doc());
+            getDoc());
         assertDocValue(
             "vendor_name_atom",
             LoadedDocValues.SortedStrings.class,
             String.class,
             expectedVendorNameAtom,
-            doc());
+            getDoc());
         assertDocValue(
             "description",
             LoadedDocValues.SortedStrings.class,
             String.class,
             expectedDescription,
-            doc());
+            getDoc());
         assertDocValue(
             "double_field_multi",
             LoadedDocValues.SortedDoubles.class,
             Double.class,
             expectedDoubleFieldMulti,
-            doc());
+            getDoc());
         assertDocValue(
             "double_field",
             LoadedDocValues.SingleDouble.class,
             Double.class,
             expectedDoubleField,
-            doc());
+            getDoc());
         assertDocValue(
             "float_field_multi",
             LoadedDocValues.SortedFloats.class,
             Float.class,
             expectedFloatFieldMulti,
-            doc());
+            getDoc());
         assertDocValue(
             "float_field",
             LoadedDocValues.SingleFloat.class,
             Float.class,
             expectedFloatField,
-            doc());
+            getDoc());
         assertDocValue(
             "long_field_multi",
             LoadedDocValues.SortedLongs.class,
             Long.class,
             expectedLongFieldMulti,
-            doc());
+            getDoc());
         assertDocValue(
-            "long_field", LoadedDocValues.SingleLong.class, Long.class, expectedLongField, doc());
+            "long_field",
+            LoadedDocValues.SingleLong.class,
+            Long.class,
+            expectedLongField,
+            getDoc());
         assertDocValue(
             "boolean_field_multi",
             LoadedDocValues.SortedBooleans.class,
             Boolean.class,
             expectedBooleanFieldMulti,
-            doc());
+            getDoc());
         assertDocValue(
             "boolean_field",
             LoadedDocValues.SingleBoolean.class,
             Boolean.class,
             expectedBooleanField,
-            doc());
+            getDoc());
         assertDocValue(
-            "date", LoadedDocValues.SingleDateTime.class, Instant.class, expectedDate, doc());
+            "date", LoadedDocValues.SingleDateTime.class, Instant.class, expectedDate, getDoc());
         assertDocValue(
             "date_multi",
             LoadedDocValues.SortedDateTimes.class,
             Instant.class,
             expectedDateMulti,
-            doc());
+            getDoc());
       } catch (Error e) {
         throw new RuntimeException(e.getMessage(), e.getCause());
       }
@@ -342,9 +345,9 @@ public class ScoreScriptTest {
     }
 
     @Override
-    public double doubleValue() throws IOException {
+    public double execute() {
       try {
-        LoadedDocValues<?> idDocValues = doc().get("doc_id");
+        LoadedDocValues<?> idDocValues = getDoc().get("doc_id");
         assertEquals("doc_id size", 1, idDocValues.size());
         assertEquals("doc_id class", LoadedDocValues.SingleString.class, idDocValues.getClass());
         String id = ((LoadedDocValues.SingleString) idDocValues).get(0);
@@ -373,22 +376,22 @@ public class ScoreScriptTest {
             LoadedDocValues.SortedIntegers.class,
             Integer.class,
             expectedLicenseNo,
-            doc());
+            getDoc());
         assertDocValue(
             "vendor_name",
             LoadedDocValues.SortedStrings.class,
             String.class,
             expectedVendorName,
-            doc());
+            getDoc());
         assertDocValue(
             "vendor_name_atom",
             LoadedDocValues.SortedStrings.class,
             String.class,
             expectedVendorNameAtom,
-            doc());
+            getDoc());
 
         String fieldName = "lat_lon";
-        LoadedDocValues<?> docValues = doc().get(fieldName);
+        LoadedDocValues<?> docValues = getDoc().get(fieldName);
         assertNotNull(fieldName + " is null", docValues);
         assertEquals(LoadedDocValues.Locations.class, docValues.getClass());
         LoadedDocValues.Locations locations = (LoadedDocValues.Locations) docValues;
@@ -423,17 +426,17 @@ public class ScoreScriptTest {
     }
 
     @Override
-    public double doubleValue() throws IOException {
+    public double execute() {
       try {
-        LoadedDocValues<?> idDocValues = doc().get("doc_id");
+        LoadedDocValues<?> idDocValues = getDoc().get("doc_id");
         assertEquals("doc_id size", 1, idDocValues.size());
         assertEquals("doc_id class", LoadedDocValues.SingleString.class, idDocValues.getClass());
         String id = ((LoadedDocValues.SingleString) idDocValues).get(0);
 
         if (id.equals("1")) {
-          assertEquals(0.516, getScore(), 0.001);
+          assertEquals(0.516, get_score(), 0.001);
         } else if (id.equals("2")) {
-          assertEquals(0.0828, getScore(), 0.001);
+          assertEquals(0.0828, get_score(), 0.001);
         } else {
           fail(String.format("docId %s not indexed", id));
         }
@@ -454,28 +457,28 @@ public class ScoreScriptTest {
     }
 
     @Override
-    public double doubleValue() throws IOException {
+    public double execute() {
       try {
-        LoadedDocValues<?> idDocValues = doc().get("doc_id");
+        LoadedDocValues<?> idDocValues = getDoc().get("doc_id");
         assertEquals("doc_id size", 1, idDocValues.size());
         assertEquals("doc_id class", LoadedDocValues.SingleString.class, idDocValues.getClass());
         assertEquals("doc_id exists", 1, idDocValues.size());
 
-        assertEmptyDocValues("license_no", doc());
-        assertEmptyDocValues("vendor_name", doc());
-        assertEmptyDocValues("vendor_name_atom", doc());
-        assertEmptyDocValues("count", doc());
-        assertEmptyDocValues("long_field_multi", doc());
-        assertEmptyDocValues("long_field", doc());
-        assertEmptyDocValues("double_field_multi", doc());
-        assertEmptyDocValues("double_field", doc());
-        assertEmptyDocValues("float_field_multi", doc());
-        assertEmptyDocValues("float_field", doc());
-        assertEmptyDocValues("boolean_field_multi", doc());
-        assertEmptyDocValues("boolean_field", doc());
-        assertEmptyDocValues("date_multi", doc());
-        assertEmptyDocValues("date", doc());
-        assertEmptyDocValues("description", doc());
+        assertEmptyDocValues("license_no", getDoc());
+        assertEmptyDocValues("vendor_name", getDoc());
+        assertEmptyDocValues("vendor_name_atom", getDoc());
+        assertEmptyDocValues("count", getDoc());
+        assertEmptyDocValues("long_field_multi", getDoc());
+        assertEmptyDocValues("long_field", getDoc());
+        assertEmptyDocValues("double_field_multi", getDoc());
+        assertEmptyDocValues("double_field", getDoc());
+        assertEmptyDocValues("float_field_multi", getDoc());
+        assertEmptyDocValues("float_field", getDoc());
+        assertEmptyDocValues("boolean_field_multi", getDoc());
+        assertEmptyDocValues("boolean_field", getDoc());
+        assertEmptyDocValues("date_multi", getDoc());
+        assertEmptyDocValues("date", getDoc());
+        assertEmptyDocValues("description", getDoc());
       } catch (Error e) {
         throw new RuntimeException(e.getMessage(), e.getCause());
       }
@@ -493,17 +496,17 @@ public class ScoreScriptTest {
     }
 
     @Override
-    public double doubleValue() throws IOException {
+    public double execute() {
       try {
-        LoadedDocValues<?> idDocValues = doc().get("doc_id");
+        LoadedDocValues<?> idDocValues = getDoc().get("doc_id");
         assertEquals("doc_id size", 1, idDocValues.size());
         assertEquals("doc_id class", LoadedDocValues.SingleString.class, idDocValues.getClass());
         assertEquals("doc_id exists", 1, idDocValues.size());
 
-        assertEmptyDocValues("license_no", doc());
-        assertEmptyDocValues("vendor_name", doc());
-        assertEmptyDocValues("vendor_name_atom", doc());
-        assertEmptyDocValues("lat_lon", doc());
+        assertEmptyDocValues("license_no", getDoc());
+        assertEmptyDocValues("vendor_name", getDoc());
+        assertEmptyDocValues("vendor_name_atom", getDoc());
+        assertEmptyDocValues("lat_lon", getDoc());
       } catch (Error e) {
         throw new RuntimeException(e.getMessage(), e.getCause());
       }
@@ -521,42 +524,42 @@ public class ScoreScriptTest {
     }
 
     @Override
-    public double doubleValue() throws IOException {
+    public double execute() {
       try {
-        LoadedDocValues<?> idDocValues = doc().get("doc_id");
+        LoadedDocValues<?> idDocValues = getDoc().get("doc_id");
         assertEquals("doc_id size", 1, idDocValues.size());
         assertEquals("doc_id class", LoadedDocValues.SingleString.class, idDocValues.getClass());
         assertEquals("doc_id exists", 1, idDocValues.size());
 
         try {
-          doc().get(null);
+          getDoc().get(null);
           fail("null field name");
         } catch (NullPointerException ignore) {
         }
         try {
-          doc().get("not_field");
+          getDoc().get("not_field");
           fail("Invalid field");
         } catch (IllegalArgumentException ignore) {
         }
-        LoadedDocValues<?> docValues = doc().get("long_field");
+        LoadedDocValues<?> docValues = getDoc().get("long_field");
         try {
           docValues.get(2);
           fail("Invaild array index");
         } catch (IndexOutOfBoundsException ignore) {
         }
-        docValues = doc().get("long_field_multi");
+        docValues = getDoc().get("long_field_multi");
         try {
           docValues.get(2);
           fail("Invaild array index");
         } catch (IndexOutOfBoundsException ignore) {
         }
-        docValues = doc().get("vendor_name_atom");
+        docValues = getDoc().get("vendor_name_atom");
         try {
           docValues.get(2);
           fail("Invaild array index");
         } catch (IndexOutOfBoundsException ignore) {
         }
-        docValues = doc().get("vendor_name");
+        docValues = getDoc().get("vendor_name");
         try {
           docValues.get(2);
           fail("Invaild array index");
@@ -579,7 +582,7 @@ public class ScoreScriptTest {
     }
 
     @Override
-    public double doubleValue() throws IOException {
+    public double execute() {
       try {
         assertNotNull("params is null", getParams());
         assertEquals("params size", 0, getParams().size());
@@ -601,7 +604,7 @@ public class ScoreScriptTest {
     }
 
     @Override
-    public double doubleValue() throws IOException {
+    public double execute() {
       try {
         assertNotNull("params is null", getParams());
         assertEquals("params size", 6, getParams().size());
@@ -941,7 +944,7 @@ public class ScoreScriptTest {
       Class<T> docValueClass,
       Class<V> fieldValueClass,
       List<V> expectedValues,
-      SegmentDocLookup doc) {
+      Map<String, LoadedDocValues<?>> doc) {
     LoadedDocValues<?> docValues = doc.get(fieldName);
     assertNotNull(fieldName + " is null", docValues);
     assertEquals(docValueClass, docValues.getClass());
@@ -954,7 +957,7 @@ public class ScoreScriptTest {
     assertEquals(fieldName + " values", expectedValues, valuesList);
   }
 
-  private static void assertEmptyDocValues(String fieldName, SegmentDocLookup doc) {
+  private static void assertEmptyDocValues(String fieldName, Map<String, LoadedDocValues<?>> doc) {
     assertTrue("doc contains " + fieldName, doc.containsKey(fieldName));
     LoadedDocValues<?> docValues = doc.get(fieldName);
     assertNotNull(fieldName + " doc value is null", docValues);

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScriptContextTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScriptContextTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.script;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class ScriptContextTest {
+  public interface TestFactoryWithFactoryInterface {
+    TestStatefulFactoryInterface newFactory(int a, long b);
+  }
+
+  public interface TestFactoryWithFactoryAbstract {
+    TestStatefulFactoryAbstract newFactory(int a, long b);
+  }
+
+  public interface TestFactoryWithInstance {
+    TestInstance newInstance(int a, long b, double c, float d);
+  }
+
+  public interface TestStatefulFactoryInterface {
+    TestInstance newInstance(double c, float d);
+  }
+
+  public abstract static class TestStatefulFactoryAbstract {
+    TestStatefulFactoryAbstract(int a, long b) {}
+
+    public abstract TestInstance newInstance(double c, float d);
+  }
+
+  public abstract static class TestInstance {
+    public static final String[] PARAMETERS = new String[] {};
+
+    TestInstance(int a, long b, double c, float d) {}
+
+    public abstract Object execute();
+  }
+
+  interface InvalidFactoryNone {}
+
+  interface InvalidFactoryBoth {
+    TestStatefulFactoryInterface newFactory(int a, long b);
+
+    TestInstance newInstance(int a, long b, double c, float d);
+  }
+
+  interface InvalidFactoryMultiFactory {
+    TestStatefulFactoryInterface newFactory(int a, long b);
+
+    TestStatefulFactoryInterface newFactory(int a, long b, double c);
+  }
+
+  interface InvalidFactoryMultiInstance {
+    TestInstance newInstance(int a, long b, double c, float d);
+
+    TestInstance newInstance(int a, long b, double c, float d, boolean e);
+  }
+
+  @Test
+  public void testContextWithStatefulInterface() {
+    ScriptContext<TestFactoryWithFactoryInterface> context =
+        new ScriptContext<>("test", TestFactoryWithFactoryInterface.class);
+    assertEquals(TestFactoryWithFactoryInterface.class, context.factoryClazz);
+    assertEquals(TestStatefulFactoryInterface.class, context.statefulFactoryClazz);
+    assertEquals(TestInstance.class, context.instanceClazz);
+  }
+
+  @Test
+  public void testContextWithStatefulAbstract() {
+    ScriptContext<TestFactoryWithFactoryAbstract> context =
+        new ScriptContext<>("test", TestFactoryWithFactoryAbstract.class);
+    assertEquals(TestFactoryWithFactoryAbstract.class, context.factoryClazz);
+    assertEquals(TestStatefulFactoryAbstract.class, context.statefulFactoryClazz);
+    assertEquals(TestInstance.class, context.instanceClazz);
+  }
+
+  @Test
+  public void testContextWithInstance() {
+    ScriptContext<TestFactoryWithInstance> context =
+        new ScriptContext<>("test", TestFactoryWithInstance.class);
+    assertEquals(TestFactoryWithInstance.class, context.factoryClazz);
+    assertNull(context.statefulFactoryClazz);
+    assertEquals(TestInstance.class, context.instanceClazz);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNeitherMethodDefined() {
+    new ScriptContext<InvalidFactoryNone>("test", InvalidFactoryNone.class);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBothMethodsDefined() {
+    new ScriptContext<InvalidFactoryBoth>("test", InvalidFactoryBoth.class);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMultiGetFactoryMethodsDefined() {
+    new ScriptContext<InvalidFactoryMultiFactory>("test", InvalidFactoryMultiFactory.class);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMultiGetInstanceMethodsDefined() {
+    new ScriptContext<InvalidFactoryMultiInstance>("test", InvalidFactoryMultiInstance.class);
+  }
+}


### PR DESCRIPTION
Define the expected structure of script classes. This design is very similar to what is required for the painless scripting language. Factories produce script instances and can optionally use stateful factories. See the class documentation for ScriptContext.

This should hopefully allow the use of scripting languages that use generated classes, and make it easy to add new script functionality as needed.

Additionally, ScoreScript has been modified to use getX/needsX functions in the manner expected by painless.