### PR TITLE
Provide default similarity for unknown fields

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
@@ -384,9 +384,15 @@ public class IndexState implements Closeable, Restorable {
 
         @Override
         public Similarity get(String name) {
-          FieldDef fd = getField(name);
-          if (fd instanceof IndexableFieldDef) {
-            return ((IndexableFieldDef) fd).getSimilarity();
+          try {
+            FieldDef fd = getField(name);
+            if (fd instanceof IndexableFieldDef) {
+              return ((IndexableFieldDef) fd).getSimilarity();
+            }
+          } catch (IllegalArgumentException ignored) {
+            // ReplicaNode tries to do a Term query for a field called 'marker'
+            // in finishNRTCopy. Since the field is not in the index, we want
+            // to ignore the exception.
           }
           return defaultSim;
         }


### PR DESCRIPTION
Provides the default similarity if a field does not exist. This behavior changed when the index meta fields were added.

Fixes:
`java.lang.IllegalArgumentException: field "marker" is unknown: it was not registered with registerField
        at com.yelp.nrtsearch.server.luceneserver.IndexState.getField(IndexState.java:689)
        at com.yelp.nrtsearch.server.luceneserver.IndexState$3.get(IndexState.java:387)
        at org.apache.lucene.search.similarities.PerFieldSimilarityWrapper.scorer(PerFieldSimilarityWrapper.java:47)
        at org.apache.lucene.search.TermQuery$TermWeight.<init>(TermQuery.java:74)
        at org.apache.lucene.search.TermQuery.createWeight(TermQuery.java:205)
        at org.apache.lucene.search.IndexSearcher.createWeight(IndexSearcher.java:726)
        at org.apache.lucene.search.IndexSearcher.search(IndexSearcher.java:593)
        at org.apache.lucene.search.IndexSearcher.count(IndexSearcher.java:366)
        at org.apache.lucene.replicator.nrt.ReplicaNode.finishNRTCopy(ReplicaNode.java:433)
        at com.yelp.nrtsearch.server.luceneserver.NRTReplicaNode.finishNRTCopy(NRTReplicaNode.java:175)
        at org.apache.lucene.replicator.nrt.ReplicaNode$1.run(ReplicaNode.java:516)
        at com.yelp.nrtsearch.server.luceneserver.Jobs.run(Jobs.java:112)`