### PR TITLE
add facets

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
@@ -359,7 +359,7 @@ enum FacetType {
     FLAT = 1; //Facets are indexed with no hierarchy.
     HIERARCHY = 2; //Facets are indexed and are hierarchical.
     NUMERIC_RANGE = 3; //Compute facet counts for custom numeric ranges
-    SORTED_SET_DOC_VALUES = 4; //"Use SortedSetDocValuesFacetCounts, which must be flat but don't require a taxonomy index
+    SORTED_SET_DOC_VALUES = 4; //Uses SortedSetDocValuesFacetCounts, which must be flat but don't require a taxonomy index
 }
 
 message Field {
@@ -452,8 +452,14 @@ message AddDocumentRequest {
     //we use this wrapper object to represent each field as a multivalued field.
     message MultiValuedField {
         repeated string value = 1; //list of values for this field
+        //Facet paths/hierarchy to bucket these values by, if indexed field is of type Facet.HIERARCHY
+        repeated FacetHierarchyPath faceHierarchyPaths = 2;
     }
     map<string, MultiValuedField> fields = 3; //map of field name to a list of string values.
+}
+
+message FacetHierarchyPath {
+    repeated string value = 1;
 }
 
 message AddDocumentResponse {

--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -174,7 +174,7 @@ enum QueryType {
 
 // Defines a full query consisting of a QueryNode which may be one of several types.
 message Query {
-    QueryType queryType = 1 [deprecated=true]; // no longer needed, type inferred from set QueryNode
+    QueryType queryType = 1 [deprecated = true]; // no longer needed, type inferred from set QueryNode
     float boost = 2; // Boost values that are less than one will give less importance to this query compared to other ones while values that are greater than one will give more importance to the scores returned by this query. Boost value of zero will do nothing (default). Boost less than 0 is invalid.
 
     oneof QueryNode {
@@ -209,7 +209,7 @@ message SearchRequest {
         string snapshot = 12; //Search a snapshot previously created with #createSnapshot
     }
     int32 totalHitsThreshold = 13; //By default we count hits accurately up to 1000. This makes sure that we don't spend most time on computing hit counts
-
+    repeated Facet facets = 14; // Which facets to retrieve
 }
 
 /* Virtual field used during search */
@@ -336,4 +336,36 @@ message SearchResponse {
     TotalHits totalHits = 3;
     repeated Hit hits = 4;
     SearchState searchState = 5;
+    repeated FacetResult facetResult = 6; ////Counts or aggregates for a single dimension
+}
+
+message NumericRangeType {
+    string label = 1; //Label for this range
+    int64 min = 2; //Min value for the range
+    bool minInclusive = 3; //True if the min value is inclusive
+    int64 max = 4; //Max value for the range
+    bool maxInclusive = 5; //True if the max value is inclusive
+}
+
+message Facet {
+    string dim = 1; //Dimension (field)
+    repeated string paths = 2; //Prefix path to facet 'under'
+    repeated NumericRangeType numericRange = 3; //Custom numeric ranges.  Field must be indexed with facet=numericRange.
+    bool useOrdsCache = 4; // True if the ordinals cache should be used
+    repeated string labels = 5; // Specific facet lables to retrieve
+    int32 topN = 6; //How many top facets to return
+}
+
+
+message FacetResult {
+    string dim = 1; //Dimension that was requested
+    repeated string path = 2; //Path whose children were requested.
+    double value = 3; //Total value for this path (sum of all child counts, or sum of all child values), even those not included in the topN.
+    repeated LabelAndValue labelValues = 4; // Child counts.
+    int64 childCount = 5; //How many child labels were encountered.
+}
+
+message LabelAndValue {
+    string label = 1; //Facet's label.
+    double value = 2; // Value associated with this label.
 }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/RegisterFieldsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/RegisterFieldsHandler.java
@@ -162,10 +162,14 @@ public class RegisterFieldsHandler implements Handler<FieldDefRequest, FieldDefR
         if (indexableFieldDef.isMultiValue()) {
           indexState.facetsConfig.setMultiValued(fieldName, true);
         }
-        indexState.facetsConfig.setIndexFieldName(fieldName, currentField.getFacetIndexFieldName());
+        // set indexFieldName for HIERARCHY (TAXO), SORTED_SET_DOC_VALUE and FLAT  facet
+        String facetFieldName =
+            currentField.getFacetIndexFieldName().isEmpty()
+                ? String.format("$_%s", currentField.getName())
+                : currentField.getFacetIndexFieldName();
+        indexState.facetsConfig.setIndexFieldName(fieldName, facetFieldName);
       }
     }
-
     // nocommit facetsConfig.setRequireDimCount
     logger.info("REGISTER: " + fieldName + " -> " + fieldDef);
     return fieldDef;

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
@@ -350,8 +350,11 @@ public class SearchHandler implements Handler<SearchRequest, SearchResponse> {
                 s,
                 shardState,
                 queryFields,
-                grpcFacetResults);
-        drillS.search(ddq, collectorManager);
+                grpcFacetResults,
+                threadPoolExecutor);
+        DrillSideways.ConcurrentDrillSidewaysResult<? extends TopDocs>
+            concurrentDrillSidewaysResult = drillS.search(ddq, collectorManager);
+        topDocs = concurrentDrillSidewaysResult.collectorResult;
         searchResponse.addAllFacetResult(grpcFacetResults);
       } else {
         try {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/facet/DrillSidewaysImpl.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/facet/DrillSidewaysImpl.java
@@ -330,12 +330,6 @@ public class DrillSidewaysImpl extends DrillSideways {
               String.format("each facet request must have either topN or labels"));
         }
       }
-      //
-      //            if (facetResult == null) {
-      //                facetResults.add(null);
-      //            } else {
-      //                facetResults.add(buildFacetResultJSON(facetResult));
-      //            }
       if (facetResult != null) {
         grpcFacetResults.add(buildFacetResultGrpc(facetResult));
       }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/facet/DrillSidewaysImpl.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/facet/DrillSidewaysImpl.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import org.apache.lucene.facet.DrillSideways;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.Facets;
