### PR TITLE
Add label filtering for sorted set doc value facets

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/facet/DrillSidewaysImpl.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/facet/DrillSidewaysImpl.java
@@ -399,12 +399,22 @@ public class DrillSidewaysImpl extends DrillSideways {
       if (c == null) {
         c = drillDowns;
       }
-      SortedSetDocValuesFacetCounts sortedSetDocValuesFacetCounts =
-          new SortedSetDocValuesFacetCounts(
-              shardState.getSSDVState(searcherAndTaxonomyManager, fieldDef), c);
-      facetResult =
-          sortedSetDocValuesFacetCounts.getTopChildren(
-              facet.getTopN(), fieldDef.getName(), new String[0]);
+      if (facet.getLabelsCount() > 0) {
+        // filter facet if a label list is provided
+        FilteredSSDVFacetCounts filteredSSDVFacetCounts =
+            new FilteredSSDVFacetCounts(
+                facet.getLabelsList(),
+                fieldDef.getName(),
+                shardState.getSSDVState(searcherAndTaxonomyManager, fieldDef),
+                c);
+        facetResult = filteredSSDVFacetCounts.getTopChildren(facet.getTopN(), fieldDef.getName());
+      } else {
+        SortedSetDocValuesFacetCounts sortedSetDocValuesFacetCounts =
+            new SortedSetDocValuesFacetCounts(
+                shardState.getSSDVState(searcherAndTaxonomyManager, fieldDef), c);
+        facetResult =
+            sortedSetDocValuesFacetCounts.getTopChildren(facet.getTopN(), fieldDef.getName());
+      }
     } else if (fieldDef.getFacetValueType() != IndexableFieldDef.FacetValueType.NO_FACETS) {
 
       // Taxonomy  facets

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/facet/FilteredSSDVFacetCounts.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/facet/FilteredSSDVFacetCounts.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.facet;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.lucene.facet.FacetResult;
+import org.apache.lucene.facet.Facets;
+import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsCollector.MatchingDocs;
+import org.apache.lucene.facet.FacetsConfig;
+import org.apache.lucene.facet.LabelAndValue;
+import org.apache.lucene.facet.TopOrdAndIntQueue;
+import org.apache.lucene.facet.sortedset.SortedSetDocValuesReaderState;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.MultiDocValues;
+import org.apache.lucene.index.MultiDocValues.MultiSortedSetDocValues;
+import org.apache.lucene.index.OrdinalMap;
+import org.apache.lucene.index.ReaderUtil;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.search.ConjunctionDISI;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.LongValues;
+
+/**
+ * Facet implementation based off the {@link
+ * org.apache.lucene.facet.sortedset.SortedSetDocValuesFacetCounts}. Computes facet counts based on
+ * the sorted set doc value ordinals for a provided list of values, acting as an inclusion filter.
+ * Only applies to a single dimension.
+ */
+public class FilteredSSDVFacetCounts extends Facets {
+
+  final SortedSetDocValuesReaderState state;
+  final SortedSetDocValues dv;
+  final String field;
+  final Map<Long, Integer> globalOrdinalToCountIndex;
+  final List<String> values;
+  final int[] counts;
+
+  /**
+   * Facet to count based on sorted set doc values, but only considering the provided values.
+   *
+   * @param values values to count
+   * @param dim facet dimension
+   * @param state reader state
+   * @param hits hits to facet over
+   * @throws IOException
+   */
+  public FilteredSSDVFacetCounts(
+      List<String> values, String dim, SortedSetDocValuesReaderState state, FacetsCollector hits)
+      throws IOException {
+    this.state = state;
+    this.field = state.getField();
+    this.values = values;
+    dv = state.getDocValues();
+    counts = new int[values.size()];
+
+    // find mapping to go from global ordinal to the value count index
+    globalOrdinalToCountIndex = new HashMap<>();
+    for (int i = 0; i < values.size(); ++i) {
+      String[] fullPath = new String[2];
+      fullPath[0] = dim;
+      fullPath[1] = values.get(i);
+      long gOrd = dv.lookupTerm(new BytesRef(FacetsConfig.pathToString(fullPath)));
+      if (gOrd >= 0) {
+        globalOrdinalToCountIndex.put(gOrd, i);
+      }
+    }
+
+    count(hits.getMatchingDocs());
+  }
+
+  /** Does all the "real work" of tallying up the counts. */
+  private void count(List<MatchingDocs> matchingDocs) throws IOException {
+    OrdinalMap ordinalMap;
+
+    // TODO: is this right?  really, we need a way to
+    // verify that this ordinalMap "matches" the leaves in
+    // matchingDocs...
+    if (dv instanceof MultiDocValues.MultiSortedSetDocValues && matchingDocs.size() > 1) {
+      ordinalMap = ((MultiSortedSetDocValues) dv).mapping;
+    } else {
+      ordinalMap = null;
+    }
+    IndexReader reader = state.getReader();
+
+    for (MatchingDocs hits : matchingDocs) {
+      // LUCENE-5090: make sure the provided reader context "matches"
+      // the top-level reader passed to the
+      // SortedSetDocValuesReaderState, else cryptic
+      // AIOOBE can happen:
+      if (ReaderUtil.getTopLevelContext(hits.context).reader() != reader) {
+        throw new IllegalStateException(
+            "the SortedSetDocValuesReaderState provided to this class does not match the reader being searched; you must create a new SortedSetDocValuesReaderState every time you open a new IndexReader");
+      }
+
+      countOneSegment(ordinalMap, hits.context.reader(), hits.context.ord, hits);
+    }
+  }
+
+  private void countOneSegment(
+      OrdinalMap ordinalMap, LeafReader reader, int segOrd, MatchingDocs hits) throws IOException {
+    SortedSetDocValues segValues = reader.getSortedSetDocValues(field);
+    if (segValues == null) {
+      // nothing to count
+      return;
+    }
+
+    DocIdSetIterator it;
+    if (hits == null) {
+      it = segValues;
+    } else {
+      it = ConjunctionDISI.intersectIterators(Arrays.asList(hits.bits.iterator(), segValues));
+    }
+
+    // TODO: yet another option is to count all segs
+    // first, only in seg-ord space, and then do a
+    // merge-sort-PQ in the end to only "resolve to
+    // global" those seg ords that can compete, if we know
+    // we just want top K?  ie, this is the same algo
+    // that'd be used for merging facets across shards
+    // (distributed faceting).  but this has much higher
+    // temp ram req'ts (sum of number of ords across all
+    // segs)
+    if (ordinalMap != null) {
+      final LongValues ordMap = ordinalMap.getGlobalOrds(segOrd);
+
+      int numSegOrds = (int) segValues.getValueCount();
+
+      if (hits != null && hits.totalHits < numSegOrds / 10) {
+        // Remap every ord to global ord as we iterate:
+        for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
+          int term = (int) segValues.nextOrd();
+          while (term != SortedSetDocValues.NO_MORE_ORDS) {
+            Integer countIndex = globalOrdinalToCountIndex.get(ordMap.get(term));
+            if (countIndex != null) {
+              counts[countIndex]++;
+            }
+            term = (int) segValues.nextOrd();
+          }
+        }
+      } else {
+        // First count in seg-ord space:
+        final int[] segCounts = new int[numSegOrds];
+        for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
+          int term = (int) segValues.nextOrd();
+          while (term != SortedSetDocValues.NO_MORE_ORDS) {
+            segCounts[term]++;
+            term = (int) segValues.nextOrd();
+          }
+        }
+
+        // Then, migrate to global ords:
+        for (int ord = 0; ord < numSegOrds; ord++) {
+          int count = segCounts[ord];
+          if (count != 0) {
+            Integer countIndex = globalOrdinalToCountIndex.get(ordMap.get(ord));
+            if (countIndex != null) {
+              counts[countIndex]++;
+            }
+          }
+        }
+      }
+    } else {
+      // No ord mapping (e.g., single segment index):
+      // just aggregate directly into counts:
+      for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
+        long term = segValues.nextOrd();
+        while (term != SortedSetDocValues.NO_MORE_ORDS) {
+          Integer countIndex = globalOrdinalToCountIndex.get(term);
+          if (countIndex != null) {
+            counts[countIndex]++;
+          }
+          term = segValues.nextOrd();
+        }
+      }
+    }
+  }
+
+  @Override
+  public FacetResult getTopChildren(int topN, String dim, String... path) throws IOException {
+    if (topN <= 0) {
+      throw new IllegalArgumentException("topN must be > 0 (got: " + topN + ")");
+    }
+    if (path.length > 0) {
+      throw new IllegalArgumentException("path should be 0 length");
+    }
+    return getDim(dim, topN);
+  }
+
+  private FacetResult getDim(String dim, int topN) throws IOException {
+    TopOrdAndIntQueue q = null;
+
+    int bottomCount = 0;
+    int dimCount = 0;
+    int childCount = 0;
+
+    TopOrdAndIntQueue.OrdAndValue reuse = null;
+    for (int ord = 0; ord < counts.length; ord++) {
+      if (counts[ord] > 0) {
+        dimCount += counts[ord];
+        childCount++;
+        if (counts[ord] > bottomCount) {
+          if (reuse == null) {
+            reuse = new TopOrdAndIntQueue.OrdAndValue();
+          }
+          reuse.ord = ord;
+          reuse.value = counts[ord];
+          if (q == null) {
+            // Lazy init, so we don't create this for the
+            // sparse case unnecessarily
+            q = new TopOrdAndIntQueue(topN);
+          }
+          reuse = q.insertWithOverflow(reuse);
+          if (q.size() == topN) {
+            bottomCount = q.top().value;
+          }
+        }
+      }
+    }
+
+    if (q == null) {
+      return null;
+    }
+
+    LabelAndValue[] labelValues = new LabelAndValue[q.size()];
+    for (int i = labelValues.length - 1; i >= 0; i--) {
+      TopOrdAndIntQueue.OrdAndValue ordAndValue = q.pop();
+      labelValues[i] = new LabelAndValue(values.get(ordAndValue.ord), ordAndValue.value);
+    }
+    return new FacetResult(dim, new String[0], dimCount, labelValues, childCount);
+  }
+
+  @Override
+  public Number getSpecificValue(String dim, String... path) throws IOException {
+    if (path.length != 1) {
+      throw new IllegalArgumentException("path must be length=1");
+    }
+    long ord = dv.lookupTerm(new BytesRef(FacetsConfig.pathToString(dim, path)));
+    if (ord < 0) {
+      return -1;
+    }
+
+    Integer countIndex = globalOrdinalToCountIndex.get(ord);
+    if (countIndex == null) {
+      return -1;
+    }
+
+    return counts[countIndex];
+  }
+
+  @Override
+  public List<FacetResult> getAllDims(int topN) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/FilteredSSDVFacetCountsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/FilteredSSDVFacetCountsTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.facet;
+
+import static org.junit.Assert.assertEquals;
+
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.Facet;
+import com.yelp.nrtsearch.server.grpc.FacetResult;
+import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
+import com.yelp.nrtsearch.server.grpc.LabelAndValue;
+import com.yelp.nrtsearch.server.grpc.SearchRequest;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.NoMergePolicy;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class FilteredSSDVFacetCountsTest extends ServerTestCase {
+  private static final String MULTI_SEGMENT_INDEX = "test_index_multi";
+  @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  @Override
+  public FieldDefRequest getIndexDef(String name) throws IOException {
+    if (MULTI_SEGMENT_INDEX.equals(name)) {
+      return getFieldsFromResourceFile("/facet/filtered_field_facets_multi.json");
+    } else {
+      return getFieldsFromResourceFile("/facet/filtered_field_facets.json");
+    }
+  }
+
+  @Override
+  public List<String> getIndices() {
+    return Arrays.asList(DEFAULT_TEST_INDEX, MULTI_SEGMENT_INDEX);
+  }
+
+  @Override
+  public void initIndex(String name) throws Exception {
+    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    // don't want any merges for these tests
+    writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
+
+    AddDocumentRequest doc1 =
+        AddDocumentRequest.newBuilder()
+            .setIndexName(name)
+            .putFields(
+                "sorted_doc_values_facet_field",
+                AddDocumentRequest.MultiValuedField.newBuilder()
+                    .addValue("M1")
+                    .addValue("M2")
+                    .build())
+            .putFields(
+                "sorted_doc_values_facet_field_single_valued",
+                AddDocumentRequest.MultiValuedField.newBuilder().addValue("S1").build())
+            .build();
+    AddDocumentRequest doc2 =
+        AddDocumentRequest.newBuilder()
+            .setIndexName(name)
+            .putFields(
+                "sorted_doc_values_facet_field",
+                AddDocumentRequest.MultiValuedField.newBuilder().addValue("M2").build())
+            .putFields(
+                "sorted_doc_values_facet_field_single_valued",
+                AddDocumentRequest.MultiValuedField.newBuilder().addValue("S1").build())
+            .build();
+    AddDocumentRequest doc3 =
+        AddDocumentRequest.newBuilder()
+            .setIndexName(name)
+            .putFields(
+                "sorted_doc_values_facet_field",
+                AddDocumentRequest.MultiValuedField.newBuilder()
+                    .addValue("M1")
+                    .addValue("M2")
+                    .addValue("M3")
+                    .build())
+            .putFields(
+                "sorted_doc_values_facet_field_single_valued",
+                AddDocumentRequest.MultiValuedField.newBuilder().addValue("S2").build())
+            .build();
+
+    if (MULTI_SEGMENT_INDEX.equals(name)) {
+      addDocuments(Stream.of(doc1));
+      writer.commit();
+      addDocuments(Stream.of(doc2));
+      writer.commit();
+      addDocuments(Stream.of(doc3));
+      writer.commit();
+    } else {
+      List<AddDocumentRequest> documents = new ArrayList<>();
+      documents.add(doc1);
+      documents.add(doc2);
+      documents.add(doc3);
+      addDocuments(documents.stream());
+    }
+  }
+
+  @Test
+  public void testFiltered() {
+    Facet facet =
+        Facet.newBuilder()
+            .setName("test_facet")
+            .setDim("sorted_doc_values_facet_field")
+            .addLabels("M1")
+            .addLabels("M2")
+            .setTopN(3)
+            .build();
+    queryAndVerify(
+        facet,
+        2,
+        LabelAndValue.newBuilder().setLabel("M2").setValue(3).build(),
+        LabelAndValue.newBuilder().setLabel("M1").setValue(2).build());
+  }
+
+  @Test
+  public void testFilteredWithNotPresent() {
+    Facet facet =
+        Facet.newBuilder()
+            .setName("test_facet")
+            .setDim("sorted_doc_values_facet_field")
+            .addLabels("M2")
+            .addLabels("M3")
+            .addLabels("M4")
+            .setTopN(3)
+            .build();
+    queryAndVerify(
+        facet,
+        2,
+        LabelAndValue.newBuilder().setLabel("M2").setValue(3).build(),
+        LabelAndValue.newBuilder().setLabel("M3").setValue(1).build());
+  }
+
+  @Test
+  public void testFilteredNonePresent() {
+    Facet facet =
+        Facet.newBuilder()
+            .setName("test_facet")
+            .setDim("sorted_doc_values_facet_field")
+            .addLabels("M4")
+            .addLabels("M5")
+            .addLabels("M6")
+            .setTopN(3)
+            .build();
+    queryAndVerify(facet, 0);
+  }
+
+  @Test
+  public void testFilteredLessTopN() {
+    Facet facet =
+        Facet.newBuilder()
+            .setName("test_facet")
+            .setDim("sorted_doc_values_facet_field")
+            .addLabels("M1")
+            .addLabels("M2")
+            .setTopN(1)
+            .build();
+    queryAndVerify(facet, 2, LabelAndValue.newBuilder().setLabel("M2").setValue(3).build());
+  }
+
+  @Test
+  public void testFilteredSingle() {
+    Facet facet =
+        Facet.newBuilder()
+            .setName("test_facet")
+            .setDim("sorted_doc_values_facet_field_single_valued")
+            .addLabels("S1")
+            .setTopN(3)
+            .build();
+    queryAndVerify(facet, 1, LabelAndValue.newBuilder().setLabel("S1").setValue(2).build());
+  }
+
+  @Test
+  public void testFilteredWithNotPresentSingle() {
+    Facet facet =
+        Facet.newBuilder()
+            .setName("test_facet")
+            .setDim("sorted_doc_values_facet_field_single_valued")
+            .addLabels("S2")
+            .addLabels("S3")
+            .setTopN(3)
+            .build();
+    queryAndVerify(facet, 1, LabelAndValue.newBuilder().setLabel("S2").setValue(1).build());
+  }
+
+  @Test
+  public void testFilteredNonePresentSingle() {
+    Facet facet =
+        Facet.newBuilder()
+            .setName("test_facet")
+            .setDim("sorted_doc_values_facet_field_single_valued")
+            .addLabels("S3")
+            .addLabels("S4")
+            .setTopN(3)
+            .build();
+    queryAndVerify(facet, 0);
+  }
+
+  @Test
+  public void testFilteredLessTopNSingle() {
+    Facet facet =
+        Facet.newBuilder()
+            .setName("test_facet")
+            .setDim("sorted_doc_values_facet_field_single_valued")
+            .addLabels("S1")
+            .addLabels("S2")
+            .setTopN(1)
+            .build();
+    queryAndVerify(facet, 2, LabelAndValue.newBuilder().setLabel("S1").setValue(2).build());
+  }
+
+  private void queryAndVerify(Facet facet, int childCount, LabelAndValue... expectedValues) {
+    SearchResponse response = doQuery(DEFAULT_TEST_INDEX, facet);
+    assertResponse(response, childCount, expectedValues);
+    response = doQuery(MULTI_SEGMENT_INDEX, facet);
+    assertResponse(response, childCount, expectedValues);
+  }
+
+  private void assertResponse(
+      SearchResponse response, int childCount, LabelAndValue... expectedValues) {
+    assertEquals(1, response.getFacetResultCount());
+    FacetResult result = response.getFacetResult(0);
+    assertEquals("test_facet", result.getName());
+    assertEquals(childCount, result.getChildCount());
+    assertEquals(expectedValues.length, result.getLabelValuesCount());
+
+    for (int i = 0; i < expectedValues.length; ++i) {
+      assertEquals(expectedValues[i].getLabel(), result.getLabelValues(i).getLabel());
+      assertEquals(expectedValues[i].getValue(), result.getLabelValues(i).getValue(), 0);
+    }
+  }
+
+  private SearchResponse doQuery(String index, Facet facet) {
+    return getGrpcServer()
+        .getBlockingStub()
+        .search(
+            SearchRequest.newBuilder()
+                .setIndexName(index)
+                .setStartHit(0)
+                .setTopHits(10)
+                .addFacets(facet)
+                .build());
+  }
+}

