### PR TITLE
Fix direct memory leaks when transferring copy job

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/SimpleCopyJob.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/SimpleCopyJob.java
@@ -32,7 +32,6 @@ import org.apache.lucene.replicator.nrt.NodeCommunicationException;
 import org.apache.lucene.replicator.nrt.ReplicaNode;
 
 public class SimpleCopyJob extends CopyJob {
-  final byte[] copyBuffer = new byte[65536];
   private final CopyState copyState;
   private final ReplicationServerClient primaryAddres;
   private final String indexName;
@@ -56,19 +55,8 @@ public class SimpleCopyJob extends CopyJob {
 
   @Override
   protected CopyOneFile newCopyOneFile(CopyOneFile prev) {
-    Iterator<RawFileChunk> rawFileChunkIterator;
-    try {
-      rawFileChunkIterator = primaryAddres.recvRawFile(prev.name, prev.getBytesCopied(), indexName);
-    } catch (Throwable t) {
-      try {
-        cancel("exc during start", t);
-      } catch (IOException e) {
-        throw new NodeCommunicationException("cancel IOException during newCopyOneFile", e);
-      }
-      throw new NodeCommunicationException("exc during start", t);
-    }
-
-    return new CopyOneFile(prev, rawFileChunkIterator);
+    // no state needs to be changed when transferring to a new job
+    return prev;
   }
 
   @Override
@@ -229,7 +217,7 @@ public class SimpleCopyJob extends CopyJob {
         cancel("exc during start", t);
         throw new NodeCommunicationException("exc during start", t);
       }
-      current = new CopyOneFile(rawFileChunkIterator, dest, fileName, metaData, copyBuffer);
+      current = new CopyOneFile(rawFileChunkIterator, dest, fileName, metaData);
     }
     if (current.visit()) {
       // This file is done copying

--- a/src/main/java/org/apache/lucene/replicator/nrt/CopyOneFile.java
+++ b/src/main/java/org/apache/lucene/replicator/nrt/CopyOneFile.java
@@ -34,7 +34,6 @@ public class CopyOneFile implements Closeable {
   public final FileMetaData metaData;
   public final long bytesToCopy;
   private final long copyStartNS;
-  private final byte[] buffer;
 
   private long bytesCopied;
   private long remoteFileChecksum;
@@ -43,14 +42,12 @@ public class CopyOneFile implements Closeable {
       Iterator<RawFileChunk> rawFileChunkIterator,
       ReplicaNode dest,
       String name,
-      FileMetaData metaData,
-      byte[] buffer)
+      FileMetaData metaData)
       throws IOException {
 
     this.rawFileChunkIterator = rawFileChunkIterator;
     this.name = name;
     this.dest = dest;
-    this.buffer = buffer;
     // TODO: pass correct IOCtx, e.g. seg total size
     out = dest.createTempOutput(name, "copy", IOContext.DEFAULT);
     tmpName = out.getName();
@@ -70,20 +67,6 @@ public class CopyOneFile implements Closeable {
     dest.startCopyFile(name);
   }
 
-  /** Transfers this file copy to another input, continuing where the first one left off */
-  public CopyOneFile(CopyOneFile other, Iterator<RawFileChunk> rawFileChunkIterator) {
-    this.rawFileChunkIterator = rawFileChunkIterator;
-    this.dest = other.dest;
-    this.name = other.name;
-    this.out = other.out;
-    this.tmpName = other.tmpName;
-    this.metaData = other.metaData;
-    this.bytesCopied = other.bytesCopied;
-    this.bytesToCopy = other.bytesToCopy;
-    this.copyStartNS = other.copyStartNS;
-    this.buffer = other.buffer;
-  }
-
   /**
    * Closes this stream and releases any system resources associated with it. If the stream is
    * already closed then invoking this method has no effect.
@@ -98,6 +81,11 @@ public class CopyOneFile implements Closeable {
   public void close() throws IOException {
     out.close();
     dest.finishCopyFile(name);
+    // This job may have been canceled before being completed, meaning the replica no longer needs
+    // it. Drain the iterator to not leak direct memory.
+    while (rawFileChunkIterator.hasNext()) {
+      rawFileChunkIterator.next();
+    }
   }
 
   public long getBytesCopied() {


### PR DESCRIPTION
The newCopyOneFile method is called when transferring the current file being copied to a new copy job. Since the file copy is not tied to the job at all, it can be moved as is. The previous code made a new file copy request and didn't drain the old iterator.

A copy job can be closed before completion if the replica no longer needs the file. The chunk iterator should be drained in the close.