### PR TITLE
Shortened error message in LuceneServer search to not include full searchRequest.toString()

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -802,15 +802,15 @@ public class LuceneServer {
       } catch (Exception e) {
         logger.warn(
             String.format(
-                "error while trying to execute search %s for index %s",
+                "error while trying to execute search for index %s: %n%s",
                 searchRequest.getIndexName(), searchRequest.toString()),
             e);
         searchResponseStreamObserver.onError(
             Status.UNKNOWN
                 .withDescription(
                     String.format(
-                        "error while trying to execute search %s for index %s",
-                        searchRequest.getIndexName(), searchRequest.toString()))
+                        "error while trying to execute search for index %s. check logs for full searchRequest.",
+                        searchRequest.getIndexName()))
                 .augmentDescription(e.getMessage())
                 .asRuntimeException());
       }


### PR DESCRIPTION
**Context**
Nrtsearch throws the following when the request to `search` is too big:
```
Jan 19, 2021 5:33:01 PM io.grpc.netty.shaded.io.grpc.netty.NettyServerHandler onStreamError
WARNING: Stream Error
io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2Exception$HeaderListSizeException: Header size exceeded max allowed size (8192)
...
```

**Changes**
* This PR makes nrtsearch log `searchRequest.toString()`, but avoid adding it `searchRequest.toString()` to the error message description returned to the client, which causes the header size exception above.
* Also fixed the ordering of the formatString to make sense.