### PR TITLE
Added tests for range queries on datetime field 

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/DateTimeFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/DateTimeFieldDef.java
@@ -53,8 +53,6 @@ import org.apache.lucene.util.CloseableThreadLocal;
 
 /** Field class for 'DATE_TIME' field type. */
 public class DateTimeFieldDef extends IndexableFieldDef implements Sortable, RangeQueryable {
-  private static final long MIN_DATE_TIME = 0;
-
   private static final String EPOCH_MILLIS = "epoch_millis";
 
   private final CloseableThreadLocal<DateTimeParser> dateTimeParsers;
@@ -80,7 +78,7 @@ public class DateTimeFieldDef extends IndexableFieldDef implements Sortable, Ran
 
     long lower =
         rangeQuery.getLower().isEmpty()
-            ? MIN_DATE_TIME
+            ? Long.MIN_VALUE
             : convertDateStringToMillis(rangeQuery.getLower(), dateTimeFormat);
     long upper =
         rangeQuery.getUpper().isEmpty()


### PR DESCRIPTION
Adding remaining test for #258 . Additionally set default lower bound for range queries on datetime to Long.MIN_VALUE instead of 0.