### PR TITLE
Removed required from the completeDirectory boolean option for backupIndex CLI command

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/cli/BackupIndexCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/server/cli/BackupIndexCommand.java
@@ -58,8 +58,7 @@ public class BackupIndexCommand implements Callable<Integer> {
   @CommandLine.Option(
       names = {"-c", "--completeDirectory"},
       description =
-          "Backup complete directory including all current snapshots if true (may backup corrupt segments if backup is created while indexing is happening), otherwise only backup the required segments and segment files",
-      required = true)
+          "Backup complete directory including all current snapshots if true (may backup corrupt segments if backup is created while indexing is happening), otherwise only backup the required segments and segment files")
   private boolean completeDirectory;
 
   public boolean getCompleteDirectory() {


### PR DESCRIPTION
Since the option is a boolean it is set to true if `-c` is specified and is false if it is not specified. Removing the `required` parameter for this option so that we can set the value to false without it throwing an error.