### PR TITLE
Add arcDistance for Location doc values

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/doc/LoadedDocValues.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/doc/LoadedDocValues.java
@@ -296,6 +296,10 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
           LatLng.newBuilder().setLatitude(point.getLat()).setLongitude(point.getLon()).build();
       return SearchResponse.Hit.FieldValue.newBuilder().setLatLngValue(latLon).build();
     }
+
+    public double arcDistance(double lat, double lon) {
+      return getValue().arcDistance(lat, lon);
+    }
   }
 
   public static final class Locations extends SortedNumericValues<GeoPoint> {
@@ -309,6 +313,11 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
       LatLng latLon =
           LatLng.newBuilder().setLatitude(point.getLat()).setLongitude(point.getLon()).build();
       return SearchResponse.Hit.FieldValue.newBuilder().setLatLngValue(latLon).build();
+    }
+
+    public double arcDistance(double lat, double lon) {
+      throw new IllegalArgumentException(
+          "Cannot determine the arcDistance of a multi-valued location");
     }
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/geo/GeoPoint.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/geo/GeoPoint.java
@@ -15,6 +15,8 @@
  */
 package com.yelp.nrtsearch.server.luceneserver.geo;
 
+import org.apache.lucene.util.SloppyMath;
+
 /**
  * Class to encapsulate a geo location loaded out of a doc value. Currently represents a lat/lon
  * value.
@@ -34,6 +36,10 @@ public final class GeoPoint {
 
   public double getLon() {
     return longitude;
+  }
+
+  public double arcDistance(double lat, double lon) {
+    return SloppyMath.haversinMeters(latitude, longitude, lat, lon);
   }
 
   @Override


### PR DESCRIPTION
Uses Haversin distance:
`SingleLocation`: Calculates distance between input point, and the doc value GeoPoint
`Locations`: Throws `IllegalArgumentException`, because distance is between two points, and we only want one output distance.