### PR TITLE
Add option to preload certain file extensions

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/IndexPreloadConfig.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/IndexPreloadConfig.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.config;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/** Class containing configuration related to index data preloading. */
+public class IndexPreloadConfig {
+  public static final String ALL_EXTENSIONS = "*";
+  public static final IndexPreloadConfig PRELOAD_ALL =
+      new IndexPreloadConfig(true, Collections.singleton(ALL_EXTENSIONS));
+  private final boolean preload;
+  private final Set<String> extensions;
+
+  /**
+   * Create instance from provided configuration reader.
+   *
+   * @param configReader config reader
+   * @return class instance
+   */
+  public static IndexPreloadConfig fromConfig(YamlConfigReader configReader) {
+    boolean preload = configReader.getBoolean("preloadIndexData", true);
+    List<String> preloadExtensions =
+        configReader.getStringList("preloadExtensions", Collections.singletonList(ALL_EXTENSIONS));
+    return new IndexPreloadConfig(preload, new HashSet<>(preloadExtensions));
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param preload if index data should be preloaded
+   * @param extensions set of file extensions that should be preloaded, or * for all
+   */
+  public IndexPreloadConfig(boolean preload, Set<String> extensions) {
+    this.preload = preload;
+    this.extensions = Collections.unmodifiableSet(extensions);
+  }
+
+  /** Get if any index data should be preloaded. */
+  public boolean getShouldPreload() {
+    return preload && !extensions.isEmpty();
+  }
+
+  /** Get if all index files should be preloaded. */
+  public boolean getPreloadAll() {
+    return preload && extensions.contains(ALL_EXTENSIONS);
+  }
+
+  /** Get file extensions that should be preloaded. */
+  public Set<String> getExtensions() {
+    return extensions;
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -64,7 +64,7 @@ public class LuceneServerConfiguration {
   private final String serviceName;
   private final boolean restoreState;
   private final ThreadPoolConfiguration threadPoolConfiguration;
-  private final boolean preloadIndexData;
+  private final IndexPreloadConfig preloadConfig;
   private final boolean downloadAsStream;
 
   private final YamlConfigReader configReader;
@@ -101,7 +101,7 @@ public class LuceneServerConfiguration {
         configReader.getString("pluginSearchPath", DEFAULT_PLUGIN_SEARCH_PATH.toString());
     serviceName = configReader.getString("serviceName", DEFAULT_SERVICE_NAME);
     restoreState = configReader.getBoolean("restoreState", false);
-    preloadIndexData = configReader.getBoolean("preloadIndexData", true);
+    preloadConfig = IndexPreloadConfig.fromConfig(configReader);
     downloadAsStream = configReader.getBoolean("downloadAsStream", false);
     threadPoolConfiguration = new ThreadPoolConfiguration(configReader);
   }
@@ -174,8 +174,8 @@ public class LuceneServerConfiguration {
     return restoreState;
   }
 
-  public boolean getPreloadIndexData() {
-    return preloadIndexData;
+  public IndexPreloadConfig getPreloadConfig() {
+    return preloadConfig;
   }
 
   public boolean getDownloadAsStream() {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/BuildSuggestHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/BuildSuggestHandler.java
@@ -21,6 +21,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
+import com.yelp.nrtsearch.server.config.IndexPreloadConfig;
 import com.yelp.nrtsearch.server.grpc.BuildSuggestRequest;
 import com.yelp.nrtsearch.server.grpc.BuildSuggestResponse;
 import com.yelp.nrtsearch.server.grpc.FuzzySuggester;
@@ -227,7 +228,8 @@ public class BuildSuggestHandler implements Handler<BuildSuggestRequest, BuildSu
       suggester =
           new AnalyzingInfixSuggester(
               indexState.df.open(
-                  indexState.rootDir.resolve("suggest." + suggestName + ".infix"), true),
+                  indexState.rootDir.resolve("suggest." + suggestName + ".infix"),
+                  IndexPreloadConfig.PRELOAD_ALL),
               indexAnalyzer,
               queryAnalyzer,
               AnalyzingInfixSuggester.DEFAULT_MIN_PREFIX_CHARS,
@@ -319,7 +321,8 @@ public class BuildSuggestHandler implements Handler<BuildSuggestRequest, BuildSu
       suggester =
           new CompletionInfixSuggester(
               indexState.df.open(
-                  indexState.rootDir.resolve("suggest." + suggestName + ".infix"), true),
+                  indexState.rootDir.resolve("suggest." + suggestName + ".infix"),
+                  IndexPreloadConfig.PRELOAD_ALL),
               indexAnalyzer,
               queryAnalyzer);
     } else if (buildSuggestRequest.hasFuzzyInfixSuggester()) {
@@ -357,7 +360,8 @@ public class BuildSuggestHandler implements Handler<BuildSuggestRequest, BuildSu
       suggester =
           new FuzzyInfixSuggester(
               indexState.df.open(
-                  indexState.rootDir.resolve("suggest." + suggestName + ".infix"), true),
+                  indexState.rootDir.resolve("suggest." + suggestName + ".infix"),
+                  IndexPreloadConfig.PRELOAD_ALL),
               indexAnalyzer,
               queryAnalyzer,
               maxEdits,

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/DirectoryFactory.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/DirectoryFactory.java
@@ -15,21 +15,80 @@
  */
 package com.yelp.nrtsearch.server.luceneserver;
 
+import com.yelp.nrtsearch.server.config.IndexPreloadConfig;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
+import java.util.Set;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.FSLockFactory;
+import org.apache.lucene.store.FileSwitchDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.LockFactory;
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.store.RAMDirectory;
 import org.apache.lucene.store.SimpleFSDirectory;
-
-// import org.apache.lucene.store.AsyncFSDirectory;
+import org.apache.lucene.util.IOUtils;
 
 /** A factory to open a {@link Directory} from a provided filesystem path. */
 public abstract class DirectoryFactory {
+
+  /**
+   * MMapDirectory implementation to split file access between this and a separate MMapDirectory
+   * implementation based on a provided list of file extensions. This is mainly intended to allow
+   * selective file preloading.
+   */
+  public static class SplitMMapDirectory extends MMapDirectory {
+    private final MMapDirectory splitToDirectory;
+    private final Set<String> extensions;
+
+    /**
+     * Constructor.
+     *
+     * @param lockFactory lock factory, should be the same as used by the provided directory
+     * @param splitToDirectory input requests that have one of the provided file extensions use this
+     *     directory implementation
+     * @param extensions extensions to route to provided directory
+     * @throws IOException on filesystem issues
+     */
+    public SplitMMapDirectory(
+        LockFactory lockFactory, MMapDirectory splitToDirectory, Set<String> extensions)
+        throws IOException {
+      super(splitToDirectory.getDirectory(), lockFactory);
+      this.splitToDirectory = splitToDirectory;
+      this.extensions = extensions;
+    }
+
+    @Override
+    public IndexInput openInput(String name, IOContext context) throws IOException {
+      if (shouldSplit(name)) {
+        // need to check this against the primary directory
+        ensureOpen();
+        ensureCanRead(name);
+        return splitToDirectory.openInput(name, context);
+      }
+      return super.openInput(name, context);
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+      IOUtils.close(super::close, splitToDirectory);
+    }
+
+    boolean shouldSplit(String name) {
+      String extension = FileSwitchDirectory.getExtension(name);
+      return extensions.contains(extension);
+    }
+
+    /** Get directory implementation used when file matches one of the specified extentions. */
+    public MMapDirectory getSplitToDirectory() {
+      return splitToDirectory;
+    }
+  }
 
   /** Sole constructor. */
   public DirectoryFactory() {}
@@ -38,9 +97,9 @@ public abstract class DirectoryFactory {
    * Open a new {@link Directory} at the specified path.
    *
    * @param path directory path
-   * @param preload if index data should be preloaded into memory (only for MMapDirectory type)
+   * @param preloadConfig config for preloading index data into memory (only for MMapDirectory type)
    */
-  public abstract Directory open(Path path, boolean preload) throws IOException;
+  public abstract Directory open(Path path, IndexPreloadConfig preloadConfig) throws IOException;
 
   /**
    * Returns an instance, using the specified implementation {FSDirectory, MMapDirectory,
@@ -50,37 +109,50 @@ public abstract class DirectoryFactory {
     if (dirImpl.equals("FSDirectory")) {
       return new DirectoryFactory() {
         @Override
-        public Directory open(Path path, boolean preload) throws IOException {
+        public Directory open(Path path, IndexPreloadConfig preloadConfig) throws IOException {
           return FSDirectory.open(path);
         }
       };
     } else if (dirImpl.equals("MMapDirectory")) {
       return new DirectoryFactory() {
         @Override
-        public Directory open(Path path, boolean preload) throws IOException {
-          MMapDirectory mMapDirectory = new MMapDirectory(path);
-          mMapDirectory.setPreload(preload);
-          return mMapDirectory;
+        public Directory open(Path path, IndexPreloadConfig preloadConfig) throws IOException {
+          LockFactory lockFactory = FSLockFactory.getDefault();
+          MMapDirectory mMapDirectory = new MMapDirectory(path, lockFactory);
+          // no preloading
+          if (!preloadConfig.getShouldPreload()) {
+            return mMapDirectory;
+          }
+
+          // all preloading
+          if (preloadConfig.getPreloadAll()) {
+            mMapDirectory.setPreload(true);
+            return mMapDirectory;
+          }
+
+          // some preloading
+          mMapDirectory.setPreload(true);
+          return new SplitMMapDirectory(lockFactory, mMapDirectory, preloadConfig.getExtensions());
         }
       };
     } else if (dirImpl.equals("NIOFSDirectory")) {
       return new DirectoryFactory() {
         @Override
-        public Directory open(Path path, boolean preload) throws IOException {
+        public Directory open(Path path, IndexPreloadConfig preloadConfig) throws IOException {
           return new NIOFSDirectory(path);
         }
       };
     } else if (dirImpl.equals("SimpleFSDirectory")) {
       return new DirectoryFactory() {
         @Override
-        public Directory open(Path path, boolean preload) throws IOException {
+        public Directory open(Path path, IndexPreloadConfig preloadConfig) throws IOException {
           return new SimpleFSDirectory(path);
         }
       };
     } else if (dirImpl.equals("RAMDirectory")) {
       return new DirectoryFactory() {
         @Override
-        public Directory open(Path path, boolean preload) throws IOException {
+        public Directory open(Path path, IndexPreloadConfig preloadConfig) throws IOException {
           return new RAMDirectory();
         }
       };
@@ -98,7 +170,7 @@ public abstract class DirectoryFactory {
       } catch (NoSuchMethodException ignored) {
       }
       try {
-        ctor = dirClass.getConstructor(Path.class, boolean.class);
+        ctor = dirClass.getConstructor(Path.class, IndexPreloadConfig.class);
       } catch (NoSuchMethodException ignored) {
       }
       if (ctor == null) {
@@ -111,12 +183,12 @@ public abstract class DirectoryFactory {
       final Constructor<? extends Directory> finalCtor = ctor;
       return new DirectoryFactory() {
         @Override
-        public Directory open(Path path, boolean preload) throws IOException {
+        public Directory open(Path path, IndexPreloadConfig preloadConfig) throws IOException {
           try {
             if (finalCtor.getParameterCount() == 1) {
               return finalCtor.newInstance(path);
             } else {
-              return finalCtor.newInstance(path, preload);
+              return finalCtor.newInstance(path, preloadConfig);
             }
           } catch (InstantiationException ie) {
             throw new RuntimeException(

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
@@ -25,6 +25,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
+import com.yelp.nrtsearch.server.config.IndexPreloadConfig;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
 import com.yelp.nrtsearch.server.grpc.FieldType;
@@ -473,7 +474,7 @@ public class IndexState implements Closeable, Restorable {
 
     // nocommit who closes this?
     // nocommit can't this be in the rootDir directly?
-    Directory stateDir = df.open(stateDirFile, true);
+    Directory stateDir = df.open(stateDirFile, IndexPreloadConfig.PRELOAD_ALL);
 
     saveLoadGenRefCounts = new SaveLoadRefCounts(stateDir);
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -502,8 +502,7 @@ public class ShardState implements Closeable {
         indexDirFile = rootDir.resolve("index");
       }
       origIndexDir =
-          indexState.df.open(
-              indexDirFile, indexState.globalState.configuration.getPreloadIndexData());
+          indexState.df.open(indexDirFile, indexState.globalState.configuration.getPreloadConfig());
 
       // nocommit don't allow RAMDir
       // nocommit remove NRTCachingDir too?
@@ -541,8 +540,7 @@ public class ShardState implements Closeable {
         taxoDirFile = rootDir.resolve("taxonomy");
       }
       taxoDir =
-          indexState.df.open(
-              taxoDirFile, indexState.globalState.configuration.getPreloadIndexData());
+          indexState.df.open(taxoDirFile, indexState.globalState.configuration.getPreloadConfig());
 
       taxoSnapshots =
           new PersistentSnapshotDeletionPolicy(
@@ -647,8 +645,7 @@ public class ShardState implements Closeable {
         indexDirFile = rootDir.resolve("index");
       }
       origIndexDir =
-          indexState.df.open(
-              indexDirFile, indexState.globalState.configuration.getPreloadIndexData());
+          indexState.df.open(indexDirFile, indexState.globalState.configuration.getPreloadConfig());
 
       if ((origIndexDir instanceof MMapDirectory) == false) {
         double maxMergeSizeMB =
@@ -887,8 +884,7 @@ public class ShardState implements Closeable {
         indexDirFile = rootDir.resolve("index");
       }
       origIndexDir =
-          indexState.df.open(
-              indexDirFile, indexState.globalState.configuration.getPreloadIndexData());
+          indexState.df.open(indexDirFile, indexState.globalState.configuration.getPreloadConfig());
       // nocommit don't allow RAMDir
       // nocommit remove NRTCachingDir too?
       if ((origIndexDir instanceof MMapDirectory) == false) {

--- a/src/test/java/com/yelp/nrtsearch/server/config/IndexPreloadConfigTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/IndexPreloadConfigTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.Test;
+
+public class IndexPreloadConfigTest {
+
+  private static IndexPreloadConfig getConfig(String configFile) {
+    return IndexPreloadConfig.fromConfig(
+        new YamlConfigReader(new ByteArrayInputStream(configFile.getBytes())));
+  }
+
+  @Test
+  public void testDefault() {
+    String configFile = "nodeName: \"lucene_server_foo\"";
+    IndexPreloadConfig config = getConfig(configFile);
+    assertTrue(config.getShouldPreload());
+    assertTrue(config.getPreloadAll());
+    assertEquals(config.getExtensions(), Collections.singleton(IndexPreloadConfig.ALL_EXTENSIONS));
+  }
+
+  @Test
+  public void testNoPreload() {
+    String configFile = "preloadIndexData: false";
+    IndexPreloadConfig config = getConfig(configFile);
+    assertFalse(config.getShouldPreload());
+    assertFalse(config.getPreloadAll());
+  }
+
+  @Test
+  public void testPreloadExtensions() {
+    String configFile = String.join("\n", "preloadExtensions:", "  - dvd", "  - tim");
+    IndexPreloadConfig config = getConfig(configFile);
+    assertTrue(config.getShouldPreload());
+    assertFalse(config.getPreloadAll());
+    assertEquals(config.getExtensions(), Set.of("dvd", "tim"));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/DirectoryFactoryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/DirectoryFactoryTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.yelp.nrtsearch.server.config.IndexPreloadConfig;
+import com.yelp.nrtsearch.server.config.YamlConfigReader;
+import com.yelp.nrtsearch.server.luceneserver.DirectoryFactory.SplitMMapDirectory;
+import java.io.BufferedWriter;
+import java.io.ByteArrayInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Set;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.MMapDirectory;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class DirectoryFactoryTest {
+
+  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+
+  private static final DirectoryFactory mmFactory = DirectoryFactory.get("MMapDirectory");
+
+  @Test
+  public void testAllPreset() throws IOException {
+    try (Directory directory =
+        mmFactory.open(folder.getRoot().toPath(), IndexPreloadConfig.PRELOAD_ALL)) {
+      assertTrue(directory instanceof MMapDirectory);
+      assertFalse(directory instanceof SplitMMapDirectory);
+      assertTrue(((MMapDirectory) directory).getPreload());
+    }
+  }
+
+  @Test
+  public void testDefault() throws IOException {
+    String configFile = "nodeName: \"lucene_server_foo\"";
+    IndexPreloadConfig config =
+        IndexPreloadConfig.fromConfig(
+            new YamlConfigReader(new ByteArrayInputStream(configFile.getBytes())));
+    try (Directory directory = mmFactory.open(folder.getRoot().toPath(), config)) {
+      assertTrue(directory instanceof MMapDirectory);
+      assertFalse(directory instanceof SplitMMapDirectory);
+      assertTrue(((MMapDirectory) directory).getPreload());
+    }
+  }
+
+  @Test
+  public void testPreloadFalse() throws IOException {
+    IndexPreloadConfig config = new IndexPreloadConfig(false, Collections.emptySet());
+    try (Directory directory = mmFactory.open(folder.getRoot().toPath(), config)) {
+      assertTrue(directory instanceof MMapDirectory);
+      assertFalse(directory instanceof SplitMMapDirectory);
+      assertFalse(((MMapDirectory) directory).getPreload());
+    }
+  }
+
+  @Test
+  public void testPreloadFalseWithExtension() throws IOException {
+    IndexPreloadConfig config =
+        new IndexPreloadConfig(false, Collections.singleton(IndexPreloadConfig.ALL_EXTENSIONS));
+    try (Directory directory = mmFactory.open(folder.getRoot().toPath(), config)) {
+      assertTrue(directory instanceof MMapDirectory);
+      assertFalse(directory instanceof SplitMMapDirectory);
+      assertFalse(((MMapDirectory) directory).getPreload());
+    }
+  }
+
+  @Test
+  public void testPreloadEmptyExtensions() throws IOException {
+    IndexPreloadConfig config = new IndexPreloadConfig(true, Collections.emptySet());
+    try (Directory directory = mmFactory.open(folder.getRoot().toPath(), config)) {
+      assertTrue(directory instanceof MMapDirectory);
+      assertFalse(directory instanceof SplitMMapDirectory);
+      assertFalse(((MMapDirectory) directory).getPreload());
+    }
+  }
+
+  @Test
+  public void testPreloadAll() throws IOException {
+    IndexPreloadConfig config =
+        new IndexPreloadConfig(true, Collections.singleton(IndexPreloadConfig.ALL_EXTENSIONS));
+    try (Directory directory = mmFactory.open(folder.getRoot().toPath(), config)) {
+      assertTrue(directory instanceof MMapDirectory);
+      assertFalse(directory instanceof SplitMMapDirectory);
+      assertTrue(((MMapDirectory) directory).getPreload());
+    }
+  }
+
+  @Test
+  public void testPreloadExtensions() throws IOException {
+    IndexPreloadConfig config = new IndexPreloadConfig(true, Set.of("doc", "dim"));
+    try (Directory directory = mmFactory.open(folder.getRoot().toPath(), config)) {
+      assertTrue(directory instanceof MMapDirectory);
+      assertTrue(directory instanceof SplitMMapDirectory);
+      SplitMMapDirectory splitMMapDirectory = (SplitMMapDirectory) directory;
+      assertFalse(splitMMapDirectory.getPreload());
+      assertTrue(splitMMapDirectory.getSplitToDirectory().getPreload());
+      assertTrue(splitMMapDirectory.shouldSplit("file.doc"));
+      assertTrue(splitMMapDirectory.shouldSplit("file.dim"));
+      assertFalse(splitMMapDirectory.shouldSplit("file.nvd"));
+      assertFalse(splitMMapDirectory.shouldSplit("file.tim"));
+    }
+  }
+
+  @Test
+  public void testSplitReading() throws IOException {
+    IndexPreloadConfig config = new IndexPreloadConfig(true, Set.of("doc", "dim"));
+    writeTestFiles();
+    try (Directory directory = mmFactory.open(folder.getRoot().toPath(), config)) {
+      assertTrue(directory instanceof MMapDirectory);
+      assertTrue(directory instanceof SplitMMapDirectory);
+      SplitMMapDirectory splitMMapDirectory = (SplitMMapDirectory) directory;
+      assertFalse(splitMMapDirectory.getPreload());
+      assertTrue(splitMMapDirectory.getSplitToDirectory().getPreload());
+      assertTrue(splitMMapDirectory.shouldSplit("file.doc"));
+      assertFalse(splitMMapDirectory.shouldSplit("file.tim"));
+      assertFileContents("file.doc", directory, "DOC File Contents");
+      assertFileContents("file.tim", directory, "TIM File Contents");
+    }
+  }
+
+  private void writeTestFiles() throws IOException {
+    writeTestFile("file.doc", "DOC File Contents");
+    writeTestFile("file.tim", "TIM File Contents");
+  }
+
+  private void writeTestFile(String name, String contents) throws IOException {
+    String fullName = Paths.get(folder.getRoot().getAbsolutePath(), name).toString();
+    BufferedWriter writer = new BufferedWriter(new FileWriter(fullName));
+    writer.write(contents);
+    writer.close();
+  }
+
+  private void assertFileContents(String file, Directory directory, String expectedContents)
+      throws IOException {
+    try (IndexInput fileInput = directory.openInput(file, IOContext.DEFAULT)) {
+      byte[] fileArray = new byte[(int) fileInput.length()];
+      fileInput.readBytes(fileArray, 0, (int) fileInput.length());
+      String fileString = new String(fileArray);
+      assertEquals(expectedContents, fileString);
+    }
+  }
+}


### PR DESCRIPTION
Add option for an MMapDirectory to only preload a subset of file extensions. Uses a custom MMapDirectory implementation that routes file access to the correct directory instance based on file extension.

Config may be specified as either a list of file extensions, or with the wildcard value `*` for all files.