### PR TITLE
Add NRT metrics

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/NrtMetrics.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/NrtMetrics.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.monitoring;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Summary;
+
+/**
+ * Class for managing collection of nrt related metrics. Collects metrics on publishing of new nrt
+ * points and pre copying merged segments.
+ */
+public class NrtMetrics {
+  public static final Gauge searcherVersion =
+      Gauge.build()
+          .name("nrt_searcher_version")
+          .help("Current searcher version.")
+          .labelNames("index")
+          .create();
+
+  public static final Counter nrtPrimaryPointCount =
+      Counter.build()
+          .name("nrt_primary_point_count")
+          .help("Number of nrt points created on the primary.")
+          .labelNames("index")
+          .create();
+  public static final Summary nrtPrimaryMergeTime =
+      Summary.build()
+          .name("nrt_primary_merge_time_ms")
+          .help("Time to copy data for merge (ms).")
+          .quantile(0.5, 0.05)
+          .quantile(0.95, 0.01)
+          .quantile(0.99, 0.01)
+          .labelNames("index")
+          .create();
+
+  public static final Counter nrtPointFailure =
+      Counter.build()
+          .name("nrt_point_failure_count")
+          .help("Number of failed nrt point copies")
+          .labelNames("index")
+          .create();
+  public static final Summary nrtPointSize =
+      Summary.build()
+          .name("nrt_point_copy_size")
+          .help("Data copied for nrt points.")
+          .quantile(0.5, 0.05)
+          .quantile(0.95, 0.01)
+          .quantile(0.99, 0.01)
+          .labelNames("index")
+          .create();
+  public static final Summary nrtPointTime =
+      Summary.build()
+          .name("nrt_point_copy_time_ms")
+          .help("Time to copy data for nrt point (ms).")
+          .quantile(0.5, 0.05)
+          .quantile(0.95, 0.01)
+          .quantile(0.99, 0.01)
+          .labelNames("index")
+          .create();
+
+  public static final Counter nrtMergeFailure =
+      Counter.build()
+          .name("nrt_merge_failure_count")
+          .help("Number of failed merge copies.")
+          .labelNames("index")
+          .create();
+  public static final Summary nrtMergeSize =
+      Summary.build()
+          .name("nrt_merge_copy_size")
+          .help("Data copied for merges.")
+          .quantile(0.5, 0.05)
+          .quantile(0.95, 0.01)
+          .quantile(0.99, 0.01)
+          .labelNames("index")
+          .create();
+  public static final Summary nrtMergeTime =
+      Summary.build()
+          .name("nrt_merge_copy_time_ms")
+          .help("Time to copy data for merge (ms).")
+          .quantile(0.5, 0.05)
+          .quantile(0.95, 0.01)
+          .quantile(0.99, 0.01)
+          .labelNames("index")
+          .create();
+
+  /**
+   * Add all nrt metrics to the collector registry.
+   *
+   * @param registry collector registry
+   */
+  public static void register(CollectorRegistry registry) {
+    registry.register(searcherVersion);
+    registry.register(nrtPrimaryPointCount);
+    registry.register(nrtPrimaryMergeTime);
+    registry.register(nrtPointFailure);
+    registry.register(nrtPointSize);
+    registry.register(nrtPointTime);
+    registry.register(nrtMergeFailure);
+    registry.register(nrtMergeSize);
+    registry.register(nrtMergeTime);
+  }
+}


### PR DESCRIPTION
Adds the following nrt related metrics:
nrt_searcher_version - Last published searcher version (primary), or last successfully copied nrt point (replica).

Primary:
nrt_primary_point_count - count of nrt points triggered
nrt_primary_merge_time_ms - summary of merge pre copy timing seen by primary (p50/95/99)

Replicas:
nrt_point_failure_count - count of nrt point copy jobs that failed
nrt_point_copy_size - summary of amount of data copied for nrt points (p50/95/99)
nrt_point_copy_time_ms - summary of time for nrt points (p50/95/99)
nrt_merge_failure_count - count of merge copy jobs that failed
nrt_merge_copy_size - summary of amount of data copied for merges (p50/95/99)
nrt_merge_copy_time_ms - summary of time for merges (p50/95/99)

All metrics have and 'index' label.

I wanted to try using Summary instead of Histogram because there a very large range to cover. Also, we will probably want to look at these on a per host level anyways. Summaries add some work on the client side, but these operations happen with fairly low frequency.