### PR TITLE
Add a new _ID field for updating documents

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ sourceCompatibility = 1.14
 targetCompatibility = 1.14
 
 allprojects {
-    version = '0.1.6'
+    version = '0.1.7'
     group = 'com.yelp.nrtsearch'
 }
 

--- a/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
@@ -341,7 +341,7 @@ enum FieldType {
     // TODO need tests for internal:
     INTERNAL = 10; //Internal field, currently only for holding indexed facets data.
     CUSTOM = 11; // Field type specified by name.
-    _ID = 12;
+    _ID = 12; // Field which will be used as document IDs
 }
 
 //How the tokens should be indexed.

--- a/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
@@ -341,6 +341,7 @@ enum FieldType {
     // TODO need tests for internal:
     INTERNAL = 10; //Internal field, currently only for holding indexed facets data.
     CUSTOM = 11; // Field type specified by name.
+    _ID = 12;
 }
 
 //How the tokens should be indexed.

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/AddDocumentHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/AddDocumentHandler.java
@@ -20,6 +20,7 @@ import com.google.protobuf.ProtocolStringList;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.FacetHierarchyPath;
 import com.yelp.nrtsearch.server.luceneserver.field.FieldDef;
+import com.yelp.nrtsearch.server.luceneserver.field.IdFieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.IndexableFieldDef;
 import java.io.IOException;
 import java.util.Iterator;
@@ -135,46 +136,13 @@ public class AddDocumentHandler implements Handler<AddDocumentRequest, Any> {
         }
       }
       ShardState shardState = indexState.getShard(0);