@@ -73,8 +74,9 @@ public class DrillSidewaysImpl extends DrillSideways {
       SearcherTaxonomyManager.SearcherAndTaxonomy searcherAndTaxonomyManager,
       ShardState shardState,
       Map<String, FieldDef> dynamicFields,
-      List<com.yelp.nrtsearch.server.grpc.FacetResult> grpcFacetResults) {
-    super(searcher, config, taxoReader);
+      List<com.yelp.nrtsearch.server.grpc.FacetResult> grpcFacetResults,
+      ExecutorService executorService) {
+    super(searcher, config, taxoReader, null, executorService);
     this.grpcFacets = grpcFacets;
     this.searcherAndTaxonomyManager = searcherAndTaxonomyManager;
     this.shardState = shardState;
@@ -294,7 +296,7 @@ public class DrillSidewaysImpl extends DrillSideways {
                       shardState.getOrdsCache(indexFieldName),
                       searcherAndTaxonomyManager.taxonomyReader,
                       indexState.facetsConfig,
-                      c);
+                      drillDowns);
             } else {
               luceneFacets =
                   new FastTaxonomyFacetCounts(

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/facet/DrillSidewaysImpl.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/facet/DrillSidewaysImpl.java
@@ -180,9 +180,14 @@ public class DrillSidewaysImpl extends DrillSideways {
                   0,
                   indexableFieldDef.getName(),
                   facet.getPathsList().toArray(new String[facet.getPathsCount()]));
-        } else if (indexableFieldDef instanceof FloatFieldDef
-            || indexableFieldDef
-                instanceof DoubleFieldDef) { // TODO  this should allow VirtualFieldDef to
+        } else if (indexableFieldDef instanceof FloatFieldDef) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "field %s is of type float with FloatFieldDocValues which do not support numeric_range faceting",
+                  indexableFieldDef.getName()));
+
+        } else if (indexableFieldDef
+            instanceof DoubleFieldDef) { // TODO  this should allow VirtualFieldDef to
           List<NumericRangeType> rangeList = facet.getNumericRangeList();
           DoubleRange[] ranges = new DoubleRange[rangeList.size()];
           for (int i = 0; i < ranges.length; i++) {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/facet/DrillSidewaysImpl.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/facet/DrillSidewaysImpl.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.facet;
+
+import com.google.protobuf.ProtocolStringList;
+import com.yelp.nrtsearch.server.grpc.Facet;
+import com.yelp.nrtsearch.server.grpc.NumericRangeType;
+import com.yelp.nrtsearch.server.luceneserver.IndexState;
+import com.yelp.nrtsearch.server.luceneserver.ShardState;
+import com.yelp.nrtsearch.server.luceneserver.field.DoubleFieldDef;
+import com.yelp.nrtsearch.server.luceneserver.field.FieldDef;
+import com.yelp.nrtsearch.server.luceneserver.field.FloatFieldDef;
+import com.yelp.nrtsearch.server.luceneserver.field.IndexableFieldDef;
+import com.yelp.nrtsearch.server.luceneserver.field.IntFieldDef;
+import com.yelp.nrtsearch.server.luceneserver.field.LongFieldDef;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.lucene.facet.DrillSideways;
+import org.apache.lucene.facet.FacetResult;
+import org.apache.lucene.facet.Facets;
+import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsConfig;
+import org.apache.lucene.facet.LabelAndValue;
+import org.apache.lucene.facet.range.DoubleRange;
+import org.apache.lucene.facet.range.DoubleRangeFacetCounts;
+import org.apache.lucene.facet.range.LongRange;
+import org.apache.lucene.facet.range.LongRangeFacetCounts;
+import org.apache.lucene.facet.sortedset.SortedSetDocValuesFacetCounts;
+import org.apache.lucene.facet.taxonomy.FastTaxonomyFacetCounts;
+import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager;
+import org.apache.lucene.facet.taxonomy.TaxonomyFacetCounts;
+import org.apache.lucene.facet.taxonomy.TaxonomyReader;
+import org.apache.lucene.search.IndexSearcher;
+
+public class DrillSidewaysImpl extends DrillSideways {
+  private final List<Facet> grpcFacets;
+  private final SearcherTaxonomyManager.SearcherAndTaxonomy searcherAndTaxonomyManager;
+  private final ShardState shardState;
+  private final Map<String, FieldDef> dynamicFields;
+  private final List<com.yelp.nrtsearch.server.grpc.FacetResult> grpcFacetResults;
+
+  /**
+   * @param searcher
+   * @param config
+   * @param taxoReader
+   * @param grpcFacets
+   * @param searcherAndTaxonomyManager
+   * @param shardState
+   * @param dynamicFields
+   */
+  public DrillSidewaysImpl(
+      IndexSearcher searcher,
+      FacetsConfig config,
+      TaxonomyReader taxoReader,
+      List<Facet> grpcFacets,
+      SearcherTaxonomyManager.SearcherAndTaxonomy searcherAndTaxonomyManager,
+      ShardState shardState,
+      Map<String, FieldDef> dynamicFields,
+      List<com.yelp.nrtsearch.server.grpc.FacetResult> grpcFacetResults) {
+    super(searcher, config, taxoReader);
+    this.grpcFacets = grpcFacets;
+    this.searcherAndTaxonomyManager = searcherAndTaxonomyManager;
+    this.shardState = shardState;
+    this.dynamicFields = dynamicFields;
+    this.grpcFacetResults = grpcFacetResults;
+  }
+
+  protected Facets buildFacetsResult(
+      FacetsCollector drillDowns, FacetsCollector[] drillSideways, String[] drillSidewaysDims)
+      throws IOException {
+    fillFacetResults(
+        drillDowns,
+        drillSideways,
+        drillSidewaysDims,
+        shardState,
+        grpcFacets,
+        dynamicFields,
+        searcherAndTaxonomyManager,
+        grpcFacetResults);
+    return null;
+  }
+
+  static void fillFacetResults(
+      FacetsCollector drillDowns,
+      FacetsCollector[] drillSideways,
+      String[] drillSidewaysDims,
+      ShardState shardState,
+      List<Facet> grpcFacets,
+      Map<String, FieldDef> dynamicFields,
+      SearcherTaxonomyManager.SearcherAndTaxonomy searcherAndTaxonomyManager,
+      List<com.yelp.nrtsearch.server.grpc.FacetResult> grpcFacetResults)
+      throws IOException {
+
+    IndexState indexState = shardState.indexState;
+
+    Map<String, FacetsCollector> dsDimMap = new HashMap<String, FacetsCollector>();
+    if (drillSidewaysDims != null) {
+      for (int i = 0; i < drillSidewaysDims.length; i++) {
+        dsDimMap.put(drillSidewaysDims[i], drillSideways[i]);
+      }
+    }
+
+    // Holds already computed Facets, since more
+    // than one dimension can share a single
+    // index field name.  We need one map for "normal" and
+    // another for SSDV facets because an app can index both
+    // into the same Lucene field (this is the default):
+    Map<String, Facets> indexFieldNameToFacets = new HashMap<String, Facets>();
+    Map<String, Facets> indexFieldNameToSSDVFacets = new HashMap<String, Facets>();
+
+    for (Facet facet : grpcFacets) {
+      String fieldName = facet.getDim();
+      FieldDef fd = dynamicFields.get(fieldName);
+      if (fd == null) {
+        throw new IllegalArgumentException(
+            String.format(
+                "field %s was not registered and was not specified as a dynamic field ",
+                fieldName));
+      }
+
+      FacetResult facetResult;
+      if (!(fd instanceof IndexableFieldDef)) { // TODO: Also enable facet support in Virtual Fields
+        throw new IllegalArgumentException(
+            String.format(
+                "field % not registered as an indexable field. Facets applicable only to indexable fields",
+                fieldName));
+      }
+      IndexableFieldDef indexableFieldDef = (IndexableFieldDef) fd;
+      if (!facet.getNumericRangeList().isEmpty()) {
+
+        if (indexableFieldDef.getFacetValueType()
+            != IndexableFieldDef.FacetValueType.NUMERIC_RANGE) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "field %s was not registered with facet=numericRange",
+                  indexableFieldDef.getName()));
+        }
+        if (indexableFieldDef instanceof IntFieldDef || indexableFieldDef instanceof LongFieldDef) {
+          List<NumericRangeType> rangeList = facet.getNumericRangeList();
+          LongRange[] ranges = new LongRange[rangeList.size()];
+          for (int i = 0; i < ranges.length; i++) {
+            NumericRangeType numericRangeType = rangeList.get(i);
+            ranges[i] =
+                new LongRange(
+                    numericRangeType.getLabel(),
+                    numericRangeType.getMin(),
+                    numericRangeType.getMinInclusive(),
+                    numericRangeType.getMax(),
+                    numericRangeType.getMaxInclusive());
+          }
+
+          FacetsCollector c = dsDimMap.get(indexableFieldDef.getName());
+          if (c == null) {
+            c = drillDowns;
+          }
+
+          LongRangeFacetCounts longRangeFacetCounts =
+              new LongRangeFacetCounts(indexableFieldDef.getName(), c, ranges);
+          facetResult =
+              longRangeFacetCounts.getTopChildren(
+                  0,
+                  indexableFieldDef.getName(),
+                  facet.getPathsList().toArray(new String[facet.getPathsCount()]));
+        } else if (indexableFieldDef instanceof FloatFieldDef
+            || indexableFieldDef
+                instanceof DoubleFieldDef) { // TODO  this should allow VirtualFieldDef to
+          List<NumericRangeType> rangeList = facet.getNumericRangeList();
+          DoubleRange[] ranges = new DoubleRange[rangeList.size()];
+          for (int i = 0; i < ranges.length; i++) {
+            NumericRangeType numericRangeType = rangeList.get(i);
+            ranges[i] =
+                new DoubleRange(
+                    numericRangeType.getLabel(),
+                    numericRangeType.getMin(),
+                    numericRangeType.getMinInclusive(),
+                    numericRangeType.getMax(),
+                    numericRangeType.getMaxInclusive());
+          }
+
+          FacetsCollector c = dsDimMap.get(indexableFieldDef.getName());
+          if (c == null) {
+            c = drillDowns;
+          }
+
+          DoubleRangeFacetCounts doubleRangeFacetCounts =
+              new DoubleRangeFacetCounts(
+                  indexableFieldDef.getName(),
+                  c, // TODO: for VirtualFieldDef pass valueSource here
+                  ranges);
+          facetResult =
+              doubleRangeFacetCounts.getTopChildren(
+                  0,
+                  indexableFieldDef.getName(),
+                  facet.getPathsList().toArray(new String[facet.getPathsCount()]));
+        } else {
+          throw new IllegalArgumentException(
+              String.format(
+                  "numericRanges must be provided only on field type numeric e.g. int, double, flat"));
+        }
+      } else if (indexableFieldDef.getFacetValueType()
+          == IndexableFieldDef.FacetValueType.SORTED_SET_DOC_VALUES) {
+        FacetsCollector c = dsDimMap.get(indexableFieldDef.getName());
+        if (c == null) {
+          c = drillDowns;
+        }
+        SortedSetDocValuesFacetCounts sortedSetDocValuesFacetCounts =
+            new SortedSetDocValuesFacetCounts(
+                shardState.getSSDVState(searcherAndTaxonomyManager, indexableFieldDef), c);
+        facetResult =
+            sortedSetDocValuesFacetCounts.getTopChildren(
+                facet.getTopN(), indexableFieldDef.getName(), new String[0]);
+      } else {
+
+        // Taxonomy  facets
+        if (indexableFieldDef.getFacetValueType() == IndexableFieldDef.FacetValueType.NO_FACETS) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "%s was not registered with facet enabled", indexableFieldDef.getName()));
+        } else if (indexableFieldDef.getFacetValueType()
+            == IndexableFieldDef.FacetValueType.NUMERIC_RANGE) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "%s was registered with facet = numericRange; must pass numericRanges in the request",
+                  indexableFieldDef.getName()));
+        }
+
+        String[] path;
+        if (!facet.getPathsList().isEmpty()) {
+          ProtocolStringList pathList = facet.getPathsList();
+          path = new String[facet.getPathsList().size()];
+          for (int idx = 0; idx < path.length; idx++) {
+            path[idx] = pathList.get(idx);
+          }
+        } else {
+          path = new String[0];
+        }
+
+        FacetsCollector c = dsDimMap.get(indexableFieldDef.getName());
+        boolean useCachedOrds = facet.getUseOrdsCache();
+
+        Facets luceneFacets;
+        if (c != null) {
+          // This dimension was used in
+          // drill-down; compute its facet counts from the
+          // drill-sideways collector:
+          String indexFieldName =
+              indexState.facetsConfig.getDimConfig(indexableFieldDef.getName()).indexFieldName;
+          if (useCachedOrds) {
+            luceneFacets =
+                new TaxonomyFacetCounts(
+                    shardState.getOrdsCache(indexFieldName),
+                    searcherAndTaxonomyManager.taxonomyReader,
+                    indexState.facetsConfig,
+                    c);
+          } else {
+            luceneFacets =
+                new FastTaxonomyFacetCounts(
+                    indexFieldName,
+                    searcherAndTaxonomyManager.taxonomyReader,
+                    indexState.facetsConfig,
+                    c);
+          }
+        } else {
+
+          // nocommit test both normal & ssdv facets in same index
+
+          // See if we already computed facet
+          // counts for this indexFieldName:
+          String indexFieldName =
+              indexState.facetsConfig.getDimConfig(indexableFieldDef.getName()).indexFieldName;
+          Map<String, Facets> facetsMap = indexFieldNameToFacets;
+          luceneFacets = facetsMap.get(indexFieldName);
+          if (luceneFacets == null) {
+            if (useCachedOrds) {
+              luceneFacets =
+                  new TaxonomyFacetCounts(
+                      shardState.getOrdsCache(indexFieldName),
+                      searcherAndTaxonomyManager.taxonomyReader,
+                      indexState.facetsConfig,
+                      c);
+            } else {
+              luceneFacets =
+                  new FastTaxonomyFacetCounts(
+                      indexFieldName,
+                      searcherAndTaxonomyManager.taxonomyReader,
+                      indexState.facetsConfig,
+                      drillDowns);
+            }
+            facetsMap.put(indexFieldName, luceneFacets);
+          }
+        }
+        if (facet.getTopN() != 0) {
+          facetResult =
+              luceneFacets.getTopChildren(facet.getTopN(), indexableFieldDef.getName(), path);
+        } else if (!facet.getLabelsList().isEmpty()) {
+          List<LabelAndValue> results = new ArrayList<LabelAndValue>();
+          for (String label : facet.getLabelsList()) {
+            results.add(
+                new LabelAndValue(
+                    label, luceneFacets.getSpecificValue(indexableFieldDef.getName(), label)));
+          }
+          facetResult =
+              new FacetResult(
+                  indexableFieldDef.getName(),
+                  path,
+                  -1,
+                  results.toArray(new LabelAndValue[results.size()]),
+                  -1);
+        } else {
+          throw new IllegalArgumentException(
+              String.format("each facet request must have either topN or labels"));
+        }
+      }
+      //
+      //            if (facetResult == null) {
+      //                facetResults.add(null);
+      //            } else {
+      //                facetResults.add(buildFacetResultJSON(facetResult));
+      //            }
+      if (facetResult != null) {
+        grpcFacetResults.add(buildFacetResultGrpc(facetResult));
+      }
+    }
+  }
+
+  private static com.yelp.nrtsearch.server.grpc.FacetResult buildFacetResultGrpc(
+      FacetResult facetResult) {
+    var builder = com.yelp.nrtsearch.server.grpc.FacetResult.newBuilder();
+    builder.setDim(facetResult.dim);
+    builder.addAllPath(Arrays.asList(facetResult.path));
+    builder.setValue(facetResult.value.doubleValue());
+    builder.setChildCount(facetResult.childCount);
+    List<com.yelp.nrtsearch.server.grpc.LabelAndValue> labelAndValues = new ArrayList<>();
+    for (LabelAndValue labelValue : facetResult.labelValues) {
+      var labelAndValue =
+          com.yelp.nrtsearch.server.grpc.LabelAndValue.newBuilder()
+              .setLabel(labelValue.label)
+              .setValue(labelValue.value.doubleValue())
+              .build();
+      labelAndValues.add(labelAndValue);
+    }
+    builder.addAllLabelValues(labelAndValues);
+    return builder.build();
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/BooleanFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/BooleanFieldDef.java
@@ -87,7 +87,8 @@ public class BooleanFieldDef extends IndexableFieldDef {
   }
 
   @Override
-  public void parseDocumentField(Document document, List<String> fieldValues) {
+  public void parseDocumentField(
+      Document document, List<String> fieldValues, List<List<String>> facetHierarchyPaths) {
     if (fieldValues.size() > 1 && !isMultiValue()) {
       throw new IllegalArgumentException("Cannot index multiple values into single value field");
     }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/BooleanFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/BooleanFieldDef.java
@@ -69,7 +69,9 @@ public class BooleanFieldDef extends IndexableFieldDef {
 
   protected FacetValueType parseFacetValueType(Field requestField) {
     if (requestField.getFacet() == FacetType.HIERARCHY
-        || requestField.getFacet() == FacetType.NUMERIC_RANGE) {
+        || requestField.getFacet() == FacetType.NUMERIC_RANGE
+        || requestField.getFacet() == FacetType.SORTED_SET_DOC_VALUES
+        || requestField.getFacet() == FacetType.FLAT) {
       throw new IllegalArgumentException("unsupported facet type: " + requestField.getFacet());
     }
     return FacetValueType.NO_FACETS;

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/DateTimeFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/DateTimeFieldDef.java
@@ -191,7 +191,8 @@ public class DateTimeFieldDef extends IndexableFieldDef implements Sortable, Ran
   }
 
   @Override
-  public void parseDocumentField(Document document, List<String> fieldValues) {
+  public void parseDocumentField(
+      Document document, List<String> fieldValues, List<List<String>> facetHierarchyPaths) {
     if (fieldValues.size() > 1 && !isMultiValue()) {
       throw new IllegalArgumentException("Cannot index multiple values into single value field");
     }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/FloatFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/FloatFieldDef.java
@@ -20,7 +20,7 @@ import com.yelp.nrtsearch.server.grpc.RangeQuery;
 import com.yelp.nrtsearch.server.grpc.TermInSetQuery;
 import com.yelp.nrtsearch.server.grpc.TermQuery;
 import com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues;
-import org.apache.lucene.document.FloatDocValuesField;
+import org.apache.lucene.document.DoubleDocValuesField;
 import org.apache.lucene.document.FloatPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.DocValuesType;
@@ -42,7 +42,9 @@ public class FloatFieldDef extends NumberFieldDef {
   @Override
   protected org.apache.lucene.document.Field getDocValueField(Number fieldValue) {
     if (docValuesType == DocValuesType.NUMERIC) {
-      return new FloatDocValuesField(getName(), fieldValue.floatValue());
+      // FloatDocValuesField does not work with NUMERIC_RANGE facets hence we store the doc value as
+      // double here
+      return new DoubleDocValuesField(getName(), fieldValue.floatValue());
     } else if (docValuesType == DocValuesType.SORTED_NUMERIC) {
       return new SortedNumericDocValuesField(
           getName(), SORTED_FLOAT_ENCODER.applyAsLong(fieldValue));

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/FloatFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/FloatFieldDef.java
@@ -20,7 +20,7 @@ import com.yelp.nrtsearch.server.grpc.RangeQuery;
 import com.yelp.nrtsearch.server.grpc.TermInSetQuery;
 import com.yelp.nrtsearch.server.grpc.TermQuery;
 import com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues;
-import org.apache.lucene.document.DoubleDocValuesField;
+import org.apache.lucene.document.FloatDocValuesField;
 import org.apache.lucene.document.FloatPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.DocValuesType;
@@ -42,9 +42,7 @@ public class FloatFieldDef extends NumberFieldDef {
   @Override
   protected org.apache.lucene.document.Field getDocValueField(Number fieldValue) {
     if (docValuesType == DocValuesType.NUMERIC) {
-      // FloatDocValuesField does not work with NUMERIC_RANGE facets hence we store the doc value as
-      // double here
-      return new DoubleDocValuesField(getName(), fieldValue.floatValue());
+      return new FloatDocValuesField(getName(), fieldValue.floatValue());
     } else if (docValuesType == DocValuesType.SORTED_NUMERIC) {
       return new SortedNumericDocValuesField(
           getName(), SORTED_FLOAT_ENCODER.applyAsLong(fieldValue));

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/IndexableFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/IndexableFieldDef.java
@@ -236,8 +236,11 @@ public abstract class IndexableFieldDef extends FieldDef {
    *
    * @param document lucene document to be added to the index
    * @param fieldValues list of String encoded field values
+   * @param facetHierarchyPaths list of list of String encoded paths for each field value be
+   *     determine hierarchy for faceting
    */
-  public abstract void parseDocumentField(Document document, List<String> fieldValues);
+  public abstract void parseDocumentField(
+      Document document, List<String> fieldValues, List<List<String>> facetHierarchyPaths);
 
   /**
    * Get Similarity implementation that should be used for this field.

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/LatLonFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/LatLonFieldDef.java
@@ -73,7 +73,8 @@ public class LatLonFieldDef extends IndexableFieldDef implements Sortable {
   }
 
   @Override
-  public void parseDocumentField(Document document, List<String> fieldValues) {
+  public void parseDocumentField(
+      Document document, List<String> fieldValues, List<List<String>> facetHierarchyPaths) {
     // this field is technically multi valued, but we only allow it to have one right now
     if (fieldValues.size() != 2) {
       throw new IllegalArgumentException("lat_lon field requires two values to be provided");

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/NumberFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/NumberFieldDef.java
@@ -103,6 +103,11 @@ public abstract class NumberFieldDef extends IndexableFieldDef
         throw new IllegalArgumentException("facet=numericRange fields must have search=true");
       }
       return FacetValueType.NUMERIC_RANGE;
+    } else if (facetType.equals(FacetType.SORTED_SET_DOC_VALUES)) {
+      throw new IllegalArgumentException(
+          "facet=SORTED_SET_DOC_VALUES can work only for TEXT fields");
+    } else if (facetType.equals(FacetType.FLAT)) {
+      return FacetValueType.FLAT;
     }
     return FacetValueType.NO_FACETS;
   }
@@ -188,7 +193,7 @@ public abstract class NumberFieldDef extends IndexableFieldDef
   }
 
   private void addFacet(Document document, Number value) {
-    if (facetValueType == FacetValueType.HIERARCHY) {
+    if (facetValueType == FacetValueType.HIERARCHY || facetValueType == FacetValueType.FLAT) {
       String facetValue = value.toString();
       document.add(new FacetField(getName(), facetValue));
     }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/NumberFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/NumberFieldDef.java
@@ -172,7 +172,8 @@ public abstract class NumberFieldDef extends IndexableFieldDef
   protected abstract Number getSortMissingValue(boolean missingLast);
 
   @Override
-  public void parseDocumentField(Document document, List<String> fieldValues) {
+  public void parseDocumentField(
+      Document document, List<String> fieldValues, List<List<String>> facetHierarchyPaths) {
     if (fieldValues.size() > 1 && !isMultiValue()) {
       throw new IllegalArgumentException("Cannot index multiple values into single value field");
     }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/TextBaseFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/TextBaseFieldDef.java
@@ -31,6 +31,7 @@ import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.facet.FacetField;
+import org.apache.lucene.facet.sortedset.SortedSetDocValuesFacetField;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesType;
@@ -114,6 +115,10 @@ public abstract class TextBaseFieldDef extends IndexableFieldDef {
       return FacetValueType.HIERARCHY;
     } else if (facetType.equals(FacetType.NUMERIC_RANGE)) {
       throw new IllegalArgumentException("numericRange facets only applies to numeric types");
+    } else if (facetType.equals(FacetType.SORTED_SET_DOC_VALUES)) {
+      return FacetValueType.SORTED_SET_DOC_VALUES;
+    } else if (facetType.equals(FacetType.FLAT)) {
+      return FacetValueType.FLAT;
     }
     return FacetValueType.NO_FACETS;
   }
@@ -285,8 +290,11 @@ public abstract class TextBaseFieldDef extends IndexableFieldDef {
   }
 
   private void addFacet(Document document, String value) {
-    if (facetValueType == FacetValueType.HIERARCHY) {
+    if (facetValueType == FacetValueType.HIERARCHY || facetValueType == FacetValueType.FLAT) {
       document.add(new FacetField(getName(), value));
+    } else if (facetValueType == FacetValueType.SORTED_SET_DOC_VALUES) {
+      String facetValue = String.valueOf(value);
+      document.add(new SortedSetDocValuesFacetField(getName(), facetValue));
     }
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/LuceneServerTestConfigurationFactory.java
+++ b/src/test/java/com/yelp/nrtsearch/server/LuceneServerTestConfigurationFactory.java
@@ -15,24 +15,23 @@
  */
 package com.yelp.nrtsearch.server;
 
-import static com.yelp.nrtsearch.server.config.LuceneServerConfiguration.DEFAULT_USER_DIR;
-
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.Mode;
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class LuceneServerTestConfigurationFactory {
   static AtomicLong atomicLong = new AtomicLong();
 
-  public static LuceneServerConfiguration getConfig(Mode mode) {
+  public static LuceneServerConfiguration getConfig(Mode mode, File dataRootDir) {
     String dirNum = String.valueOf(atomicLong.addAndGet(1));
     if (mode.equals(Mode.STANDALONE)) {
       String stateDir =
-          Paths.get(DEFAULT_USER_DIR.toString(), "standalone", dirNum, "state").toString();
+          Paths.get(dataRootDir.getAbsolutePath(), "standalone", dirNum, "state").toString();
       String indexDir =
-          Paths.get(DEFAULT_USER_DIR.toString(), "standalone", dirNum, "index").toString();
+          Paths.get(dataRootDir.getAbsolutePath(), "standalone", dirNum, "index").toString();
       String config =
           String.join(
               "\n",
@@ -44,9 +43,9 @@ public class LuceneServerTestConfigurationFactory {
       return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
     } else if (mode.equals(Mode.PRIMARY)) {
       String stateDir =
-          Paths.get(DEFAULT_USER_DIR.toString(), "primary", dirNum, "state").toString();
+          Paths.get(dataRootDir.getAbsolutePath(), "primary", dirNum, "state").toString();
       String indexDir =
-          Paths.get(DEFAULT_USER_DIR.toString(), "primary", dirNum, "index").toString();
+          Paths.get(dataRootDir.getAbsolutePath(), "primary", dirNum, "index").toString();
       String config =
           String.join(
               "\n",
@@ -58,9 +57,9 @@ public class LuceneServerTestConfigurationFactory {
       return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
     } else if (mode.equals(Mode.REPLICA)) {
       String stateDir =
-          Paths.get(DEFAULT_USER_DIR.toString(), "replica", dirNum, "state").toString();
+          Paths.get(dataRootDir.getAbsolutePath(), "replica", dirNum, "state").toString();
       String indexDir =
-          Paths.get(DEFAULT_USER_DIR.toString(), "replica", dirNum, "index").toString();
+          Paths.get(dataRootDir.getAbsolutePath(), "replica", dirNum, "index").toString();
       String config =
           String.join(
               "\n",

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/BackupRestoreIndexRequestHandlerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/BackupRestoreIndexRequestHandlerTest.java
@@ -83,7 +83,7 @@ public class BackupRestoreIndexRequestHandlerTest {
 
   private GrpcServer setUpGrpcServer() throws IOException {
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE);
+        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     GlobalState globalState = new GlobalState(luceneServerConfiguration);
     return new GrpcServer(
         grpcCleanup,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/CustomFieldTypeTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/CustomFieldTypeTest.java
@@ -82,7 +82,7 @@ public class CustomFieldTypeTest {
   private GrpcServer setUpGrpcServer(CollectorRegistry collectorRegistry) throws IOException {
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE);
+        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     GlobalState globalState = new GlobalState(luceneServerConfiguration);
     return new GrpcServer(
         collectorRegistry,
@@ -116,7 +116,8 @@ public class CustomFieldTypeTest {
     }
 
     @Override
-    public void parseDocumentField(Document document, List<String> fieldValues) {
+    public void parseDocumentField(
+        Document document, List<String> fieldValues, List<List<String>> facetHierarchyPaths) {
       int val = Integer.parseInt(fieldValues.get(0)) + 10;
       org.apache.lucene.document.Field field = new NumericDocValuesField(getName(), val);
       document.add(field);

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -106,7 +106,7 @@ public class LuceneServerTest {
   private GrpcServer setUpGrpcServer(CollectorRegistry collectorRegistry) throws IOException {
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE);
+        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     GlobalState globalState = new GlobalState(luceneServerConfiguration);
     return new GrpcServer(
         collectorRegistry,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
@@ -72,7 +72,7 @@ public class QueryTest {
   private GrpcServer setUpGrpcServer() throws IOException {
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE);
+        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     GlobalState globalState = new GlobalState(luceneServerConfiguration);
     return new GrpcServer(
         grpcCleanup,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
@@ -94,7 +94,7 @@ public class ReplicationServerTest {
     // set up primary servers
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerPrimaryConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.PRIMARY);
+        LuceneServerTestConfigurationFactory.getConfig(Mode.PRIMARY, folder.getRoot());
     GlobalState globalStatePrimary = new GlobalState(luceneServerPrimaryConfiguration);
     luceneServerPrimary =
         new GrpcServer(
@@ -120,7 +120,7 @@ public class ReplicationServerTest {
             archiver);
     // set up secondary servers
     LuceneServerConfiguration luceneServerSecondaryConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.REPLICA);
+        LuceneServerTestConfigurationFactory.getConfig(Mode.REPLICA, folder.getRoot());
     GlobalState globalStateSecondary = new GlobalState(luceneServerSecondaryConfiguration);
 
     luceneServerSecondary =

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationTestFailureScenarios.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationTestFailureScenarios.java
@@ -97,7 +97,7 @@ public class ReplicationTestFailureScenarios {
 
   public void startPrimaryServer() throws IOException {
     LuceneServerConfiguration luceneServerPrimaryConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.PRIMARY);
+        LuceneServerTestConfigurationFactory.getConfig(Mode.PRIMARY, folder.getRoot());
     GlobalState globalStatePrimary = new GlobalState(luceneServerPrimaryConfiguration);
     luceneServerPrimary =
         new GrpcServer(
@@ -125,7 +125,7 @@ public class ReplicationTestFailureScenarios {
 
   public void startSecondaryServer() throws IOException {
     LuceneServerConfiguration luceneSecondaryConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.REPLICA);
+        LuceneServerTestConfigurationFactory.getConfig(Mode.REPLICA, folder.getRoot());
     GlobalState globalStateSecondary = new GlobalState(luceneSecondaryConfiguration);
 
     luceneServerSecondary =

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/SuggestTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/SuggestTest.java
@@ -76,7 +76,7 @@ public class SuggestTest {
   @Before
   public void setUp() throws IOException {
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE);
+        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     GlobalState globalState = new GlobalState(luceneServerConfiguration);
     grpcServer =
         new GrpcServer(

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/RestoreStateHandlerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/RestoreStateHandlerTest.java
@@ -64,7 +64,7 @@ public class RestoreStateHandlerTest {
         new ArchiverImpl(
             s3, BUCKET_NAME, archiverDirectory, new TarImpl(TarImpl.CompressionMode.LZ4));
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE);
+        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     globalState = new GlobalState(luceneServerConfiguration);
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/ServerTestCase.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/ServerTestCase.java
@@ -158,6 +158,7 @@ public class ServerTestCase {
       grpcServer.getGlobalState().close();
       grpcServer.shutdown();
       rmDir(Paths.get(grpcServer.getIndexDir()).getParent());
+      initialized = false;
     }
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/ServerTestCase.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/ServerTestCase.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver;
+
+import static com.yelp.nrtsearch.server.grpc.GrpcServer.rmDir;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import com.yelp.nrtsearch.server.LuceneServerTestConfigurationFactory;
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.AddDocumentResponse;
+import com.yelp.nrtsearch.server.grpc.CreateIndexRequest;
+import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
+import com.yelp.nrtsearch.server.grpc.GrpcServer;
+import com.yelp.nrtsearch.server.grpc.LuceneServerGrpc;
+import com.yelp.nrtsearch.server.grpc.Mode;
+import com.yelp.nrtsearch.server.grpc.RefreshRequest;
+import com.yelp.nrtsearch.server.grpc.StartIndexRequest;
+import com.yelp.nrtsearch.server.plugins.Plugin;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import io.prometheus.client.CollectorRegistry;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Base class for tests that want a lucene server that is setup once and used for all class tests.
+ * Protected methods may be overridden to specify arbitrary indices and add documents.
+ */
+public class ServerTestCase {
+  public static final String DEFAULT_TEST_INDEX = "test_index";
+  /**
+   * This rule manages automatic graceful shutdown for the registered servers and channels at the
+   * end of test.
+   */
+  @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+  /**
+   * This rule ensure the temporary folder which maintains indexes are cleaned up after each test
+   */
+  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+
+  private static GrpcServer grpcServer;
+  private static CollectorRegistry collectorRegistry;
+  private static GlobalState globalState;
+  private static boolean initialized = false;
+
+  public static GrpcServer getGrpcServer() {
+    return grpcServer;
+  }
+
+  public static CollectorRegistry getCollectorRegistry() {
+    return collectorRegistry;
+  }
+
+  public static GlobalState getGlobalState() {
+    return globalState;
+  }
+
+  public static FieldDefRequest getFieldsFromResourceFile(String resourceFileName)
+      throws IOException {
+    InputStream fileStream = ServerTestCase.class.getResourceAsStream(resourceFileName);
+    String jsonText =
+        new BufferedReader(new InputStreamReader(fileStream, StandardCharsets.UTF_8))
+            .lines()
+            .collect(Collectors.joining(System.lineSeparator()));
+    return getFieldsFromJson(jsonText);
+  }
+
+  public static FieldDefRequest getFieldsFromJson(String jsonStr) {
+    FieldDefRequest.Builder fieldDefRequestBuilder = FieldDefRequest.newBuilder();
+    try {
+      JsonFormat.parser().merge(jsonStr, fieldDefRequestBuilder);
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(e);
+    }
+    return fieldDefRequestBuilder.build();
+  }
+
+  public static AddDocumentResponse addDocuments(Stream<AddDocumentRequest> requestStream)
+      throws InterruptedException {
+    CountDownLatch finishLatch = new CountDownLatch(1);
+    // observers responses from Server(should get one onNext and oneCompleted)
+    final AtomicReference<AddDocumentResponse> response = new AtomicReference<>();
+    StreamObserver<AddDocumentResponse> responseStreamObserver =
+        new StreamObserver<>() {
+          @Override
+          public void onNext(AddDocumentResponse value) {
+            response.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            finishLatch.countDown();
+          }
+
+          @Override
+          public void onCompleted() {
+            finishLatch.countDown();
+          }
+        };
+    // requestObserver sends requests to Server (one onNext per AddDocumentRequest and one
+    // onCompleted)
+    StreamObserver<AddDocumentRequest> requestObserver =
+        grpcServer.getStub().addDocuments(responseStreamObserver);
+    // parse CSV into a stream of AddDocumentRequest
+    try {
+      requestStream.forEach(requestObserver::onNext);
+    } catch (RuntimeException e) {
+      // Cancel RPC
+      requestObserver.onError(e);
+      throw e;
+    }
+    // Mark the end of requests
+    requestObserver.onCompleted();
+    // Receiving happens asynchronously, so block here 20 seconds
+    if (!finishLatch.await(20, TimeUnit.SECONDS)) {
+      throw new RuntimeException("addDocuments can not finish within 20 seconds");
+    }
+    return response.get();
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws IOException {
+    tearDownGrpcServer();
+  }
+
+  private static void tearDownGrpcServer() throws IOException {
+    if (initialized) {
+      grpcServer.getGlobalState().close();
+      grpcServer.shutdown();
+      rmDir(Paths.get(grpcServer.getIndexDir()).getParent());
+    }
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    if (!initialized) {
+      setUpClass();
+      initialized = true;
+    }
+  }
+
+  public void setUpClass() throws Exception {
+    collectorRegistry = new CollectorRegistry();
+    grpcServer = setUpGrpcServer(collectorRegistry);
+    initIndices();
+  }
+
+  private GrpcServer setUpGrpcServer(CollectorRegistry collectorRegistry) throws IOException {
+    String testIndex = "test_index";
+    LuceneServerConfiguration luceneServerConfiguration =
+        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
+    globalState = new GlobalState(luceneServerConfiguration);
+    return new GrpcServer(
+        collectorRegistry,
+        grpcCleanup,
+        luceneServerConfiguration,
+        folder,
+        false,
+        globalState,
+        luceneServerConfiguration.getIndexDir(),
+        testIndex,
+        globalState.getPort(),
+        null,
+        getPlugins());
+  }
+
+  private void initIndices() throws Exception {
+    for (String indexName : getIndices()) {
+      String rootDirName = grpcServer.getIndexDir();
+      LuceneServerGrpc.LuceneServerBlockingStub blockingStub = grpcServer.getBlockingStub();
+
+      // create the index
+      blockingStub.createIndex(
+          CreateIndexRequest.newBuilder().setIndexName(indexName).setRootDir(rootDirName).build());
+
+      // register fields
+      blockingStub.registerFields(getIndexDef(indexName));
+
+      // start the index
+      StartIndexRequest.Builder startIndexBuilder =
+          StartIndexRequest.newBuilder().setIndexName(indexName);
+      blockingStub.startIndex(startIndexBuilder.build());
+
+      // add Docs
+      initIndex(indexName);
+
+      // refresh
+      blockingStub.refresh(RefreshRequest.newBuilder().setIndexName(indexName).build());
+    }
+  }
+
+  protected List<String> getIndices() {
+    return Collections.singletonList(DEFAULT_TEST_INDEX);
+  }
+
+  protected FieldDefRequest getIndexDef(String name) throws IOException {
+    return getFieldsFromResourceFile("/registerFieldsBasic.json");
+  }
+
+  protected void initIndex(String name) throws Exception {}
+
+  protected List<Plugin> getPlugins() {
+    return Collections.emptyList();
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/NumberFieldFacetsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/NumberFieldFacetsTest.java
@@ -33,6 +33,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import io.grpc.StatusRuntimeException;
 import org.junit.Test;
 
 public class NumberFieldFacetsTest extends ServerTestCase {
@@ -111,7 +113,7 @@ public class NumberFieldFacetsTest extends ServerTestCase {
     assertNumericRangeFacet("int_number_facet_field");
   }
 
-  @Test
+  @Test(expected = StatusRuntimeException.class)
   public void testFloatNumberNumericRange() {
     assertNumericRangeFacet("float_number_facet_field");
   }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/NumberFieldFacetsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/NumberFieldFacetsTest.java
@@ -26,6 +26,7 @@ import com.yelp.nrtsearch.server.grpc.NumericRangeType;
 import com.yelp.nrtsearch.server.grpc.SearchRequest;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
+import io.grpc.StatusRuntimeException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,8 +34,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import io.grpc.StatusRuntimeException;
 import org.junit.Test;
 
 public class NumberFieldFacetsTest extends ServerTestCase {

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/NumberFieldFacetsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/NumberFieldFacetsTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.facet;
+
+import static org.junit.Assert.assertEquals;
+
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.Facet;
+import com.yelp.nrtsearch.server.grpc.FacetResult;
+import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
+import com.yelp.nrtsearch.server.grpc.LabelAndValue;
+import com.yelp.nrtsearch.server.grpc.NumericRangeType;
+import com.yelp.nrtsearch.server.grpc.SearchRequest;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class NumberFieldFacetsTest extends ServerTestCase {
+  private static final List<String> fields =
+      Arrays.asList(
+          new String[] {
+            "int_number_facet_field",
+            "float_number_facet_field",
+            "long_number_facet_field",
+            "double_number_facet_field"
+          });
+  private static final List<String> numericValues =
+      Arrays.asList(new String[] {"1", "10", "20", "30"});
+
+  private Map<String, AddDocumentRequest.MultiValuedField> getFieldsMapForOneDocument(
+      String value) {
+    Map<String, AddDocumentRequest.MultiValuedField> fieldsMap = new HashMap<>();
+    for (String field : fields) {
+      fieldsMap.put(
+          field, AddDocumentRequest.MultiValuedField.newBuilder().addValue(value).build());
+    }
+    return fieldsMap;
+  }
+
+  private List<AddDocumentRequest> buildDocuments(String indexName) {
+    List<AddDocumentRequest> documentRequests = new ArrayList<>();
+    for (String value : numericValues) {
+      documentRequests.add(
+          AddDocumentRequest.newBuilder()
+              .setIndexName(indexName)
+              .putAllFields(getFieldsMapForOneDocument(value))
+              .build());
+    }
+    return documentRequests;
+  }
+
+  @Override
+  public FieldDefRequest getIndexDef(String name) throws IOException {
+    return getFieldsFromResourceFile("/facet/number_field_facets.json");
+  }
+
+  @Override
+  public void initIndex(String name) throws Exception {
+    List<AddDocumentRequest> documents = buildDocuments(name);
+    addDocuments(documents.stream());
+  }
+
+  private SearchResponse getSearchResponse(String dimension, String... paths) {
+    return getSearchResponse(dimension, false, Collections.emptyList(), paths);
+  }
+
+  private SearchResponse getSearchResponse(
+      String dimension,
+      boolean useOrdsCache,
+      List<NumericRangeType> numericRangeTypes,
+      String... paths) {
+    Facet.Builder facetBuilder =
+        Facet.newBuilder()
+            .setDim(dimension)
+            .setTopN(10)
+            .setUseOrdsCache(useOrdsCache)
+            .addAllNumericRange(numericRangeTypes);
+    facetBuilder.addAllPaths(Arrays.asList(paths));
+    return getGrpcServer()
+        .getBlockingStub()
+        .search(
+            SearchRequest.newBuilder()
+                .setIndexName(DEFAULT_TEST_INDEX)
+                .setTopHits(10)
+                .addFacets(facetBuilder.build())
+                .build());
+  }
+
+  @Test
+  public void testIntNumberNumericRange() {
+    assertNumericRangeFacet("int_number_facet_field");
+  }
+
+  @Test
+  public void testFloatNumberNumericRange() {
+    assertNumericRangeFacet("float_number_facet_field");
+  }
+
+  @Test
+  public void testLongNumberNumericRange() {
+    assertNumericRangeFacet("long_number_facet_field");
+  }
+
+  @Test
+  public void testDoubleNumberNumericRange() {
+    assertNumericRangeFacet("double_number_facet_field");
+  }
+
+  private void assertNumericRangeFacet(String fieldName) {
+    List<NumericRangeType> numericRangeTypes = new ArrayList<>();
+    numericRangeTypes.add(
+        NumericRangeType.newBuilder()
+            .setLabel("1-10")
+            .setMin(1L)
+            .setMinInclusive(true)
+            .setMax(10L)
+            .setMaxInclusive(true)
+            .build());
+    numericRangeTypes.add(
+        NumericRangeType.newBuilder()
+            .setLabel("11-20")
+            .setMin(11L)
+            .setMinInclusive(true)
+            .setMax(20L)
+            .setMaxInclusive(true)
+            .build());
+    SearchResponse response = getSearchResponse(fieldName, false, numericRangeTypes);
+    assertEquals(1, response.getFacetResultCount());
+    List<FacetResult> facetResults = response.getFacetResultList();
+    List<LabelAndValue> expectedLabelAndValues = new ArrayList<>();
+    expectedLabelAndValues.add(LabelAndValue.newBuilder().setLabel("1-10").setValue(2.0).build());
+    expectedLabelAndValues.add(LabelAndValue.newBuilder().setLabel("11-20").setValue(1.0).build());
+    assertFacetResult(facetResults.get(0), fieldName, 3, 2L, expectedLabelAndValues);
+  }
+
+  private void assertFacetResult(
+      FacetResult testFacetResult,
+      String dim, // dimension against which to bucket/group also the fieldName
+      double
+          value, // total values across all bucket i.e. if we add up lavelAndValue.value across all
+      // labels not just topN
+      long childCount, // total number of distinct buckets/terms
+      List<LabelAndValue> expectedLableValues,
+      String... paths) {
+    assertEquals(dim, testFacetResult.getDim());
+    assertEquals(value, testFacetResult.getValue(), 0.001);
+    assertEquals(childCount, testFacetResult.getChildCount());
+    assertEquals(expectedLableValues.size(), testFacetResult.getLabelValuesList().size());
+    for (int i = 0; i < expectedLableValues.size(); i++) {
+      assertEquals(
+          expectedLableValues.get(i).getLabel(), testFacetResult.getLabelValues(i).getLabel());
+      assertEquals(
+          expectedLableValues.get(i).getValue(),
+          testFacetResult.getLabelValues(i).getValue(),
+          0.001);
+    }
+    for (int i = 0; i < paths.length; i++) {
+      assertEquals(paths[i], testFacetResult.getPath(i));
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/NumberFieldFacetsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/NumberFieldFacetsTest.java
@@ -27,6 +27,7 @@ import com.yelp.nrtsearch.server.grpc.SearchRequest;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
 import io.grpc.StatusRuntimeException;
+import io.grpc.testing.GrpcCleanupRule;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,9 +35,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 public class NumberFieldFacetsTest extends ServerTestCase {
+  @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
   private static final List<String> fields =
       Arrays.asList(
           new String[] {
@@ -112,14 +116,14 @@ public class NumberFieldFacetsTest extends ServerTestCase {
     assertNumericRangeFacet("int_number_facet_field");
   }
 
-  @Test(expected = StatusRuntimeException.class)
-  public void testFloatNumberNumericRange() {
-    assertNumericRangeFacet("float_number_facet_field");
-  }
-
   @Test
   public void testLongNumberNumericRange() {
     assertNumericRangeFacet("long_number_facet_field");
+  }
+
+  @Test(expected = StatusRuntimeException.class)
+  public void testFloatNumberNumericRange() {
+    assertNumericRangeFacet("float_number_facet_field");
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/TextFieldFacetsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/TextFieldFacetsTest.java
@@ -26,13 +26,16 @@ import com.yelp.nrtsearch.server.grpc.LabelAndValue;
 import com.yelp.nrtsearch.server.grpc.SearchRequest;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
+import io.grpc.testing.GrpcCleanupRule;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 public class TextFieldFacetsTest extends ServerTestCase {
+  @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
   private List<AddDocumentRequest> buildDocumentsWithPath(String indexName) {
     List<AddDocumentRequest> documentRequests = new ArrayList<>();

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/TextFieldFacetsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/TextFieldFacetsTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.facet;
+
+import static org.junit.Assert.assertEquals;
+
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.Facet;
+import com.yelp.nrtsearch.server.grpc.FacetHierarchyPath;
+import com.yelp.nrtsearch.server.grpc.FacetResult;
+import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
+import com.yelp.nrtsearch.server.grpc.LabelAndValue;
+import com.yelp.nrtsearch.server.grpc.SearchRequest;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+public class TextFieldFacetsTest extends ServerTestCase {
+
+  private List<AddDocumentRequest> buildDocumentsWithPath(String indexName) {
+    List<AddDocumentRequest> documentRequests = new ArrayList<>();
+    documentRequests.add(
+        AddDocumentRequest.newBuilder()
+            .setIndexName(indexName)
+            .putFields(
+                "hierarchy_facet_field",
+                AddDocumentRequest.MultiValuedField.newBuilder()
+                    .addValue("home mike work")
+                    .addFaceHierarchyPaths(
+                        FacetHierarchyPath.newBuilder()
+                            .addValue("home")
+                            .addValue("mike")
+                            .addValue("work")
+                            .build())
+                    .addValue("home john work")
+                    .addFaceHierarchyPaths(
+                        FacetHierarchyPath.newBuilder()
+                            .addValue("home")
+                            .addValue("john")
+                            .addValue("work")
+                            .build())
+                    .addValue("home john personal")
+                    .addFaceHierarchyPaths(
+                        FacetHierarchyPath.newBuilder()
+                            .addValue("home")
+                            .addValue("john")
+                            .addValue("personal")
+                            .build())
+                    .build())
+            .build());
+
+    return documentRequests;
+  }
+
+  private List<AddDocumentRequest> buildDocuments(String indexName) {
+    List<AddDocumentRequest> documentRequests = new ArrayList<>();
+    documentRequests.add(
+        AddDocumentRequest.newBuilder()
+            .setIndexName(indexName)
+            .putFields(
+                "sorted_doc_values_facet_field",
+                AddDocumentRequest.MultiValuedField.newBuilder()
+                    .addValue("John")
+                    .addValue("Doe")
+                    .build())
+            .putFields(
+                "sorted_doc_values_facet_field_single_valued",
+                AddDocumentRequest.MultiValuedField.newBuilder().addValue("John").build())
+            .putFields(
+                "flat_facet_field",
+                AddDocumentRequest.MultiValuedField.newBuilder()
+                    .addValue("John")
+                    .addValue("Doe")
+                    .build())
+            .putFields(
+                "flat_facet_field_single_valued",
+                AddDocumentRequest.MultiValuedField.newBuilder().addValue("John").build())
+            .putFields(
+                "hierarchy_facet_field",
+                AddDocumentRequest.MultiValuedField.newBuilder()
+                    .addValue("John")
+                    .addValue("Doe")
+                    .build())
+            .putFields(
+                "hierarchy_facet_field_single_valued",
+                AddDocumentRequest.MultiValuedField.newBuilder().addValue("John").build())
+            .build());
+    documentRequests.add(
+        AddDocumentRequest.newBuilder()
+            .setIndexName(indexName)
+            .putFields(
+                "sorted_doc_values_facet_field",
+                AddDocumentRequest.MultiValuedField.newBuilder()
+                    .addValue("John")
+                    .addValue("Smith")
+                    .build())
+            .putFields(
+                "sorted_doc_values_facet_field_single_valued",
+                AddDocumentRequest.MultiValuedField.newBuilder().addValue("John").build())
+            .putFields(
+                "flat_facet_field",
+                AddDocumentRequest.MultiValuedField.newBuilder()
+                    .addValue("John")
+                    .addValue("Smith")
+                    .build())
+            .putFields(
+                "flat_facet_field_single_valued",
+                AddDocumentRequest.MultiValuedField.newBuilder().addValue("John").build())
+            .putFields(
+                "hierarchy_facet_field",
+                AddDocumentRequest.MultiValuedField.newBuilder()
+                    .addValue("John")
+                    .addValue("Smith")
+                    .build())
+            .putFields(
+                "hierarchy_facet_field_single_valued",
+                AddDocumentRequest.MultiValuedField.newBuilder().addValue("John").build())
+            .build());
+    documentRequests.add(
+        AddDocumentRequest.newBuilder()
+            .setIndexName(indexName)
+            .putFields(
+                "flat_facet_field_single_valued",
+                AddDocumentRequest.MultiValuedField.newBuilder().addValue("John").build())
+            .build());
+    documentRequests.add(
+        AddDocumentRequest.newBuilder()
+            .setIndexName(indexName)
+            .putFields(
+                "sorted_doc_values_facet_field_single_valued",
+                AddDocumentRequest.MultiValuedField.newBuilder().addValue("John").build())
+            .build());
+    documentRequests.add(
+        AddDocumentRequest.newBuilder()
+            .setIndexName(indexName)
+            .putFields(
+                "hierarchy_facet_field_single_valued",
+                AddDocumentRequest.MultiValuedField.newBuilder().addValue("John").build())
+            .build());
+    return documentRequests;
+  }
+
+  @Override
+  public FieldDefRequest getIndexDef(String name) throws IOException {
+    return getFieldsFromResourceFile("/facet/text_field_facets.json");
+  }
+
+  @Override
+  public void initIndex(String name) throws Exception {
+    List<AddDocumentRequest> documents = buildDocuments(name);
+    addDocuments(documents.stream());
+    addDocuments(buildDocumentsWithPath(name).stream()); // for hierarchy path faceting
+  }
+
+  private SearchResponse getSearchResponse(String dimension, String... paths) {
+    Facet.Builder facetBuilder = Facet.newBuilder().setDim(dimension).setTopN(10);
+    facetBuilder.addAllPaths(Arrays.asList(paths));
+    return getGrpcServer()
+        .getBlockingStub()
+        .search(
+            SearchRequest.newBuilder()
+                .setIndexName(DEFAULT_TEST_INDEX)
+                .setTopHits(10)
+                .addFacets(facetBuilder.build())
+                .build());
+  }
+
+  @Test
+  public void testSortedDocValuesFacet() {
+    SearchResponse response = getSearchResponse("sorted_doc_values_facet_field");
+    assertEquals(1, response.getFacetResultCount());
+    List<FacetResult> facetResults = response.getFacetResultList();
+    List<LabelAndValue> expectedLabelAndValues = new ArrayList<>();
+    expectedLabelAndValues.add(LabelAndValue.newBuilder().setLabel("John").setValue(2.0).build());
+    expectedLabelAndValues.add(LabelAndValue.newBuilder().setLabel("Doe").setValue(1.0).build());
+    expectedLabelAndValues.add(LabelAndValue.newBuilder().setLabel("Smith").setValue(1.0).build());
+    assertFacetResult(
+        facetResults.get(0), "sorted_doc_values_facet_field", 4, 3L, expectedLabelAndValues);
+  }
+
+  @Test
+  public void testSortedDocValuesSingleValued() {
+    SearchResponse response = getSearchResponse("sorted_doc_values_facet_field_single_valued");
+    assertEquals(1, response.getFacetResultCount());
+    List<FacetResult> facetResults = response.getFacetResultList();
+    List<LabelAndValue> expectedLabelAndValues = new ArrayList<>();
+    expectedLabelAndValues.add(LabelAndValue.newBuilder().setLabel("John").setValue(3.0).build());
+    assertFacetResult(
+        facetResults.get(0),
+        "sorted_doc_values_facet_field_single_valued",
+        3,
+        1L,
+        expectedLabelAndValues);
+  }
+
+  @Test
+  public void testHierarchyMultivaluedNoPath() {
+    SearchResponse response = getSearchResponse("hierarchy_facet_field");
+    assertEquals(1, response.getFacetResultCount());
+    List<FacetResult> facetResults = response.getFacetResultList();
+    List<LabelAndValue> expectedLabelAndValues = new ArrayList<>();
+    expectedLabelAndValues.add(LabelAndValue.newBuilder().setLabel("John").setValue(2.0).build());
+    expectedLabelAndValues.add(LabelAndValue.newBuilder().setLabel("Doe").setValue(1.0).build());
+    expectedLabelAndValues.add(LabelAndValue.newBuilder().setLabel("Smith").setValue(1.0).build());
+    expectedLabelAndValues.add(LabelAndValue.newBuilder().setLabel("home").setValue(1.0).build());
+    // NOTE: total number of buckets/value returned by FastTaxonomyFacetCounts is -1 on multivalued
+    // fields.
+    assertFacetResult(facetResults.get(0), "hierarchy_facet_field", -1, 4L, expectedLabelAndValues);
+  }
+
+  @Test
+  public void testHierarchyWithPath() {
+    SearchResponse response = getSearchResponse("hierarchy_facet_field", "home");
+    System.out.println(response);
+  }
+
+  @Test
+  public void testHierarchySingleValued() {
+    SearchResponse response = getSearchResponse("hierarchy_facet_field_single_valued");
+    assertEquals(1, response.getFacetResultCount());
+    List<FacetResult> facetResults = response.getFacetResultList();
+    List<LabelAndValue> expectedLabelAndValues = new ArrayList<>();
+    expectedLabelAndValues.add(LabelAndValue.newBuilder().setLabel("John").setValue(3.0).build());
+    assertFacetResult(
+        facetResults.get(0), "hierarchy_facet_field_single_valued", 3, 1L, expectedLabelAndValues);
+  }
+
+  @Test
+  public void testFlatMultivalued() {
+    SearchResponse response = getSearchResponse("flat_facet_field");
+    assertEquals(1, response.getFacetResultCount());
+    List<FacetResult> facetResults = response.getFacetResultList();
+    List<LabelAndValue> expectedLabelAndValues = new ArrayList<>();
+    expectedLabelAndValues.add(LabelAndValue.newBuilder().setLabel("John").setValue(2.0).build());
+    expectedLabelAndValues.add(LabelAndValue.newBuilder().setLabel("Doe").setValue(1.0).build());
+    expectedLabelAndValues.add(LabelAndValue.newBuilder().setLabel("Smith").setValue(1.0).build());
+    // NOTE: total number of buckets/value returned by FastTaxonomyFacetCounts is -1 on multivalued
+    // fields.
+    assertFacetResult(facetResults.get(0), "flat_facet_field", -1, 3L, expectedLabelAndValues);
+  }
+
+  @Test
+  public void testFlatSingleValued() {
+    SearchResponse response = getSearchResponse("flat_facet_field_single_valued");
+    assertEquals(1, response.getFacetResultCount());
+    List<FacetResult> facetResults = response.getFacetResultList();
+    List<LabelAndValue> expectedLabelAndValues = new ArrayList<>();
+    expectedLabelAndValues.add(LabelAndValue.newBuilder().setLabel("John").setValue(3.0).build());
+    assertFacetResult(
+        facetResults.get(0), "flat_facet_field_single_valued", 3, 1L, expectedLabelAndValues);
+  }
+
+  private void assertFacetResult(
+      FacetResult testFacetResult,
+      String dim, // dimension against which to bucket/group also the fieldName
+      double
+          value, // total values across all bucket i.e. if we add up lavelAndValue.value across all
+      // labels not just topN
+      long childCount, // total number of distinct buckets/terms
+      List<LabelAndValue> expectedLableValues,
+      String... path) {
+    assertEquals(dim, testFacetResult.getDim());
+    assertEquals(value, testFacetResult.getValue(), 0.001);
+    assertEquals(childCount, testFacetResult.getChildCount());
+    assertEquals(expectedLableValues.size(), testFacetResult.getLabelValuesList().size());
+    for (int i = 0; i < expectedLableValues.size(); i++) {
+      assertEquals(
+          expectedLableValues.get(i).getLabel(), testFacetResult.getLabelValues(i).getLabel());
+      assertEquals(
+          expectedLableValues.get(i).getValue(),
+          testFacetResult.getLabelValues(i).getValue(),
+          0.001);
+    }
+    // assertEquals(path, testFacetResult.getPathList());
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
@@ -96,7 +96,7 @@ public class ScoreScriptTest {
   private GrpcServer setUpGrpcServer(CollectorRegistry collectorRegistry) throws IOException {
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE);
+        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     GlobalState globalState = new GlobalState(luceneServerConfiguration);
     return new GrpcServer(
         collectorRegistry,

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/js/JsScriptEngineTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/js/JsScriptEngineTest.java
@@ -80,7 +80,7 @@ public class JsScriptEngineTest {
   private GrpcServer setUpGrpcServer(CollectorRegistry collectorRegistry) throws IOException {
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE);
+        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     GlobalState globalState = new GlobalState(luceneServerConfiguration);
     return new GrpcServer(
         collectorRegistry,

--- a/src/test/resources/facet/number_field_facets.json
+++ b/src/test/resources/facet/number_field_facets.json
@@ -1,0 +1,37 @@
+{
+  "indexName": "test_index",
+  "field": [
+    {
+      "name": "int_number_facet_field",
+      "type": "INT",
+      "storeDocValues": true,
+      "multiValued": false,
+      "search": true,
+      "facet": "NUMERIC_RANGE"
+    },
+    {
+      "name": "float_number_facet_field",
+      "type": "FLOAT",
+      "storeDocValues": true,
+      "multiValued": false,
+      "search": true,
+      "facet": "NUMERIC_RANGE"
+    },
+    {
+      "name": "long_number_facet_field",
+      "type": "LONG",
+      "storeDocValues": true,
+      "multiValued": false,
+      "search": true,
+      "facet": "NUMERIC_RANGE"
+    },
+    {
+      "name": "double_number_facet_field",
+      "type": "DOUBLE",
+      "storeDocValues": true,
+      "multiValued": false,
+      "search": true,
+      "facet": "NUMERIC_RANGE"
+    }
+  ]
+}

--- a/src/test/resources/facet/text_field_facets.json
+++ b/src/test/resources/facet/text_field_facets.json
@@ -1,0 +1,62 @@
+{
+  "indexName": "test_index",
+  "field": [
+    {
+      "name": "sorted_doc_values_facet_field",
+      "type": "TEXT",
+      "storeDocValues": true,
+      "multiValued": true,
+      "tokenize": true,
+      "search": true,
+      "facet": "SORTED_SET_DOC_VALUES",
+      "facetIndexFieldName" : "$sorted_doc_values_facet_field"
+    },
+    {
+      "name": "sorted_doc_values_facet_field_single_valued",
+      "type": "TEXT",
+      "storeDocValues": true,
+      "tokenize": true,
+      "search": true,
+      "facet": "SORTED_SET_DOC_VALUES",
+      "facetIndexFieldName" : "$sorted_doc_values_facet_field_single_valued"
+    },
+    {
+      "name": "flat_facet_field",
+      "type": "TEXT",
+      "storeDocValues": true,
+      "multiValued": true,
+      "tokenize": true,
+      "search": true,
+      "facet": "FLAT",
+      "facetIndexFieldName" : "$flat_facet_field"
+    },
+    {
+      "name": "flat_facet_field_single_valued",
+      "type": "TEXT",
+      "storeDocValues": true,
+      "tokenize": true,
+      "search": true,
+      "facet": "FLAT",
+      "facetIndexFieldName" : "$flat_facet_field_single_valued"
+    },
+    {
+      "name": "hierarchy_facet_field",
+      "type": "TEXT",
+      "storeDocValues": true,
+      "multiValued": true,
+      "tokenize": true,
+      "search": false,
+      "facet": "HIERARCHY",
+      "facetIndexFieldName" : "$hierarchy_facet_field"
+    },
+    {
+      "name": "hierarchy_facet_field_single_valued",
+      "type": "TEXT",
+      "storeDocValues": true,
+      "tokenize": true,
+      "search": false,
+      "facet": "HIERARCHY",
+      "facetIndexFieldName" : "$hierarchy_facet_field_single_valued"
+    }
+  ]
+}


### PR DESCRIPTION
Added support for facets of type:
- NUMERIC_RANGE see [RangeFacetsExample](https://github.com/apache/lucene-solr/blob/d7dc53ff7c3a16110aac4120e5bfdf7721b21bcd/lucene/demo/src/java/org/apache/lucene/demo/facet/RangeFacetsExample.java) for reference. This works on numeric field types to collect facets in ranges. Note these dont work on multivalued numeric fields though.

- SORTED_SET_DOC_VALUES see [SortedSetFacetsExample](https://github.com/apache/lucene-solr/blob/d7dc53ff7c3a16110aac4120e5bfdf7721b21bcd/lucene/demo/src/java/org/apache/lucene/demo/facet/SimpleSortedSetFacetsExample.java) for reference. This works on text field types. 
Pros compared to HIERARCHY type 
we dont need to maintain a separate index for facets
Cons compared to HIERARCHY type
 we cannot structure terms by hierarchy 

- HIERARCHY see [MultiCategoryListsFacetsExample](https://github.com/apache/lucene-solr/blob/d7dc53ff7c3a16110aac4120e5bfdf7721b21bcd/lucene/demo/src/java/org/apache/lucene/demo/facet/MultiCategoryListsFacetsExample.java) for reference. This works on  text field types.  All the unique values for a taxonomy facet are stored in a separate Lucene index (often called the sidecar index). But, this implementation supports hierarchical facets.
during index time request can contain list of  `paths` which determine the hierarchy and during search time request can bucket at required level of hierarchy.

- FLAT Similar HIERARCHY in that it uses taxonomy index (sidecar) but does not deal with hierarchy.

Simplified tests using base class from branch: https://github.com/Yelp/nrtsearch/pull/137/commits/905d4a2a9b4f270eeb74862f1401d1f2bb370528

