### PR TITLE
Add MatchAllDocsQuery to FunctionScoreQuery if its inner query isn't set

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
@@ -58,10 +58,6 @@ public class QueryNodeMapper {
               MatchOperator.MUST, BooleanClause.Occur.MUST));
 
   public Query getQuery(com.yelp.nrtsearch.server.grpc.Query query, IndexState state) {
-    if (query.getQueryNodeCase()
-        == com.yelp.nrtsearch.server.grpc.Query.QueryNodeCase.QUERYNODE_NOT_SET) {
-      return new MatchAllDocsQuery();
-    }
     Query queryNode = getQueryNode(query, state);
 
     if (query.getBoost() < 0) {
@@ -118,6 +114,8 @@ public class QueryNodeMapper {
         return getGeoRadiusQuery(query.getGeoRadiusQuery(), state);
       case FUNCTIONFILTERQUERY:
         return getFunctionFilterQuery(query.getFunctionFilterQuery(), state);
+      case QUERYNODE_NOT_SET:
+        return new MatchAllDocsQuery();
       default:
         throw new UnsupportedOperationException(
             "Unsupported query type received: " + query.getQueryNodeCase());

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
@@ -186,7 +186,8 @@ public class QueryNodeMapper {
         ScriptParamsUtils.decodeParams(functionScoreQuery.getScript().getParamsMap());
     com.yelp.nrtsearch.server.grpc.Query q = functionScoreQuery.getQuery();
     Query query;
-    if (!q.toString().isEmpty()) {
+    if (q.getQueryNodeCase()
+        != com.yelp.nrtsearch.server.grpc.Query.QueryNodeCase.QUERYNODE_NOT_SET) {
       query = getQuery(q, state);
     } else {
       query = new MatchAllDocsQuery();

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
@@ -181,11 +181,17 @@ public class QueryNodeMapper {
       com.yelp.nrtsearch.server.grpc.FunctionScoreQuery functionScoreQuery, IndexState state) {
     ScoreScript.Factory scriptFactory =
         ScriptService.getInstance().compile(functionScoreQuery.getScript(), ScoreScript.CONTEXT);
+
     Map<String, Object> params =
         ScriptParamsUtils.decodeParams(functionScoreQuery.getScript().getParamsMap());
-    return new FunctionScoreQuery(
-        getQuery(functionScoreQuery.getQuery(), state),
-        scriptFactory.newFactory(params, state.docLookup));
+    com.yelp.nrtsearch.server.grpc.Query q = functionScoreQuery.getQuery();
+    Query query;
+    if (!q.toString().isEmpty()) {
+      query = getQuery(q, state);
+    } else {
+      query = new MatchAllDocsQuery();
+    }
+    return new FunctionScoreQuery(query, scriptFactory.newFactory(params, state.docLookup));
   }
 
   private FunctionMatchQuery getFunctionFilterQuery(

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
@@ -48,7 +48,6 @@ import org.apache.lucene.queryparser.classic.MultiFieldQueryParser;
 import org.apache.lucene.queryparser.classic.QueryParserBase;
 import org.apache.lucene.queryparser.simple.SimpleQueryParser;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Rescorer;
 import org.apache.lucene.util.QueryBuilder;
@@ -251,11 +250,8 @@ public class SearchRequestProcessor {
         throw new IllegalArgumentException(
             String.format("could not parse queryText: %s", queryText));
       }
-    } else if (searchRequest.getQuery().getQueryNodeCase()
-        != com.yelp.nrtsearch.server.grpc.Query.QueryNodeCase.QUERYNODE_NOT_SET) {
-      q = QUERY_NODE_MAPPER.getQuery(searchRequest.getQuery(), state);
     } else {
-      q = new MatchAllDocsQuery();
+      q = QUERY_NODE_MAPPER.getQuery(searchRequest.getQuery(), state);
     }
 
     if (state.hasNestedChildFields()) {

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
@@ -206,6 +206,39 @@ public class QueryTest {
   }
 
   @Test
+  public void testSearchFunctionScoreQueryNoInnerQuery() {
+    Query query =
+        Query.newBuilder()
+            .setFunctionScoreQuery(
+                FunctionScoreQuery.newBuilder()
+                    .setScript(
+                        Script.newBuilder().setLang("js").setSource("sqrt(4) * count").build())
+                    .build())
+            .build();
+
+    Consumer<SearchResponse> responseTester =
+        searchResponse -> {
+          assertEquals(2, searchResponse.getTotalHits().getValue());
+          assertEquals(2, searchResponse.getHitsList().size());
+
+          SearchResponse.Hit firstHit = searchResponse.getHits(0);
+          String firstDocId = firstHit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
+          assertEquals("2", firstDocId);
+          assertEquals(14.0, firstHit.getScore(), 0.0);
+          LuceneServerTest.checkHits(firstHit);
+
+          SearchResponse.Hit secondHit = searchResponse.getHits(1);
+          String secondDocId =
+              secondHit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
+          assertEquals("1", secondDocId);
+          assertEquals(6.0, secondHit.getScore(), 0.0);
+          LuceneServerTest.checkHits(secondHit);
+        };
+
+    testQuery(query, responseTester);
+  }
+
+  @Test
   public void testSearchFunctionFilterQuery() {
     Query query =
         Query.newBuilder()


### PR DESCRIPTION
I'm not too sure how an inner query cannot be set in practice to do an end-to-end test. This fixed is purely based on unit tests.
### Testing
```
./gradlew clean && ./gradlew installDist && ./gradlew test
```
Passed ✅ 