-      long gen;
+      IdFieldDef idFieldDef = indexState.getIdFieldDef();
       try {
-        shardState.writer.addDocuments(
-            new Iterable<Document>() {
-              @Override
-              public Iterator<Document> iterator() {
-                final boolean hasFacets = shardState.indexState.hasFacets();
-                int docListSize = addDocumentRequestList.size();
-                return new Iterator<Document>() {
-                  private Document nextDoc;
-
-                  @Override
-                  public boolean hasNext() {
-                    if (!documents.isEmpty()) {
-                      nextDoc = documents.poll();
-                      if (hasFacets) {
-                        try {
-                          nextDoc =
-                              shardState.indexState.facetsConfig.build(
-                                  shardState.taxoWriter, nextDoc);
-                        } catch (IOException ioe) {
-                          throw new RuntimeException(
-                              String.format("document: %s hit exception building facets", nextDoc),
-                              ioe);
-                        }
-                      }
-                      return true;
-                    } else {
-                      nextDoc = null;
-                      return false;
-                    }
-                  }
-
-                  @Override
-                  public Document next() {
-                    return nextDoc;
-                  }
-                };
-              }
-            });
+        if (idFieldDef != null) {
+          updateDocuments(documents, idFieldDef, shardState);
+        } else {
+          addDocuments(documents, shardState);
+        }
       } catch (IOException e) { // This exception should be caught in parent to and set
         // responseObserver.onError(e) so client knows the job failed
         logger.warn(
@@ -189,6 +157,54 @@ public class AddDocumentHandler implements Handler<AddDocumentRequest, Any> {
               Thread.currentThread().getName() + Thread.currentThread().getId(),
               shardState.writer.getMaxCompletedSequenceNumber()));
       return shardState.writer.getMaxCompletedSequenceNumber();
+    }
+
+    private void updateDocuments(
+        Queue<Document> documents, IdFieldDef idFieldDef, ShardState shardState)
+        throws IOException {
+      for (Document nextDoc : documents) {
+        nextDoc = handleFacets(shardState, nextDoc);
+        shardState.writer.updateDocument(idFieldDef.getTerm(nextDoc), nextDoc);
+      }
+    }
+
+    private void addDocuments(Queue<Document> documents, ShardState shardState) throws IOException {
+      shardState.writer.addDocuments(
+          (Iterable<Document>)
+              () ->
+                  new Iterator<>() {
+                    private Document nextDoc;
+
+                    @Override
+                    public boolean hasNext() {
+                      if (!documents.isEmpty()) {
+                        nextDoc = documents.poll();
+                        nextDoc = handleFacets(shardState, nextDoc);
+                        return true;
+                      } else {
+                        nextDoc = null;
+                        return false;
+                      }
+                    }
+
+                    @Override
+                    public Document next() {
+                      return nextDoc;
+                    }
+                  });
+    }
+
+    private Document handleFacets(ShardState shardState, Document nextDoc) {
+      final boolean hasFacets = shardState.indexState.hasFacets();
+      if (hasFacets) {
+        try {
+          nextDoc = shardState.indexState.facetsConfig.build(shardState.taxoWriter, nextDoc);
+        } catch (IOException ioe) {
+          throw new RuntimeException(
+              String.format("document: %s hit exception building facets", nextDoc), ioe);
+        }
+      }
+      return nextDoc;
     }
 
     @Override

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
@@ -134,6 +134,7 @@ public class IndexState implements Closeable, Restorable {
 
   private static final Pattern reSimpleName = Pattern.compile("^[a-zA-Z_][a-zA-Z_0-9]*$");
   private ThreadPoolExecutor searchThreadPoolExecutor;
+  private IdFieldDef idFieldDef = null;
 
   public ShardState addShard(int shardOrd, boolean doCreate) {
     if (shards.containsKey(shardOrd)) {
@@ -228,12 +229,7 @@ public class IndexState implements Closeable, Restorable {
   }
 
   public IdFieldDef getIdFieldDef() {
-    for (Map.Entry<String, FieldDef> entry : fields.entrySet()) {
-      if (entry.getValue() instanceof IdFieldDef) {
-        return (IdFieldDef) entry.getValue();
-      }
-    }
-    return null;
+    return idFieldDef;
   }
 
   /** Tracks snapshot references to generations. */
@@ -792,6 +788,9 @@ public class IndexState implements Closeable, Restorable {
           && facetValueType != IndexableFieldDef.FacetValueType.NUMERIC_RANGE) {
         internalFacetFieldNames.add(facetsConfig.getDimConfig(fd.getName()).indexFieldName);
       }
+    }
+    if (fd instanceof IdFieldDef) {
+      idFieldDef = (IdFieldDef) fd;
     }
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
@@ -30,6 +30,7 @@ import com.yelp.nrtsearch.server.grpc.SettingsRequest;
 import com.yelp.nrtsearch.server.luceneserver.doc.DocLookup;
 import com.yelp.nrtsearch.server.luceneserver.field.FieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.FieldDefBindings;
+import com.yelp.nrtsearch.server.luceneserver.field.IdFieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.IndexableFieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.TextBaseFieldDef;
 import java.io.Closeable;
@@ -224,6 +225,15 @@ public class IndexState implements Closeable, Restorable {
 
   public ThreadPoolExecutor getSearchThreadPoolExecutor() {
     return searchThreadPoolExecutor;
+  }
+
+  public IdFieldDef getIdFieldDef() {
+    for (Map.Entry<String, FieldDef> entry : fields.entrySet()) {
+      if (entry.getValue() instanceof IdFieldDef) {
+        return (IdFieldDef) entry.getValue();
+      }
+    }
+    return null;
   }
 
   /** Tracks snapshot references to generations. */

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/FieldDefCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/FieldDefCreator.java
@@ -41,6 +41,7 @@ public class FieldDefCreator {
     register("FLOAT", FloatFieldDef::new);
     register("LAT_LON", LatLonFieldDef::new);
     register("DATE_TIME", DateTimeFieldDef::new);
+    register("_ID", IdFieldDef::new);
     // It would be nice for this to be the factory for virtual fields too,
     // but javascript expression compilation depends on fields that are not
     // completely registered.

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/IdFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/IdFieldDef.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.field;
+
+import com.yelp.nrtsearch.server.grpc.Field;
+import com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues;
+import java.io.IOException;
+import java.util.List;
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.util.BytesRef;
+
+/** Field class for defining '_ID' fields which are used to update documents */
+public class IdFieldDef extends IndexableFieldDef {
+
+  protected IdFieldDef(String name, Field requestField) {
+    super(name, requestField);
+  }
+
+  /**
+   * We use _ID fields as strings to store and update documents. Hence we fail if the field requests
+   * for properties that are not applicable for this use
+   *
+   * @param requestField field properties to validate
+   */
+  protected void validateRequest(Field requestField) {
+    if (requestField.getMultiValued() || requestField.getTokenize()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "field: %s cannot have multivalued fields or tokenization as it's an _ID field",
+              requestField.getName()));
+    }
+    if (!requestField.getStore()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "field: %s is an _ID field and should have store=true", requestField.getName()));
+    }
+  }
+
+  /**
+   * _ID fields should always have indexing turned on so that they can be retrieved for updates
+   * Also, these fields cannot be tokenized since we would like to use the values as it is
+   *
+   * @param fieldType type that needs search properties set
+   * @param requestField field from request
+   */
+  protected void setSearchProperties(FieldType fieldType, Field requestField) {
+    fieldType.setIndexOptions(IndexOptions.DOCS);
+    fieldType.setOmitNorms(true);
+    fieldType.setTokenized(false);
+  }
+
+  /**
+   * Store the docvalues if it's requested and store the string value in the document
+   *
+   * @param document lucene document to be added to the index
+   * @param fieldValues list of String encoded field values
+   * @param facetHierarchyPaths list of list of String encoded paths for each field value be
+   */
+  @Override
+  public void parseDocumentField(
+      Document document, List<String> fieldValues, List<List<String>> facetHierarchyPaths) {
+    if (fieldValues.size() > 1) {
+      throw new IllegalArgumentException("Cannot index multiple values into _id fields");
+    }
+    String fieldStr = fieldValues.get(0);
+    if (hasDocValues()) {
+      BytesRef stringBytes = new BytesRef(fieldStr);
+      document.add(new BinaryDocValuesField(getName(), stringBytes));
+    }
+    if (isStored()) {
+      document.add(new FieldWithData(getName(), fieldType, fieldStr));
+    }
+  }
+
+  @Override
+  public DocValuesType parseDocValuesType(Field requestField) {
+    if (requestField.getStoreDocValues()) {
+      return DocValuesType.BINARY;
+    }
+    return DocValuesType.NONE;
+  }
+
+  /**
+   * Store the doc values in binary format if requested
+   *
+   * @param context lucene segment context
+   * @return
+   * @throws IOException
+   */
+  @Override
+  public LoadedDocValues<?> getDocValues(LeafReaderContext context) throws IOException {
+    if (hasDocValues()) {
+      // The value is stored in a BINARY field, but it is always a String
+      BinaryDocValues binaryDocValues = DocValues.getBinary(context.reader(), getName());
+      return new LoadedDocValues.SingleString(binaryDocValues);
+    }
+    throw new IllegalStateException("Unsupported doc value type: " + docValuesType);
+  }
+
+  @Override
+  public String getType() {
+    return "_ID";
+  }
+
+  /**
+   * Construct a Term with the given field and value to identify the document to be added or updated
+   *
+   * @param document the document to be added or updated
+   * @return a Term with field and value
+   */
+  public Term getTerm(Document document) {
+    String fieldName = this.getName();
+    if (fieldName == null) {
+      throw new IllegalArgumentException(
+          "the keyable field should have a name to be able to build a Term for updating the document");
+    }
+    String fieldValue = document.get(fieldName);
+    if (fieldValue == null) {
+      throw new IllegalArgumentException(
+          "document cannot have a null field value for a keyable field");
+    }
+    return new Term(fieldName, fieldValue);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerIdFieldTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerIdFieldTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.grpc;
+
+import static com.yelp.nrtsearch.server.grpc.GrpcServer.rmDir;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.yelp.nrtsearch.server.LuceneServerTestConfigurationFactory;
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.luceneserver.GlobalState;
+import io.grpc.StatusRuntimeException;
+import io.grpc.testing.GrpcCleanupRule;
+import io.prometheus.client.CollectorRegistry;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class LuceneServerIdFieldTest {
+
+  /**
+   * This rule manages automatic graceful shutdown for the registered servers and channels at the
+   * end of test.
+   */
+  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+  /**
+   * This rule ensure the temporary folder which maintains indexes are cleaned up after each test
+   */
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private GrpcServer grpcServer;
+
+  @After
+  public void tearDown() throws IOException {
+    tearDownGrpcServer();
+  }
+
+  private void tearDownGrpcServer() throws IOException {
+    grpcServer.getGlobalState().close();
+    grpcServer.shutdown();
+    rmDir(Paths.get(grpcServer.getIndexDir()).getParent());
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    CollectorRegistry collectorRegistry = new CollectorRegistry();
+    grpcServer = setUpGrpcServer(collectorRegistry);
+  }
+
+  private GrpcServer setUpGrpcServer(CollectorRegistry collectorRegistry) throws IOException {
+    String testIndex = "test_index";
+    LuceneServerConfiguration luceneServerConfiguration =
+        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
+    GlobalState globalState = new GlobalState(luceneServerConfiguration);
+    return new GrpcServer(
+        collectorRegistry,
+        grpcCleanup,
+        luceneServerConfiguration,
+        folder,
+        false,
+        globalState,
+        luceneServerConfiguration.getIndexDir(),
+        testIndex,
+        globalState.getPort(),
+        null,
+        Collections.emptyList());
+  }
+
+  @Test
+  public void testAddUpdateAndSearch() throws IOException, InterruptedException {
+    GrpcServer.TestServer testServer =
+        new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
+    new GrpcServer.IndexAndRoleManager(grpcServer)
+        .createStartIndexAndRegisterFields(
+            Mode.STANDALONE, 0, false, "registerFieldsBasicWithId.json");
+    // 2 docs addDocuments
+    testServer.addDocuments();
+    assertFalse(testServer.error);
+    assertTrue(testServer.completed);
+
+    // add 2 more docs
+    testServer.addDocuments();
+    assertFalse(testServer.error);
+    assertTrue(testServer.completed);
+
+    StatsResponse stats =
+        grpcServer
+            .getBlockingStub()
+            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+
+    // there are only 2 documents
+    assertEquals(2, stats.getNumDocs());
+
+    // update schema: add a new field
+    grpcServer
+        .getBlockingStub()
+        .updateFields(
+            FieldDefRequest.newBuilder()
+                .setIndexName("test_index")
+                .addField(
+                    Field.newBuilder()
+                        .setName("new_text_field")
+                        .setType(FieldType.TEXT)
+                        .setStoreDocValues(true)
+                        .setSearch(true)
+                        .setMultiValued(true)
+                        .setTokenize(true)
+                        .build())
+                .build());
+    // 2 docs addDocuments
+    testServer.addDocuments("addDocsUpdated.csv");
+    assertFalse(testServer.error);
+    assertTrue(testServer.completed);
+    stats =
+        grpcServer
+            .getBlockingStub()
+            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+
+    // there are 4 documents in total
+    assertEquals(4, stats.getNumDocs());
+
+    // Query for first document
+    SearchResponse searchResponse =
+        grpcServer
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(grpcServer.getTestIndex())
+                    .setStartHit(0)
+                    .setTopHits(10)
+                    .addAllRetrieveFields(List.of("doc_id", "vendor_name"))
+                    .setQuery(
+                        Query.newBuilder()
+                            .setPhraseQuery(
+                                PhraseQuery.newBuilder()
+                                    .setField("vendor_name")
+                                    .addTerms("first")
+                                    .addTerms("vendor")
+                                    .build())
+                            .build())
+                    .build());
+    assertEquals(1, searchResponse.getTotalHits().getValue());
+    assertEquals(1, searchResponse.getHitsList().size());
+    assertEquals(
+        "1",
+        searchResponse.getHits(0).getFieldsMap().get("doc_id").getFieldValue(0).getTextValue());
+  }
+
+  @Test(expected = StatusRuntimeException.class)
+  public void testMultiValued() throws Exception {
+    try {
+      registerFields(List.of(getFieldBuilder("doc_id", true, true, true, false)));
+    } catch (RuntimeException e) {
+      String message =
+          "INVALID_ARGUMENT: error while trying to RegisterFields for index: test_index\n"
+              + "field: doc_id cannot have multivalued fields or tokenization as it's an _ID field";
+      assertEquals(message, e.getMessage());
+      throw e;
+    }
+  }
+
+  @Test(expected = StatusRuntimeException.class)
+  public void testTokenized() throws Exception {
+    try {
+      registerFields(List.of(getFieldBuilder("doc_id", true, true, false, true)));
+    } catch (RuntimeException e) {
+      String message =
+          "INVALID_ARGUMENT: error while trying to RegisterFields for index: test_index\n"
+              + "field: doc_id cannot have multivalued fields or tokenization as it's an _ID field";
+      assertEquals(message, e.getMessage());
+      throw e;
+    }
+  }
+
+  @Test(expected = StatusRuntimeException.class)
+  public void testStoreMandatory() throws IOException {
+    try {
+      registerFields(List.of(getFieldBuilder("doc_id", false, false, false, false)));
+    } catch (RuntimeException e) {
+      String message =
+          "INVALID_ARGUMENT: error while trying to RegisterFields for index: test_index\n"
+              + "field: doc_id is an _ID field and should have store=true";
+      assertEquals(message, e.getMessage());
+      throw e;
+    }
+  }
+
+  @Test(expected = StatusRuntimeException.class)
+  public void testMultipleDocIds() throws Exception {
+    try {
+      registerFields(
+          List.of(
+              getFieldBuilder("doc_id", true, true, false, false),
+              getFieldBuilder("doc_id_2", true, true, false, false)));
+    } catch (RuntimeException e) {
+      String message =
+          "INVALID_ARGUMENT: error while trying to RegisterFields for index: test_index\n"
+              + "cannot register another _id field \"doc_id_2\" as an _id field \"doc_id\" already exists";
+      assertEquals(message, e.getMessage());
+      throw e;
+    }
+  }
+
+  private Field getFieldBuilder(
+      String fieldName,
+      boolean storeDocValues,
+      boolean store,
+      boolean multiValued,
+      boolean tokenized) {
+    return Field.newBuilder()
+        .setName(fieldName)
+        .setStoreDocValues(storeDocValues)
+        .setStore(store)
+        .setType(FieldType._ID)
+        .setMultiValued(multiValued)
+        .setTokenize(tokenized)
+        .build();
+  }
+
+  private void registerFields(List<Field> fields) throws IOException {
+    new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
+    String indexName = grpcServer.getTestIndex();
+    grpcServer
+        .getBlockingStub()
+        .createIndex(
+            CreateIndexRequest.newBuilder()
+                .setIndexName(indexName)
+                .setRootDir(grpcServer.getIndexDir())
+                .build());
+    FieldDefRequest.Builder builder = FieldDefRequest.newBuilder().setIndexName(indexName);
+    for (Field field : fields) {
+      builder.addField(field);
+    }
+    grpcServer.getBlockingStub().registerFields(builder.build());
+  }
+}

--- a/src/test/resources/registerFieldsBasicWithId.json
+++ b/src/test/resources/registerFieldsBasicWithId.json
@@ -1,0 +1,133 @@
+{
+  "indexName": "test_index",
+  "field": [
+    {
+      "name": "doc_id",
+      "type": "_ID",
+      "store": true
+    },
+    {
+      "name": "vendor_name",
+      "type": "TEXT",
+      "search": true,
+      "store": true,
+      "tokenize": true,
+      "multiValued": true,
+      "storeDocValues": true,
+      "analyzer": {
+        "custom": {
+          "tokenizer": {
+            "name": "standard"
+          },
+          "tokenFilters": [
+            {
+              "name": "lowercase"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "vendor_name_atom",
+      "type": "ATOM",
+      "search": true,
+      "store": true,
+      "multiValued": true,
+      "storeDocValues": true
+    },
+    {
+      "name": "license_no",
+      "type": "INT",
+      "multiValued": true,
+      "storeDocValues": true
+    },
+    {
+      "name": "count",
+      "type": "INT",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "long_field",
+      "type": "LONG",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "long_field_multi",
+      "type": "LONG",
+      "search": true,
+      "storeDocValues": true,
+      "multiValued": true,
+      "sort": true
+    },
+    {
+      "name": "double_field_multi",
+      "type": "DOUBLE",
+      "storeDocValues": true,
+      "multiValued": true,
+      "sort": true
+    },
+    {
+      "name": "double_field",
+      "type": "DOUBLE",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "float_field_multi",
+      "type": "FLOAT",
+      "storeDocValues": true,
+      "multiValued": true,
+      "sort": true
+    },
+    {
+      "name": "float_field",
+      "type": "FLOAT",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "boolean_field_multi",
+      "type": "BOOLEAN",
+      "storeDocValues": true,
+      "multiValued": true,
+      "sort": true
+    },
+    {
+      "name": "boolean_field",
+      "type": "BOOLEAN",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "description",
+      "type": "TEXT",
+      "search": true,
+      "store": true,
+      "tokenize": true,
+      "multiValued": true,
+      "storeDocValues": true
+    },
+    {
+      "name": "date",
+      "type": "DATE_TIME",
+      "search": true,
+      "storeDocValues": true,
+      "dateTimeFormat": "yyyy-MM-dd HH:mm:ss"
+    },
+    {
+      "name": "date_multi",
+      "type": "DATE_TIME",
+      "search": true,
+      "storeDocValues": true,
+      "multiValued": true,
+      "dateTimeFormat": "yyyy-MM-dd HH:mm:ss"
+    }
+  ]
+}


### PR DESCRIPTION
This is another way to fix #153 and seemed better than #155 

We can declare the fields this way and that will be used to update the documents:

```
{
      "name": "doc_id",
      "type": "_ID",
      "store": true
}
``` 
Few reasons why this seems cleaner :

1. The changes are smaller and confined to the field def. We could add more code to the field def without breaking it in any other place.
2. Better notation of '_ID' which is always going to be stored as a string. This won't overload other field definitions to just update the documents. 

