### PR TITLE
Avoid corrupt files in backup

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
@@ -645,6 +645,7 @@ message BackupIndexRequest {
     string indexName = 1; //name of the index to backup
     string serviceName = 2; // remote storage namespace qualifier for service
     string resourceName = 3; //remote storage namespace qualifier for resource e.g. indexName
+    bool completeDirectory = 4; // backup complete directory including all current snapshots if true (may backup corrupt segments if backup is created while indexing is happening), otherwise only backup the required segments and segment files
 }
 
 message BackupIndexResponse {

--- a/src/main/java/com/yelp/nrtsearch/server/cli/BackupIndexCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/server/cli/BackupIndexCommand.java
@@ -55,11 +55,23 @@ public class BackupIndexCommand implements Callable<Integer> {
     return resourceName;
   }
 
+  @CommandLine.Option(
+      names = {"-c", "--completeDirectory"},
+      description =
+          "Backup complete directory including all current snapshots if true (may backup corrupt segments if backup is created while indexing is happening), otherwise only backup the required segments and segment files",
+      required = true)
+  private boolean completeDirectory;
+
+  public boolean getCompleteDirectory() {
+    return completeDirectory;
+  }
+
   @Override
   public Integer call() throws Exception {
     LuceneServerClient client = baseCmd.getClient();
     try {
-      client.backupIndex(getIndexName(), getServiceName(), getResourceName());
+      client.backupIndex(
+          getIndexName(), getServiceName(), getResourceName(), getCompleteDirectory());
     } finally {
       client.shutdown();
     }

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
@@ -297,12 +297,14 @@ public class LuceneServerClient {
     blockingStub.stopIndex(StopIndexRequest.newBuilder().setIndexName(indexName).build());
   }
 
-  public void backupIndex(String indexName, String serviceName, String resourceName) {
+  public void backupIndex(
+      String indexName, String serviceName, String resourceName, boolean completeDirectory) {
     blockingStub.backupIndex(
         BackupIndexRequest.newBuilder()
             .setServiceName(serviceName)
             .setResourceName(resourceName)
             .setIndexName(indexName)
+            .setCompleteDirectory(completeDirectory)
             .build());
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
@@ -446,7 +446,7 @@ public class IndexState implements Closeable, Restorable {
   void initSaveLoadState() throws IOException {
     Path stateDirFile;
     if (rootDir != null) {
-      stateDirFile = rootDir.resolve("state");
+      stateDirFile = getStateDirectoryPath();
       // if (!stateDirFile.exists()) {
       // stateDirFile.mkdirs();
       // }
@@ -472,6 +472,10 @@ public class IndexState implements Closeable, Restorable {
     if (priorState != null) {
       load(priorState.getAsJsonObject("state"));
     }
+  }
+
+  public Path getStateDirectoryPath() {
+    return rootDir.resolve("state");
   }
 
   /** Load all previously saved state. */
@@ -1119,7 +1123,12 @@ public class IndexState implements Closeable, Restorable {
     /** Snapshot id. */
     public final String id;
 
-    /** Sole constructor. */
+    /** Initialize with an id * */
+    public Gens(String id) {
+      this(id, "id");
+    }
+
+    /** Initialize with a custom param (which is unused) */
     public Gens(String id, String param) {
       this.id = id;
       final String[] gens = id.split(":");

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ReleaseSnapshotHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ReleaseSnapshotHandler.java
@@ -31,8 +31,7 @@ public class ReleaseSnapshotHandler
     final ShardState shardState = indexState.getShard(0);
     final IndexState.Gens gens =
         new IndexState.Gens(
-            CreateSnapshotHandler.getSnapshotIdAsString(releaseSnapshotRequest.getSnapshotId()),
-            "id");
+            CreateSnapshotHandler.getSnapshotIdAsString(releaseSnapshotRequest.getSnapshotId()));
     // SearcherLifetimeManager pruning thread will drop
     // the searcher (if it's old enough) next time it
     // wakes up:

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/StatsRequestHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/StatsRequestHandler.java
@@ -52,14 +52,6 @@ public class StatsRequestHandler implements Handler<StatsRequest, StatsResponse>
 
   private StatsResponse process(IndexState indexState) throws IOException {
     StatsResponse.Builder statsResponseBuilder = StatsResponse.newBuilder();
-    if (indexState.shards.size() > 1) {
-      logger.error(
-          "{} shards present for index {}, unable to process more than 1 shard",
-          indexState.shards.size(),
-          indexState.name);
-      throw new IllegalStateException(
-          "Unable to get stats as more than 1 shard found for index " + indexState.name);
-    }
     for (Map.Entry<Integer, ShardState> entry : indexState.shards.entrySet()) {
       ShardState shardState = entry.getValue();
       statsResponseBuilder.setOrd(entry.getKey());

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/StatsRequestHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/StatsRequestHandler.java
@@ -52,6 +52,14 @@ public class StatsRequestHandler implements Handler<StatsRequest, StatsResponse>
 
   private StatsResponse process(IndexState indexState) throws IOException {
     StatsResponse.Builder statsResponseBuilder = StatsResponse.newBuilder();
+    if (indexState.shards.size() > 1) {
+      logger.error(
+          "{} shards present for index {}, unable to process more than 1 shard",
+          indexState.shards.size(),
+          indexState.name);
+      throw new IllegalStateException(
+          "Unable to get stats as more than 1 shard found for index " + indexState.name);
+    }
     for (Map.Entry<Integer, ShardState> entry : indexState.shards.entrySet()) {
       ShardState shardState = entry.getValue();
       statsResponseBuilder.setOrd(entry.getKey());

--- a/src/main/java/com/yelp/nrtsearch/server/utils/Archiver.java
+++ b/src/main/java/com/yelp/nrtsearch/server/utils/Archiver.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.server.utils;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
 
 public interface Archiver {
@@ -31,8 +32,8 @@ public interface Archiver {
       final String serviceName,
       final String resource,
       Path path,
-      List<String> filesToInclude,
-      List<String> parentDirectoriesToInclude)
+      Collection<String> filesToInclude,
+      Collection<String> parentDirectoriesToInclude)
       throws IOException;
 
   boolean blessVersion(final String serviceName, final String resource, String versionHash)

--- a/src/main/java/com/yelp/nrtsearch/server/utils/Archiver.java
+++ b/src/main/java/com/yelp/nrtsearch/server/utils/Archiver.java
@@ -22,7 +22,18 @@ import java.util.List;
 public interface Archiver {
   Path download(final String serviceName, final String resource) throws IOException;
 
-  String upload(final String serviceName, final String resource, Path path) throws IOException;
+  /**
+   * Upload the directory and files at the provided path. If either filesToInclude or
+   * parentDirectoriesToInclude or both are provided only the specified files or files in specified
+   * directories or both would be uploaded.
+   */
+  String upload(
+      final String serviceName,
+      final String resource,
+      Path path,
+      List<String> filesToInclude,
+      List<String> parentDirectoriesToInclude)
+      throws IOException;
 
   boolean blessVersion(final String serviceName, final String resource, String versionHash)
       throws IOException;

--- a/src/main/java/com/yelp/nrtsearch/server/utils/ArchiverImpl.java
+++ b/src/main/java/com/yelp/nrtsearch/server/utils/ArchiverImpl.java
@@ -165,7 +165,12 @@ public class ArchiverImpl implements Archiver {
   }
 
   @Override
-  public String upload(final String serviceName, final String resource, Path sourceDir)
+  public String upload(
+      final String serviceName,
+      final String resource,
+      Path sourceDir,
+      List<String> filesToInclude,
+      List<String> parentDirectoriesToInclude)
       throws IOException {
     if (!Files.exists(sourceDir)) {
       throw new IOException(
@@ -180,7 +185,7 @@ public class ArchiverImpl implements Archiver {
     }
     Path destPath = archiverDirectory.resolve(getTmpName());
     try {
-      tar.buildTar(sourceDir, destPath);
+      tar.buildTar(sourceDir, destPath, filesToInclude, parentDirectoriesToInclude);
       String versionHash = UUID.randomUUID().toString();
       uploadTarWithMetadata(serviceName, resource, versionHash, destPath);
       return versionHash;

--- a/src/main/java/com/yelp/nrtsearch/server/utils/ArchiverImpl.java
+++ b/src/main/java/com/yelp/nrtsearch/server/utils/ArchiverImpl.java
@@ -40,6 +40,7 @@ import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -169,8 +170,8 @@ public class ArchiverImpl implements Archiver {
       final String serviceName,
       final String resource,
       Path sourceDir,
-      List<String> filesToInclude,
-      List<String> parentDirectoriesToInclude)
+      Collection<String> filesToInclude,
+      Collection<String> parentDirectoriesToInclude)
       throws IOException {
     if (!Files.exists(sourceDir)) {
       throw new IOException(

--- a/src/main/java/com/yelp/nrtsearch/server/utils/Tar.java
+++ b/src/main/java/com/yelp/nrtsearch/server/utils/Tar.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.server.utils;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 
@@ -26,9 +27,29 @@ public interface Tar {
   void extractTar(final TarArchiveInputStream tarArchiveInputStream, final Path destDirectory)
       throws IOException;
 
-  void buildTar(Path sourceDir, Path destinationFile) throws IOException;
+  /**
+   * Build a tar at destinationFile with the directory and files at sourceDir. If either
+   * filesToInclude or parentDirectoriesToInclude or both are provided only the specified files or
+   * files in specified directories or both would be included in the tar.
+   */
+  void buildTar(
+      Path sourceDir,
+      Path destinationFile,
+      List<String> filesToInclude,
+      List<String> parentDirectoriesToInclude)
+      throws IOException;
 
-  void buildTar(TarArchiveOutputStream tarArchiveOutputStream, Path sourceDir) throws IOException;
+  /**
+   * Build a tar using the provided tarArchiveOutputStream with the directory and files at
+   * sourceDir. If either filesToInclude or parentDirectoriesToInclude or both are provided only the
+   * specified files or files in specified directories or both would be included in the tar.
+   */
+  void buildTar(
+      TarArchiveOutputStream tarArchiveOutputStream,
+      Path sourceDir,
+      List<String> filesToInclude,
+      List<String> parentDirectoriesToInclude)
+      throws IOException;
 
   CompressionMode getCompressionMode();
 

--- a/src/main/java/com/yelp/nrtsearch/server/utils/Tar.java
+++ b/src/main/java/com/yelp/nrtsearch/server/utils/Tar.java
@@ -17,7 +17,7 @@ package com.yelp.nrtsearch.server.utils;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.List;
+import java.util.Collection;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 
@@ -35,8 +35,8 @@ public interface Tar {
   void buildTar(
       Path sourceDir,
       Path destinationFile,
-      List<String> filesToInclude,
-      List<String> parentDirectoriesToInclude)
+      Collection<String> filesToInclude,
+      Collection<String> parentDirectoriesToInclude)
       throws IOException;
 
   /**
@@ -47,8 +47,8 @@ public interface Tar {
   void buildTar(
       TarArchiveOutputStream tarArchiveOutputStream,
       Path sourceDir,
-      List<String> filesToInclude,
-      List<String> parentDirectoriesToInclude)
+      Collection<String> filesToInclude,
+      Collection<String> parentDirectoriesToInclude)
       throws IOException;
 
   CompressionMode getCompressionMode();

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/BackupRestoreIndexRequestHandlerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/BackupRestoreIndexRequestHandlerTest.java
@@ -133,6 +133,8 @@ public class BackupRestoreIndexRequestHandlerTest {
     Path downloadPath = archiver.download("testservice", "testresource_data");
     List<String> actual = getFiles(downloadPath);
     List<String> expected = getFiles(Paths.get(grpcServer.getIndexDir()));
+    // There are two write.lock files, one under ../test_index/shard0/taxonomy and another one under
+    // ../test_index/shard0/index
     expected.remove("write.lock");
     expected.remove("write.lock");
     assertEquals(expected, actual);

--- a/src/test/java/com/yelp/nrtsearch/server/utils/ArchiverTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/utils/ArchiverTest.java
@@ -15,6 +15,7 @@
  */
 package com.yelp.nrtsearch.server.utils;
 
+import static com.yelp.nrtsearch.server.grpc.GrpcServer.rmDir;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -93,14 +94,15 @@ public class ArchiverTest {
     String service = "testservice";
     String resource = "testresource";
     Path sourceDir = createDirWithFiles(service, resource);
+    String subDirPath = sourceDir.resolve("subDir").toString();
 
     testUploadWithParameters(service, resource, sourceDir, List.of(), List.of(), List.of());
     testUploadWithParameters(
-        service, resource, sourceDir, List.of("test1"), List.of(), List.of("test2"));
+        service, resource, sourceDir, List.of("test1"), List.of(), List.of("test2", "subDir"));
     testUploadWithParameters(
-        service, resource, sourceDir, List.of(), List.of("subDir"), List.of("test1"));
+        service, resource, sourceDir, List.of(), List.of(subDirPath), List.of("test1"));
     testUploadWithParameters(
-        service, resource, sourceDir, List.of("test1"), List.of("subDir"), List.of());
+        service, resource, sourceDir, List.of("test1"), List.of(subDirPath), List.of());
   }
 
   private void testUploadWithParameters(
@@ -126,6 +128,8 @@ public class ArchiverTest {
     assertTrue(
         TarImplTest.dirsMatch(
             actualDownloadDir.resolve(resource).toFile(), sourceDir.toFile(), ignoreVerifying));
+
+    rmDir(actualDownloadDir);
   }
 
   @Test


### PR DESCRIPTION
Fixes #228 .

Since partially written segment files can be included in the backup when the complete directory is being archived, we instead backup only the state directory and the segment files which are relevant to the snapshot taken for backup. This however results in older segments and snapshots being ignored in the backup. So there is a new option `completeDirectory` in the backup rpc which when true will backup the complete directory as was happening before and can be used if the complete directory backup is required.