### PR TITLE
Make index data preload a config option

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -64,6 +64,7 @@ public class LuceneServerConfiguration {
   private final String serviceName;
   private final boolean restoreState;
   private final ThreadPoolConfiguration threadPoolConfiguration;
+  private final boolean preloadIndexData;
 
   private final YamlConfigReader configReader;
 
@@ -99,6 +100,7 @@ public class LuceneServerConfiguration {
         configReader.getString("pluginSearchPath", DEFAULT_PLUGIN_SEARCH_PATH.toString());
     serviceName = configReader.getString("serviceName", DEFAULT_SERVICE_NAME);
     restoreState = configReader.getBoolean("restoreState", false);
+    preloadIndexData = configReader.getBoolean("preloadIndexData", true);
     threadPoolConfiguration = new ThreadPoolConfiguration(configReader);
   }
 
@@ -168,6 +170,10 @@ public class LuceneServerConfiguration {
 
   public boolean getRestoreState() {
     return restoreState;
+  }
+
+  public boolean getPreloadIndexData() {
+    return preloadIndexData;
   }
 
   public YamlConfigReader getConfigReader() {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/BuildSuggestHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/BuildSuggestHandler.java
@@ -226,7 +226,8 @@ public class BuildSuggestHandler implements Handler<BuildSuggestRequest, BuildSu
 
       suggester =
           new AnalyzingInfixSuggester(
-              indexState.df.open(indexState.rootDir.resolve("suggest." + suggestName + ".infix")),
+              indexState.df.open(
+                  indexState.rootDir.resolve("suggest." + suggestName + ".infix"), true),
               indexAnalyzer,
               queryAnalyzer,
               AnalyzingInfixSuggester.DEFAULT_MIN_PREFIX_CHARS,
@@ -317,7 +318,8 @@ public class BuildSuggestHandler implements Handler<BuildSuggestRequest, BuildSu
 
       suggester =
           new CompletionInfixSuggester(
-              indexState.df.open(indexState.rootDir.resolve("suggest." + suggestName + ".infix")),
+              indexState.df.open(
+                  indexState.rootDir.resolve("suggest." + suggestName + ".infix"), true),
               indexAnalyzer,
               queryAnalyzer);
     } else if (buildSuggestRequest.hasFuzzyInfixSuggester()) {
@@ -354,7 +356,8 @@ public class BuildSuggestHandler implements Handler<BuildSuggestRequest, BuildSu
 
       suggester =
           new FuzzyInfixSuggester(
-              indexState.df.open(indexState.rootDir.resolve("suggest." + suggestName + ".infix")),
+              indexState.df.open(
+                  indexState.rootDir.resolve("suggest." + suggestName + ".infix"), true),
               indexAnalyzer,
               queryAnalyzer,
               maxEdits,

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/GlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/GlobalState.java
@@ -21,7 +21,6 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.config.ThreadPoolConfiguration;
-import com.yelp.nrtsearch.server.config.YamlConfigReader;
 import com.yelp.nrtsearch.server.utils.ThreadPoolExecutorFactory;
 import java.io.Closeable;
 import java.io.IOException;
@@ -65,7 +64,7 @@ public class GlobalState implements Closeable, Restorable {
 
   public final List<RemoteNodeConnection> remoteNodes = new CopyOnWriteArrayList<>();
 
-  public final YamlConfigReader configReader;
+  public final LuceneServerConfiguration configuration;
 
   /** Current indices. */
   final Map<String, IndexState> indices = new ConcurrentHashMap<String, IndexState>();
@@ -103,7 +102,7 @@ public class GlobalState implements Closeable, Restorable {
         ThreadPoolExecutorFactory.getThreadPoolExecutor(
             ThreadPoolExecutorFactory.ExecutorType.SEARCH,
             luceneServerConfiguration.getThreadPoolConfiguration());
-    this.configReader = luceneServerConfiguration.getConfigReader();
+    this.configuration = luceneServerConfiguration;
     loadIndexNames();
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/GlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/GlobalState.java
@@ -21,6 +21,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.config.ThreadPoolConfiguration;
+import com.yelp.nrtsearch.server.config.YamlConfigReader;
 import com.yelp.nrtsearch.server.utils.ThreadPoolExecutorFactory;
 import java.io.Closeable;
 import java.io.IOException;
@@ -64,6 +65,8 @@ public class GlobalState implements Closeable, Restorable {
 
   public final List<RemoteNodeConnection> remoteNodes = new CopyOnWriteArrayList<>();
 
+  public final YamlConfigReader configReader;
+
   /** Current indices. */
   final Map<String, IndexState> indices = new ConcurrentHashMap<String, IndexState>();
 
@@ -100,6 +103,7 @@ public class GlobalState implements Closeable, Restorable {
         ThreadPoolExecutorFactory.getThreadPoolExecutor(
             ThreadPoolExecutorFactory.ExecutorType.SEARCH,
             luceneServerConfiguration.getThreadPoolConfiguration());
+    this.configReader = luceneServerConfiguration.getConfigReader();
     loadIndexNames();
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
@@ -473,7 +473,7 @@ public class IndexState implements Closeable, Restorable {
 
     // nocommit who closes this?
     // nocommit can't this be in the rootDir directly?
-    Directory stateDir = df.open(stateDirFile);
+    Directory stateDir = df.open(stateDirFile, true);
 
     saveLoadGenRefCounts = new SaveLoadRefCounts(stateDir);
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -84,7 +84,6 @@ import org.slf4j.LoggerFactory;
 
 public class ShardState implements Closeable {
   public static final int REPLICA_ID = 0;
-  private static final String PRELOAD_CONFIG_KEY = "preloadIndexData";
   private final ThreadPoolExecutor searchExecutor;
   Logger logger = LoggerFactory.getLogger(ShardState.class);
 
@@ -490,7 +489,6 @@ public class ShardState implements Closeable {
     }
 
     boolean success = false;
-    boolean preloadData = indexState.globalState.configReader.getBoolean(PRELOAD_CONFIG_KEY, true);
     try {
 
       if (indexState.saveLoadState == null) {
@@ -503,7 +501,9 @@ public class ShardState implements Closeable {
       } else {
         indexDirFile = rootDir.resolve("index");
       }
-      origIndexDir = indexState.df.open(indexDirFile, preloadData);
+      origIndexDir =
+          indexState.df.open(
+              indexDirFile, indexState.globalState.configuration.getPreloadIndexData());
 
       // nocommit don't allow RAMDir
       // nocommit remove NRTCachingDir too?
@@ -540,7 +540,9 @@ public class ShardState implements Closeable {
       } else {
         taxoDirFile = rootDir.resolve("taxonomy");
       }
-      taxoDir = indexState.df.open(taxoDirFile, preloadData);
+      taxoDir =
+          indexState.df.open(
+              taxoDirFile, indexState.globalState.configuration.getPreloadIndexData());
 
       taxoSnapshots =
           new PersistentSnapshotDeletionPolicy(
@@ -621,9 +623,6 @@ public class ShardState implements Closeable {
     // nocommit share code better w/ start and startReplica!
 
     boolean success = false;
-    // It may be better to default this to false for primaries, but leaving as true for now to
-    // maintain status quo
-    boolean preloadData = indexState.globalState.configReader.getBoolean(PRELOAD_CONFIG_KEY, true);
     try {
       // we have backups and are not creating a new index
       // use that to load indexes and other state (registeredFields, settings)
@@ -647,7 +646,9 @@ public class ShardState implements Closeable {
       } else {
         indexDirFile = rootDir.resolve("index");
       }
-      origIndexDir = indexState.df.open(indexDirFile, preloadData);
+      origIndexDir =
+          indexState.df.open(
+              indexDirFile, indexState.globalState.configuration.getPreloadIndexData());
 
       if ((origIndexDir instanceof MMapDirectory) == false) {
         double maxMergeSizeMB =
@@ -875,7 +876,6 @@ public class ShardState implements Closeable {
 
     // nocommit share code better w/ start and startPrimary!
     boolean success = false;
-    boolean preloadData = indexState.globalState.configReader.getBoolean(PRELOAD_CONFIG_KEY, true);
     try {
       if (indexState.saveLoadState == null) {
         indexState.initSaveLoadState();
@@ -886,7 +886,9 @@ public class ShardState implements Closeable {
       } else {
         indexDirFile = rootDir.resolve("index");
       }
-      origIndexDir = indexState.df.open(indexDirFile, preloadData);
+      origIndexDir =
+          indexState.df.open(
+              indexDirFile, indexState.globalState.configuration.getPreloadIndexData());
       // nocommit don't allow RAMDir
       // nocommit remove NRTCachingDir too?
       if ((origIndexDir instanceof MMapDirectory) == false) {


### PR DESCRIPTION
Allows specifying the `preloadIndexData` config value to disable preloading of index data into memory on startup. This could be useful for primaries, which would not be serving search queries.

For now this only applies to regular indices, not suggest (since I'm not sure if this kind of behavior is desired).

Preloading defaults to true to maintain the status quo.