### PR TITLE
Add multi value field support and length/empty properties

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/BindingValuesSources.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/BindingValuesSources.java
@@ -1,0 +1,421 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.field;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.function.LongToDoubleFunction;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.search.DoubleValues;
+import org.apache.lucene.search.DoubleValuesSource;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.util.NumericUtils;
+
+/**
+ * Container class for {@link DoubleValuesSource} implementations that expose various field
+ * properties to lucene {@link org.apache.lucene.expressions.Expression} scripts.
+ */
+public class BindingValuesSources {
+
+  // decoders to convert the long value read from doc value fields into a double
+  public static LongToDoubleFunction INT_DECODER = value -> (double) value;
+  public static LongToDoubleFunction LONG_DECODER = value -> (double) value;
+  public static LongToDoubleFunction FLOAT_DECODER =
+      value -> (double) Float.intBitsToFloat((int) value);
+  public static LongToDoubleFunction DOUBLE_DECODER = Double::longBitsToDouble;
+  public static LongToDoubleFunction SORTED_FLOAT_DECODER =
+      value -> (double) NumericUtils.sortableIntToFloat((int) value);
+  public static LongToDoubleFunction SORTED_DOUBLE_DECODER = NumericUtils::sortableLongToDouble;
+
+  private BindingValuesSources() {}
+
+  public abstract static class NumericValuesSourceBase extends DoubleValuesSource {
+
+    final String field;
+
+    public NumericValuesSourceBase(String field) {
+      this.field = field;
+    }
+
+    @Override
+    public boolean needsScores() {
+      return false;
+    }
+
+    @Override
+    public DoubleValuesSource rewrite(IndexSearcher reader) throws IOException {
+      return this;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(field);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      NumericValuesSourceBase that = (NumericValuesSourceBase) o;
+      return Objects.equals(field, that.field);
+    }
+
+    @Override
+    public Explanation explain(LeafReaderContext ctx, int docId, Explanation scoreExplanation)
+        throws IOException {
+      DoubleValues values = getValues(ctx, null);
+      if (values.advanceExact(docId))
+        return Explanation.match(values.doubleValue(), this.toString());
+      else return Explanation.noMatch(this.toString());
+    }
+
+    @Override
+    public boolean isCacheable(LeafReaderContext ctx) {
+      return DocValues.isCacheable(ctx, field);
+    }
+  }
+
+  /** Value source for the length of a single valued field. */
+  public static class NumericLengthValuesSource extends NumericValuesSourceBase {
+
+    public NumericLengthValuesSource(String field) {
+      super(field);
+    }
+
+    @Override
+    public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores) throws IOException {
+      NumericDocValues numericDocValues = DocValues.getNumeric(ctx.reader(), field);
+      return new DoubleValues() {
+        double length;
+
+        @Override
+        public double doubleValue() throws IOException {
+          return length;
+        }
+
+        @Override
+        public boolean advanceExact(int doc) throws IOException {
+          length = numericDocValues.advanceExact(doc) ? 1 : 0;
+          return true;
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      return "length(" + field + ")";
+    }
+  }
+
+  /** Value source to determine if a single valued field is empty. */
+  public static class NumericEmptyValuesSource extends NumericValuesSourceBase {
+
+    public NumericEmptyValuesSource(String field) {
+      super(field);
+    }
+
+    @Override
+    public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores) throws IOException {
+      NumericDocValues numericDocValues = DocValues.getNumeric(ctx.reader(), field);
+      return new DoubleValues() {
+        double length;
+
+        @Override
+        public double doubleValue() throws IOException {
+          return length;
+        }
+
+        @Override
+        public boolean advanceExact(int doc) throws IOException {
+          length = numericDocValues.advanceExact(doc) ? 0 : 1;
+          return true;
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      return "empty(" + field + ")";
+    }
+  }
+
+  /** Value source for the value of a single valued field. */
+  public static class NumericDecodedValuesSource extends DoubleValuesSource {
+
+    final String field;
+    final LongToDoubleFunction decoder;
+
+    public NumericDecodedValuesSource(String field, LongToDoubleFunction decoder) {
+      this.field = field;
+      this.decoder = decoder;
+    }
+
+    @Override
+    public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores) throws IOException {
+      final NumericDocValues numericDocValues = DocValues.getNumeric(ctx.reader(), field);
+      return new DoubleValues() {
+        @Override
+        public double doubleValue() throws IOException {
+          return decoder.applyAsDouble(numericDocValues.longValue());
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+          return numericDocValues.advanceExact(target);
+        }
+      };
+    }
+
+    @Override
+    public boolean needsScores() {
+      return false;
+    }
+
+    @Override
+    public DoubleValuesSource rewrite(IndexSearcher reader) throws IOException {
+      return this;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(field, decoder);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      NumericDecodedValuesSource that = (NumericDecodedValuesSource) o;
+      return Objects.equals(field, that.field) && Objects.equals(decoder, that.decoder);
+    }
+
+    @Override
+    public String toString() {
+      return "double(" + field + ")";
+    }
+
+    @Override
+    public Explanation explain(LeafReaderContext ctx, int docId, Explanation scoreExplanation)
+        throws IOException {
+      DoubleValues values = getValues(ctx, null);
+      if (values.advanceExact(docId))
+        return Explanation.match(values.doubleValue(), this.toString());
+      else return Explanation.noMatch(this.toString());
+    }
+
+    @Override
+    public boolean isCacheable(LeafReaderContext ctx) {
+      return DocValues.isCacheable(ctx, field);
+    }
+  }
+
+  public abstract static class SortedNumericValuesSourceBase extends DoubleValuesSource {
+
+    final String field;
+
+    public SortedNumericValuesSourceBase(String field) {
+      this.field = field;
+    }
+
+    @Override
+    public boolean needsScores() {
+      return false;
+    }
+
+    @Override
+    public DoubleValuesSource rewrite(IndexSearcher reader) throws IOException {
+      return this;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(field);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      SortedNumericValuesSourceBase that = (SortedNumericValuesSourceBase) o;
+      return Objects.equals(field, that.field);
+    }
+
+    @Override
+    public Explanation explain(LeafReaderContext ctx, int docId, Explanation scoreExplanation)
+        throws IOException {
+      DoubleValues values = getValues(ctx, null);
+      if (values.advanceExact(docId))
+        return Explanation.match(values.doubleValue(), this.toString());
+      else return Explanation.noMatch(this.toString());
+    }
+
+    @Override
+    public boolean isCacheable(LeafReaderContext ctx) {
+      return DocValues.isCacheable(ctx, field);
+    }
+  }
+
+  /** Value source for the length of a multi valued field. */
+  public static class SortedNumericLengthValuesSource extends SortedNumericValuesSourceBase {
+
+    public SortedNumericLengthValuesSource(String field) {
+      super(field);
+    }
+
+    @Override
+    public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores) throws IOException {
+      SortedNumericDocValues sortedNumericDocValues =
+          DocValues.getSortedNumeric(ctx.reader(), field);
+      return new DoubleValues() {
+        boolean hasValues;
+
+        @Override
+        public double doubleValue() throws IOException {
+          if (hasValues) {
+            return sortedNumericDocValues.docValueCount();
+          }
+          return 0;
+        }
+
+        @Override
+        public boolean advanceExact(int doc) throws IOException {
+          hasValues = sortedNumericDocValues.advanceExact(doc);
+          return true;
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      return "length(" + field + ")";
+    }
+  }
+
+  /** Value source to determine if a multi valued field is empty. */
+  public static class SortedNumericEmptyValuesSource extends SortedNumericValuesSourceBase {
+
+    public SortedNumericEmptyValuesSource(String field) {
+      super(field);
+    }
+
+    @Override
+    public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores) throws IOException {
+      SortedNumericDocValues sortedNumericDocValues =
+          DocValues.getSortedNumeric(ctx.reader(), field);
+      return new DoubleValues() {
+        boolean hasValues;
+
+        @Override
+        public double doubleValue() throws IOException {
+          return hasValues ? 0 : 1;
+        }
+
+        @Override
+        public boolean advanceExact(int doc) throws IOException {
+          hasValues = sortedNumericDocValues.advanceExact(doc);
+          return true;
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      return "empty(" + field + ")";
+    }
+  }
+
+  public abstract static class SortedNumericDecodedValuesSource extends DoubleValuesSource {
+
+    final String field;
+    final LongToDoubleFunction decoder;
+
+    public SortedNumericDecodedValuesSource(String field, LongToDoubleFunction decoder) {
+      this.field = field;
+      this.decoder = decoder;
+    }
+
+    @Override
+    public boolean needsScores() {
+      return false;
+    }
+
+    @Override
+    public DoubleValuesSource rewrite(IndexSearcher reader) throws IOException {
+      return this;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(field, decoder);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      SortedNumericDecodedValuesSource that = (SortedNumericDecodedValuesSource) o;
+      return Objects.equals(field, that.field) && Objects.equals(decoder, that.decoder);
+    }
+
+    @Override
+    public Explanation explain(LeafReaderContext ctx, int docId, Explanation scoreExplanation)
+        throws IOException {
+      DoubleValues values = getValues(ctx, null);
+      if (values.advanceExact(docId))
+        return Explanation.match(values.doubleValue(), this.toString());
+      else return Explanation.noMatch(this.toString());
+    }
+
+    @Override
+    public boolean isCacheable(LeafReaderContext ctx) {
+      return DocValues.isCacheable(ctx, field);
+    }
+  }
+
+  /** Value source to return the minimum (first) value of a multi valued field. */
+  public static class SortedNumericMinValuesSource extends SortedNumericDecodedValuesSource {
+
+    public SortedNumericMinValuesSource(String field, LongToDoubleFunction decoder) {
+      super(field, decoder);
+    }
+
+    @Override
+    public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores) throws IOException {
+      SortedNumericDocValues sortedNumericDocValues =
+          DocValues.getSortedNumeric(ctx.reader(), field);
+      return new DoubleValues() {
+        @Override
+        public double doubleValue() throws IOException {
+          return decoder.applyAsDouble(sortedNumericDocValues.nextValue());
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+          return sortedNumericDocValues.advanceExact(target);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      return "minDouble(" + field + ")";
+    }
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/DoubleFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/DoubleFieldDef.java
@@ -20,13 +20,13 @@ import com.yelp.nrtsearch.server.grpc.RangeQuery;
 import com.yelp.nrtsearch.server.grpc.TermInSetQuery;
 import com.yelp.nrtsearch.server.grpc.TermQuery;
 import com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues;
+import java.util.function.LongToDoubleFunction;
 import org.apache.lucene.document.DoubleDocValuesField;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
-import org.apache.lucene.search.DoubleValuesSource;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
@@ -66,8 +66,12 @@ public class DoubleFieldDef extends NumberFieldDef {
   }
 
   @Override
-  protected DoubleValuesSource getBindingSource() {
-    return DoubleValuesSource.fromDoubleField(getName());
+  protected LongToDoubleFunction getBindingDecoder() {
+    if (isMultiValue()) {
+      return BindingValuesSources.SORTED_DOUBLE_DECODER;
+    } else {
+      return BindingValuesSources.DOUBLE_DECODER;
+    }
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/FieldDefBindings.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/FieldDefBindings.java
@@ -18,6 +18,8 @@ package com.yelp.nrtsearch.server.luceneserver.field;
 import com.yelp.nrtsearch.server.luceneserver.field.properties.Bindable;
 import java.util.Map;
 import org.apache.lucene.expressions.Bindings;
+import org.apache.lucene.expressions.js.VariableContext;
+import org.apache.lucene.expressions.js.VariableContext.Type;
 import org.apache.lucene.search.DoubleValuesSource;
 
 /** Implements {@link Bindings} on top of the registered fields. */
@@ -30,18 +32,56 @@ public final class FieldDefBindings extends Bindings {
     this.fields = fields;
   }
 
+  /**
+   * Bind a field name into a lucene {@link org.apache.lucene.expressions.Expression} by providing a
+   * {@link DoubleValuesSource}.
+   *
+   * <p>Valid values are:
+   *
+   * <p>_score : relevance score
+   *
+   * <p>field_name : the name of a field that implements {@link Bindable}, provides the field value
+   * (or first value if the field is multi value)
+   *
+   * <p>doc['field_name'].property : the field_name must be a field implementing {@link Bindable},
+   * and the property must be an implemented bindable property of the field such as value, length,
+   * or empty
+   *
+   * @param name variable name
+   * @return expression value source
+   */
   @Override
   public DoubleValuesSource getDoubleValuesSource(String name) {
     if (name.equals("_score")) {
       return DoubleValuesSource.SCORES;
     }
     FieldDef fd = fields.get(name);
+    String property = Bindable.VALUE_PROPERTY;
+    String fieldName = name;
     if (fd == null) {
-      throw new IllegalArgumentException("Invalid reference '" + name + "'");
+      // name is not a field name, try to parse it as the extended form doc['field_name'].property
+      VariableContext[] parsed = VariableContext.parse(name);
+      if (parsed.length != 3) {
+        throw new IllegalArgumentException("Invalid reference '" + name + "'");
+      }
+      if (!parsed[0].type.equals(Type.MEMBER)
+          || !parsed[0].text.equals("doc")
+          || !parsed[1].type.equals(Type.STR_INDEX)
+          || parsed[2].type.equals(Type.INT_INDEX)) {
+        throw new IllegalArgumentException(
+            "Invalid field binding format: " + name + ", expected: doc['field_name'].property");
+      }
+      fieldName = parsed[1].text;
+      fd = fields.get(fieldName);
+      if (fd == null) {
+        throw new IllegalArgumentException("Unknown field to bind: " + fieldName);
+      }
+      property = parsed[2].text;
     }
     if (!(fd instanceof Bindable)) {
-      throw new IllegalArgumentException("Field: " + name + " does not support expression binding");
+      throw new IllegalArgumentException(
+          "Field: " + fieldName + " does not support expression binding");
     }
-    return ((Bindable) fd).getExpressionBinding();
+    return ((Bindable) fd).getExpressionBinding(property);
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/FloatFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/FloatFieldDef.java
@@ -20,13 +20,13 @@ import com.yelp.nrtsearch.server.grpc.RangeQuery;
 import com.yelp.nrtsearch.server.grpc.TermInSetQuery;
 import com.yelp.nrtsearch.server.grpc.TermQuery;
 import com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues;
+import java.util.function.LongToDoubleFunction;
 import org.apache.lucene.document.FloatDocValuesField;
 import org.apache.lucene.document.FloatPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
-import org.apache.lucene.search.DoubleValuesSource;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
@@ -66,8 +66,12 @@ public class FloatFieldDef extends NumberFieldDef {
   }
 
   @Override
-  protected DoubleValuesSource getBindingSource() {
-    return DoubleValuesSource.fromFloatField(getName());
+  protected LongToDoubleFunction getBindingDecoder() {
+    if (isMultiValue()) {
+      return BindingValuesSources.SORTED_FLOAT_DECODER;
+    } else {
+      return BindingValuesSources.FLOAT_DECODER;
+    }
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/IntFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/IntFieldDef.java
@@ -20,13 +20,13 @@ import com.yelp.nrtsearch.server.grpc.RangeQuery;
 import com.yelp.nrtsearch.server.grpc.TermInSetQuery;
 import com.yelp.nrtsearch.server.grpc.TermQuery;
 import com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues;
+import java.util.function.LongToDoubleFunction;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
-import org.apache.lucene.search.DoubleValuesSource;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
@@ -64,8 +64,8 @@ public class IntFieldDef extends NumberFieldDef {
   }
 
   @Override
-  protected DoubleValuesSource getBindingSource() {
-    return DoubleValuesSource.fromIntField(getName());
+  protected LongToDoubleFunction getBindingDecoder() {
+    return BindingValuesSources.INT_DECODER;
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/LongFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/LongFieldDef.java
@@ -20,13 +20,13 @@ import com.yelp.nrtsearch.server.grpc.RangeQuery;
 import com.yelp.nrtsearch.server.grpc.TermInSetQuery;
 import com.yelp.nrtsearch.server.grpc.TermQuery;
 import com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues;
+import java.util.function.LongToDoubleFunction;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
-import org.apache.lucene.search.DoubleValuesSource;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
@@ -64,8 +64,8 @@ public class LongFieldDef extends NumberFieldDef {
   }
 
   @Override
-  protected DoubleValuesSource getBindingSource() {
-    return DoubleValuesSource.fromLongField(getName());
+  protected LongToDoubleFunction getBindingDecoder() {
+    return BindingValuesSources.LONG_DECODER;
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/VirtualFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/VirtualFieldDef.java
@@ -68,7 +68,10 @@ public class VirtualFieldDef extends FieldDef implements Bindable, Sortable {
   }
 
   @Override
-  public DoubleValuesSource getExpressionBinding() {
+  public DoubleValuesSource getExpressionBinding(String property) {
+    if (!VALUE_PROPERTY.equals(property)) {
+      throw new IllegalArgumentException("Virtual fields can only bind the value property");
+    }
     return getValuesSource();
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/properties/Bindable.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/properties/Bindable.java
@@ -22,11 +22,17 @@ import org.apache.lucene.search.DoubleValuesSource;
  * be bound into lucene {@link org.apache.lucene.expressions.Expression} scripts.
  */
 public interface Bindable {
+  String VALUE_PROPERTY = "value";
   /**
    * Get {@link DoubleValuesSource} to produce values per document when this field is bound into a
    * lucene {@link org.apache.lucene.expressions.Expression} script.
    *
+   * <p>Fields may allow for different properties to be bound. The 'value' property should return
+   * the value of the field (or first value of a multi valued field). Numeric fields also define the
+   * 'length' and 'empty' properties.
+   *
+   * @param property name of the property to bind
    * @return value source to use for expression script binding
    */
-  DoubleValuesSource getExpressionBinding();
+  DoubleValuesSource getExpressionBinding(String property);
 }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/js/JsScriptBindingsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/js/JsScriptBindingsTest.java
@@ -132,6 +132,70 @@ public class JsScriptBindingsTest {
     bindings.getDoubleValuesSource("invalid");
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testExtendedInvalidName() {
+    Map<String, Object> params = new HashMap<>();
+    params.put("param1", 100);
+    params.put("param2", 1.11);
+
+    DoubleValuesSource field1Source = new DummyValuesSource();
+    DoubleValuesSource field2Source = new DummyValuesSource();
+    Map<String, FieldDef> fieldDefMap = new HashMap<>();
+    fieldDefMap.put("field1", new VirtualFieldDef("field1", field1Source));
+    fieldDefMap.put("field2", new VirtualFieldDef("field2", field2Source));
+
+    JsScriptBindings bindings = new JsScriptBindings(new FieldDefBindings(fieldDefMap), params);
+    bindings.getDoubleValuesSource("doc['invalid'].value");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testExtendedIntIndex() {
+    Map<String, Object> params = new HashMap<>();
+    params.put("param1", 100);
+    params.put("param2", 1.11);
+
+    DoubleValuesSource field1Source = new DummyValuesSource();
+    DoubleValuesSource field2Source = new DummyValuesSource();
+    Map<String, FieldDef> fieldDefMap = new HashMap<>();
+    fieldDefMap.put("field1", new VirtualFieldDef("field1", field1Source));
+    fieldDefMap.put("field2", new VirtualFieldDef("field2", field2Source));
+
+    JsScriptBindings bindings = new JsScriptBindings(new FieldDefBindings(fieldDefMap), params);
+    bindings.getDoubleValuesSource("doc[1].value");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testExtendedInvalidPrefix() {
+    Map<String, Object> params = new HashMap<>();
+    params.put("param1", 100);
+    params.put("param2", 1.11);
+
+    DoubleValuesSource field1Source = new DummyValuesSource();
+    DoubleValuesSource field2Source = new DummyValuesSource();
+    Map<String, FieldDef> fieldDefMap = new HashMap<>();
+    fieldDefMap.put("field1", new VirtualFieldDef("field1", field1Source));
+    fieldDefMap.put("field2", new VirtualFieldDef("field2", field2Source));
+
+    JsScriptBindings bindings = new JsScriptBindings(new FieldDefBindings(fieldDefMap), params);
+    bindings.getDoubleValuesSource("not_doc['field1'].value");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testExtendedMissingProperty() {
+    Map<String, Object> params = new HashMap<>();
+    params.put("param1", 100);
+    params.put("param2", 1.11);
+
+    DoubleValuesSource field1Source = new DummyValuesSource();
+    DoubleValuesSource field2Source = new DummyValuesSource();
+    Map<String, FieldDef> fieldDefMap = new HashMap<>();
+    fieldDefMap.put("field1", new VirtualFieldDef("field1", field1Source));
+    fieldDefMap.put("field2", new VirtualFieldDef("field2", field2Source));
+
+    JsScriptBindings bindings = new JsScriptBindings(new FieldDefBindings(fieldDefMap), params);
+    bindings.getDoubleValuesSource("doc['field1']");
+  }
+
   @Test
   public void testParamBindingIsCached() {
     Map<String, Object> params = new HashMap<>();

--- a/src/test/resources/script/addDocsJs.csv
+++ b/src/test/resources/script/addDocsJs.csv
@@ -1,0 +1,3 @@
+doc_id,vendor_name,vendor_name_atom,int_field_multi,int_field,long_field_multi,long_field,double_field_multi,double_field,float_field_multi,float_field,boolean_field_multi,boolean_field,description,date,date_multi
+1,first vendor;first again,first atom vendor;first atom again,300;3100,3,1;2,12,1.1;1.11,1.01,100.11;100.1,100.01,true;false,false,FIRST food,2019-10-12 15:30:41,2019-11-13 10:20:15;2019-12-14 08:40:45
+2,second vendor;second again,second atom vendor;second atom again,4222;411,7,3;4,16,2.2;2.22,2.01,200.2;200.22,200.02,true;false,false,SECOND gas,2020-03-05 01:03:05,2018-01-20 00:31:00;2018-02-21 09:43:30

--- a/src/test/resources/script/registerFieldsJs.json
+++ b/src/test/resources/script/registerFieldsJs.json
@@ -1,0 +1,197 @@
+{
+  "indexName": "test_index",
+  "field": [
+    {
+      "name": "doc_id",
+      "type": "ATOM",
+      "storeDocValues": true
+    },
+    {
+      "name": "vendor_name",
+      "type": "TEXT",
+      "search": true,
+      "store": true,
+      "tokenize": true,
+      "multiValued": true,
+      "storeDocValues": true,
+      "analyzer": {
+        "custom": {
+          "tokenizer": {
+            "name": "standard"
+          },
+          "tokenFilters": [
+            {
+              "name": "lowercase"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "vendor_name_atom",
+      "type": "ATOM",
+      "search": true,
+      "store": true,
+      "multiValued": true,
+      "storeDocValues": true
+    },
+    {
+      "name": "int_field_multi",
+      "type": "INT",
+      "multiValued": true,
+      "storeDocValues": true
+    },
+    {
+      "name": "int_field",
+      "type": "INT",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "long_field",
+      "type": "LONG",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "long_field_multi",
+      "type": "LONG",
+      "search": true,
+      "storeDocValues": true,
+      "multiValued": true,
+      "sort": true
+    },
+    {
+      "name": "double_field_multi",
+      "type": "DOUBLE",
+      "storeDocValues": true,
+      "multiValued": true,
+      "sort": true
+    },
+    {
+      "name": "double_field",
+      "type": "DOUBLE",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "float_field_multi",
+      "type": "FLOAT",
+      "storeDocValues": true,
+      "multiValued": true,
+      "sort": true
+    },
+    {
+      "name": "float_field",
+      "type": "FLOAT",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "boolean_field_multi",
+      "type": "BOOLEAN",
+      "storeDocValues": true,
+      "multiValued": true,
+      "sort": true
+    },
+    {
+      "name": "boolean_field",
+      "type": "BOOLEAN",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "description",
+      "type": "TEXT",
+      "search": true,
+      "store": true,
+      "tokenize": true,
+      "multiValued": true,
+      "storeDocValues": true
+    },
+    {
+      "name": "date",
+      "type": "DATE_TIME",
+      "search": true,
+      "storeDocValues": true,
+      "dateTimeFormat": "yyyy-MM-dd HH:mm:ss"
+    },
+    {
+      "name": "date_multi",
+      "type": "DATE_TIME",
+      "search": true,
+      "storeDocValues": true,
+      "multiValued": true,
+      "dateTimeFormat": "yyyy-MM-dd HH:mm:ss"
+    },
+    {
+      "name": "empty_int_multi",
+      "type": "INT",
+      "multiValued": true,
+      "storeDocValues": true
+    },
+    {
+      "name": "empty_int",
+      "type": "INT",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "empty_long",
+      "type": "LONG",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "empty_long_multi",
+      "type": "LONG",
+      "search": true,
+      "storeDocValues": true,
+      "multiValued": true,
+      "sort": true
+    },
+    {
+      "name": "empty_double_multi",
+      "type": "DOUBLE",
+      "storeDocValues": true,
+      "multiValued": true,
+      "sort": true
+    },
+    {
+      "name": "empty_double",
+      "type": "DOUBLE",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "empty_float_multi",
+      "type": "FLOAT",
+      "storeDocValues": true,
+      "multiValued": true,
+      "sort": true
+    },
+    {
+      "name": "empty_float",
+      "type": "FLOAT",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "virtual_field",
+      "type": "VIRTUAL",
+      "script": {
+        "lang": "js",
+        "source": "float_field*2.0+long_field*3.0"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds support for multi valued fields in expression bindings. The default value used for these fields will be the first (minimum) value.

Fields may now be specified in the form "doc['field_name'].property"
For numeric fields the 'property' value may be:
- value : field value
- length : number of values in this field
- empty : 1 if the field has no values, 0 otherwise