### PR TITLE
Pass script context list to script plugins

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/doc/LoadedDocValues.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/doc/LoadedDocValues.java
@@ -113,6 +113,10 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
     public int size() {
       return value == null ? 0 : 1;
     }
+
+    public T getValue() {
+      return get(0);
+    }
   }
 
   public static final class SingleBoolean extends SingleNumericValue<Boolean> {
@@ -284,10 +288,7 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
     public SearchResponse.Hit.FieldValue toFieldValue(int index) {
       GeoPoint point = get(index);
       LatLng latLon =
-          LatLng.newBuilder()
-              .setLatitude(point.getLatitude())
-              .setLongitude(point.getLongitude())
-              .build();
+          LatLng.newBuilder().setLatitude(point.getLat()).setLongitude(point.getLon()).build();
       return SearchResponse.Hit.FieldValue.newBuilder().setLatLngValue(latLon).build();
     }
   }
@@ -336,6 +337,10 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
     @Override
     public int size() {
       return value == null ? 0 : 1;
+    }
+
+    public T getValue() {
+      return get(0);
     }
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/geo/GeoPoint.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/geo/GeoPoint.java
@@ -28,11 +28,11 @@ public final class GeoPoint {
     this.longitude = longitude;
   }
 
-  public double getLatitude() {
+  public double getLat() {
     return latitude;
   }
 
-  public double getLongitude() {
+  public double getLon() {
     return longitude;
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/script/ScriptService.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/script/ScriptService.java
@@ -18,12 +18,14 @@ package com.yelp.nrtsearch.server.luceneserver.script;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.Script;
 import com.yelp.nrtsearch.server.luceneserver.script.js.JsScriptEngine;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.plugins.ScriptPlugin;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
@@ -40,6 +42,9 @@ import java.util.concurrent.TimeUnit;
 public class ScriptService {
 
   private static ScriptService instance;
+
+  private static final List<ScriptContext<?>> builtInContexts =
+      ImmutableList.<ScriptContext<?>>builder().add(ScoreScript.CONTEXT).build();
 
   private final Map<String, ScriptEngine> scriptEngineMap = new HashMap<>();
   private final LoadingCache<ScriptCacheKey, Object> scriptCache;
@@ -113,7 +118,7 @@ public class ScriptService {
     for (Plugin plugin : plugins) {
       if (plugin instanceof ScriptPlugin) {
         ScriptPlugin scriptPlugin = (ScriptPlugin) plugin;
-        instance.register(scriptPlugin.getScriptEngines());
+        instance.register(scriptPlugin.getScriptEngines(builtInContexts));
       }
     }
   }

--- a/src/main/java/com/yelp/nrtsearch/server/plugins/ScriptPlugin.java
+++ b/src/main/java/com/yelp/nrtsearch/server/plugins/ScriptPlugin.java
@@ -15,8 +15,10 @@
  */
 package com.yelp.nrtsearch.server.plugins;
 
+import com.yelp.nrtsearch.server.luceneserver.script.ScriptContext;
 import com.yelp.nrtsearch.server.luceneserver.script.ScriptEngine;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Plugin interface that allows for the registration of new scripting languages. These {@link
@@ -30,9 +32,10 @@ public interface ScriptPlugin {
    * com.yelp.nrtsearch.server.luceneserver.script.ScriptService}. The service delegates compilation
    * of the script source to the appropriate engine based on the specified language.
    *
+   * @param contexts list of possible script context types
    * @return list of provided {@link ScriptEngine} implementations
    */
-  default Iterable<ScriptEngine> getScriptEngines() {
+  default Iterable<ScriptEngine> getScriptEngines(List<ScriptContext<?>> contexts) {
     return Collections.emptyList();
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
@@ -113,7 +113,8 @@ public class ScoreScriptTest {
   }
 
   static class ScoreScriptTestPlugin extends Plugin implements ScriptPlugin {
-    public Iterable<ScriptEngine> getScriptEngines() {
+    @Override
+    public Iterable<ScriptEngine> getScriptEngines(List<ScriptContext<?>> contexts) {
       return Collections.singletonList(new TestScriptEngine());
     }
   }
@@ -398,16 +399,9 @@ public class ScoreScriptTest {
         assertEquals(fieldName + " size", 1, locations.size());
         GeoPoint loadedPoint = locations.get(0);
         assertNotNull("point is null", loadedPoint);
+        assertEquals(fieldName + " latitude", expectedPoint.getLat(), loadedPoint.getLat(), 0.0001);
         assertEquals(
-            fieldName + " latitude",
-            expectedPoint.getLatitude(),
-            loadedPoint.getLatitude(),
-            0.0001);
-        assertEquals(
-            fieldName + " longitude",
-            expectedPoint.getLongitude(),
-            loadedPoint.getLongitude(),
-            0.0001);
+            fieldName + " longitude", expectedPoint.getLon(), loadedPoint.getLon(), 0.0001);
 
       } catch (Error e) {
         throw new RuntimeException(e.getMessage(), e.getCause());

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScriptServiceTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScriptServiceTest.java
@@ -50,7 +50,8 @@ public class ScriptServiceTest {
   }
 
   static class TestScriptPlugin extends Plugin implements ScriptPlugin {
-    public Iterable<ScriptEngine> getScriptEngines() {
+    @Override
+    public Iterable<ScriptEngine> getScriptEngines(List<ScriptContext<?>> contexts) {
       return Arrays.asList(new TestScriptEngine(), new TestNullFactoryEngine());
     }
   }


### PR DESCRIPTION
Pass the list of possible script contexts to script plugins that create engines. Add getValue methods to single value LoadedDocValues. Shorten getter names on GeoPoint.