### PR TITLE
Fix FacetTopDocs facetFromTopDocs

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/facet/FacetTopDocs.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/facet/FacetTopDocs.java
@@ -91,7 +91,7 @@ public class FacetTopDocs {
       LeafReaderContext context = leaves.get(ReaderUtil.subIndex(topDocs.scoreDocs[i].doc, leaves));
 
       LoadedDocValues<?> docValues = indexableFieldDef.getDocValues(context);
-      docValues.setDocId(topDocs.scoreDocs[i].doc);
+      docValues.setDocId(topDocs.scoreDocs[i].doc - context.docBase);
       if (docValues.isEmpty()) {
         continue;
       }


### PR DESCRIPTION
**Context**
Currently throws the following error:
```
java.lang.ArrayIndexOutOfBoundsException: Index 60 out of bounds for length 1
	at org.apache.lucene.util.packed.DirectMonotonicReader$2.get(DirectMonotonicReader.java:114)
	at org.apache.lucene.codecs.lucene80.Lucene80DocValuesProducer$21.advanceExact(Lucene80DocValuesProducer.java:1163)
	at com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues$SortedNumericValues.setDocId(LoadedDocValues.java:201)
	at com.yelp.nrtsearch.server.luceneserver.facet.FacetTopDocs.facetFromTopDocs(FacetTopDocs.java:94)
	at com.yelp.nrtsearch.server.luceneserver.facet.FacetTopDocs.facetTopDocsSample(FacetTopDocs.java:68)
	at com.yelp.nrtsearch.server.luceneserver.SearchHandler.handle(SearchHandler.java:131)
	at com.yelp.nrtsearch.server.grpc.LuceneServer$LuceneServerImpl.search(LuceneServer.java:790)
	at com.yelp.nrtsearch.server.grpc.LuceneServerGrpc$MethodHandlers.invoke(LuceneServerGrpc.java:2676)
	at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:172)
	at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
	at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:331)
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:820)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
```

**Fix**
* thanks @aprudhomme: `setDocId()` needs the segment id instead of the global id