### PR TITLE
Add option to include custom RuntimeExceptionHandlerInterceptor, which passes RuntimeException.getMessage to clientlib

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -59,6 +59,7 @@ public class LuceneServerConfiguration {
   private final String bucketName;
   private final double[] metricsBuckets;
   private final boolean publishJvmMetrics;
+  private final boolean richClientExceptions;
   private final String[] plugins;
   private final String pluginSearchPath;
   private final String serviceName;
@@ -94,6 +95,7 @@ public class LuceneServerConfiguration {
     }
     this.metricsBuckets = metricsBuckets;
     publishJvmMetrics = configReader.getBoolean("publishJvmMetrics", false);
+    richClientExceptions = configReader.getBoolean("richClientExceptions", false);
     plugins = configReader.getStringList("plugins", DEFAULT_PLUGINS).toArray(new String[0]);
     pluginSearchPath =
         configReader.getString("pluginSearchPath", DEFAULT_PLUGIN_SEARCH_PATH.toString());
@@ -152,6 +154,10 @@ public class LuceneServerConfiguration {
 
   public boolean getPublishJvmMetrics() {
     return publishJvmMetrics;
+  }
+  
+  public boolean getRichClientExceptions() {
+    return richClientExceptions;
   }
 
   public int getReplicaReplicationPortPingInterval() {

--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -155,7 +155,7 @@ public class LuceneServerConfiguration {
   public boolean getPublishJvmMetrics() {
     return publishJvmMetrics;
   }
-  
+
   public boolean getRichClientExceptions() {
     return richClientExceptions;
   }

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -145,13 +145,12 @@ public class LuceneServer {
     List<ServerInterceptor> serverInterceptorList = new ArrayList<>();
     serverInterceptorList.add(
         LuceneServerMonitoringServerInterceptor.create(
-          Configuration.allMetrics()
-              .withLatencyBuckets(luceneServerConfiguration.getMetricsBuckets())
-              .withCollectorRegistry(collectorRegistry),
-          serviceName,
-          nodeName)
-    );
-    if (luceneServerConfiguration.getRichClientExceptions()){
+            Configuration.allMetrics()
+                .withLatencyBuckets(luceneServerConfiguration.getMetricsBuckets())
+                .withCollectorRegistry(collectorRegistry),
+            serviceName,
+            nodeName));
+    if (luceneServerConfiguration.getRichClientExceptions()) {
       serverInterceptorList.add(new RuntimeExceptionHandlerInterceptor());
     }
 
@@ -165,11 +164,8 @@ public class LuceneServer {
                         luceneServerConfiguration,
                         archiver,
                         collectorRegistry,
-                        plugins
-                    ),
-                    serverInterceptorList.toArray(new ServerInterceptor[0])
-                )
-            )
+                        plugins),
+                    serverInterceptorList.toArray(new ServerInterceptor[0])))
             .executor(
                 ThreadPoolExecutorFactory.getThreadPoolExecutor(
                     ThreadPoolExecutorFactory.ExecutorType.LUCENESERVER,

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/RuntimeExceptionHandlerInterceptor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/RuntimeExceptionHandlerInterceptor.java
@@ -25,8 +25,10 @@ import io.grpc.Status;
 /** A {@link ServerInterceptor} which enriches Exception messages given to clients. */
 public class RuntimeExceptionHandlerInterceptor implements ServerInterceptor {
   @Override
-  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> serverCall, Metadata metadata,
-                                                               ServerCallHandler<ReqT, RespT> serverCallHandler) {
+  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+      ServerCall<ReqT, RespT> serverCall,
+      Metadata metadata,
+      ServerCallHandler<ReqT, RespT> serverCallHandler) {
     ServerCall.Listener<ReqT> listener = serverCallHandler.startCall(serverCall, metadata);
     return new RuntimeExceptionHandlingServerCallListener<>(listener, serverCall, metadata);
   }
@@ -36,8 +38,8 @@ public class RuntimeExceptionHandlerInterceptor implements ServerInterceptor {
     private ServerCall<ReqT, RespT> serverCall;
     private Metadata metadata;
 
-    RuntimeExceptionHandlingServerCallListener(ServerCall.Listener<ReqT> listener, ServerCall<ReqT, RespT> serverCall,
-                                               Metadata metadata) {
+    RuntimeExceptionHandlingServerCallListener(
+        ServerCall.Listener<ReqT> listener, ServerCall<ReqT, RespT> serverCall, Metadata metadata) {
       super(listener);
       this.serverCall = serverCall;
       this.metadata = metadata;
@@ -63,8 +65,10 @@ public class RuntimeExceptionHandlerInterceptor implements ServerInterceptor {
       }
     }
 
-    private void handleException(RuntimeException exception, ServerCall<ReqT, RespT> serverCall, Metadata metadata) {
-      serverCall.close(Status.fromThrowable(exception).withDescription(exception.getMessage()), metadata);
+    private void handleException(
+        RuntimeException exception, ServerCall<ReqT, RespT> serverCall, Metadata metadata) {
+      serverCall.close(
+          Status.fromThrowable(exception).withDescription(exception.getMessage()), metadata);
     }
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/RuntimeExceptionHandlerInterceptor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/RuntimeExceptionHandlerInterceptor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.grpc;
+
+import io.grpc.ForwardingServerCallListener;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+
+/** A {@link ServerInterceptor} which enriches Exception messages given to clients. */
+public class RuntimeExceptionHandlerInterceptor implements ServerInterceptor {
+  @Override
+  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> serverCall, Metadata metadata,
+                                                               ServerCallHandler<ReqT, RespT> serverCallHandler) {
+    ServerCall.Listener<ReqT> listener = serverCallHandler.startCall(serverCall, metadata);
+    return new RuntimeExceptionHandlingServerCallListener<>(listener, serverCall, metadata);
+  }
+
+  private class RuntimeExceptionHandlingServerCallListener<ReqT, RespT>
+      extends ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT> {
+    private ServerCall<ReqT, RespT> serverCall;
+    private Metadata metadata;
+
+    RuntimeExceptionHandlingServerCallListener(ServerCall.Listener<ReqT> listener, ServerCall<ReqT, RespT> serverCall,
+                                               Metadata metadata) {
+      super(listener);
+      this.serverCall = serverCall;
+      this.metadata = metadata;
+    }
+
+    @Override
+    public void onHalfClose() {
+      try {
+        super.onHalfClose();
+      } catch (RuntimeException ex) {
+        handleException(ex, serverCall, metadata);
+        throw ex;
+      }
+    }
+
+    @Override
+    public void onReady() {
+      try {
+        super.onReady();
+      } catch (RuntimeException ex) {
+        handleException(ex, serverCall, metadata);
+        throw ex;
+      }
+    }
+
+    private void handleException(RuntimeException exception, ServerCall<ReqT, RespT> serverCall, Metadata metadata) {
+      serverCall.close(Status.fromThrowable(exception).withDescription(exception.getMessage()), metadata);
+    }
+  }
+}


### PR DESCRIPTION
Currently nrtsearch throws:
```
Exception in thread "main" io.grpc.StatusRuntimeException: UNKNOWN
```
This change will make it:
```
Exception in thread "main" io.grpc.StatusRuntimeException: <Grpc Exception Status>: <Exception.getMessage()>
```

Following https://sultanov.dev/blog/exception-handling-in-grpc-java-server/