### PR TITLE
Add server tests jar to be used in plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ sourceCompatibility = 1.14
 targetCompatibility = 1.14
 
 allprojects {
-    version = '0.1.5'
+    version = '0.1.6'
     group = 'com.yelp.nrtsearch'
 }
 
@@ -114,7 +114,7 @@ applicationDistribution.into('bin') {
     fileMode = 0755
 }
 
-task buildGrpcGateway(dependsOn:installDist, type: Exec) {
+task buildGrpcGateway(dependsOn: installDist, type: Exec) {
     workingDir = '.'
     commandLine = './build_grpc_gateway.sh'
 }
@@ -145,6 +145,11 @@ task sourcesJar(type: Jar) {
     from sourceSets.main.java.srcDirs
 }
 
+task testsJar(type: Jar) {
+    classifier('tests')
+    from sourceSets.test.output
+}
+
 signing {
     if (project.hasProperty("signing.keyId")) {
         sign publishing.publications
@@ -160,6 +165,7 @@ publishing {
             artifact tasks.jar
             artifact tasks.javadocsJar
             artifact tasks.sourcesJar
+            artifact tasks.testsJar
             pom {
                 name = 'nrtSearch Server'
                 description = 'GRPC lucene server using near-real-time replication'


### PR DESCRIPTION
The `ServerTestCase` will be used in tests for the `maptype` plugin.