### PR TITLE
Added cli command for deleting index backups

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/cli/DeleteIndexBackupCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/server/cli/DeleteIndexBackupCommand.java
@@ -4,80 +4,77 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * limitations under the License.
  */
-
 package com.yelp.nrtsearch.server.cli;
-
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
-import picocli.CommandLine;
-
-import java.util.concurrent.Callable;
 
 import static com.yelp.nrtsearch.server.cli.DeleteIndexBackupCommand.DELETE_INDEX_BACKUP;
 
+import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
 @CommandLine.Command(name = DELETE_INDEX_BACKUP, description = "Delete index backups")
-public class DeleteIndexBackupCommand implements Callable<Integer>  {
-    public static final String DELETE_INDEX_BACKUP = "deleteIndexBackup";
+public class DeleteIndexBackupCommand implements Callable<Integer> {
+  public static final String DELETE_INDEX_BACKUP = "deleteIndexBackup";
 
-    @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
 
-    @CommandLine.Option(
-            names = {"-i", "--indexName"},
-            description = "Name of the index which is to be backed up",
-            required = true)
-    private String indexName;
+  @CommandLine.Option(
+      names = {"-i", "--indexName"},
+      description = "Name of the index which is to be backed up",
+      required = true)
+  private String indexName;
 
-    public String getIndexName() {
-        return indexName;
+  public String getIndexName() {
+    return indexName;
+  }
+
+  @CommandLine.Option(
+      names = {"-s", "--serviceName"},
+      description = "Name of the service which is to be backed up",
+      required = true)
+  private String serviceName;
+
+  public String getServiceName() {
+    return serviceName;
+  }
+
+  @CommandLine.Option(
+      names = {"-r", "--resourceName"},
+      description = "Name of the resource which is to be backed up",
+      required = true)
+  private String resourceName;
+
+  public String getResourceName() {
+    return resourceName;
+  }
+
+  @CommandLine.Option(
+      names = {"-n", "--nDays"},
+      description = "Backups older than these many days will be deleted from s3",
+      required = true)
+  private int nDays;
+
+  public int getNDays() {
+    return nDays;
+  }
+
+  @Override
+  public Integer call() throws Exception {
+    LuceneServerClient client = baseCmd.getClient();
+    try {
+      client.deleteIndexBackup(getIndexName(), getServiceName(), getResourceName(), getNDays());
+    } finally {
+      client.shutdown();
     }
-
-    @CommandLine.Option(
-            names = {"-s", "--serviceName"},
-            description = "Name of the service which is to be backed up",
-            required = true)
-    private String serviceName;
-
-    public String getServiceName() {
-        return serviceName;
-    }
-
-    @CommandLine.Option(
-            names = {"-r", "--resourceName"},
-            description = "Name of the resource which is to be backed up",
-            required = true)
-    private String resourceName;
-
-    public String getResourceName() {
-        return resourceName;
-    }
-
-    @CommandLine.Option(
-            names = {"-n", "--nDays"},
-            description = "Backups older than these many days will be deleted from s3",
-            required = true)
-    private int nDays;
-
-    public int getNDays() {
-        return nDays;
-    }
-
-    @Override
-    public Integer call() throws Exception {
-        LuceneServerClient client = baseCmd.getClient();
-        try {
-            client.deleteIndexBackup(getIndexName(), getServiceName(), getResourceName(), getNDays());
-        } finally {
-            client.shutdown();
-        }
-        return 0;
-    }
+    return 0;
+  }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/cli/DeleteIndexBackupCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/server/cli/DeleteIndexBackupCommand.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.yelp.nrtsearch.server.cli;
+
+import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+import static com.yelp.nrtsearch.server.cli.DeleteIndexBackupCommand.DELETE_INDEX_BACKUP;
+
+@CommandLine.Command(name = DELETE_INDEX_BACKUP, description = "Delete index backups")
+public class DeleteIndexBackupCommand implements Callable<Integer>  {
+    public static final String DELETE_INDEX_BACKUP = "deleteIndexBackup";
+
+    @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+
+    @CommandLine.Option(
+            names = {"-i", "--indexName"},
+            description = "Name of the index which is to be backed up",
+            required = true)
+    private String indexName;
+
+    public String getIndexName() {
+        return indexName;
+    }
+
+    @CommandLine.Option(
+            names = {"-s", "--serviceName"},
+            description = "Name of the service which is to be backed up",
+            required = true)
+    private String serviceName;
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    @CommandLine.Option(
+            names = {"-r", "--resourceName"},
+            description = "Name of the resource which is to be backed up",
+            required = true)
+    private String resourceName;
+
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    @CommandLine.Option(
+            names = {"-n", "--nDays"},
+            description = "Backups older than these many days will be deleted from s3",
+            required = true)
+    private int nDays;
+
+    public int getNDays() {
+        return nDays;
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        LuceneServerClient client = baseCmd.getClient();
+        try {
+            client.deleteIndexBackup(getIndexName(), getServiceName(), getResourceName(), getNDays());
+        } finally {
+            client.shutdown();
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/cli/LuceneClientCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/server/cli/LuceneClientCommand.java
@@ -33,6 +33,7 @@ import picocli.CommandLine;
       GetCurrentSearcherVersion.class,
       DeleteDocumentsCommand.class,
       DeleteAllDocumentsCommand.class,
+      DeleteIndexBackupCommand.class,
       DeleteIndexCommand.class,
       LiveSettingsCommand.class,
       RefreshCommand.class,
@@ -60,7 +61,7 @@ public class LuceneClientCommand implements Runnable {
   }
 
   @CommandLine.Option(
-      names = {"-h", "--hostname"},
+      names = {"-h", "--hostname", "--host"},
       description = "Host name of server to connect to (default: ${DEFAULT-VALUE})",
       defaultValue = "localhost")
   private String hostname;

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
@@ -23,17 +23,18 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 /** A simple client that requests a greeting from the {@link LuceneServer}. */
 public class LuceneServerClient {
-  private static final Logger logger = Logger.getLogger(LuceneServerClient.class.getName());
+  private static final Logger logger = LoggerFactory.getLogger(LuceneServerClient.class.getName());
 
   private final ManagedChannel channel;
 
@@ -83,7 +84,7 @@ public class LuceneServerClient {
     try {
       response = blockingStub.createIndex(request);
     } catch (StatusRuntimeException e) {
-      logger.log(Level.WARNING, "RPC failed: {0}", e.getStatus());
+      logger.warn("RPC failed: {}", e.getStatus());
       return;
     }
     logger.info("Server returned : " + response.getResponse());
@@ -120,7 +121,7 @@ public class LuceneServerClient {
     try {
       response = blockingStub.liveSettings(request);
     } catch (StatusRuntimeException e) {
-      logger.log(Level.WARNING, "RPC failed: {0}", e.getStatus());
+      logger.warn("RPC failed: {}", e.getStatus());
       return;
     }
     logger.info("Server returned : " + response.getResponse());
@@ -132,7 +133,7 @@ public class LuceneServerClient {
     try {
       response = blockingStub.registerFields(fieldDefRequest);
     } catch (StatusRuntimeException e) {
-      logger.log(Level.WARNING, "RPC failed: {0}", e.getStatus());
+      logger.warn("RPC failed: {}", e.getStatus());
       return;
     }
     logger.info("Server returned : " + response.getResponse());
@@ -145,7 +146,7 @@ public class LuceneServerClient {
     try {
       response = blockingStub.settings(settingsRequest);
     } catch (StatusRuntimeException e) {
-      logger.log(Level.WARNING, "RPC failed: {0}", e.getStatus());
+      logger.warn("RPC failed: {}", e.getStatus());
       return;
     }
     logger.info("Server returned : " + response.getResponse());
@@ -158,7 +159,7 @@ public class LuceneServerClient {
     try {
       response = blockingStub.startIndex(startIndexRequest);
     } catch (StatusRuntimeException e) {
-      logger.log(Level.WARNING, "RPC failed: {0}", e.getStatus());
+      logger.warn("RPC failed: {}", e.getStatus());
       return;
     }
     logger.info("Server returned : " + response.toString());
@@ -182,7 +183,7 @@ public class LuceneServerClient {
 
           @Override
           public void onError(Throwable t) {
-            logger.log(Level.SEVERE, t.getMessage(), t);
+            logger.error(t.getMessage(), t);
             finishLatch.countDown();
           }
 
@@ -211,7 +212,7 @@ public class LuceneServerClient {
 
     // Receiving happens asynchronously, so block here for 5 minutes
     if (!finishLatch.await(5, TimeUnit.MINUTES)) {
-      logger.log(Level.WARNING, "addDocuments can not finish within 5 minutes");
+      logger.warn("addDocuments can not finish within 5 minutes");
     }
   }
 
@@ -222,7 +223,7 @@ public class LuceneServerClient {
     try {
       response = blockingStub.refresh(request);
     } catch (StatusRuntimeException e) {
-      logger.log(Level.WARNING, "RPC failed: {0}", e.getStatus());
+      logger.warn("RPC failed: {}", e.getStatus());
       return;
     }
     logger.info("Server returned refreshTimeMS : " + response.getRefreshTimeMS());
@@ -235,7 +236,7 @@ public class LuceneServerClient {
     try {
       response = blockingStub.commit(request);
     } catch (StatusRuntimeException e) {
-      logger.log(Level.WARNING, "RPC failed: {0}", e.getStatus());
+      logger.warn("RPC failed: {}", e.getStatus());
       return;
     }
     logger.info("Server returned sequence id: " + response.getGen());
@@ -248,7 +249,7 @@ public class LuceneServerClient {
     try {
       response = blockingStub.stats(request);
     } catch (StatusRuntimeException e) {
-      logger.log(Level.WARNING, "RPC failed: {0}", e.getStatus());
+      logger.warn("RPC failed: {}", e.getStatus());
       return;
     }
     logger.info("Server returned sequence id: " + response);
@@ -261,7 +262,7 @@ public class LuceneServerClient {
     try {
       response = blockingStub.search(searchRequest);
     } catch (StatusRuntimeException e) {
-      logger.log(Level.WARNING, "RPC failed: {0}", e.getStatus());
+      logger.warn("RPC failed: {}", e.getStatus());
       return;
     }
     logger.info("Server returned : " + response.toString());
@@ -274,7 +275,7 @@ public class LuceneServerClient {
     try {
       response = blockingStub.delete(addDocumentRequest);
     } catch (StatusRuntimeException e) {
-      logger.log(Level.WARNING, "RPC failed: {0}", e.getStatus());
+      logger.warn("RPC failed: {}", e.getStatus());
       return;
     }
     logger.info("Server returned indexGen : " + response.getGenId());
@@ -319,6 +320,17 @@ public class LuceneServerClient {
     }
     this.shutdown();
     System.exit(1);
+  }
+
+  public void deleteIndexBackup(String indexName, String serviceName, String resourceName, int nDays) {
+    DeleteIndexBackupRequest request = DeleteIndexBackupRequest.newBuilder()
+            .setIndexName(indexName)
+            .setServiceName(serviceName)
+            .setResourceName(resourceName)
+            .setNDays(nDays)
+            .build();
+    DeleteIndexBackupResponse deleteIndexBackupResponse = blockingStub.deleteIndexBackup(request);
+    logger.info("Response: {}", deleteIndexBackupResponse);
   }
 
   private FieldDefRequest getFieldDefRequest(String jsonStr) {

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
@@ -23,14 +23,13 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** A simple client that requests a greeting from the {@link LuceneServer}. */
 public class LuceneServerClient {
@@ -322,8 +321,10 @@ public class LuceneServerClient {
     System.exit(1);
   }
 
-  public void deleteIndexBackup(String indexName, String serviceName, String resourceName, int nDays) {
-    DeleteIndexBackupRequest request = DeleteIndexBackupRequest.newBuilder()
+  public void deleteIndexBackup(
+      String indexName, String serviceName, String resourceName, int nDays) {
+    DeleteIndexBackupRequest request =
+        DeleteIndexBackupRequest.newBuilder()
             .setIndexName(indexName)
             .setServiceName(serviceName)
             .setResourceName(resourceName)

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/BackupIndexRequestHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/BackupIndexRequestHandler.java
@@ -57,7 +57,7 @@ public class BackupIndexRequestHandler implements Handler<BackupIndexRequest, Ba
       throw new IllegalStateException(
           String.format(
               "A backup is ongoing for index %s, please try again after the current backup is finished",
-                  lastBackedUpIndex));
+              lastBackedUpIndex));
     }
     String indexName = backupIndexRequest.getIndexName();
     SnapshotId snapshotId = null;


### PR DESCRIPTION
Added a command to the CLI client which will call the deleteIndexBackup RPC.
```
Usage: lucene-client deleteIndexBackup -i=<indexName> -n=<nDays>
                                       -r=<resourceName> -s=<serviceName>
Delete index backups
  -i, --indexName=<indexName>
                        Name of the index which is to be backed up
  -n, --nDays=<nDays>   Backups older than these many days will be deleted from
                          s3
  -r, --resourceName=<resourceName>
                        Name of the resource which is to be backed up
  -s, --serviceName=<serviceName>
                        Name of the service which is to be backed up
```

Additionally using slf4j logging instead of java logging in `LuceneServerClient`.