### PR TITLE
Cleaning up snapshot and temporary files from interrupted backups when index is started

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -250,6 +250,7 @@ public class LuceneServer {
     private final Archiver archiver;
     private final CollectorRegistry collectorRegistry;
     private final ThreadPoolExecutor searchThreadPoolExecutor;
+    private final String archiveDirectory;
 
     LuceneServerImpl(
         GlobalState globalState,
@@ -259,6 +260,7 @@ public class LuceneServer {
         List<Plugin> plugins) {
       this.globalState = globalState;
       this.archiver = archiver;
+      this.archiveDirectory = configuration.getArchiveDirectory();
       this.collectorRegistry = collectorRegistry;
       this.searchThreadPoolExecutor =
           ThreadPoolExecutorFactory.getThreadPoolExecutor(
@@ -474,7 +476,7 @@ public class LuceneServer {
         StartIndexRequest startIndexRequest, StreamObserver<StartIndexResponse> responseObserver) {
       try {
         IndexState indexState = null;
-        StartIndexHandler startIndexHandler = new StartIndexHandler(archiver);
+        StartIndexHandler startIndexHandler = new StartIndexHandler(archiver, archiveDirectory);
         indexState =
             globalState.getIndex(startIndexRequest.getIndexName(), startIndexRequest.hasRestore());
         StartIndexResponse reply = startIndexHandler.handle(indexState, startIndexRequest);
@@ -1177,7 +1179,7 @@ public class LuceneServer {
       try {
         IndexState indexState = globalState.getIndex(backupIndexRequest.getIndexName());
         BackupIndexRequestHandler backupIndexRequestHandler =
-            new BackupIndexRequestHandler(archiver);
+            new BackupIndexRequestHandler(archiver, archiveDirectory);
         BackupIndexResponse reply =
             backupIndexRequestHandler.handle(indexState, backupIndexRequest);
         logger.info(String.format("BackupRequestHandler returned results %s", reply.toString()));

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/BackupIndexRequestHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/BackupIndexRequestHandler.java
@@ -15,30 +15,43 @@
  */
 package com.yelp.nrtsearch.server.luceneserver;
 
-import com.yelp.nrtsearch.server.grpc.BackupIndexRequest;
-import com.yelp.nrtsearch.server.grpc.BackupIndexResponse;
-import com.yelp.nrtsearch.server.grpc.CreateSnapshotRequest;
-import com.yelp.nrtsearch.server.grpc.CreateSnapshotResponse;
-import com.yelp.nrtsearch.server.grpc.ReleaseSnapshotRequest;
-import com.yelp.nrtsearch.server.grpc.ReleaseSnapshotResponse;
+import com.google.gson.Gson;
+import com.yelp.nrtsearch.server.grpc.*;
 import com.yelp.nrtsearch.server.utils.Archiver;
+import java.io.BufferedWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BackupIndexRequestHandler implements Handler<BackupIndexRequest, BackupIndexResponse> {
+  private static final String BACKUP_INDICATOR_FILE_NAME = "backup.txt";
   Logger logger = LoggerFactory.getLogger(BackupIndexRequestHandler.class);
   private final Archiver archiver;
+  private final Path archiveDirectory;
+  private final Path backupIndicatorFilePath;
 
-  public BackupIndexRequestHandler(Archiver archiver) {
+  public BackupIndexRequestHandler(Archiver archiver, String archiveDirectory) {
     this.archiver = archiver;
+    this.archiveDirectory = Paths.get(archiveDirectory);
+    this.backupIndicatorFilePath = Paths.get(archiveDirectory, BACKUP_INDICATOR_FILE_NAME);
   }
 
   @Override
   public BackupIndexResponse handle(IndexState indexState, BackupIndexRequest backupIndexRequest)
       throws HandlerException {
     BackupIndexResponse.Builder backupIndexResponseBuilder = BackupIndexResponse.newBuilder();
+    if (wasBackupPotentiallyInterrupted()) {
+      throw new IllegalStateException(
+          String.format(
+              "A backup is ongoing for index %s, please try again after the current backup is finished",
+              getIndexNameOfInterruptedBackup()));
+    }
     String indexName = backupIndexRequest.getIndexName();
+    SnapshotId snapshotId = null;
     try {
       // only upload metadata in case we are replica
       if (indexState.getShard(0).isReplica()) {
@@ -53,22 +66,18 @@ public class BackupIndexRequestHandler implements Handler<BackupIndexRequest, Ba
         CreateSnapshotRequest createSnapshotRequest =
             CreateSnapshotRequest.newBuilder().setIndexName(indexName).build();
 
-        CreateSnapshotResponse createSnapshotResponse =
-            new CreateSnapshotHandler().createSnapshot(indexState, createSnapshotRequest);
+        snapshotId =
+            new CreateSnapshotHandler()
+                .createSnapshot(indexState, createSnapshotRequest)
+                .getSnapshotId();
+
+        createBackupIndicator(indexName, snapshotId);
 
         uploadArtifacts(
             backupIndexRequest.getServiceName(),
             backupIndexRequest.getResourceName(),
             indexState,
             backupIndexResponseBuilder);
-
-        ReleaseSnapshotRequest releaseSnapshotRequest =
-            ReleaseSnapshotRequest.newBuilder()
-                .setIndexName(indexName)
-                .setSnapshotId(createSnapshotResponse.getSnapshotId())
-                .build();
-        ReleaseSnapshotResponse releaseSnapshotResponse =
-            new ReleaseSnapshotHandler().handle(indexState, releaseSnapshotRequest);
       }
 
     } catch (IOException e) {
@@ -78,9 +87,108 @@ public class BackupIndexRequestHandler implements Handler<BackupIndexRequest, Ba
               indexName, backupIndexRequest.getServiceName(), backupIndexRequest.getResourceName()),
           e);
       return backupIndexResponseBuilder.build();
+    } finally {
+      if (snapshotId != null) {
+        releaseSnapshot(indexState, indexName, snapshotId);
+        deleteBackupIndicator();
+      }
     }
 
     return backupIndexResponseBuilder.build();
+  }
+
+  public boolean wasBackupPotentiallyInterrupted() {
+    return Files.exists(backupIndicatorFilePath);
+  }
+
+  public String getIndexNameOfInterruptedBackup() {
+    return readBackupIndicatorDetails().indexName;
+  }
+
+  private void createBackupIndicator(String indexName, SnapshotId snapshotId) {
+    if (!Files.exists(backupIndicatorFilePath.getParent())) {
+      try {
+        Files.createDirectories(backupIndicatorFilePath.getParent());
+      } catch (IOException e) {
+        throw new IllegalStateException(
+            "Unable to create parent directories for backup indicator file "
+                + backupIndicatorFilePath,
+            e);
+      }
+    }
+    try (BufferedWriter writer = Files.newBufferedWriter(backupIndicatorFilePath)) {
+      BackupIndicatorDetails backupInfo =
+          new BackupIndicatorDetails(
+              indexName,
+              snapshotId.getIndexGen(),
+              snapshotId.getStateGen(),
+              snapshotId.getTaxonomyGen());
+      writer.write(new Gson().toJson(backupInfo));
+    } catch (IOException e) {
+      throw new IllegalStateException("Unable to create backup indicator file", e);
+    }
+  }
+
+  private void deleteBackupIndicator() {
+    if (Files.exists(backupIndicatorFilePath)) {
+      try {
+        Files.delete(backupIndicatorFilePath);
+      } catch (IOException e) {
+        throw new IllegalStateException("Unable to delete backup indicator file", e);
+      }
+    }
+  }
+
+  public void interruptedBackupCleanup(IndexState indexState, Set<Long> allSnapshotIndexGen) {
+    BackupIndicatorDetails details = readBackupIndicatorDetails();
+    releaseLeftoverSnapshot(indexState, allSnapshotIndexGen, details);
+    deleteTemporaryBackupFilesIfAny();
+    deleteBackupIndicator();
+  }
+
+  private BackupIndicatorDetails readBackupIndicatorDetails() {
+    try {
+      return new Gson()
+          .fromJson(Files.readString(backupIndicatorFilePath), BackupIndicatorDetails.class);
+    } catch (IOException e) {
+      throw new IllegalStateException("Unable to read backup indicator file", e);
+    }
+  }
+
+  private void releaseLeftoverSnapshot(
+      IndexState indexState,
+      Set<Long> allSnapshotIndexGen,
+      BackupIndicatorDetails backupIndicatorDetails) {
+    if (allSnapshotIndexGen.contains(backupIndicatorDetails.indexGen)) {
+      String indexName = backupIndicatorDetails.indexName;
+      SnapshotId snapshotId =
+          SnapshotId.newBuilder()
+              .setIndexGen(backupIndicatorDetails.indexGen)
+              .setStateGen(backupIndicatorDetails.stateGen)
+              .setTaxonomyGen(backupIndicatorDetails.taxonomyGen)
+              .build();
+      logger.info("Releasing snapshot: {} for index: {}", snapshotId, indexName);
+      releaseSnapshot(indexState, indexName, snapshotId);
+    }
+  }
+
+  private void deleteTemporaryBackupFilesIfAny() {
+    try {
+      Files.walk(archiveDirectory)
+          .filter(file -> file.startsWith(archiveDirectory))
+          .filter(file -> file.toString().endsWith(".tmp"))
+          .forEach(
+              file -> {
+                try {
+                  logger.info("Deleting temporary file: {}", file);
+                  Files.delete(file);
+                } catch (IOException e) {
+                  logger.error("Unable to delete temporary file: {}", file, e);
+                }
+              });
+    } catch (IOException e) {
+      throw new IllegalStateException("Unable to read files in archive directory", e);
+    }
   }
 
   public void uploadArtifacts(
@@ -108,5 +216,30 @@ public class BackupIndexRequestHandler implements Handler<BackupIndexRequest, Ba
         archiver.upload(serviceName, resourceMetadata, indexState.globalState.stateDir);
     archiver.blessVersion(serviceName, resourceMetadata, versionHash);
     backupIndexResponseBuilder.setMetadataVersionHash(versionHash);
+  }
+
+  private void releaseSnapshot(IndexState indexState, String indexName, SnapshotId snapshotId) {
+    ReleaseSnapshotRequest releaseSnapshotRequest =
+        ReleaseSnapshotRequest.newBuilder()
+            .setIndexName(indexName)
+            .setSnapshotId(snapshotId)
+            .build();
+    ReleaseSnapshotResponse releaseSnapshotResponse =
+        new ReleaseSnapshotHandler().handle(indexState, releaseSnapshotRequest);
+  }
+
+  private static class BackupIndicatorDetails {
+    String indexName;
+    long indexGen;
+    long stateGen;
+    long taxonomyGen;
+
+    public BackupIndicatorDetails(
+        String indexName, long indexGen, long stateGen, long taxonomyGen) {
+      this.indexName = indexName;
+      this.indexGen = indexGen;
+      this.stateGen = stateGen;
+      this.taxonomyGen = taxonomyGen;
+    }
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/BackupIndexRequestHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/BackupIndexRequestHandler.java
@@ -16,12 +16,14 @@
 package com.yelp.nrtsearch.server.luceneserver;
 
 import com.google.gson.Gson;
-import com.yelp.nrtsearch.server.grpc.*;
+import com.yelp.nrtsearch.server.grpc.BackupIndexRequest;
+import com.yelp.nrtsearch.server.grpc.BackupIndexResponse;
+import com.yelp.nrtsearch.server.grpc.CreateSnapshotRequest;
+import com.yelp.nrtsearch.server.grpc.ReleaseSnapshotRequest;
+import com.yelp.nrtsearch.server.grpc.ReleaseSnapshotResponse;
+import com.yelp.nrtsearch.server.grpc.SnapshotId;
 import com.yelp.nrtsearch.server.utils.Archiver;
-import java.io.BufferedWriter;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,7 +31,6 @@ import java.nio.file.Paths;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-
 import org.apache.lucene.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -143,7 +144,7 @@ public class BackupIndexRequestHandler implements Handler<BackupIndexRequest, Ba
               snapshotId.getTaxonomyGen());
       writer.write(new Gson().toJson(backupInfo));
       writer.flush();
-      IOUtils.fsync(backupIndicatorFilePath.getParent(), false);
+      IOUtils.fsync(backupIndicatorFilePath, false);
     } catch (IOException e) {
       throw new IllegalStateException("Unable to create backup indicator file", e);
     }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/BackupIndexRequestHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/BackupIndexRequestHandler.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 public class BackupIndexRequestHandler implements Handler<BackupIndexRequest, BackupIndexResponse> {
   private static final String BACKUP_INDICATOR_FILE_NAME = "backup.txt";
   private static final ReentrantLock LOCK = new ReentrantLock();
-  private static String LAST_BACKED_UP_INDEX = "";
+  private static String lastBackedUpIndex = "";
   Logger logger = LoggerFactory.getLogger(BackupIndexRequestHandler.class);
   private final Archiver archiver;
   private final Path archiveDirectory;
@@ -57,7 +57,7 @@ public class BackupIndexRequestHandler implements Handler<BackupIndexRequest, Ba
       throw new IllegalStateException(
           String.format(
               "A backup is ongoing for index %s, please try again after the current backup is finished",
-                  LAST_BACKED_UP_INDEX));
+                  lastBackedUpIndex));
     }
     String indexName = backupIndexRequest.getIndexName();
     SnapshotId snapshotId = null;
@@ -70,7 +70,7 @@ public class BackupIndexRequestHandler implements Handler<BackupIndexRequest, Ba
                 readBackupIndicatorDetails().indexName));
       }
 
-      LAST_BACKED_UP_INDEX = indexName;
+      lastBackedUpIndex = indexName;
 
       // only upload metadata in case we are replica
       if (indexState.getShard(0).isReplica()) {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/BackupIndexRequestHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/BackupIndexRequestHandler.java
@@ -115,7 +115,7 @@ public class BackupIndexRequestHandler implements Handler<BackupIndexRequest, Ba
     return readBackupIndicatorDetails().indexName;
   }
 
-  private synchronized void createBackupIndicator(String indexName, SnapshotId snapshotId) {
+  private void createBackupIndicator(String indexName, SnapshotId snapshotId) {
     if (wasBackupPotentiallyInterrupted()) {
       throw new IllegalStateException(
           String.format(
@@ -126,7 +126,6 @@ public class BackupIndexRequestHandler implements Handler<BackupIndexRequest, Ba
     if (!Files.exists(backupIndicatorFilePath.getParent())) {
       try {
         Files.createDirectories(backupIndicatorFilePath.getParent());
-        IOUtils.fsync(backupIndicatorFilePath.getParent(), true);
       } catch (IOException e) {
         throw new IllegalStateException(
             "Unable to create parent directories for backup indicator file "
@@ -145,6 +144,7 @@ public class BackupIndexRequestHandler implements Handler<BackupIndexRequest, Ba
       writer.write(new Gson().toJson(backupInfo));
       writer.flush();
       IOUtils.fsync(backupIndicatorFilePath, false);
+      IOUtils.fsync(backupIndicatorFilePath.getParent(), true);
     } catch (IOException e) {
       throw new IllegalStateException("Unable to create backup indicator file", e);
     }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/NRTPrimaryNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/NRTPrimaryNode.java
@@ -365,7 +365,7 @@ public class NRTPrimaryNode extends PrimaryNode {
                   allCopyStatus.get(currentReplicationServerClient);
               while (transferStatusIterator.hasNext()) {
                 TransferStatus transferStatus = transferStatusIterator.next();
-                logger.info(
+                logger.debug(
                     "transferStatus for replicationServerClient="
                         + currentReplicationServerClient
                         + " merge files="

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ReleaseSnapshotHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ReleaseSnapshotHandler.java
@@ -27,8 +27,7 @@ public class ReleaseSnapshotHandler
 
   @Override
   public ReleaseSnapshotResponse handle(
-      IndexState indexState, ReleaseSnapshotRequest releaseSnapshotRequest)
-      throws HandlerException {
+      IndexState indexState, ReleaseSnapshotRequest releaseSnapshotRequest) {
     final ShardState shardState = indexState.getShard(0);
     final IndexState.Gens gens =
         new IndexState.Gens(

--- a/src/test/java/com/yelp/nrtsearch/server/LuceneServerTestConfigurationFactory.java
+++ b/src/test/java/com/yelp/nrtsearch/server/LuceneServerTestConfigurationFactory.java
@@ -19,6 +19,7 @@ import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.Mode;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -26,6 +27,11 @@ public class LuceneServerTestConfigurationFactory {
   static AtomicLong atomicLong = new AtomicLong();
 
   public static LuceneServerConfiguration getConfig(Mode mode, File dataRootDir) {
+    return getConfig(mode, dataRootDir, Paths.get(dataRootDir.toString(), "archiver"));
+  }
+
+  public static LuceneServerConfiguration getConfig(
+      Mode mode, File dataRootDir, Path archiverDirectory) {
     String dirNum = String.valueOf(atomicLong.addAndGet(1));
     if (mode.equals(Mode.STANDALONE)) {
       String stateDir =
@@ -39,7 +45,8 @@ public class LuceneServerTestConfigurationFactory {
               "stateDir: " + stateDir,
               "indexDir: " + indexDir,
               "port: " + 9000,
-              "replicationPort: " + 9000);
+              "replicationPort: " + 9000,
+              "archiveDirectory: " + archiverDirectory.toString());
       return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
     } else if (mode.equals(Mode.PRIMARY)) {
       String stateDir =
@@ -53,7 +60,8 @@ public class LuceneServerTestConfigurationFactory {
               "stateDir: " + stateDir,
               "indexDir: " + indexDir,
               "port: " + 9900,
-              "replicationPort: " + 9001);
+              "replicationPort: " + 9001,
+              "archiveDirectory: " + archiverDirectory.toString());
       return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
     } else if (mode.equals(Mode.REPLICA)) {
       String stateDir =

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/FailedBackupCleanupTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/FailedBackupCleanupTest.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.grpc;
+
+import static com.yelp.nrtsearch.server.grpc.GrpcServer.rmDir;
+import static com.yelp.nrtsearch.server.grpc.LuceneServerTest.RETRIEVED_VALUES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import com.google.gson.Gson;
+import com.yelp.nrtsearch.server.LuceneServerTestConfigurationFactory;
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.luceneserver.GlobalState;
+import com.yelp.nrtsearch.server.utils.Archiver;
+import com.yelp.nrtsearch.server.utils.ArchiverImpl;
+import com.yelp.nrtsearch.server.utils.Tar;
+import com.yelp.nrtsearch.server.utils.TarImpl;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class FailedBackupCleanupTest {
+  private final String BUCKET_NAME = "archiver-unittest";
+  private Archiver archiver;
+  private AmazonS3 s3;
+  private Path archiverDirectory;
+  private CountDownLatch s3TransferStartedLatch;
+  private LuceneServerConfiguration luceneServerConfiguration;
+
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  /**
+   * This rule manages automatic graceful shutdown for the registered servers and channels at the
+   * end of test.
+   */
+  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private GrpcServer grpcServer;
+
+  @Before
+  public void setup() throws IOException {
+    archiverDirectory = Paths.get(folder.getRoot().toString(), "archiver");
+    s3TransferStartedLatch = new CountDownLatch(1);
+    s3 = new DoNothingAndWaitAmazonS3(s3TransferStartedLatch);
+    archiver =
+        new ArchiverImpl(s3, BUCKET_NAME, archiverDirectory, new TarImpl(Tar.CompressionMode.LZ4));
+    luceneServerConfiguration =
+        LuceneServerTestConfigurationFactory.getConfig(
+            Mode.PRIMARY, folder.getRoot(), archiverDirectory);
+    grpcServer = setUpGrpcServer();
+  }
+
+  private GrpcServer setUpGrpcServer() throws IOException {
+    GlobalState globalState = new GlobalState(luceneServerConfiguration);
+    return new GrpcServer(
+        grpcCleanup,
+        luceneServerConfiguration,
+        folder,
+        false,
+        globalState,
+        luceneServerConfiguration.getIndexDir(),
+        "test_index",
+        globalState.getPort(),
+        archiver);
+  }
+
+  @After
+  public void teardown() throws IOException {
+    grpcServer.getGlobalState().close();
+    grpcServer.forceShutdown();
+    rmDir(Paths.get(grpcServer.getIndexDir()).getParent());
+  }
+
+  @Test(expected = StatusRuntimeException.class)
+  public void testBackupWhileAnotherBackupRunning() throws IOException, InterruptedException {
+    // Create index and add 2 documents
+    GrpcServer.TestServer testAddDocs = new GrpcServer.TestServer(grpcServer, true, Mode.PRIMARY);
+    testAddDocs.addDocuments();
+
+    attemptBackupAsync();
+
+    // This will wait until the server tries to upload the backup to S3, so that
+    // a snapshot and the backup indicator file have been created
+    s3TransferStartedLatch.await(10, TimeUnit.SECONDS);
+
+    BackupIndexRequest request =
+        BackupIndexRequest.newBuilder()
+            .setIndexName(grpcServer.getTestIndex())
+            .setServiceName("testservice")
+            .setResourceName("testresource")
+            .build();
+
+    try {
+      grpcServer.getBlockingStub().backupIndex(request);
+    } catch (StatusRuntimeException e) {
+      assertEquals(
+          "UNKNOWN: error while trying to backupIndex for index test_index for service: testservice, resource: testresource\n"
+              + "A backup is ongoing for index test_index, please try again after the current backup is finished",
+          e.getMessage());
+      throw e;
+    }
+  }
+
+  @Test
+  public void testFailedBackupCleanup() throws IOException, InterruptedException {
+    // Create index and add 2 documents
+    GrpcServer.TestServer testAddDocs = new GrpcServer.TestServer(grpcServer, true, Mode.PRIMARY);
+    testAddDocs.addDocuments();
+
+    // Verify that 2 documents were added
+    SearchResponse searchResponse = search();
+    assertEquals(2, searchResponse.getHitsCount());
+
+    // Verify that no snapshots or tmp files are present
+    List<Long> allSnapshotIndexGen = getSnapshotIndexGensList();
+    assertTrue(allSnapshotIndexGen.isEmpty());
+
+    attemptBackupAsync();
+
+    // This will wait until the server tries to upload the backup to S3, so that
+    // a snapshot and the backup indicator file have been created
+    s3TransferStartedLatch.await(10, TimeUnit.SECONDS);
+
+    // Verify that snapshot was created during backup
+    allSnapshotIndexGen = getSnapshotIndexGensList();
+    assertEquals(List.of(1L), allSnapshotIndexGen);
+
+    forceShutdownServer();
+
+    Path backupIndicatorFilePath = Paths.get(archiverDirectory.toString(), "backup.txt");
+
+    // Verify that the backup indicator file was created
+    assertTrue(Files.exists(backupIndicatorFilePath));
+
+    String backupIndicatorFileContents = Files.readString(backupIndicatorFilePath);
+
+    // Hacky way to assert exact file contents instead of asserting parsed json
+    TestBackupIndicatorDetails expectedBackupDetails =
+        new TestBackupIndicatorDetails(grpcServer.getTestIndex(), 1, 0, 0);
+    TestBackupIndicatorDetails actualBackupDetails =
+        new Gson().fromJson(backupIndicatorFileContents, TestBackupIndicatorDetails.class);
+    assertEquals(expectedBackupDetails, actualBackupDetails);
+
+    // Verify that the backup created a temporary file which wasn't cleaned up
+    List<Path> tmpFilesInArchiverDirectory = getTmpFilesInArchiverDirectory();
+    assertEquals(1, tmpFilesInArchiverDirectory.size());
+
+    grpcServer = setUpGrpcServer();
+    grpcServer
+        .getBlockingStub()
+        .startIndex(
+            StartIndexRequest.newBuilder()
+                .setIndexName(grpcServer.getTestIndex())
+                .setMode(Mode.PRIMARY)
+                .build());
+
+    // Confirm that the previous index with the data was started
+    searchResponse = search();
+    assertEquals(2, searchResponse.getHitsCount());
+
+    // Verify that backup indicator file was deleted
+    assertFalse(Files.exists(backupIndicatorFilePath));
+
+    // Verify that the snapshot taken during backup was released
+    allSnapshotIndexGen = getSnapshotIndexGensList();
+    assertTrue(allSnapshotIndexGen.isEmpty());
+
+    // Verify that temporary file created during backup was cleaned up
+    tmpFilesInArchiverDirectory = getTmpFilesInArchiverDirectory();
+    assertEquals(0, tmpFilesInArchiverDirectory.size());
+  }
+
+  private List<Long> getSnapshotIndexGensList() {
+    return grpcServer
+        .getBlockingStub()
+        .getAllSnapshotIndexGen(
+            GetAllSnapshotGenRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build())
+        .getIndexGensList();
+  }
+
+  private void forceShutdownServer() throws IOException {
+    grpcServer.getGlobalState().close();
+    grpcServer.forceShutdown();
+  }
+
+  private SearchResponse search() {
+    return grpcServer
+        .getBlockingStub()
+        .search(
+            SearchRequest.newBuilder()
+                .setIndexName(grpcServer.getTestIndex())
+                .setStartHit(0)
+                .setTopHits(10)
+                .addAllRetrieveFields(RETRIEVED_VALUES)
+                .build());
+  }
+
+  private void attemptBackupAsync() {
+    BackupIndexRequest request =
+        BackupIndexRequest.newBuilder()
+            .setIndexName(grpcServer.getTestIndex())
+            .setServiceName("testservice")
+            .setResourceName("testresource")
+            .build();
+
+    StreamObserver<BackupIndexResponse> responseObserver =
+        new StreamObserver<>() {
+          @Override
+          public void onNext(BackupIndexResponse value) {}
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        };
+    grpcServer.getStub().backupIndex(request, responseObserver);
+  }
+
+  private List<Path> getTmpFilesInArchiverDirectory() throws IOException {
+    return Files.walk(archiverDirectory)
+        .filter(path -> path.toString().endsWith(".tmp"))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * An S3 client implementation that will do nothing and simply wait when calling putObject. This
+   * lets us easily interrupt the backup process after the backup indicator file is created,
+   * snapshot is taken and also the temporary file for backup has been created.
+   */
+  private static class DoNothingAndWaitAmazonS3 extends AmazonS3Client {
+
+    private final CountDownLatch countDownLatch;
+
+    public DoNothingAndWaitAmazonS3(CountDownLatch countDownLatch) {
+      this.countDownLatch = countDownLatch;
+    }
+
+    @Override
+    public PutObjectResult putObject(PutObjectRequest putObjectRequest) {
+      countDownLatch.countDown();
+      sleepForALongTime();
+      return null;
+    }
+
+    private void sleepForALongTime() {
+      try {
+        Thread.sleep(100000);
+      } catch (InterruptedException ignored) {
+      }
+    }
+  }
+
+  private static class TestBackupIndicatorDetails {
+    String indexName;
+    long indexGen;
+    long stateGen;
+    long taxonomyGen;
+
+    public TestBackupIndicatorDetails(
+        String indexName, long indexGen, long stateGen, long taxonomyGen) {
+      this.indexName = indexName;
+      this.indexGen = indexGen;
+      this.stateGen = stateGen;
+      this.taxonomyGen = taxonomyGen;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      TestBackupIndicatorDetails that = (TestBackupIndicatorDetails) o;
+      return indexGen == that.indexGen
+          && stateGen == that.stateGen
+          && taxonomyGen == that.taxonomyGen
+          && Objects.equals(indexName, that.indexName);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(indexName, indexGen, stateGen, taxonomyGen);
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/GrpcServer.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/GrpcServer.java
@@ -184,6 +184,21 @@ public class GrpcServer {
     }
   }
 
+  public void forceShutdown() {
+    if (luceneServer != null && luceneServerManagedChannel != null) {
+      luceneServer.shutdownNow();
+      luceneServerManagedChannel.shutdownNow();
+      luceneServer = null;
+      luceneServerManagedChannel = null;
+    }
+    if (replicationServer != null && replicationServerManagedChannel != null) {
+      replicationServer.shutdownNow();
+      replicationServerManagedChannel.shutdownNow();
+      replicationServer = null;
+      replicationServerStub = null;
+    }
+  }
+
   /**
    * To test the server, make calls with a real stub using the in-process channel, and verify
    * behaviors or state changes from the client side.


### PR DESCRIPTION
Fixes #208 .

This PR deletes temporary files and releases snapshot created during a backup if nrtsearch was shutdown due to any reason and the backup was interrupted. This is done by writing the index name and the snapshot ID in a file and then checking for this file when the index is started. Additionally this also enables checking if backup is in progress before starting a new backup.

There are two places where this PR deviates from the proposal in #208 :
1. The cleanup happens when index is started and not when nrtsearch is started since we need the index to be started to release its snapshots
2. The snapshot ID from the snapshot is written to the file instead of the current index gen from commit. This is because the snapshot index gen and commit index gen are different with the commit returning more of a sequence number of operations rather than the index gen. This means that if the server stops right after the snapshot and right before or during the creation of the backup indicator file, automatic release of snapshot will not be possible. We can change this if we align the sequence number from commit with the snapshot index gen in the future. 