### PR TITLE
Add optional JVM metrics in /status/metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
 
     //prometheus (metrics) deps
     implementation "io.prometheus:simpleclient_servlet:${prometheusClientVersion}"
+    implementation "io.prometheus:simpleclient_hotspot:${prometheusClientVersion}"
 
     //
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"

--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -58,6 +58,7 @@ public class LuceneServerConfiguration {
   private final String botoCfgPath;
   private final String bucketName;
   private final double[] metricsBuckets;
+  private final boolean publishJvmMetrics;
   private final String[] plugins;
   private final String pluginSearchPath;
   private final String serviceName;
@@ -92,6 +93,7 @@ public class LuceneServerConfiguration {
       metricsBuckets = DEFAULT_METRICS_BUCKETS;
     }
     this.metricsBuckets = metricsBuckets;
+    publishJvmMetrics = configReader.getBoolean("publishJvmMetrics", false);
     plugins = configReader.getStringList("plugins", DEFAULT_PLUGINS).toArray(new String[0]);
     pluginSearchPath =
         configReader.getString("pluginSearchPath", DEFAULT_PLUGIN_SEARCH_PATH.toString());
@@ -146,6 +148,10 @@ public class LuceneServerConfiguration {
 
   public double[] getMetricsBuckets() {
     return metricsBuckets;
+  }
+
+  public boolean getPublishJvmMetrics() {
+    return publishJvmMetrics;
   }
 
   public int getReplicaReplicationPortPingInterval() {

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -77,6 +77,7 @@ import io.grpc.ServerInterceptors;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.hotspot.DefaultExports;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -119,6 +120,10 @@ public class LuceneServer {
 
   private void start() throws IOException {
     GlobalState globalState = new GlobalState(luceneServerConfiguration);
+
+    if (luceneServerConfiguration.getPublishJvmMetrics()) {
+      DefaultExports.register(collectorRegistry);
+    }
 
     List<Plugin> plugins = pluginsService.loadPlugins();
 


### PR DESCRIPTION
Adds the option (default: false) of collecting JVM metrics in prometheus, exposed through the /status/metrics endpoint.

Registers all of the default hotspot collectors https://github.com/prometheus/client_java/tree/master/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot