### PR TITLE
Add DrillDownQueryExtractor

### DIFF
--- a/src/main/java/org/apache/lucene/facet/DrillDownQueryExtractor.java
+++ b/src/main/java/org/apache/lucene/facet/DrillDownQueryExtractor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.facet;
+
+import org.apache.lucene.search.Query;
+
+/**
+ * Class to extract the base query from a {@link DrillDownQuery}. This is needed because the method
+ * is package private (for some reason).
+ */
+public class DrillDownQueryExtractor {
+  private DrillDownQueryExtractor() {}
+
+  public static Query getBaseQuery(DrillDownQuery ddq) {
+    return ddq.getBaseQuery();
+  }
+}

--- a/src/test/java/org/apache/lucene/facet/DrillDownQueryExtractorTest.java
+++ b/src/test/java/org/apache/lucene/facet/DrillDownQueryExtractorTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.facet;
+
+import static org.junit.Assert.assertSame;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.junit.Test;
+
+public class DrillDownQueryExtractorTest {
+
+  @Test
+  public void testExtractBaseQuery() {
+    Query baseQuery = new TermQuery(new Term("test_term"));
+    DrillDownQuery drillDownQuery = new DrillDownQuery(new FacetsConfig(), baseQuery);
+    assertSame(baseQuery, DrillDownQueryExtractor.getBaseQuery(drillDownQuery));
+  }
+}


### PR DESCRIPTION
Add class to extract base query from a DrillDownQuery. We tried to do this in a plugin, but it fails across the classloader boundary.