### PR TITLE
Logging search request as json in case of an error

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -812,7 +812,7 @@ public class LuceneServer {
         }
         logger.warn(
             String.format(
-                "error while trying to execute search for index %s: request: %n%s",
+                "error while trying to execute search for index %s: request: %s",
                 searchRequest.getIndexName(), searchRequestJson),
             e);
         searchResponseStreamObserver.onError(

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -20,6 +20,8 @@ import static com.yelp.nrtsearch.server.grpc.ReplicationServerClient.MAX_MESSAGE
 import com.google.api.HttpBody;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -251,6 +253,7 @@ public class LuceneServer {
   }
 
   static class LuceneServerImpl extends LuceneServerGrpc.LuceneServerImplBase {
+    private final Gson gson = new GsonBuilder().create();
     private final GlobalState globalState;
     private final Archiver archiver;
     private final CollectorRegistry collectorRegistry;
@@ -802,8 +805,8 @@ public class LuceneServer {
       } catch (Exception e) {
         logger.warn(
             String.format(
-                "error while trying to execute search for index %s: %n%s",
-                searchRequest.getIndexName(), searchRequest.toString()),
+                "error while trying to execute search for index %s: request: %n%s",
+                searchRequest.getIndexName(), gson.toJson(searchRequest)),
             e);
         searchResponseStreamObserver.onError(
             Status.UNKNOWN

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
@@ -57,7 +57,7 @@ public class QueryNodeMapper {
     Query queryNode = getQueryNode(query, state);
 
     if (query.getBoost() < 0) {
-      throw new IllegalArgumentException("Boost must be a positive number, query: " + query);
+      throw new IllegalArgumentException("Boost must be a positive number");
     }
 
     if (query.getBoost() > 0) {


### PR DESCRIPTION
Logging search request as json in case of an error so the log now looks like this:

```
WARNING: error while trying to execute search for index test_index: request: {"indexName":"test_index","topHits":10,"retrieveFields":["doc_id","license_no"],"query":{"boost":-1.0,"booleanQuery":{"clauses":[{"query":{"phraseQuery":{"field":"vendor_name","terms":["first","again"]}},"occur":"MUST"}]}}}
```
Removed the newline so the complete error is logged in one line and also removed logging the query when the boost is negative as the request will be logged anyway.