### PR TITLE
Pin grpc-gateway version

### DIFF
--- a/grpc-gateway/Dockerfile
+++ b/grpc-gateway/Dockerfile
@@ -30,10 +30,16 @@ ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+
+#use go modules to pin module versions
+ENV GO111MODULE=on
+ENV GRPC_GATEWAY_VERSION=1.15.2
+
 #install required go protoc plugins to build grpc-gateway server
-RUN go get -u \
-    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
-    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger \
+RUN go mod init
+RUN go get \
+    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v${GRPC_GATEWAY_VERSION} \
+    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v${GRPC_GATEWAY_VERSION} \
     github.com/golang/protobuf/protoc-gen-go \
     google.golang.org/grpc
 

--- a/http_wrapper.go
+++ b/http_wrapper.go
@@ -11,7 +11,7 @@ import (
   "github.com/grpc-ecosystem/grpc-gateway/runtime"
   "google.golang.org/grpc"
 
-  gw "./grpc-gateway"
+  gw "github.com/Yelp/nrtsearch/grpc-gateway"
 )
 
 var (


### PR DESCRIPTION
Pin `grpc-gateway` to a stable release version `v1.15.2`. 

Tests:
`./gradlew buildGrpcGateway` succeeds