### PR TITLE
Added serviceName and nodeName to prometheus metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,13 +44,11 @@ def commonsCompressVersion = '1.19'
 def awsJavaSdkVersion = '1.11.695'
 def guicedeeVersion = '1.0.1.7-jre13'
 def lz4Version = '1.7.0'
-def prometheusVersion = '0.3.0'
 def prometheusClientVersion = '0.8.0'
 
 dependencies {
 
     //prometheus (metrics) deps
-    implementation "me.dinowernli:java-grpc-prometheus:${prometheusVersion}"
     implementation "io.prometheus:simpleclient_servlet:${prometheusClientVersion}"
 
     //
@@ -178,6 +176,11 @@ publishing {
                         id = 'alok'
                         name = 'Alok Mysore'
                         email = 'alok@yelp.com'
+                    }
+                    developer {
+                        id = 'erikyang'
+                        name = 'Erik Yang'
+                        email = 'erikyang@yelp.com'
                     }
                     developer {
                         id = 'karthik'

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -125,8 +125,7 @@ public class LuceneServer {
                 .withLatencyBuckets(luceneServerConfiguration.getMetricsBuckets())
                 .withCollectorRegistry(collectorRegistry),
             serviceName,
-            nodeName
-        );
+            nodeName);
     /* The port on which the server should run */
     server =
         ServerBuilder.forPort(luceneServerConfiguration.getPort())

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -60,6 +60,8 @@ import com.yelp.nrtsearch.server.luceneserver.WriteNRTPointHandler;
 import com.yelp.nrtsearch.server.luceneserver.analysis.AnalyzerCreator;
 import com.yelp.nrtsearch.server.luceneserver.field.FieldDefCreator;
 import com.yelp.nrtsearch.server.luceneserver.script.ScriptService;
+import com.yelp.nrtsearch.server.monitoring.Configuration;
+import com.yelp.nrtsearch.server.monitoring.LuceneServerMonitoringServerInterceptor;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.plugins.PluginsService;
 import com.yelp.nrtsearch.server.utils.Archiver;
@@ -81,8 +83,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
-import me.dinowernli.grpc.prometheus.Configuration;
-import me.dinowernli.grpc.prometheus.MonitoringServerInterceptor;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.slf4j.Logger;
@@ -116,11 +116,17 @@ public class LuceneServer {
 
     List<Plugin> plugins = pluginsService.loadPlugins();
 
-    MonitoringServerInterceptor monitoringInterceptor =
-        MonitoringServerInterceptor.create(
+    String serviceName = luceneServerConfiguration.getServiceName();
+    String nodeName = luceneServerConfiguration.getNodeName();
+
+    LuceneServerMonitoringServerInterceptor monitoringInterceptor =
+        LuceneServerMonitoringServerInterceptor.create(
             Configuration.allMetrics()
                 .withLatencyBuckets(luceneServerConfiguration.getMetricsBuckets())
-                .withCollectorRegistry(collectorRegistry));
+                .withCollectorRegistry(collectorRegistry),
+            serviceName,
+            nodeName
+        );
     /* The port on which the server should run */
     server =
         ServerBuilder.forPort(luceneServerConfiguration.getPort())

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/Configuration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/Configuration.java
@@ -1,0 +1,76 @@
+package com.yelp.nrtsearch.server.monitoring;
+
+import io.prometheus.client.CollectorRegistry;
+
+/**
+ * Holds information about which metrics should be kept track of during rpc calls. Can be used to
+ * turn on more elaborate and expensive metrics, such as latency histograms.
+ */
+public class Configuration {
+  private static double[] DEFAULT_LATENCY_BUCKETS =
+      new double[] {.001, .005, .01, .05, 0.075, .1, .25, .5, 1, 2, 5, 10};
+
+  private final boolean isIncludeLatencyHistograms;
+  private final CollectorRegistry collectorRegistry;
+  private final double[] latencyBuckets;
+
+  /** Returns a {@link com.yelp.nrtsearch.server.monitoring.Configuration} for recording all cheap metrics about the rpcs. */
+  public static com.yelp.nrtsearch.server.monitoring.Configuration cheapMetricsOnly() {
+    return new com.yelp.nrtsearch.server.monitoring.Configuration(
+        false /* isIncludeLatencyHistograms */,
+        CollectorRegistry.defaultRegistry,
+        DEFAULT_LATENCY_BUCKETS);
+  }
+
+  /**
+   * Returns a {@link com.yelp.nrtsearch.server.monitoring.Configuration} for recording all metrics about the rpcs. This includes
+   * metrics which might produce a lot of data, such as latency histograms.
+   */
+  public static com.yelp.nrtsearch.server.monitoring.Configuration allMetrics() {
+    return new com.yelp.nrtsearch.server.monitoring.Configuration(
+        true /* isIncludeLatencyHistograms */,
+        CollectorRegistry.defaultRegistry,
+        DEFAULT_LATENCY_BUCKETS);
+  }
+
+  /**
+   * Returns a copy {@link com.yelp.nrtsearch.server.monitoring.Configuration} with the difference that Prometheus metrics are
+   * recorded using the supplied {@link CollectorRegistry}.
+   */
+  public com.yelp.nrtsearch.server.monitoring.Configuration withCollectorRegistry(CollectorRegistry collectorRegistry) {
+    return new com.yelp.nrtsearch.server.monitoring.Configuration(isIncludeLatencyHistograms, collectorRegistry, latencyBuckets);
+  }
+
+  /**
+   * Returns a copy {@link com.yelp.nrtsearch.server.monitoring.Configuration} with the difference that the latency histogram values are
+   * recorded with the specified set of buckets.
+   */
+  public com.yelp.nrtsearch.server.monitoring.Configuration withLatencyBuckets(double[] buckets) {
+    return new com.yelp.nrtsearch.server.monitoring.Configuration(isIncludeLatencyHistograms, collectorRegistry, buckets);
+  }
+
+  /** Returns whether or not latency histograms for calls should be included. */
+  public boolean isIncludeLatencyHistograms() {
+    return isIncludeLatencyHistograms;
+  }
+
+  /** Returns the {@link CollectorRegistry} used to record stats. */
+  public CollectorRegistry getCollectorRegistry() {
+    return collectorRegistry;
+  }
+
+  /** Returns the histogram buckets to use for latency metrics. */
+  public double[] getLatencyBuckets() {
+    return latencyBuckets;
+  }
+
+  private Configuration(
+      boolean isIncludeLatencyHistograms,
+      CollectorRegistry collectorRegistry,
+      double[] latencyBuckets) {
+    this.isIncludeLatencyHistograms = isIncludeLatencyHistograms;
+    this.collectorRegistry = collectorRegistry;
+    this.latencyBuckets = latencyBuckets;
+  }
+}
+

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/Configuration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/Configuration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.yelp.nrtsearch.server.monitoring;
 
 import io.prometheus.client.CollectorRegistry;
@@ -14,7 +29,10 @@ public class Configuration {
   private final CollectorRegistry collectorRegistry;
   private final double[] latencyBuckets;
 
-  /** Returns a {@link com.yelp.nrtsearch.server.monitoring.Configuration} for recording all cheap metrics about the rpcs. */
+  /**
+   * Returns a {@link com.yelp.nrtsearch.server.monitoring.Configuration} for recording all cheap
+   * metrics about the rpcs.
+   */
   public static com.yelp.nrtsearch.server.monitoring.Configuration cheapMetricsOnly() {
     return new com.yelp.nrtsearch.server.monitoring.Configuration(
         false /* isIncludeLatencyHistograms */,
@@ -23,8 +41,9 @@ public class Configuration {
   }
 
   /**
-   * Returns a {@link com.yelp.nrtsearch.server.monitoring.Configuration} for recording all metrics about the rpcs. This includes
-   * metrics which might produce a lot of data, such as latency histograms.
+   * Returns a {@link com.yelp.nrtsearch.server.monitoring.Configuration} for recording all metrics
+   * about the rpcs. This includes metrics which might produce a lot of data, such as latency
+   * histograms.
    */
   public static com.yelp.nrtsearch.server.monitoring.Configuration allMetrics() {
     return new com.yelp.nrtsearch.server.monitoring.Configuration(
@@ -34,19 +53,22 @@ public class Configuration {
   }
 
   /**
-   * Returns a copy {@link com.yelp.nrtsearch.server.monitoring.Configuration} with the difference that Prometheus metrics are
-   * recorded using the supplied {@link CollectorRegistry}.
+   * Returns a copy {@link com.yelp.nrtsearch.server.monitoring.Configuration} with the difference
+   * that Prometheus metrics are recorded using the supplied {@link CollectorRegistry}.
    */
-  public com.yelp.nrtsearch.server.monitoring.Configuration withCollectorRegistry(CollectorRegistry collectorRegistry) {
-    return new com.yelp.nrtsearch.server.monitoring.Configuration(isIncludeLatencyHistograms, collectorRegistry, latencyBuckets);
+  public com.yelp.nrtsearch.server.monitoring.Configuration withCollectorRegistry(
+      CollectorRegistry collectorRegistry) {
+    return new com.yelp.nrtsearch.server.monitoring.Configuration(
+        isIncludeLatencyHistograms, collectorRegistry, latencyBuckets);
   }
 
   /**
-   * Returns a copy {@link com.yelp.nrtsearch.server.monitoring.Configuration} with the difference that the latency histogram values are
-   * recorded with the specified set of buckets.
+   * Returns a copy {@link com.yelp.nrtsearch.server.monitoring.Configuration} with the difference
+   * that the latency histogram values are recorded with the specified set of buckets.
    */
   public com.yelp.nrtsearch.server.monitoring.Configuration withLatencyBuckets(double[] buckets) {
-    return new com.yelp.nrtsearch.server.monitoring.Configuration(isIncludeLatencyHistograms, collectorRegistry, buckets);
+    return new com.yelp.nrtsearch.server.monitoring.Configuration(
+        isIncludeLatencyHistograms, collectorRegistry, buckets);
   }
 
   /** Returns whether or not latency histograms for calls should be included. */
@@ -73,4 +95,3 @@ public class Configuration {
     this.latencyBuckets = latencyBuckets;
   }
 }
-

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/GrpcMethod.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/GrpcMethod.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.yelp.nrtsearch.server.monitoring;
 
 import io.grpc.MethodDescriptor;
@@ -14,7 +29,8 @@ class GrpcMethod {
 
     // Full method names are of the form: "full.serviceName/MethodName". We extract the last part.
     String methodName = method.getFullMethodName().substring(serviceName.length() + 1);
-    return new com.yelp.nrtsearch.server.monitoring.GrpcMethod(serviceName, methodName, method.getType());
+    return new com.yelp.nrtsearch.server.monitoring.GrpcMethod(
+        serviceName, methodName, method.getType());
   }
 
   private GrpcMethod(String serviceName, String methodName, MethodType type) {

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/GrpcMethod.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/GrpcMethod.java
@@ -1,0 +1,45 @@
+package com.yelp.nrtsearch.server.monitoring;
+
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.MethodType;
+
+/** Knows how to extract information about a single grpc method. */
+class GrpcMethod {
+  private final String serviceName;
+  private final String methodName;
+  private final MethodType type;
+
+  static com.yelp.nrtsearch.server.monitoring.GrpcMethod of(MethodDescriptor<?, ?> method) {
+    String serviceName = MethodDescriptor.extractFullServiceName(method.getFullMethodName());
+
+    // Full method names are of the form: "full.serviceName/MethodName". We extract the last part.
+    String methodName = method.getFullMethodName().substring(serviceName.length() + 1);
+    return new com.yelp.nrtsearch.server.monitoring.GrpcMethod(serviceName, methodName, method.getType());
+  }
+
+  private GrpcMethod(String serviceName, String methodName, MethodType type) {
+    this.serviceName = serviceName;
+    this.methodName = methodName;
+    this.type = type;
+  }
+
+  String serviceName() {
+    return serviceName;
+  }
+
+  String methodName() {
+    return methodName;
+  }
+
+  String type() {
+    return type.toString();
+  }
+
+  boolean streamsRequests() {
+    return type == MethodType.CLIENT_STREAMING || type == MethodType.BIDI_STREAMING;
+  }
+
+  boolean streamsResponses() {
+    return type == MethodType.SERVER_STREAMING || type == MethodType.BIDI_STREAMING;
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/LuceneServerMonitoringServerInterceptor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/LuceneServerMonitoringServerInterceptor.java
@@ -1,12 +1,26 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.yelp.nrtsearch.server.monitoring;
-
-import java.time.Clock;
 
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
+import java.time.Clock;
 
 /** A {@link ServerInterceptor} which sends stats about incoming grpc calls to Prometheus. */
 public class LuceneServerMonitoringServerInterceptor implements ServerInterceptor {
@@ -15,15 +29,11 @@ public class LuceneServerMonitoringServerInterceptor implements ServerIntercepto
   private final ServerMetrics.Factory serverMetricsFactory;
 
   public static LuceneServerMonitoringServerInterceptor create(
-      Configuration configuration,
-      String serviceName,
-      String nodeName
-  ) {
+      Configuration configuration, String serviceName, String nodeName) {
     return new LuceneServerMonitoringServerInterceptor(
         Clock.systemDefaultZone(),
         configuration,
-        new ServerMetrics.Factory(configuration, serviceName, nodeName)
-    );
+        new ServerMetrics.Factory(configuration, serviceName, nodeName));
   }
 
   private LuceneServerMonitoringServerInterceptor(
@@ -35,16 +45,17 @@ public class LuceneServerMonitoringServerInterceptor implements ServerIntercepto
 
   @Override
   public <R, S> ServerCall.Listener<R> interceptCall(
-      ServerCall<R, S> call,
-      Metadata requestHeaders,
-      ServerCallHandler<R, S> next) {
+      ServerCall<R, S> call, Metadata requestHeaders, ServerCallHandler<R, S> next) {
     MethodDescriptor<R, S> method = call.getMethodDescriptor();
-    com.yelp.nrtsearch.server.monitoring.ServerMetrics metrics = serverMetricsFactory.createMetricsForMethod(method);
-    com.yelp.nrtsearch.server.monitoring.GrpcMethod grpcMethod = com.yelp.nrtsearch.server.monitoring.GrpcMethod.of(method);
-    ServerCall<R,S> monitoringCall = new MonitoringServerCall(call, clock, grpcMethod, metrics, configuration);
+    com.yelp.nrtsearch.server.monitoring.ServerMetrics metrics =
+        serverMetricsFactory.createMetricsForMethod(method);
+    com.yelp.nrtsearch.server.monitoring.GrpcMethod grpcMethod =
+        com.yelp.nrtsearch.server.monitoring.GrpcMethod.of(method);
+    ServerCall<R, S> monitoringCall =
+        new MonitoringServerCall(call, clock, grpcMethod, metrics, configuration);
     return new MonitoringServerCallListener<>(
-        next.startCall(monitoringCall, requestHeaders), metrics, com.yelp.nrtsearch.server.monitoring.GrpcMethod
-        .of(method));
+        next.startCall(monitoringCall, requestHeaders),
+        metrics,
+        com.yelp.nrtsearch.server.monitoring.GrpcMethod.of(method));
   }
-
 }

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/LuceneServerMonitoringServerInterceptor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/LuceneServerMonitoringServerInterceptor.java
@@ -1,0 +1,50 @@
+package com.yelp.nrtsearch.server.monitoring;
+
+import java.time.Clock;
+
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+
+/** A {@link ServerInterceptor} which sends stats about incoming grpc calls to Prometheus. */
+public class LuceneServerMonitoringServerInterceptor implements ServerInterceptor {
+  private final Clock clock;
+  private final Configuration configuration;
+  private final ServerMetrics.Factory serverMetricsFactory;
+
+  public static LuceneServerMonitoringServerInterceptor create(
+      Configuration configuration,
+      String serviceName,
+      String nodeName
+  ) {
+    return new LuceneServerMonitoringServerInterceptor(
+        Clock.systemDefaultZone(),
+        configuration,
+        new ServerMetrics.Factory(configuration, serviceName, nodeName)
+    );
+  }
+
+  private LuceneServerMonitoringServerInterceptor(
+      Clock clock, Configuration configuration, ServerMetrics.Factory serverMetricsFactory) {
+    this.clock = clock;
+    this.configuration = configuration;
+    this.serverMetricsFactory = serverMetricsFactory;
+  }
+
+  @Override
+  public <R, S> ServerCall.Listener<R> interceptCall(
+      ServerCall<R, S> call,
+      Metadata requestHeaders,
+      ServerCallHandler<R, S> next) {
+    MethodDescriptor<R, S> method = call.getMethodDescriptor();
+    com.yelp.nrtsearch.server.monitoring.ServerMetrics metrics = serverMetricsFactory.createMetricsForMethod(method);
+    com.yelp.nrtsearch.server.monitoring.GrpcMethod grpcMethod = com.yelp.nrtsearch.server.monitoring.GrpcMethod.of(method);
+    ServerCall<R,S> monitoringCall = new MonitoringServerCall(call, clock, grpcMethod, metrics, configuration);
+    return new MonitoringServerCallListener<>(
+        next.startCall(monitoringCall, requestHeaders), metrics, com.yelp.nrtsearch.server.monitoring.GrpcMethod
+        .of(method));
+  }
+
+}

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/MonitoringServerCall.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/MonitoringServerCall.java
@@ -1,0 +1,67 @@
+package com.yelp.nrtsearch.server.monitoring;
+
+import java.time.Clock;
+import java.time.Instant;
+
+import io.grpc.ForwardingServerCall;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.Status;
+
+/**
+ * A {@link ForwardingServerCall} which updates Prometheus metrics based on the server-side actions
+ * taken for a single rpc, e.g., messages sent, latency, etc.
+ */
+class MonitoringServerCall<R,S> extends ForwardingServerCall.SimpleForwardingServerCall<R,S> {
+  private static final long MILLIS_PER_SECOND = 1000L;
+
+  private final Clock clock;
+  private final com.yelp.nrtsearch.server.monitoring.GrpcMethod grpcMethod;
+  private final com.yelp.nrtsearch.server.monitoring.ServerMetrics serverMetrics;
+  private final com.yelp.nrtsearch.server.monitoring.Configuration configuration;
+  private final Instant startInstant;
+
+  MonitoringServerCall(
+      ServerCall<R,S> delegate,
+      Clock clock,
+      com.yelp.nrtsearch.server.monitoring.GrpcMethod grpcMethod,
+      com.yelp.nrtsearch.server.monitoring.ServerMetrics serverMetrics,
+      Configuration configuration) {
+    super(delegate);
+    this.clock = clock;
+    this.grpcMethod = grpcMethod;
+    this.serverMetrics = serverMetrics;
+    this.configuration = configuration;
+    this.startInstant = clock.instant();
+
+    // TODO(dino): Consider doing this in the onReady() method of the listener instead.
+    reportStartMetrics();
+  }
+
+  @Override
+  public void close(Status status, Metadata responseHeaders) {
+    reportEndMetrics(status);
+    super.close(status, responseHeaders);
+  }
+
+  @Override
+  public void sendMessage(S message) {
+    if (grpcMethod.streamsResponses()) {
+      serverMetrics.recordStreamMessageSent();
+    }
+    super.sendMessage(message);
+  }
+
+  private void reportStartMetrics() {
+    serverMetrics.recordCallStarted();
+  }
+
+  private void reportEndMetrics(Status status) {
+    serverMetrics.recordServerHandled(status.getCode());
+    if (configuration.isIncludeLatencyHistograms()) {
+      double latencySec =
+          (clock.millis() - startInstant.toEpochMilli()) / (double) MILLIS_PER_SECOND;
+      serverMetrics.recordLatency(latencySec);
+    }
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/MonitoringServerCall.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/MonitoringServerCall.java
@@ -1,18 +1,32 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.yelp.nrtsearch.server.monitoring;
-
-import java.time.Clock;
-import java.time.Instant;
 
 import io.grpc.ForwardingServerCall;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.Status;
+import java.time.Clock;
+import java.time.Instant;
 
 /**
  * A {@link ForwardingServerCall} which updates Prometheus metrics based on the server-side actions
  * taken for a single rpc, e.g., messages sent, latency, etc.
  */
-class MonitoringServerCall<R,S> extends ForwardingServerCall.SimpleForwardingServerCall<R,S> {
+class MonitoringServerCall<R, S> extends ForwardingServerCall.SimpleForwardingServerCall<R, S> {
   private static final long MILLIS_PER_SECOND = 1000L;
 
   private final Clock clock;
@@ -22,7 +36,7 @@ class MonitoringServerCall<R,S> extends ForwardingServerCall.SimpleForwardingSer
   private final Instant startInstant;
 
   MonitoringServerCall(
-      ServerCall<R,S> delegate,
+      ServerCall<R, S> delegate,
       Clock clock,
       com.yelp.nrtsearch.server.monitoring.GrpcMethod grpcMethod,
       com.yelp.nrtsearch.server.monitoring.ServerMetrics serverMetrics,

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/MonitoringServerCallListener.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/MonitoringServerCallListener.java
@@ -1,0 +1,34 @@
+package com.yelp.nrtsearch.server.monitoring;
+
+import io.grpc.ForwardingServerCallListener;
+import io.grpc.ServerCall;
+
+/**
+ * A {@link ForwardingServerCallListener} which updates Prometheus metrics for a single rpc based
+ * on updates received from grpc.
+ */
+class MonitoringServerCallListener<R> extends ForwardingServerCallListener<R> {
+  private final ServerCall.Listener<R> delegate;
+  private final com.yelp.nrtsearch.server.monitoring.GrpcMethod grpcMethod;
+  private final com.yelp.nrtsearch.server.monitoring.ServerMetrics serverMetrics;
+
+  MonitoringServerCallListener(
+      ServerCall.Listener<R> delegate, com.yelp.nrtsearch.server.monitoring.ServerMetrics serverMetrics, com.yelp.nrtsearch.server.monitoring.GrpcMethod grpcMethod) {
+    this.delegate = delegate;
+    this.serverMetrics = serverMetrics;
+    this.grpcMethod = grpcMethod;
+  }
+
+  @Override
+  protected ServerCall.Listener<R> delegate() {
+    return delegate;
+  }
+
+  @Override
+  public void onMessage(R request) {
+    if (grpcMethod.streamsRequests()) {
+      serverMetrics.recordStreamMessageReceived();
+    }
+    super.onMessage(request);
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/MonitoringServerCallListener.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/MonitoringServerCallListener.java
@@ -1,11 +1,26 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.yelp.nrtsearch.server.monitoring;
 
 import io.grpc.ForwardingServerCallListener;
 import io.grpc.ServerCall;
 
 /**
- * A {@link ForwardingServerCallListener} which updates Prometheus metrics for a single rpc based
- * on updates received from grpc.
+ * A {@link ForwardingServerCallListener} which updates Prometheus metrics for a single rpc based on
+ * updates received from grpc.
  */
 class MonitoringServerCallListener<R> extends ForwardingServerCallListener<R> {
   private final ServerCall.Listener<R> delegate;
@@ -13,7 +28,9 @@ class MonitoringServerCallListener<R> extends ForwardingServerCallListener<R> {
   private final com.yelp.nrtsearch.server.monitoring.ServerMetrics serverMetrics;
 
   MonitoringServerCallListener(
-      ServerCall.Listener<R> delegate, com.yelp.nrtsearch.server.monitoring.ServerMetrics serverMetrics, com.yelp.nrtsearch.server.monitoring.GrpcMethod grpcMethod) {
+      ServerCall.Listener<R> delegate,
+      com.yelp.nrtsearch.server.monitoring.ServerMetrics serverMetrics,
+      com.yelp.nrtsearch.server.monitoring.GrpcMethod grpcMethod) {
     this.delegate = delegate;
     this.serverMetrics = serverMetrics;
     this.grpcMethod = grpcMethod;

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/ServerMetrics.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/ServerMetrics.java
@@ -1,0 +1,172 @@
+package com.yelp.nrtsearch.server.monitoring;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import io.grpc.MethodDescriptor;
+import io.grpc.Status.Code;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Histogram;
+import io.prometheus.client.SimpleCollector;
+
+/**
+ * Prometheus metric definitions used for server-side monitoring of grpc services.
+ *
+ * Instances of this class hold the counters we increment for a specific pair of grpc service
+ * definition and collection registry.
+ */
+class ServerMetrics {
+  private static final Counter.Builder serverStartedBuilder = Counter.build()
+      .namespace("grpc")
+      .subsystem("server")
+      .name("started_total")
+      .labelNames("grpc_type", "grpc_service", "grpc_method", "serviceName", "nodeName")
+      .help("Total number of RPCs started on the server.");
+
+  private static final Counter.Builder serverHandledBuilder = Counter.build()
+      .namespace("grpc")
+      .subsystem("server")
+      .name("handled_total")
+      .labelNames("grpc_type", "grpc_service", "grpc_method", "serviceName", "nodeName", "code")
+      .help("Total number of RPCs completed on the server, regardless of success or failure.");
+
+  private static final Histogram.Builder serverHandledLatencySecondsBuilder =
+      Histogram.build()
+          .namespace("grpc")
+          .subsystem("server")
+          .name("handled_latency_seconds")
+          .labelNames("grpc_type", "grpc_service", "grpc_method", "serviceName", "nodeName")
+          .help("Histogram of response latency (seconds) of gRPC that had been application-level " +
+              "handled by the server.");
+
+  private static final Counter.Builder serverStreamMessagesReceivedBuilder = Counter.build()
+      .namespace("grpc")
+      .subsystem("server")
+      .name("msg_received_total")
+      .labelNames("grpc_type", "grpc_service", "grpc_method", "serviceName", "nodeName")
+      .help("Total number of stream messages received from the client.");
+
+  private static final Counter.Builder serverStreamMessagesSentBuilder = Counter.build()
+      .namespace("grpc")
+      .subsystem("server")
+      .name("msg_sent_total")
+      .labelNames("grpc_type", "grpc_service", "grpc_method", "serviceName", "nodeName")
+      .help("Total number of stream messages sent by the server.");
+
+  private final Counter serverStarted;
+  private final Counter serverHandled;
+  private final Counter serverStreamMessagesReceived;
+  private final Counter serverStreamMessagesSent;
+  private final Optional<Histogram> serverHandledLatencySeconds;
+
+  private final String serviceName;
+  private final String nodeName;
+
+  private final com.yelp.nrtsearch.server.monitoring.GrpcMethod method;
+
+  private ServerMetrics(
+      com.yelp.nrtsearch.server.monitoring.GrpcMethod method,
+      Counter serverStarted,
+      Counter serverHandled,
+      Counter serverStreamMessagesReceived,
+      Counter serverStreamMessagesSent,
+      Optional<Histogram> serverHandledLatencySeconds,
+      String serviceName,
+      String nodeName
+  ) {
+    this.method = method;
+    this.serverStarted = serverStarted;
+    this.serverHandled = serverHandled;
+    this.serverStreamMessagesReceived = serverStreamMessagesReceived;
+    this.serverStreamMessagesSent = serverStreamMessagesSent;
+    this.serverHandledLatencySeconds = serverHandledLatencySeconds;
+    this.serviceName = serviceName;
+    this.nodeName = nodeName;
+  }
+
+  public void recordCallStarted() {
+    addLabels(serverStarted).inc();
+  }
+
+  public void recordServerHandled(Code code) {
+    addLabels(serverHandled, code.toString()).inc();
+  }
+
+  public void recordStreamMessageSent() {
+    addLabels(serverStreamMessagesSent).inc();
+  }
+
+  public void recordStreamMessageReceived() {
+    addLabels(serverStreamMessagesReceived).inc();
+  }
+
+  /**
+   * Only has any effect if monitoring is configured to include latency histograms. Otherwise, this
+   * does nothing.
+   */
+  public void recordLatency(double latencySec) {
+    if (!this.serverHandledLatencySeconds.isPresent()) {
+      return;
+    }
+    addLabels(this.serverHandledLatencySeconds.get()).observe(latencySec);
+  }
+
+  /**
+   * Knows how to produce {@link com.yelp.nrtsearch.server.monitoring.ServerMetrics} instances for individual methods.
+   */
+  static class Factory {
+    private final Counter serverStarted;
+    private final Counter serverHandled;
+    private final Counter serverStreamMessagesReceived;
+    private final Counter serverStreamMessagesSent;
+    private final Optional<Histogram> serverHandledLatencySeconds;
+
+    private final String serviceName;
+    private final String nodeName;
+
+    Factory(Configuration configuration, String serviceName, String nodeName) {
+      CollectorRegistry registry = configuration.getCollectorRegistry();
+      this.serverStarted = serverStartedBuilder.register(registry);
+      this.serverHandled = serverHandledBuilder.register(registry);
+      this.serverStreamMessagesReceived = serverStreamMessagesReceivedBuilder.register(registry);
+      this.serverStreamMessagesSent = serverStreamMessagesSentBuilder.register(registry);
+
+      this.serviceName = serviceName;
+      this.nodeName = nodeName;
+
+      if (configuration.isIncludeLatencyHistograms()) {
+        this.serverHandledLatencySeconds = Optional.of(serverHandledLatencySecondsBuilder
+            .buckets(configuration.getLatencyBuckets())
+            .register(registry));
+      } else {
+        this.serverHandledLatencySeconds = Optional.empty();
+      }
+    }
+
+    /** Creates a {@link com.yelp.nrtsearch.server.monitoring.ServerMetrics} for the supplied method. */
+    <R, S> com.yelp.nrtsearch.server.monitoring.ServerMetrics createMetricsForMethod(MethodDescriptor<R, S> methodDescriptor) {
+      return new com.yelp.nrtsearch.server.monitoring.ServerMetrics(
+          com.yelp.nrtsearch.server.monitoring.GrpcMethod.of(methodDescriptor),
+          serverStarted,
+          serverHandled,
+          serverStreamMessagesReceived,
+          serverStreamMessagesSent,
+          serverHandledLatencySeconds,
+          serviceName,
+          nodeName
+      );
+    }
+  }
+
+  private <T> T addLabels(SimpleCollector<T> collector, String... labels) {
+    List<String> allLabels = new ArrayList<>();
+    Collections.addAll(allLabels, method.type(), method.serviceName(), method.methodName(),
+        serviceName, nodeName);
+    Collections.addAll(allLabels, labels);
+    return collector.labels(allLabels.toArray(new String[0]));
+  }
+}
+

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/ServerMetrics.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/ServerMetrics.java
@@ -1,9 +1,19 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.yelp.nrtsearch.server.monitoring;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 
 import io.grpc.MethodDescriptor;
 import io.grpc.Status.Code;
@@ -11,27 +21,33 @@ import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Histogram;
 import io.prometheus.client.SimpleCollector;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Prometheus metric definitions used for server-side monitoring of grpc services.
  *
- * Instances of this class hold the counters we increment for a specific pair of grpc service
+ * <p>Instances of this class hold the counters we increment for a specific pair of grpc service
  * definition and collection registry.
  */
 class ServerMetrics {
-  private static final Counter.Builder serverStartedBuilder = Counter.build()
-      .namespace("grpc")
-      .subsystem("server")
-      .name("started_total")
-      .labelNames("grpc_type", "grpc_service", "grpc_method", "serviceName", "nodeName")
-      .help("Total number of RPCs started on the server.");
+  private static final Counter.Builder serverStartedBuilder =
+      Counter.build()
+          .namespace("grpc")
+          .subsystem("server")
+          .name("started_total")
+          .labelNames("grpc_type", "grpc_service", "grpc_method", "serviceName", "nodeName")
+          .help("Total number of RPCs started on the server.");
 
-  private static final Counter.Builder serverHandledBuilder = Counter.build()
-      .namespace("grpc")
-      .subsystem("server")
-      .name("handled_total")
-      .labelNames("grpc_type", "grpc_service", "grpc_method", "serviceName", "nodeName", "code")
-      .help("Total number of RPCs completed on the server, regardless of success or failure.");
+  private static final Counter.Builder serverHandledBuilder =
+      Counter.build()
+          .namespace("grpc")
+          .subsystem("server")
+          .name("handled_total")
+          .labelNames("grpc_type", "grpc_service", "grpc_method", "serviceName", "nodeName", "code")
+          .help("Total number of RPCs completed on the server, regardless of success or failure.");
 
   private static final Histogram.Builder serverHandledLatencySecondsBuilder =
       Histogram.build()
@@ -39,22 +55,25 @@ class ServerMetrics {
           .subsystem("server")
           .name("handled_latency_seconds")
           .labelNames("grpc_type", "grpc_service", "grpc_method", "serviceName", "nodeName")
-          .help("Histogram of response latency (seconds) of gRPC that had been application-level " +
-              "handled by the server.");
+          .help(
+              "Histogram of response latency (seconds) of gRPC that had been application-level "
+                  + "handled by the server.");
 
-  private static final Counter.Builder serverStreamMessagesReceivedBuilder = Counter.build()
-      .namespace("grpc")
-      .subsystem("server")
-      .name("msg_received_total")
-      .labelNames("grpc_type", "grpc_service", "grpc_method", "serviceName", "nodeName")
-      .help("Total number of stream messages received from the client.");
+  private static final Counter.Builder serverStreamMessagesReceivedBuilder =
+      Counter.build()
+          .namespace("grpc")
+          .subsystem("server")
+          .name("msg_received_total")
+          .labelNames("grpc_type", "grpc_service", "grpc_method", "serviceName", "nodeName")
+          .help("Total number of stream messages received from the client.");
 
-  private static final Counter.Builder serverStreamMessagesSentBuilder = Counter.build()
-      .namespace("grpc")
-      .subsystem("server")
-      .name("msg_sent_total")
-      .labelNames("grpc_type", "grpc_service", "grpc_method", "serviceName", "nodeName")
-      .help("Total number of stream messages sent by the server.");
+  private static final Counter.Builder serverStreamMessagesSentBuilder =
+      Counter.build()
+          .namespace("grpc")
+          .subsystem("server")
+          .name("msg_sent_total")
+          .labelNames("grpc_type", "grpc_service", "grpc_method", "serviceName", "nodeName")
+          .help("Total number of stream messages sent by the server.");
 
   private final Counter serverStarted;
   private final Counter serverHandled;
@@ -75,8 +94,7 @@ class ServerMetrics {
       Counter serverStreamMessagesSent,
       Optional<Histogram> serverHandledLatencySeconds,
       String serviceName,
-      String nodeName
-  ) {
+      String nodeName) {
     this.method = method;
     this.serverStarted = serverStarted;
     this.serverHandled = serverHandled;
@@ -115,7 +133,8 @@ class ServerMetrics {
   }
 
   /**
-   * Knows how to produce {@link com.yelp.nrtsearch.server.monitoring.ServerMetrics} instances for individual methods.
+   * Knows how to produce {@link com.yelp.nrtsearch.server.monitoring.ServerMetrics} instances for
+   * individual methods.
    */
   static class Factory {
     private final Counter serverStarted;
@@ -138,16 +157,21 @@ class ServerMetrics {
       this.nodeName = nodeName;
 
       if (configuration.isIncludeLatencyHistograms()) {
-        this.serverHandledLatencySeconds = Optional.of(serverHandledLatencySecondsBuilder
-            .buckets(configuration.getLatencyBuckets())
-            .register(registry));
+        this.serverHandledLatencySeconds =
+            Optional.of(
+                serverHandledLatencySecondsBuilder
+                    .buckets(configuration.getLatencyBuckets())
+                    .register(registry));
       } else {
         this.serverHandledLatencySeconds = Optional.empty();
       }
     }
 
-    /** Creates a {@link com.yelp.nrtsearch.server.monitoring.ServerMetrics} for the supplied method. */
-    <R, S> com.yelp.nrtsearch.server.monitoring.ServerMetrics createMetricsForMethod(MethodDescriptor<R, S> methodDescriptor) {
+    /**
+     * Creates a {@link com.yelp.nrtsearch.server.monitoring.ServerMetrics} for the supplied method.
+     */
+    <R, S> com.yelp.nrtsearch.server.monitoring.ServerMetrics createMetricsForMethod(
+        MethodDescriptor<R, S> methodDescriptor) {
       return new com.yelp.nrtsearch.server.monitoring.ServerMetrics(
           com.yelp.nrtsearch.server.monitoring.GrpcMethod.of(methodDescriptor),
           serverStarted,
@@ -156,17 +180,15 @@ class ServerMetrics {
           serverStreamMessagesSent,
           serverHandledLatencySeconds,
           serviceName,
-          nodeName
-      );
+          nodeName);
     }
   }
 
   private <T> T addLabels(SimpleCollector<T> collector, String... labels) {
     List<String> allLabels = new ArrayList<>();
-    Collections.addAll(allLabels, method.type(), method.serviceName(), method.methodName(),
-        serviceName, nodeName);
+    Collections.addAll(
+        allLabels, method.type(), method.serviceName(), method.methodName(), serviceName, nodeName);
     Collections.addAll(allLabels, labels);
     return collector.labels(allLabels.toArray(new String[0]));
   }
 }
-

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/GrpcServer.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/GrpcServer.java
@@ -20,6 +20,8 @@ import com.google.protobuf.util.JsonFormat;
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.luceneserver.GlobalState;
 import com.yelp.nrtsearch.server.luceneserver.RestoreStateHandler;
+import com.yelp.nrtsearch.server.monitoring.Configuration;
+import com.yelp.nrtsearch.server.monitoring.LuceneServerMonitoringServerInterceptor;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.utils.Archiver;
 import io.grpc.ManagedChannel;
@@ -42,8 +44,6 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-import me.dinowernli.grpc.prometheus.Configuration;
-import me.dinowernli.grpc.prometheus.MonitoringServerInterceptor;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.junit.rules.TemporaryFolder;
@@ -210,9 +210,13 @@ public class GrpcServer {
                 .build()
                 .start();
       } else {
-        MonitoringServerInterceptor monitoringInterceptor =
-            MonitoringServerInterceptor.create(
-                Configuration.allMetrics().withCollectorRegistry(collectorRegistry));
+        String serviceName = configuration.getServiceName();
+        String nodeName = configuration.getNodeName();
+        LuceneServerMonitoringServerInterceptor monitoringInterceptor =
+            LuceneServerMonitoringServerInterceptor.create(
+                Configuration.allMetrics().withCollectorRegistry(collectorRegistry),
+                serviceName,
+                nodeName);
         // Create a server, add service, start, and register for automatic graceful shutdown.
         server =
             ServerBuilder.forPort(port)


### PR DESCRIPTION
**Summary**
serviceName and nodeName are now dimensions in `/status/metrics`:
```grpc_server_handled_latency_seconds_count{grpc_type="UNARY",grpc_service="luceneserver.LuceneServer",grpc_method="metrics",serviceName="nrtsearch-generic",nodeName="lucene_server",} 3.0```

**Changes**
Most files are copy-pasted from me.dinowernli:java-grpc-prometheus. Classes in `java-grpc-prometheus` could not be extended because of classes being package private (e.g. `ServerMetrics`) and no default constructors being available (e.g. `LuceneServerMonitoringServerInterceptor`). me.dinowernli:java-grpc-prometheus is [under Apache 2.0 License](https://github.com/grpc-ecosystem/java-grpc-prometheus/blob/master/LICENSE).