### PR TITLE
Bump to 0.6.2 (patch)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ sourceCompatibility = 1.14
 targetCompatibility = 1.14
 
 allprojects {
-    version = '0.6.1'
+    version = '0.6.2'
     group = 'com.yelp.nrtsearch'
 }
 


### PR DESCRIPTION
Releases `arcDistance` for `SingleLocation`

closes #230 