### PR TITLE
Add multi-value support to LAT_LON field type

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/doc/LoadedDocValues.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/doc/LoadedDocValues.java
@@ -279,6 +279,25 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
     }
   }
 
+  // Even single points use SortedNumericDocValues, since they are LatLonDocValuesFields
+  public static final class SingleLocation extends SortedNumericValues<GeoPoint> {
+    public SingleLocation(SortedNumericDocValues docValues) {
+      super(docValues, GEO_POINT_DECODER);
+    }
+
+    public GeoPoint getValue() {
+      return get(0);
+    }
+
+    @Override
+    public SearchResponse.Hit.FieldValue toFieldValue(int index) {
+      GeoPoint point = get(index);
+      LatLng latLon =
+          LatLng.newBuilder().setLatitude(point.getLat()).setLongitude(point.getLon()).build();
+      return SearchResponse.Hit.FieldValue.newBuilder().setLatLngValue(latLon).build();
+    }
+  }
+
   public static final class Locations extends SortedNumericValues<GeoPoint> {
     public Locations(SortedNumericDocValues docValues) {
       super(docValues, GEO_POINT_DECODER);

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -71,7 +71,8 @@ public class LuceneServerTest {
   public static final List<String> QUERY_VIRTUAL_FIELDS =
       Arrays.asList("query_virtual_field", "query_virtual_field_w_score");
   static final List<String> LAT_LON_VALUES =
-      Arrays.asList("doc_id", "vendor_name", "vendor_name_atom", "license_no", "lat_lon");
+      Arrays.asList(
+          "doc_id", "vendor_name", "vendor_name_atom", "license_no", "lat_lon", "lat_lon_multi");
   /**
    * This rule manages automatic graceful shutdown for the registered servers and channels at the
    * end of test.
@@ -1121,6 +1122,8 @@ public class LuceneServerTest {
     List<String> expectedVendorNameAtom = null;
     List<Double> expectedLat = null;
     List<Double> expectedLon = null;
+    List<Double> expectedMultiLat = null;
+    List<Double> expectedMultiLon = null;
 
     if (docId.equals("1")) {
       expectedLicenseNo = Arrays.asList("300", "3100");
@@ -1128,12 +1131,16 @@ public class LuceneServerTest {
       expectedVendorNameAtom = Arrays.asList("first atom vendor", "first atom again");
       expectedLat = Arrays.asList(37.7749);
       expectedLon = Arrays.asList(-122.393990);
+      expectedMultiLat = Arrays.asList(30.9988, 40.1748);
+      expectedMultiLon = Arrays.asList(-120.33977, -142.453490);
     } else if (docId.equals("2")) {
       expectedLicenseNo = Arrays.asList("411", "4222");
       expectedVendorName = Arrays.asList("second vendor", "second again");
       expectedVendorNameAtom = Arrays.asList("second atom vendor", "second atom again");
       expectedLat = Arrays.asList(37.5485);
       expectedLon = Arrays.asList(-121.9886);
+      expectedMultiLat = Arrays.asList(29.9988, 39.1748);
+      expectedMultiLon = Arrays.asList(-119.33977, -141.453490);
     } else {
       fail(String.format("docId %s not indexed", docId));
     }
@@ -1152,6 +1159,15 @@ public class LuceneServerTest {
     for (int i = 0; i < latLonList.size(); ++i) {
       assertEquals(expectedLat.get(i), latLonList.get(i).getLatLngValue().getLatitude(), 0.00001);
       assertEquals(expectedLon.get(i), latLonList.get(i).getLatLngValue().getLongitude(), 0.00001);
+    }
+    List<SearchResponse.Hit.FieldValue> latLonMultiList =
+        fields.get("lat_lon_multi").getFieldValueList();
+    assertEquals(latLonMultiList.size(), expectedMultiLat.size());
+    for (int i = 0; i < latLonMultiList.size(); ++i) {
+      assertEquals(
+          expectedMultiLat.get(i), latLonMultiList.get(i).getLatLngValue().getLatitude(), 0.00001);
+      assertEquals(
+          expectedMultiLon.get(i), latLonMultiList.get(i).getLatLngValue().getLongitude(), 0.00001);
     }
   }
 

--- a/src/test/resources/addDocsLatLon.csv
+++ b/src/test/resources/addDocsLatLon.csv
@@ -1,3 +1,3 @@
-doc_id,vendor_name,vendor_name_atom,license_no,lat_lon
-1,first vendor;first again,first atom vendor;first atom again,300;3100,37.7749;-122.393990
-2,second vendor;second again,second atom vendor;second atom again,411;4222,37.5485;-121.9886
+doc_id,vendor_name,vendor_name_atom,license_no,lat_lon,lat_lon_multi
+1,first vendor;first again,first atom vendor;first atom again,300;3100,37.7749;-122.393990,30.9988;-120.33977;40.1748;-142.453490
+2,second vendor;second again,second atom vendor;second atom again,411;4222,37.5485;-121.9886,29.9988;-119.33977;39.1748;-141.453490

--- a/src/test/resources/registerFieldsLatLon.json
+++ b/src/test/resources/registerFieldsLatLon.json
@@ -32,6 +32,12 @@
     {
       "name": "lat_lon",
       "type": "LAT_LON",
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "lat_lon_multi",
+      "type": "LAT_LON",
       "multiValued": true,
       "storeDocValues": true,
       "sort": true


### PR DESCRIPTION
Extend LAT_LON field type to support multiple point values. Points are indexed by specifying a sequence of lat lon values.

Script and Query tests updated to verify a multi-value point field.

https://github.com/Yelp/nrtsearch/issues/166