--- a/src/test/resources/facet/filtered_field_facets.json
+++ b/src/test/resources/facet/filtered_field_facets.json
@@ -1,0 +1,24 @@
+{
+  "indexName": "test_index",
+  "field": [
+    {
+      "name": "sorted_doc_values_facet_field",
+      "type": "TEXT",
+      "storeDocValues": true,
+      "multiValued": true,
+      "tokenize": true,
+      "search": true,
+      "facet": "SORTED_SET_DOC_VALUES",
+      "facetIndexFieldName" : "$sorted_doc_values_facet_field"
+    },
+    {
+      "name": "sorted_doc_values_facet_field_single_valued",
+      "type": "TEXT",
+      "storeDocValues": true,
+      "tokenize": true,
+      "search": true,
+      "facet": "SORTED_SET_DOC_VALUES",
+      "facetIndexFieldName" : "$sorted_doc_values_facet_field_single_valued"
+    }
+  ]
+}

--- a/src/test/resources/facet/filtered_field_facets_multi.json
+++ b/src/test/resources/facet/filtered_field_facets_multi.json
@@ -1,0 +1,24 @@
+{
+  "indexName": "test_index_multi",
+  "field": [
+    {
+      "name": "sorted_doc_values_facet_field",
+      "type": "TEXT",
+      "storeDocValues": true,
+      "multiValued": true,
+      "tokenize": true,
+      "search": true,
+      "facet": "SORTED_SET_DOC_VALUES",
+      "facetIndexFieldName" : "$sorted_doc_values_facet_field"
+    },
+    {
+      "name": "sorted_doc_values_facet_field_single_valued",
+      "type": "TEXT",
+      "storeDocValues": true,
+      "tokenize": true,
+      "search": true,
+      "facet": "SORTED_SET_DOC_VALUES",
+      "facetIndexFieldName" : "$sorted_doc_values_facet_field_single_valued"
+    }
+  ]
+}


### PR DESCRIPTION
The sorted set doc values facet currently ignores the list of labels provided in the request. It is expected for these labels would be the only values counted during the facet aggregation. This branch adds a new Facets implementation based off the SortedSetDocValuesFacetCounts, but only considers a provided list of values.