### PR TITLE
File-based custom grpc NameResolver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,13 +29,8 @@ def _artifactId = 'server'
 //This is for https://github.com/gradle/gradle/issues/11308
 System.setProperty("org.gradle.internal.publish.checksums.insecure", "True")
 
-// IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
-// are looking at a tagged version of the example and not "master"!
-
-// Feel free to delete the comment at the next line. It is just for safely
-// updating the version in our release process.
 def luceneVersion = '8.4.0'
-def slf4jVersion = '2.0.0-alpha0'
+project.ext.slf4jVersion = '2.0.0-alpha0'
 def gsonVersion = '2.8.5'
 def snakeYamlVersion = '1.25'
 def spatial4jVersion = '0.7'
@@ -53,7 +48,7 @@ dependencies {
     implementation "io.prometheus:simpleclient_hotspot:${prometheusClientVersion}"
 
     //
-    implementation "org.slf4j:slf4j-api:${slf4jVersion}"
+    implementation "org.slf4j:slf4j-api:${project.ext.slf4jVersion}"
     implementation "org.slf4j:slf4j-jdk14:2.0.0-alpha1"
     implementation "com.google.code.gson:gson:${gsonVersion}"
     implementation 'org.apache.commons:commons-io:1.3.2'

--- a/clientlib/build.gradle
+++ b/clientlib/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-okhttp:${grpcVersion}"
     implementation "javax.annotation:javax.annotation-api:1.2"
+    implementation "org.slf4j:slf4j-api:${rootProject.slf4jVersion}"
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
 
     // examples/advanced need this for JsonFormat
     compile "com.google.protobuf:protobuf-java-util:${protobufVersion}"

--- a/clientlib/src/main/java/com/yelp/nrtsearch/clientlib/Node.java
+++ b/clientlib/src/main/java/com/yelp/nrtsearch/clientlib/Node.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.clientlib;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+public class Node {
+  private final String host;
+  private final int port;
+
+  public Node(String host, int port) {
+    this.host = host;
+    this.port = port;
+  }
+
+  @JsonCreator
+  public static Node fromJson(@JsonProperty("host") String host, @JsonProperty("port") int port) {
+    return new Node(host, port);
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Node node = (Node) o;
+    return port == node.port && Objects.equals(host, node.host);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(host, port);
+  }
+
+  @Override
+  public String toString() {
+    return "HostPort{" + "host='" + host + '\'' + ", port=" + port + '}';
+  }
+}

--- a/clientlib/src/main/java/com/yelp/nrtsearch/clientlib/NodeAddressFileNameResolver.java
+++ b/clientlib/src/main/java/com/yelp/nrtsearch/clientlib/NodeAddressFileNameResolver.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.clientlib;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.grpc.Attributes;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.NameResolver;
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** {@link NameResolver} that works with a json file containing lists of {@link Node}s. */
+public class NodeAddressFileNameResolver extends NameResolver {
+  private static final Logger logger = LoggerFactory.getLogger(NodeAddressFileNameResolver.class);
+
+  private final File nodeAddressesFile;
+  private final ObjectMapper objectMapper;
+  private final int updateInterval;
+  private Listener listener;
+  private Timer fileChangeCheckTimer;
+  private List<Node> currentNodes;
+
+  public NodeAddressFileNameResolver(URI fileUri, ObjectMapper objectMapper, int updateIntervalMs) {
+    this.nodeAddressesFile = new File(fileUri.getPath());
+    this.objectMapper = objectMapper;
+    this.updateInterval = updateIntervalMs;
+  }
+
+  @Override
+  public String getServiceAuthority() {
+    // fileUri will always have null authority
+    return "";
+  }
+
+  @Override
+  public void start(Listener listener) {
+    this.listener = listener;
+    loadNodes();
+
+    // Run timer thread in background
+    fileChangeCheckTimer = new Timer("NodeAddressFileNameResolverThread", true);
+
+    fileChangeCheckTimer.schedule(new FileChangedTask(), updateInterval, updateInterval);
+  }
+
+  @Override
+  public void shutdown() {
+    fileChangeCheckTimer.cancel();
+  }
+
+  private void loadNodes() {
+    List<Node> nodes = readNodesFromFile();
+    if (nodes == null || nodes.size() == 0) {
+      throw new IllegalStateException("No nodes found in file: " + nodeAddressesFile);
+    }
+    updateNodes(nodes);
+  }
+
+  private void updateNodes(List<Node> nodes) {
+    List<EquivalentAddressGroup> addrs =
+        nodes.stream()
+            .map(node -> (SocketAddress) new InetSocketAddress(node.getHost(), node.getPort()))
+            .map(Collections::singletonList)
+            .map(EquivalentAddressGroup::new)
+            .collect(Collectors.toList());
+    this.listener.onAddresses(addrs, Attributes.EMPTY);
+  }
+
+  private List<Node> readNodesFromFile() {
+    try {
+      return objectMapper.readValue(nodeAddressesFile, new TypeReference<List<Node>>() {});
+    } catch (IOException e) {
+      logger.error("Unable to read file: {}", nodeAddressesFile, e);
+      return Collections.emptyList();
+    }
+  }
+
+  private class FileChangedTask extends TimerTask {
+
+    public FileChangedTask() {
+      currentNodes = readNodesFromFile();
+    }
+
+    @Override
+    public void run() {
+      List<Node> nodes = readNodesFromFile();
+      if (nodes != currentNodes) {
+        updateNodes(nodes);
+        currentNodes = nodes;
+      }
+    }
+  }
+}

--- a/clientlib/src/main/java/com/yelp/nrtsearch/clientlib/NodeAddressFileNameResolver.java
+++ b/clientlib/src/main/java/com/yelp/nrtsearch/clientlib/NodeAddressFileNameResolver.java
@@ -108,7 +108,7 @@ public class NodeAddressFileNameResolver extends NameResolver {
     @Override
     public void run() {
       List<Node> nodes = readNodesFromFile();
-      if (nodes != currentNodes) {
+      if (!nodes.isEmpty() && nodes != currentNodes) {
         updateNodes(nodes);
         currentNodes = nodes;
       }

--- a/clientlib/src/main/java/com/yelp/nrtsearch/clientlib/NodeAddressesFileNameResolverProvider.java
+++ b/clientlib/src/main/java/com/yelp/nrtsearch/clientlib/NodeAddressesFileNameResolverProvider.java
@@ -20,9 +20,7 @@ import io.grpc.NameResolver;
 import io.grpc.NameResolverProvider;
 import java.net.URI;
 
-/**
- * Provides a {@link NameResolver} which can resolve node addresses from a json file.
- */
+/** Provides a {@link NameResolver} which can resolve node addresses from a json file. */
 public class NodeAddressesFileNameResolverProvider extends NameResolverProvider {
 
   private final ObjectMapper objectMapper;

--- a/clientlib/src/main/java/com/yelp/nrtsearch/clientlib/NodeAddressesFileNameResolverProvider.java
+++ b/clientlib/src/main/java/com/yelp/nrtsearch/clientlib/NodeAddressesFileNameResolverProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.clientlib;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.grpc.NameResolver;
+import io.grpc.NameResolverProvider;
+import java.net.URI;
+
+/**
+ * Provides a {@link NameResolver} which can resolve node addresses from a json file.
+ */
+public class NodeAddressesFileNameResolverProvider extends NameResolverProvider {
+
+  private final ObjectMapper objectMapper;
+  private final int updateInterval;
+
+  public NodeAddressesFileNameResolverProvider(ObjectMapper objectMapper, int updateInterval) {
+    this.objectMapper = objectMapper;
+    this.updateInterval = updateInterval;
+  }
+
+  @Override
+  protected boolean isAvailable() {
+    return true;
+  }
+
+  @Override
+  protected int priority() {
+    // Priority is 0-10. Giving slightly higher priority than 5 (considered default).
+    return 6;
+  }
+
+  @Override
+  public String getDefaultScheme() {
+    return "file";
+  }
+
+  @Override
+  public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
+    return new NodeAddressFileNameResolver(targetUri, objectMapper, updateInterval);
+  }
+}

--- a/clientlib/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerStubBuilder.java
+++ b/clientlib/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerStubBuilder.java
@@ -24,6 +24,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 /** Easy entrypoint for clients to create a Lucene Server Stub. */
 public class LuceneServerStubBuilder implements Closeable {
@@ -78,7 +79,8 @@ public class LuceneServerStubBuilder implements Closeable {
     this(
         ManagedChannelBuilder.forTarget(nodeAddressFile)
             .defaultLoadBalancingPolicy("round_robin")
-            .nameResolverFactory(new NodeAddressesFileNameResolverProvider(objectMapper, updateInterval))
+            .nameResolverFactory(
+                new NodeAddressesFileNameResolverProvider(objectMapper, updateInterval))
             .usePlaintext()
             .build());
   }
@@ -117,5 +119,13 @@ public class LuceneServerStubBuilder implements Closeable {
     if (channel != null && !channel.isShutdown()) {
       channel.shutdown();
     }
+  }
+
+  public void waitUntilClosed(long timeout, TimeUnit unit)
+      throws IOException, InterruptedException {
+    if (!channel.isShutdown()) {
+      close();
+    }
+    channel.awaitTermination(timeout, unit);
   }
 }

--- a/clientlib/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerStubBuilder.java
+++ b/clientlib/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerStubBuilder.java
@@ -15,14 +15,20 @@
  */
 package com.yelp.nrtsearch.server.grpc;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yelp.nrtsearch.clientlib.NodeAddressesFileNameResolverProvider;
 import com.yelp.nrtsearch.server.grpc.LuceneServerGrpc.LuceneServerBlockingStub;
 import com.yelp.nrtsearch.server.grpc.LuceneServerGrpc.LuceneServerFutureStub;
 import com.yelp.nrtsearch.server.grpc.LuceneServerGrpc.LuceneServerStub;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import java.io.Closeable;
+import java.io.IOException;
 
 /** Easy entrypoint for clients to create a Lucene Server Stub. */
-public class LuceneServerStubBuilder {
+public class LuceneServerStubBuilder implements Closeable {
+  private static final int DEFAULT_UPDATE_INTERVAL = 10 * 1000; // 10 seconds
+
   public ManagedChannel channel;
 
   /**
@@ -42,6 +48,39 @@ public class LuceneServerStubBuilder {
    */
   public LuceneServerStubBuilder(String host, int port) {
     this(ManagedChannelBuilder.forAddress(host, port).usePlaintext().build());
+  }
+
+  /**
+   * Create {@link LuceneServerStubBuilder} with a {@link io.grpc.Channel} which finds Nrtsearch
+   * node addresses from a file. The file must contain host and port as properties in list in json
+   * format. The file be checked for updates every {@link #DEFAULT_UPDATE_INTERVAL} milliseconds.
+   * E.g.: [{"host":"10.10.1.1", "port": 12000}, {"host":"10.20.1.1", "port": 14000}] If there are
+   * additional properties than host and port, the {@link ObjectMapper} must be configured to ignore
+   * them before passing it to this constructor.
+   *
+   * @param nodeAddressFile Path to file containing node addresses
+   * @param objectMapper {@link ObjectMapper} to use to deserialize the json file
+   */
+  public LuceneServerStubBuilder(String nodeAddressFile, ObjectMapper objectMapper) {
+    this(nodeAddressFile, objectMapper, DEFAULT_UPDATE_INTERVAL);
+  }
+
+  /**
+   * Like {@link #LuceneServerStubBuilder(String, ObjectMapper)} but additionally provide an
+   * interval to check the node address file for updates.
+   *
+   * @param nodeAddressFile Path to file containing node addresses
+   * @param objectMapper {@link ObjectMapper} to use to deserialize the json file
+   * @param updateInterval Time-between checks for changes to node addresses file in milli-seconds
+   */
+  public LuceneServerStubBuilder(
+      String nodeAddressFile, ObjectMapper objectMapper, int updateInterval) {
+    this(
+        ManagedChannelBuilder.forTarget(nodeAddressFile)
+            .defaultLoadBalancingPolicy("round_robin")
+            .nameResolverFactory(new NodeAddressesFileNameResolverProvider(objectMapper, updateInterval))
+            .usePlaintext()
+            .build());
   }
 
   /**
@@ -71,5 +110,12 @@ public class LuceneServerStubBuilder {
    */
   public LuceneServerFutureStub createFutureStub() {
     return LuceneServerGrpc.newFutureStub(channel);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (channel != null && !channel.isShutdown()) {
+      channel.shutdown();
+    }
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -270,7 +270,7 @@ public class LuceneServer {
     }
   }
 
-  static class LuceneServerImpl extends LuceneServerGrpc.LuceneServerImplBase {
+  public static class LuceneServerImpl extends LuceneServerGrpc.LuceneServerImplBase {
     private final JsonFormat.Printer protoMessagePrinter =
         JsonFormat.printer().omittingInsignificantWhitespace();
     private final GlobalState globalState;
@@ -279,7 +279,7 @@ public class LuceneServer {
     private final ThreadPoolExecutor searchThreadPoolExecutor;
     private final String archiveDirectory;
 
-    LuceneServerImpl(
+    public LuceneServerImpl(
         GlobalState globalState,
         LuceneServerConfiguration configuration,
         Archiver archiver,

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -270,7 +270,7 @@ public class LuceneServer {
     }
   }
 
-  public static class LuceneServerImpl extends LuceneServerGrpc.LuceneServerImplBase {
+  static class LuceneServerImpl extends LuceneServerGrpc.LuceneServerImplBase {
     private final JsonFormat.Printer protoMessagePrinter =
         JsonFormat.printer().omittingInsignificantWhitespace();
     private final GlobalState globalState;
@@ -279,7 +279,7 @@ public class LuceneServer {
     private final ThreadPoolExecutor searchThreadPoolExecutor;
     private final String archiveDirectory;
 
-    public LuceneServerImpl(
+    LuceneServerImpl(
         GlobalState globalState,
         LuceneServerConfiguration configuration,
         Archiver archiver,

--- a/src/test/java/com/yelp/nrtsearch/clientlib/NodeNameResolverAndLoadBalancingTests.java
+++ b/src/test/java/com/yelp/nrtsearch/clientlib/NodeNameResolverAndLoadBalancingTests.java
@@ -429,7 +429,7 @@ public class NodeNameResolverAndLoadBalancingTests {
   private int performSearch(LuceneServerGrpc.LuceneServerBlockingStub stub) {
     SearchRequest searchRequest = buildSearchRequest();
     SearchResponse searchResponse =
-        stub.withDeadlineAfter(200, TimeUnit.MILLISECONDS).search(searchRequest);
+        stub.withDeadlineAfter(400, TimeUnit.MILLISECONDS).search(searchRequest);
     return searchResponse.getHits(0).getFieldsOrThrow(FIELD_NAME).getFieldValue(0).getIntValue();
   }
 
@@ -474,6 +474,6 @@ public class NodeNameResolverAndLoadBalancingTests {
             completionCounter.increment();
           }
         };
-    stub.withDeadlineAfter(200, TimeUnit.MILLISECONDS).search(searchRequest, responseObserver);
+    stub.withDeadlineAfter(400, TimeUnit.MILLISECONDS).search(searchRequest, responseObserver);
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/clientlib/NodeNameResolverAndLoadBalancingTests.java
+++ b/src/test/java/com/yelp/nrtsearch/clientlib/NodeNameResolverAndLoadBalancingTests.java
@@ -1,0 +1,464 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.clientlib;
+
+import static com.yelp.nrtsearch.server.grpc.GrpcServer.TEST_INDEX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yelp.nrtsearch.server.LuceneServerTestConfigurationFactory;
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.CommitRequest;
+import com.yelp.nrtsearch.server.grpc.CreateIndexRequest;
+import com.yelp.nrtsearch.server.grpc.Field;
+import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
+import com.yelp.nrtsearch.server.grpc.FieldType;
+import com.yelp.nrtsearch.server.grpc.GrpcServer;
+import com.yelp.nrtsearch.server.grpc.LuceneServerGrpc;
+import com.yelp.nrtsearch.server.grpc.LuceneServerStubBuilder;
+import com.yelp.nrtsearch.server.grpc.Mode;
+import com.yelp.nrtsearch.server.grpc.RefreshRequest;
+import com.yelp.nrtsearch.server.grpc.SearchRequest;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import com.yelp.nrtsearch.server.grpc.StartIndexRequest;
+import com.yelp.nrtsearch.server.luceneserver.GlobalState;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class NodeNameResolverAndLoadBalancingTests {
+  private static final String FIELD_NAME = "test_field";
+  private static final String NODE_ADDRESSES_FILE_NAME = "nrtsearch-addresses.json";
+
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  private static final int SERVER_1_ID = 1;
+  private static final int SERVER_2_ID = 2;
+  private static final int SERVER_3_ID = 3;
+
+  /**
+   * This rule manages automatic graceful shutdown for the registered servers and channels at the
+   * end of test.
+   */
+  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+  /**
+   * This rule ensures the temporary folder which maintains indexes are cleaned up after each test
+   */
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  private GrpcServer server1;
+  private GrpcServer server2;
+  private GrpcServer server3;
+  private int port1;
+  private int port2;
+  private int port3;
+  private File addressesFile;
+  private LuceneServerStubBuilder luceneServerStubBuilder;
+
+  @Before
+  public void setup() throws IOException, InterruptedException {
+    addressesFile = folder.newFile(NODE_ADDRESSES_FILE_NAME);
+
+    server1 = createGrpcServer();
+    server2 = createGrpcServer();
+    server3 = createGrpcServer();
+
+    port1 = server1.getGlobalState().getPort();
+    port2 = server2.getGlobalState().getPort();
+    port3 = server3.getGlobalState().getPort();
+
+    startIndexAndAddDocuments(server1, SERVER_1_ID);
+    startIndexAndAddDocuments(server2, SERVER_2_ID);
+    startIndexAndAddDocuments(server3, SERVER_3_ID);
+
+    writeNodeAddressFile(port1, port2, port3);
+    luceneServerStubBuilder = new LuceneServerStubBuilder(addressesFile.toString(), OBJECT_MAPPER);
+  }
+
+  private GrpcServer createGrpcServer() throws IOException {
+    LuceneServerConfiguration luceneServerConfiguration =
+        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
+    GlobalState globalState = new GlobalState(luceneServerConfiguration);
+    return new GrpcServer(
+        grpcCleanup,
+        luceneServerConfiguration,
+        folder,
+        false,
+        globalState,
+        luceneServerConfiguration.getIndexDir(),
+        TEST_INDEX,
+        luceneServerConfiguration.getPort());
+  }
+
+  private void startIndexAndAddDocuments(GrpcServer server, int id)
+      throws InterruptedException, IOException {
+    LuceneServerGrpc.LuceneServerBlockingStub stub = server.getBlockingStub();
+
+    stub.createIndex(CreateIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+
+    FieldDefRequest fieldDefRequest =
+        FieldDefRequest.newBuilder()
+            .setIndexName(TEST_INDEX)
+            .addField(
+                Field.newBuilder()
+                    .setName(FIELD_NAME)
+                    .setType(FieldType.INT)
+                    .setSearch(true)
+                    .setStoreDocValues(true)
+                    .build())
+            .build();
+    stub.registerFields(fieldDefRequest);
+    stub.startIndex(StartIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+
+    AddDocumentRequest addDocumentRequest =
+        AddDocumentRequest.newBuilder()
+            .setIndexName(TEST_INDEX)
+            .putFields(
+                FIELD_NAME,
+                AddDocumentRequest.MultiValuedField.newBuilder()
+                    .addValue(String.valueOf(id))
+                    .build())
+            .build();
+    new GrpcServer.TestServer(server, false, Mode.STANDALONE)
+        .addDocumentsFromStream(Stream.of(addDocumentRequest));
+    stub.commit(CommitRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    stub.refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
+  }
+
+  @After
+  public void tearDown() throws IOException, InterruptedException {
+    luceneServerStubBuilder.close();
+    luceneServerStubBuilder.waitUntilClosed(100, TimeUnit.MILLISECONDS);
+    teardownGrpcServer(server1);
+    teardownGrpcServer(server2);
+    teardownGrpcServer(server3);
+  }
+
+  private void teardownGrpcServer(GrpcServer server) throws IOException {
+    server.getGlobalState().close();
+    server.shutdown();
+  }
+
+  @Test
+  public void testSimpleLoadBalancing() throws IOException {
+    LuceneServerGrpc.LuceneServerBlockingStub stub = luceneServerStubBuilder.createBlockingStub();
+
+    warmConnections(stub);
+
+    Map<Integer, Integer> resultCounts = new HashMap<>();
+    int requestsToEachServer = 20;
+    int numServers = 3;
+
+    for (int i = 0; i < numServers * requestsToEachServer; i++) {
+      int result = performSearch(stub);
+      resultCounts.compute(
+          result, (key, currentValue) -> currentValue == null ? 1 : currentValue + 1);
+    }
+
+    // All servers should get the same number of requests
+    assertEquals(requestsToEachServer, resultCounts.get(SERVER_1_ID).intValue());
+    assertEquals(requestsToEachServer, resultCounts.get(SERVER_2_ID).intValue());
+    assertEquals(requestsToEachServer, resultCounts.get(SERVER_3_ID).intValue());
+  }
+
+  @Test(timeout = 1000)
+  public void testSimpleLoadBalancingAsync() throws IOException, InterruptedException {
+    LuceneServerGrpc.LuceneServerStub stub = luceneServerStubBuilder.createAsyncStub();
+
+    warmConnections(stub);
+
+    Map<Integer, Integer> resultCounts = new ConcurrentHashMap<>();
+    int requestsToEachServer = 20;
+    int numServers = 3;
+    int totalRequests = numServers * requestsToEachServer;
+    LongAdder errorCounter = new LongAdder();
+    LongAdder completionCounter = new LongAdder();
+
+    for (int i = 0; i < totalRequests; i++) {
+      Consumer<Integer> resultConsumer =
+          result ->
+              resultCounts.compute(
+                  result, (key, currentValue) -> currentValue == null ? 1 : currentValue + 1);
+      performSearchAsync(stub, resultConsumer, completionCounter, errorCounter);
+    }
+
+    while (errorCounter.longValue() + completionCounter.longValue() < totalRequests) {
+      Thread.sleep(10);
+    }
+
+    assertEquals(completionCounter.longValue(), totalRequests);
+
+    // All servers should get the same number of requests
+    assertEquals(requestsToEachServer, resultCounts.get(SERVER_1_ID).intValue());
+    assertEquals(requestsToEachServer, resultCounts.get(SERVER_2_ID).intValue());
+    assertEquals(requestsToEachServer, resultCounts.get(SERVER_3_ID).intValue());
+  }
+
+  @Test
+  public void testServerShutDown() throws IOException {
+    LuceneServerGrpc.LuceneServerBlockingStub stub = luceneServerStubBuilder.createBlockingStub();
+    warmConnections(stub);
+
+    // Stop server 1 after 20 ms
+    new Timer(true)
+        .schedule(
+            new TimerTask() {
+              @Override
+              public void run() {
+                server1.shutdown();
+              }
+            },
+            20);
+
+    Map<Integer, Integer> resultCounts = new HashMap<>();
+    int requestsToEachServer = 40;
+    int numServers = 3;
+
+    for (int i = 0; i < numServers * requestsToEachServer; i++) {
+      int result = performSearch(stub);
+      resultCounts.compute(result, (k, v) -> v == null ? 1 : v + 1);
+    }
+
+    // Server 1 will get less than the expected number of requests since it was shutdown midway
+    // but still non-zero number of requests
+    assertTrue(resultCounts.get(SERVER_1_ID) > 0);
+    assertTrue(resultCounts.get(SERVER_1_ID) < requestsToEachServer);
+    // Servers 2 and 3 will get more than the expected number of requests since server 1 was
+    // shutdown
+    assertTrue(resultCounts.get(SERVER_2_ID) > requestsToEachServer);
+    assertTrue(resultCounts.get(SERVER_3_ID) > requestsToEachServer);
+
+    // Servers 2 and 3 should still get about the same number of requests
+    int diffServers2And3NumRequests =
+        Math.abs(resultCounts.get(SERVER_2_ID) - resultCounts.get(SERVER_3_ID));
+    assertTrue(diffServers2And3NumRequests == 0 || diffServers2And3NumRequests == 1);
+  }
+
+  @Test
+  public void testNodeRemovedFromAddressFile() {
+    // Use a lower update interval for this test
+    int updateInterval = 10;
+    luceneServerStubBuilder =
+        new LuceneServerStubBuilder(addressesFile.toString(), OBJECT_MAPPER, updateInterval);
+
+    LuceneServerGrpc.LuceneServerBlockingStub stub = luceneServerStubBuilder.createBlockingStub();
+    warmConnections(stub);
+
+    // Remove server 1 from the file after 30 ms
+    new Timer(true)
+        .schedule(
+            new TimerTask() {
+              @Override
+              public void run() {
+                try {
+                  writeNodeAddressFile(port2, port3);
+                } catch (IOException ignored) {
+                }
+              }
+            },
+            30);
+
+    Map<Integer, Integer> resultCounts = new HashMap<>();
+    int requestsToEachServer = 40;
+    int numServers = 3;
+
+    for (int i = 0; i < numServers * requestsToEachServer; i++) {
+      int result = performSearch(stub);
+      resultCounts.compute(result, (k, v) -> v == null ? 1 : v + 1);
+    }
+
+    // Server 1 will get less than the expected number of requests since it was removed midway
+    // but still non-zero number of requests
+    assertTrue(resultCounts.get(SERVER_1_ID) > 0);
+    assertTrue(resultCounts.get(SERVER_1_ID) < requestsToEachServer);
+    // Servers 2 and 3 will get more than the expected number of requests since server 1 was
+    // removed
+    assertTrue(resultCounts.get(SERVER_2_ID) > requestsToEachServer);
+    assertTrue(resultCounts.get(SERVER_3_ID) > requestsToEachServer);
+
+    // Servers 2 and 3 should still get about the same number of requests
+    int diffServers2And3NumRequests =
+        Math.abs(resultCounts.get(SERVER_2_ID) - resultCounts.get(SERVER_3_ID));
+    assertTrue(diffServers2And3NumRequests == 0 || diffServers2And3NumRequests == 1);
+  }
+
+  @Test
+  public void testNodeAddedToAddressFile() throws IOException {
+    writeNodeAddressFile(port2, port3);
+
+    // Use a lower update interval for this test
+    int updateInterval = 10;
+    luceneServerStubBuilder =
+        new LuceneServerStubBuilder(addressesFile.toString(), OBJECT_MAPPER, updateInterval);
+
+    LuceneServerGrpc.LuceneServerBlockingStub stub = luceneServerStubBuilder.createBlockingStub();
+    warmConnections(stub);
+
+    // Add server 1 to the file after 30 ms
+    new Timer(true)
+        .schedule(
+            new TimerTask() {
+              @Override
+              public void run() {
+                try {
+                  writeNodeAddressFile(port1, port2, port3);
+                } catch (IOException ignored) {
+                }
+              }
+            },
+            30);
+
+    Map<Integer, Integer> resultCounts = new HashMap<>();
+    int requestsToEachServer = 40;
+    int numServers = 3;
+
+    for (int i = 0; i < numServers * requestsToEachServer; i++) {
+      int result = performSearch(stub);
+      resultCounts.compute(result, (k, v) -> v == null ? 1 : v + 1);
+    }
+
+    // Server 1 will get less than the expected number of requests since it was added midway
+    // but still non-zero number of requests
+    assertTrue(resultCounts.get(SERVER_1_ID) > 0);
+    assertTrue(resultCounts.get(SERVER_1_ID) < requestsToEachServer);
+    // Servers 2 and 3 will get more than the expected number of requests since server 1 was
+    // added later
+    assertTrue(resultCounts.get(SERVER_2_ID) > requestsToEachServer);
+    assertTrue(resultCounts.get(SERVER_3_ID) > requestsToEachServer);
+
+    // Servers 2 and 3 should still get about the same number of requests
+    int diffServers2And3NumRequests =
+        Math.abs(resultCounts.get(SERVER_2_ID) - resultCounts.get(SERVER_3_ID));
+    assertTrue(diffServers2And3NumRequests == 0 || diffServers2And3NumRequests == 1);
+  }
+
+  /**
+   * While the connections are initially being established perfect load balancing won't happen. Use
+   * this method to call the stub and warm the connections.
+   */
+  private void warmConnections(LuceneServerGrpc.LuceneServerBlockingStub stub) {
+    int numRequests = 10;
+    for (int i = 0; i < numRequests; i++) {
+      performSearch(stub);
+    }
+  }
+
+  private void warmConnections(LuceneServerGrpc.LuceneServerStub stub) throws InterruptedException {
+    LongAdder completionCounter = new LongAdder();
+    LongAdder errorCounter = new LongAdder();
+
+    int numRequests = 20;
+    for (int i = 0; i < numRequests; i++) {
+      performSearchAsync(stub, null, completionCounter, errorCounter);
+    }
+    while (completionCounter.longValue() + errorCounter.longValue() < numRequests) {
+      Thread.sleep(10);
+    }
+  }
+
+  private void writeNodeAddressFile(int... ports) throws IOException {
+    try (BufferedWriter writer = Files.newBufferedWriter(addressesFile.toPath())) {
+      writer.write("[");
+      if (ports.length != 0) {
+        for (int currentPort = 0; currentPort < ports.length; currentPort += 1) {
+          // name field isn't needed but added just to verify that with the right ObjectMapper
+          // setting it is okay to add additional fields to the addresses file
+          String node =
+              String.format(
+                  "{\"name\":\"server%d\",\"host\":\"127.0.0.1\",\"port\":%d}",
+                  currentPort + 1, ports[currentPort]);
+          writer.write(node);
+          if (currentPort != ports.length - 1) {
+            writer.write(",");
+          }
+        }
+      }
+      writer.write("]");
+    }
+  }
+
+  private int performSearch(LuceneServerGrpc.LuceneServerBlockingStub stub) {
+    SearchRequest searchRequest = buildSearchRequest();
+    SearchResponse searchResponse =
+        stub.withDeadlineAfter(200, TimeUnit.MILLISECONDS).search(searchRequest);
+    return searchResponse.getHits(0).getFieldsOrThrow(FIELD_NAME).getFieldValue(0).getIntValue();
+  }
+
+  private SearchRequest buildSearchRequest() {
+    return SearchRequest.newBuilder()
+        .setIndexName(TEST_INDEX)
+        .setStartHit(0)
+        .setTopHits(1)
+        .addRetrieveFields(FIELD_NAME)
+        .build();
+  }
+
+  private void performSearchAsync(
+      LuceneServerGrpc.LuceneServerStub stub,
+      Consumer<Integer> resultConsumer,
+      LongAdder completionCounter,
+      LongAdder errorCounter) {
+    SearchRequest searchRequest = buildSearchRequest();
+    StreamObserver<SearchResponse> responseObserver =
+        new StreamObserver<>() {
+
+          @Override
+          public void onNext(SearchResponse searchResponse) {
+            int result =
+                searchResponse
+                    .getHits(0)
+                    .getFieldsOrThrow(FIELD_NAME)
+                    .getFieldValue(0)
+                    .getIntValue();
+            if (resultConsumer != null) {
+              resultConsumer.accept(result);
+            }
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            errorCounter.increment();
+          }
+
+          @Override
+          public void onCompleted() {
+            completionCounter.increment();
+          }
+        };
+    stub.withDeadlineAfter(200, TimeUnit.MILLISECONDS).search(searchRequest, responseObserver);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/LuceneServerTestConfigurationFactory.java
+++ b/src/test/java/com/yelp/nrtsearch/server/LuceneServerTestConfigurationFactory.java
@@ -54,8 +54,8 @@ public class LuceneServerTestConfigurationFactory {
               "nodeName: standalone",
               "stateDir: " + stateDir,
               "indexDir: " + indexDir,
-              "port: " + 9000,
-              "replicationPort: " + 9000,
+              "port: " + (9000 + atomicLong.intValue()),
+              "replicationPort: " + (10000 + atomicLong.intValue()),
               "archiveDirectory: " + archiverDirectory.toString(),
               extraConfig);
       return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));


### PR DESCRIPTION
Created a grpc NameResolver which maps a file URI to Nrtsearch addresses. The file must contain the hosts and ports in json format. E.g. file contents:
```
[
  {"host":"10.20.31.28","port":8080},
  {"host":"10.20.41.29","port":8081},
  {"host":"10.20.51.30","port":8082}
]
```

The tests verify that the requests are load balanced across all servers, there are no errors when a server is closed and that updates to the file are applied to the channel.