### PR TITLE
Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ cat search.json
         "indexName": "testIdx",
         "startHit": 0,
         "topHits": 100,
-        "retrieveFields": ["doc_id", license_no", "vendor_name"],
+        "retrieveFields": ["doc_id", "license_no", "vendor_name"],
          "queryText": "vendor_name:first vendor"
 }
 ```


### PR DESCRIPTION
There was a missing `"` in the `search.json` content making it malformed. This PR fixes the typo.