### PR TITLE
Allow empty FacetResult for sorted set doc value facets

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/facet/DrillSidewaysImpl.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/facet/DrillSidewaysImpl.java
@@ -512,30 +512,29 @@ public class DrillSidewaysImpl extends DrillSideways {
       }
       return getDocValuesFacetResult(facet, drillDowns, indexableFieldDef);
     }
-    if (facetResult != null) {
-      return buildFacetResultGrpc(facetResult, facet.getName());
-    }
-    return null;
+    return buildFacetResultGrpc(facetResult, facet.getName());
   }
 
   private static com.yelp.nrtsearch.server.grpc.FacetResult buildFacetResultGrpc(
       FacetResult facetResult, String name) {
     var builder = com.yelp.nrtsearch.server.grpc.FacetResult.newBuilder();
     builder.setName(name);
-    builder.setDim(facetResult.dim);
-    builder.addAllPath(Arrays.asList(facetResult.path));
-    builder.setValue(facetResult.value.doubleValue());
-    builder.setChildCount(facetResult.childCount);
-    List<com.yelp.nrtsearch.server.grpc.LabelAndValue> labelAndValues = new ArrayList<>();
-    for (LabelAndValue labelValue : facetResult.labelValues) {
-      var labelAndValue =
-          com.yelp.nrtsearch.server.grpc.LabelAndValue.newBuilder()
-              .setLabel(labelValue.label)
-              .setValue(labelValue.value.doubleValue())
-              .build();
-      labelAndValues.add(labelAndValue);
+    if (facetResult != null) {
+      builder.setDim(facetResult.dim);
+      builder.addAllPath(Arrays.asList(facetResult.path));
+      builder.setValue(facetResult.value.doubleValue());
+      builder.setChildCount(facetResult.childCount);
+      List<com.yelp.nrtsearch.server.grpc.LabelAndValue> labelAndValues = new ArrayList<>();
+      for (LabelAndValue labelValue : facetResult.labelValues) {
+        var labelAndValue =
+            com.yelp.nrtsearch.server.grpc.LabelAndValue.newBuilder()
+                .setLabel(labelValue.label)
+                .setValue(labelValue.value.doubleValue())
+                .build();
+        labelAndValues.add(labelAndValue);
+      }
+      builder.addAllLabelValues(labelAndValues);
     }
-    builder.addAllLabelValues(labelAndValues);
     return builder.build();
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/TextFieldFacetsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/TextFieldFacetsTest.java
@@ -23,8 +23,10 @@ import com.yelp.nrtsearch.server.grpc.FacetHierarchyPath;
 import com.yelp.nrtsearch.server.grpc.FacetResult;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
 import com.yelp.nrtsearch.server.grpc.LabelAndValue;
+import com.yelp.nrtsearch.server.grpc.Query;
 import com.yelp.nrtsearch.server.grpc.SearchRequest;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import com.yelp.nrtsearch.server.grpc.TermQuery;
 import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.IOException;
@@ -217,6 +219,33 @@ public class TextFieldFacetsTest extends ServerTestCase {
         3,
         1L,
         expectedLabelAndValues);
+  }
+
+  @Test
+  public void testSortedDocValuesEmpty() {
+    Facet.Builder facetBuilder =
+        Facet.newBuilder().setName("test_name").setDim("sorted_doc_values_facet_field").setTopN(10);
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(DEFAULT_TEST_INDEX)
+                    .setTopHits(10)
+                    .addFacets(facetBuilder.build())
+                    .setQuery(
+                        Query.newBuilder()
+                            .setTermQuery(
+                                TermQuery.newBuilder()
+                                    .setField("sorted_doc_values_facet_field")
+                                    .setTextValue("unknown")
+                                    .build())
+                            .build())
+                    .build());
+    assertEquals(1, response.getFacetResultCount());
+    FacetResult result = response.getFacetResult(0);
+    assertEquals("test_name", result.getName());
+    assertEquals(0, result.getLabelValuesCount());
   }
 
   @Test


### PR DESCRIPTION
Return an empty FacetResult when there are no results for a facet, instead of omitting it from the response.