### PR TITLE
better handle child fields in object

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/ObjectFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/ObjectFieldDef.java
@@ -139,8 +139,13 @@ public class ObjectFieldDef extends IndexableFieldDef {
           Object childValue = fieldValue.get(key);
           if (childValue != null) {
             if (childValue instanceof List) {
-              ((List<Object>) childValue)
-                  .stream().forEach(e -> childrenValues.add(String.valueOf(e)));
+              for (Object e : (List<Object>) childValue) {
+                if (e instanceof List || e instanceof Map) {
+                  childrenValues.add(gson.toJson(e));
+                } else {
+                  childrenValues.add(String.valueOf(e));
+                }
+              }
             } else {
               childrenValues.add(String.valueOf(childValue));
             }


### PR DESCRIPTION
For non object child fields, I converted data to string.valueOf before which worked fine for string, numeric fields. However, there are cases that the object is not just number or string. It can be map or list for fields like polygon and other future cases like range. So I am going to change it to json dump if the object is a map or list.