### PR TITLE
Removed synchronized from hasFacets in IndexState

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
@@ -726,8 +726,8 @@ public class IndexState implements Closeable, Restorable {
     return liveSettingsSaveState.toString();
   }
 
-  public synchronized boolean hasFacets() {
-    return internalFacetFieldNames.isEmpty() == false;
+  public boolean hasFacets() {
+    return !internalFacetFieldNames.isEmpty();
   }
 
   /** Returns JSON representation of all registered fields. */


### PR DESCRIPTION
Removed synchronized from hasFacets in IndexState as the internalFacetFieldNames set is already backed by a concurrent hashmap and with synchronized accessors of hasFacets need to lock IndexState which can lead to deadlocks.