### PR TITLE
Initialize Taxo Writer for Primary to support flat facets

### DIFF
--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/ServerTestCase.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/ServerTestCase.java
@@ -64,6 +64,7 @@ import org.junit.rules.TemporaryFolder;
  */
 public class ServerTestCase {
   public static final String DEFAULT_TEST_INDEX = "test_index";
+
   /**
    * This rule manages automatic graceful shutdown for the registered servers and channels at the
    * end of test.
@@ -226,6 +227,9 @@ public class ServerTestCase {
       // start the index
       StartIndexRequest.Builder startIndexBuilder =
           StartIndexRequest.newBuilder().setIndexName(indexName);
+      if (shouldInitializeIndicesAsPrimary()) {
+        startIndexBuilder.setMode(Mode.PRIMARY);
+      }
       blockingStub.startIndex(startIndexBuilder.build());
 
       // add Docs
@@ -234,6 +238,10 @@ public class ServerTestCase {
       // refresh
       blockingStub.refresh(RefreshRequest.newBuilder().setIndexName(indexName).build());
     }
+  }
+
+  protected boolean shouldInitializeIndicesAsPrimary() {
+    return false;
   }
 
   protected List<String> getIndices() {

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/NumberFieldFlatFacetsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/NumberFieldFlatFacetsTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.facet;
+
+import static org.junit.Assert.assertNotNull;
+
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
+import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class NumberFieldFlatFacetsTest extends ServerTestCase {
+  @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private static final List<String> fields =
+      Arrays.asList(
+          new String[] {
+            "int_number_facet_field",
+            "float_number_facet_field",
+            "long_number_facet_field",
+            "double_number_facet_field"
+          });
+  private static final List<String> numericValues =
+      Arrays.asList(new String[] {"1", "10", "20", "30"});
+
+  private Map<String, AddDocumentRequest.MultiValuedField> getFieldsMapForOneDocument(
+      String value) {
+    Map<String, AddDocumentRequest.MultiValuedField> fieldsMap = new HashMap<>();
+    for (String field : fields) {
+      fieldsMap.put(
+          field, AddDocumentRequest.MultiValuedField.newBuilder().addValue(value).build());
+    }
+    return fieldsMap;
+  }
+
+  @Override
+  public FieldDefRequest getIndexDef(String name) throws IOException {
+    return getFieldsFromResourceFile("/facet/number_field_flat_facets.json");
+  }
+
+  @Override
+  protected boolean shouldInitializeIndicesAsPrimary() {
+    return true;
+  }
+
+  @Test
+  public void addDocuments() throws InterruptedException {
+    List<AddDocumentRequest> documentRequests = new ArrayList<>();
+    for (String value : numericValues) {
+      documentRequests.add(
+          AddDocumentRequest.newBuilder()
+              .setIndexName(DEFAULT_TEST_INDEX)
+              .putAllFields(getFieldsMapForOneDocument(value))
+              .build());
+    }
+    assertNotNull(addDocuments(documentRequests.stream()));
+  }
+}

--- a/src/test/resources/facet/number_field_flat_facets.json
+++ b/src/test/resources/facet/number_field_flat_facets.json
@@ -1,0 +1,37 @@
+{
+  "indexName": "test_index",
+  "field": [
+    {
+      "name": "int_number_facet_field",
+      "type": "INT",
+      "storeDocValues": true,
+      "multiValued": false,
+      "search": true,
+      "facet": "FLAT"
+    },
+    {
+      "name": "float_number_facet_field",
+      "type": "FLOAT",
+      "storeDocValues": true,
+      "multiValued": false,
+      "search": true,
+      "facet": "FLAT"
+    },
+    {
+      "name": "long_number_facet_field",
+      "type": "LONG",
+      "storeDocValues": true,
+      "multiValued": false,
+      "search": true,
+      "facet": "FLAT"
+    },
+    {
+      "name": "double_number_facet_field",
+      "type": "DOUBLE",
+      "storeDocValues": true,
+      "multiValued": false,
+      "search": true,
+      "facet": "FLAT"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #199 
Initialize taxonomy writer for Primary which is needed for building flat facets.

Added a test for adding documents to succeed when fields have Flat facets.