### PR TITLE
Implement fuzzy infix suggester

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/suggest/CompletionInfixSuggester.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/suggest/CompletionInfixSuggester.java
@@ -155,7 +155,7 @@ public class CompletionInfixSuggester extends AnalyzingInfixSuggester {
     return contextQuery;
   }
 
-  private CompletionQuery createCompletionQuery(CharSequence key) {
+  protected CompletionQuery createCompletionQuery(CharSequence key) {
     return new PrefixCompletionQuery(
         queryAnalyzer, new Term(SEARCH_TEXT_FIELD_NAME, new BytesRef(key)));
   }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/suggest/FuzzyInfixSuggester.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/suggest/FuzzyInfixSuggester.java
@@ -27,10 +27,13 @@ import org.apache.lucene.util.automaton.LevenshteinAutomata;
 import org.apache.lucene.util.automaton.Operations;
 
 /**
- * Analyzes the input text and suggests fuzzy-matched suggest items based on the prefix fuzzily
- * matches to any pre-analyzed suffix-token gram in the indexed text.
+ * Suggests fuzzy-matched suggest items.
  *
- * <p>maxEdits = 1 is recommended for faster lookup
+ * <p>The similarity is measured by default Damerau-Levenshtein algorithm or classic Levenshtein
+ * algorithm with false value in transpositions.
+ *
+ * <p>The maximum edit distance is controlled by maxEdit variable. It is recommended to set maxEdit
+ * as 1 for faster lookup.
  */
 public class FuzzyInfixSuggester extends CompletionInfixSuggester {
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/suggest/FuzzyInfixSuggester.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/suggest/FuzzyInfixSuggester.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.suggest;
+
+import java.io.IOException;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.suggest.BitsProducer;
+import org.apache.lucene.search.suggest.document.CompletionQuery;
+import org.apache.lucene.search.suggest.document.FuzzyCompletionQuery;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.LevenshteinAutomata;
+import org.apache.lucene.util.automaton.Operations;
+
+/**
+ * Analyzes the input text and suggests fuzzy-matched suggest items based on the prefix fuzzily
+ * matches to any pre-analyzed suffix-token gram in the indexed text.
+ *
+ * <p>maxEdits = 1 is recommended for faster lookup
+ */
+public class FuzzyInfixSuggester extends CompletionInfixSuggester {
+
+  private static final BitsProducer DEFAULT_BITS_PRODUCER = null;
+  private int minFuzzyLength;
+  private int nonFuzzyPrefix;
+  private int maxEdits;
+  private boolean transpositions;
+  private boolean unicodeAware;
+
+  public FuzzyInfixSuggester(
+      Directory dir,
+      Analyzer analyzer,
+      int maxEdits,
+      boolean transpositions,
+      int nonFuzzyPrefix,
+      int minFuzzyLength,
+      boolean unicodeAware)
+      throws IOException {
+    super(dir, analyzer);
+    if (maxEdits < 0 || maxEdits > LevenshteinAutomata.MAXIMUM_SUPPORTED_DISTANCE) {
+      throw new IllegalArgumentException(
+          "maxEdits must be between 0 and " + LevenshteinAutomata.MAXIMUM_SUPPORTED_DISTANCE);
+    }
+    if (nonFuzzyPrefix < 0) {
+      throw new IllegalArgumentException(
+          "nonFuzzyPrefix must not be >= 0 (got " + nonFuzzyPrefix + ")");
+    }
+    if (minFuzzyLength < 0) {
+      throw new IllegalArgumentException(
+          "minFuzzyLength must not be >= 0 (got " + minFuzzyLength + ")");
+    }
+
+    this.maxEdits = maxEdits;
+    this.transpositions = transpositions;
+    this.nonFuzzyPrefix = nonFuzzyPrefix;
+    this.minFuzzyLength = minFuzzyLength;
+    this.unicodeAware = unicodeAware;
+  }
+
+  public FuzzyInfixSuggester(Directory dir, Analyzer analyzer) throws IOException {
+    super(dir, analyzer);
+    this.maxEdits = FuzzyCompletionQuery.DEFAULT_MAX_EDITS;
+    this.transpositions = FuzzyCompletionQuery.DEFAULT_TRANSPOSITIONS;
+    this.nonFuzzyPrefix = FuzzyCompletionQuery.DEFAULT_NON_FUZZY_PREFIX;
+    this.minFuzzyLength = FuzzyCompletionQuery.DEFAULT_MIN_FUZZY_LENGTH;
+    this.unicodeAware = FuzzyCompletionQuery.DEFAULT_UNICODE_AWARE;
+  }
+
+  @Override
+  protected CompletionQuery createCompletionQuery(CharSequence key) {
+    return new FuzzyCompletionQuery(
+        queryAnalyzer,
+        new Term(SEARCH_TEXT_FIELD_NAME, new BytesRef(key)),
+        DEFAULT_BITS_PRODUCER,
+        maxEdits,
+        transpositions,
+        nonFuzzyPrefix,
+        minFuzzyLength,
+        unicodeAware,
+        Operations.DEFAULT_MAX_DETERMINIZED_STATES);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/suggest/FuzzyInfixSuggesterTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/suggest/FuzzyInfixSuggesterTest.java
@@ -57,7 +57,7 @@ public class FuzzyInfixSuggesterTest extends LuceneTestCase {
 
   @Test
   public void testCompletionSuggestionWithLongPrefixWithoutContext() throws IOException {
-    List<LookupResult> actualResults = lookupHelper(suggester, "hom", Set.of(), 10);
+    List<LookupResult> actualResults = lookupHelper(suggester, "hom", Set.of(), 9);
 
     // "iom decoration" text is not returned since non_fuzzy_prefix is 1.
     assertNotNull(actualResults);
@@ -70,7 +70,7 @@ public class FuzzyInfixSuggesterTest extends LuceneTestCase {
 
   @Test
   public void testCompletionSuggestionWithShortPrefixWithoutContext() throws IOException {
-    List<LookupResult> actualResults = lookupHelper(suggester, "hi", Set.of(), 10);
+    List<LookupResult> actualResults = lookupHelper(suggester, "hi", Set.of(), 9);
 
     // No fuzzy match is returned since the length of prefix is less than non_fuzzy_prefix (3 in
     // this case).
@@ -81,7 +81,7 @@ public class FuzzyInfixSuggesterTest extends LuceneTestCase {
 
   @Test
   public void testCompletionSuggestionWithLongPrefixWithContext() throws IOException {
-    List<LookupResult> actualResults = lookupHelper(suggester, "hom", Set.of("9q9hfe"), 10);
+    List<LookupResult> actualResults = lookupHelper(suggester, "hom", Set.of("9q9hfe"), 9);
 
     // "iom decoration" text is not returned since non_fuzzy_prefix is 1.
     assertNotNull(actualResults);

--- a/src/test/java/com/yelp/nrtsearch/server/suggest/FuzzyInfixSuggesterTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/suggest/FuzzyInfixSuggesterTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.suggest;
+
+import com.google.common.io.Resources;
+import com.yelp.nrtsearch.server.luceneserver.suggest.CompletionInfixSuggester;
+import com.yelp.nrtsearch.server.luceneserver.suggest.FromFileSuggestItemIterator;
+import com.yelp.nrtsearch.server.luceneserver.suggest.FuzzyInfixSuggester;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.search.suggest.Lookup;
+import org.apache.lucene.search.suggest.Lookup.LookupResult;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.LuceneTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FuzzyInfixSuggesterTest extends LuceneTestCase {
+
+  private FuzzyInfixSuggester suggester;
+
+  @Before
+  public void before() throws Exception {
+    Directory dir = newDirectory();
+    FromFileSuggestItemIterator iter = createIterator("suggest/fuzzy_suggest_item.file");
+    Analyzer analyzer = new StandardAnalyzer();
+    // Setup fuzzy infix suggester with default values
+    suggester = new FuzzyInfixSuggester(dir, analyzer);
+    suggester.build(iter);
+  }
+
+  @After
+  public void after() throws Exception {
+    suggester.close();
+  }
+
+  @Test
+  public void testCompletionSuggestionWithLongPrefixWithoutContext() throws IOException {
+    List<LookupResult> actualResults = lookupHelper(suggester, "hom", Set.of(), 10);
+
+    // "iom decoration" text is not returned since non_fuzzy_prefix is 1.
+    assertNotNull(actualResults);
+    assertEquals(4, actualResults.size());
+    assertEquals("hime decoration", actualResults.get(0).key);
+    assertEquals("lowe's hot spring", actualResults.get(1).key);
+    assertEquals("home decoration", actualResults.get(2).key);
+    assertEquals("hot depot", actualResults.get(3).key);
+  }
+
+  @Test
+  public void testCompletionSuggestionWithShortPrefixWithoutContext() throws IOException {
+    List<LookupResult> actualResults = lookupHelper(suggester, "hi", Set.of(), 10);
+
+    // No fuzzy match is returned since the length of prefix is less than non_fuzzy_prefix (3 in
+    // this case).
+    assertNotNull(actualResults);
+    assertEquals(1, actualResults.size());
+    assertEquals("hime decoration", actualResults.get(0).key);
+  }
+
+  @Test
+  public void testCompletionSuggestionWithLongPrefixWithContext() throws IOException {
+    List<LookupResult> actualResults = lookupHelper(suggester, "hom", Set.of("9q9hfe"), 10);
+
+    // "iom decoration" text is not returned since non_fuzzy_prefix is 1.
+    assertNotNull(actualResults);
+    assertEquals(2, actualResults.size());
+    assertEquals("lowe's hot spring", actualResults.get(0).key);
+    assertEquals("hot depot", actualResults.get(1).key);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testSuggesterLookupWithoutValidIndexBuild() throws IOException {
+    Directory dir = newDirectory();
+    Analyzer analyzer = new StandardAnalyzer();
+    CompletionInfixSuggester testSuggester = new CompletionInfixSuggester(dir, analyzer);
+    try {
+      lookupHelper(testSuggester, "sha", Set.of("9q9hf"), 2);
+    } finally {
+      testSuggester.close();
+    }
+  }
+
+  private List<LookupResult> lookupHelper(
+      Lookup suggester, String key, Set<String> contexts, int count) throws IOException {
+    Set<BytesRef> contextSet = new HashSet<>();
+    for (String context : contexts) {
+      contextSet.add(new BytesRef(context));
+    }
+
+    return suggester.lookup(key, contextSet, true, count);
+  }
+
+  private FromFileSuggestItemIterator createIterator(String pathString)
+      throws IOException, URISyntaxException {
+    File suggestItemFile = new File(Resources.getResource(pathString).toURI());
+    return new FromFileSuggestItemIterator(suggestItemFile, true, true);
+  }
+}

--- a/src/test/resources/suggest/fuzzy_suggest_item.file
+++ b/src/test/resources/suggest/fuzzy_suggest_item.file
@@ -1,0 +1,5 @@
+hot depothot depotdepot1payload19q9hfe9q9hf
+lowe's hot springlowe's hot springhot springspring4payload49q9hfe9q9hf
+home decorationhome decorationdecoration2payload29q9hxb9q9hx
+iome decorationiome decorationdecoration10payload39q9hxb9q9hx
+hime decorationhime decorationdecoration12payload39q9hxb9q9hx


### PR DESCRIPTION
Based on the `CompletionInfixSuggester` implemented in the prior [PR](https://github.com/Yelp/nrtsearch/pull/179), one `FuzzyInfixSuggester` is implemented. The only difference is `ContextQuery` is constructed based on `FuzzyCompletionQuery`.

Test:
`make test` pass