### PR TITLE
Implement CompletionInfixSuggester

### DIFF
--- a/grpc-gateway/Dockerfile
+++ b/grpc-gateway/Dockerfile
@@ -30,10 +30,16 @@ ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+
+#use go modules to pin module versions
+ENV GO111MODULE=on
+ENV GRPC_GATEWAY_VERSION=1.15.2
+
 #install required go protoc plugins to build grpc-gateway server
-RUN go get -u \
-    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
-    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger \
+RUN go mod init
+RUN go get \
+    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v${GRPC_GATEWAY_VERSION} \
+    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v${GRPC_GATEWAY_VERSION} \
     github.com/golang/protobuf/protoc-gen-go \
     google.golang.org/grpc
 

--- a/http_wrapper.go
+++ b/http_wrapper.go
@@ -11,7 +11,7 @@ import (
   "github.com/grpc-ecosystem/grpc-gateway/runtime"
   "google.golang.org/grpc"
 
-  gw "./grpc-gateway"
+  gw "github.com/Yelp/nrtsearch/grpc-gateway"
 )
 
 var (

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/suggest/CompletionInfixSuggester.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/suggest/CompletionInfixSuggester.java
@@ -46,26 +46,27 @@ import org.apache.lucene.search.suggest.document.TopSuggestDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 
-/** Analyzes the input text and suggests matched suggest items
- * based on the prefix matches to any pre-analyzed suffix-token gram in the indexed text.
+/**
+ * Analyzes the input text and suggests matched suggest items based on the prefix matches to any
+ * pre-analyzed suffix-token gram in the indexed text.
  *
- * <p> This suggester relies on a customized InputIterator FromFileSuggestItemIterator to build suggestion index.
- * Each suggest text is pre-analyzed as a list of suffix-token grams.
+ * <p>This suggester relies on a customized InputIterator FromFileSuggestItemIterator to build
+ * suggestion index. Each suggest text is pre-analyzed as a list of suffix-token grams.
  *
- * <p> This suggester requires payload defined for each suggest item. The payload persist necessary information
- * for the downstream services.
+ * <p>This suggester requires payload defined for each suggest item. The payload persist necessary
+ * information for the downstream services.
  *
- * <p> This suggester supports multiple contexts. The suggested results are returned only when any of its contexts
- * matches any context in the lookup query. Context match is not considered if there is no context specified in the
- * lookup query.
+ * <p>This suggester supports multiple contexts. The suggested results are returned only when any of
+ * its contexts matches any context in the lookup query. Context match is not considered if there is
+ * no context specified in the lookup query.
  *
- * <p> The same as AnalyzingInfixSuggester, results are sorted by descending weight values.
+ * <p>The same as AnalyzingInfixSuggester, results are sorted by descending weight values.
  *
- * Example usage of this suggester:
- *  1. Use FromFileSuggestItemIterator iterator to read the raw file of suggest items
- *  2. call build method with FromFileSuggestItemIterator iterator to build indexes
- *  3. call lookup method to look up the matched items based on the input text and optional contexts.
- **/
+ * <p>Example usage of this suggester: 1. Use FromFileSuggestItemIterator iterator to read the raw
+ * file of suggest items 2. call build method with FromFileSuggestItemIterator iterator to build
+ * indexes 3. call lookup method to look up the matched items based on the input text and optional
+ * contexts.
+ */
 public class CompletionInfixSuggester extends AnalyzingInfixSuggester {
 
   private static final String EXACT_TEXT_FIELD_NAME = "text";

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/suggest/CompletionInfixSuggester.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/suggest/CompletionInfixSuggester.java
@@ -46,6 +46,26 @@ import org.apache.lucene.search.suggest.document.TopSuggestDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 
+/** Analyzes the input text and suggests matched suggest items
+ * based on the prefix matches to any pre-analyzed suffix-token gram in the indexed text.
+ *
+ * <p> This suggester relies on a customized InputIterator FromFileSuggestItemIterator to build suggestion index.
+ * Each suggest text is pre-analyzed as a list of suffix-token grams.
+ *
+ * <p> This suggester requires payload defined for each suggest item. The payload persist necessary information
+ * for the downstream services.
+ *
+ * <p> This suggester supports multiple contexts. The suggested results are returned only when any of its contexts
+ * matches any context in the lookup query. Context match is not considered if there is no context specified in the
+ * lookup query.
+ *
+ * <p> The same as AnalyzingInfixSuggester, results are sorted by descending weight values.
+ *
+ * Example usage of this suggester:
+ *  1. Use FromFileSuggestItemIterator iterator to read the raw file of suggest items
+ *  2. call build method with FromFileSuggestItemIterator iterator to build indexes
+ *  3. call lookup method to look up the matched items based on the input text and optional contexts.
+ **/
 public class CompletionInfixSuggester extends AnalyzingInfixSuggester {
 
   private static final String EXACT_TEXT_FIELD_NAME = "text";
@@ -64,8 +84,11 @@ public class CompletionInfixSuggester extends AnalyzingInfixSuggester {
   @Override
   public List<LookupResult> lookup(
       CharSequence key, Set<BytesRef> contexts, boolean onlyMorePopular, int num)
-      throws IOException {
-    ensureOpen();
+      throws IOException, RuntimeException {
+    if (searcherMgr == null) {
+      throw new RuntimeException("No valid searcher manager available!");
+    }
+
     IndexSearcher searcher;
     SearcherManager mgr;
     List<LookupResult> results;

--- a/src/test/java/com/yelp/nrtsearch/server/suggest/CompletionInfixSuggesterTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/suggest/CompletionInfixSuggesterTest.java
@@ -154,6 +154,18 @@ public class CompletionInfixSuggesterTest extends LuceneTestCase {
     assertEquals("shack shack", actualResults.get(0).key);
   }
 
+  @Test(expected = RuntimeException.class)
+  public void testSuggesterLookupWithoutValidIndexBuild() throws IOException {
+    Directory dir = newDirectory();
+    Analyzer analyzer = new StandardAnalyzer();
+    CompletionInfixSuggester testSuggester = new CompletionInfixSuggester(dir, analyzer);
+    try {
+      lookupHelper(testSuggester, "sha", Set.of("9q9hf"), 2);
+    } finally {
+      testSuggester.close();
+    }
+  }
+
   private List<LookupResult> lookupHelper(
       Lookup suggester, String key, Set<String> contexts, int count) throws IOException {
     Set<BytesRef> contextSet = new HashSet<>();


### PR DESCRIPTION
CompletionInfixSuggester is implemented for suggestion infix matching. This suggester is based on the implementation details in `AnalyzingInfixSuggester`. Suggestions are looked up by wfst algorithm and context is used to filter out unexpected documents. 

- Index is created by build method, where the `InputIterator` should be `FromFileSuggestItemIterator` type, where `text`, set of `search text`, set of `context`, and `payload` can be parsed.
- Each Document includes two stored field (`text` field and `payload` field) and multiple `ContextSuggestField`
- `lookup` method is supported by `SuggestIndexSearcher`, where `nrtsuggester` is used under the hood.
- codec is customized. `Completion84PostingsFormat` is used to index suggest_text field.

In the next PR, a `FuzzyInfixSuggester` will be implemented by extending `CompletionInfixSuggester`.

Test done:

test cases pass