### PR TITLE
fix null printstream

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -22,6 +22,8 @@ import io.grpc.StatusRuntimeException;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.net.InetAddress;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -647,7 +649,7 @@ public class ShardState implements Closeable {
                   return searcher;
                 }
               },
-              verbose ? System.out : null);
+              verbose ? System.out : new PrintStream(OutputStream.nullOutputStream()));
 
       // nocommit this isn't used?
       searcherManager =
@@ -780,7 +782,7 @@ public class ShardState implements Closeable {
                   return searcher;
                 }
               },
-              verbose ? System.out : null,
+              verbose ? System.out : new PrintStream(OutputStream.nullOutputStream()),
               primaryGen);
 
       startSearcherPruningThread(indexState.globalState.shutdownNow);


### PR DESCRIPTION
Fixes #136. We simply use nullOutputStream when we dont want verbose which allows the PrintStream to not throw NPE while bubbling the exception back up to the caller like so: https://gist.github.com/umeshdangat/0205ccdf44ef00c16b289249f3e962f2