### PR TITLE
Setting diagnostics after all the fields are set

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
@@ -87,8 +87,6 @@ public class SearchHandler implements Handler<SearchRequest, SearchResponse> {
           SearchRequestProcessor.buildContextForRequest(
               searchRequest, indexState, shardState, s, diagnostics);
 
-      searchContext.getResponseBuilder().setDiagnostics(diagnostics);
-
       long searchStartTime = System.nanoTime();
 
       TopDocs hits;
@@ -186,6 +184,7 @@ public class SearchHandler implements Handler<SearchRequest, SearchResponse> {
       }
 
       diagnostics.setGetFieldsTimeMs(((System.nanoTime() - t0) / 1000000.0));
+      searchContext.getResponseBuilder().setDiagnostics(diagnostics);
     } catch (IOException | InterruptedException e) {
       logger.warn(e.getMessage(), e);
       throw new SearchHandlerException(e);

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
@@ -613,9 +613,9 @@ public class QueryTest {
   }
 
   private void verifyDiagnostics(SearchResponse.Diagnostics diagnostics) {
-      assertFalse(diagnostics.getParsedQuery().isEmpty());
-      assertFalse(diagnostics.getRewrittenQuery().isEmpty());
-      assertTrue(diagnostics.getFirstPassSearchTimeMs() > 0);
-      assertTrue(diagnostics.getGetFieldsTimeMs() > 0);
+    assertFalse(diagnostics.getParsedQuery().isEmpty());
+    assertFalse(diagnostics.getRewrittenQuery().isEmpty());
+    assertTrue(diagnostics.getFirstPassSearchTimeMs() > 0);
+    assertTrue(diagnostics.getGetFieldsTimeMs() > 0);
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
@@ -16,6 +16,8 @@
 package com.yelp.nrtsearch.server.grpc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.yelp.nrtsearch.server.LuceneServerTestConfigurationFactory;
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
@@ -595,6 +597,8 @@ public class QueryTest {
         searchResponse.getTotalHits().getValue(), searchResponseBoosted.getTotalHits().getValue());
     assertEquals(searchResponse.getHitsList().size(), searchResponseBoosted.getHitsList().size());
 
+    verifyDiagnostics(searchResponse.getDiagnostics());
+
     for (int i = 0; i < searchResponse.getHitsCount(); i++) {
       SearchResponse.Hit hit = searchResponse.getHits(i);
       SearchResponse.Hit boostedHit = searchResponseBoosted.getHits(i);
@@ -606,5 +610,12 @@ public class QueryTest {
           SearchResponse.Hit.newBuilder(boostedHit).setScore(0).build();
       assertEquals(hitWithoutScore, boostedHitWithoutScore);
     }
+  }
+
+  private void verifyDiagnostics(SearchResponse.Diagnostics diagnostics) {
+      assertFalse(diagnostics.getParsedQuery().isEmpty());
+      assertFalse(diagnostics.getRewrittenQuery().isEmpty());
+      assertTrue(diagnostics.getFirstPassSearchTimeMs() > 0);
+      assertTrue(diagnostics.getGetFieldsTimeMs() > 0);
   }
 }


### PR DESCRIPTION
Setting the diagnostics in the responseBuilder after all the fields are set.

For an example query:
Before this change:
```
"diagnostics": {
    "parsedQuery": "id:[35317354 TO 35317354]",
    "rewrittenQuery": "id:[35317354 TO 35317354]"
  }
```

After this change:
```
 "diagnostics": {
    "parsedQuery": "id:[35317354 TO 35317354]",
    "rewrittenQuery": "id:[35317354 TO 35317354]",
    "firstPassSearchTimeMs": 12.575924,
    "getFieldsTimeMs": 3.028026
  }
```

Also verified by adding tests which passed after my changes.