### PR TITLE
Added go package to proto files and changed grpc-gateway to fail build if the docker build fails

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,8 @@ applicationDistribution.into('bin') {
 
 task buildGrpcGateway(dependsOn: installDist, type: Exec) {
     workingDir = '.'
-    commandLine = './build_grpc_gateway.sh'
+    executable = 'bash'
+    args = ['-c', './build_grpc_gateway.sh']
 }
 
 //Dynamic exclude through property defined in the build.gradle file

--- a/build_grpc_gateway.sh
+++ b/build_grpc_gateway.sh
@@ -1,10 +1,5 @@
+set -euxo pipefail
 docker build -t grpc-gateway -f grpc-gateway/Dockerfile .
-status=$?
-if [ $status -ne 0 ];
-then
-  echo "Unable to build grpc-gateway";
-  exit $status;
-fi
 docker run grpc-gateway
 docker cp $(docker ps -alq):/code/output/yelp/nrtsearch/. ./grpc-gateway/
 docker cp $(docker ps -alq):/code/bin/. ./build/install/nrtsearch/bin

--- a/build_grpc_gateway.sh
+++ b/build_grpc_gateway.sh
@@ -1,4 +1,10 @@
 docker build -t grpc-gateway -f grpc-gateway/Dockerfile .
+status=$?
+if [ $status -ne 0 ];
+then
+  echo "Unable to build grpc-gateway";
+  exit $status;
+fi
 docker run grpc-gateway
 docker cp $(docker ps -alq):/code/output/yelp/nrtsearch/. ./grpc-gateway/
 docker cp $(docker ps -alq):/code/bin/. ./build/install/nrtsearch/bin

--- a/clientlib/src/main/proto/yelp/nrtsearch/analysis.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/analysis.proto
@@ -6,6 +6,8 @@ option java_package = "com.yelp.nrtsearch.server.grpc";
 option java_outer_classname = "AnalysisProto";
 option objc_class_prefix = "HLW";
 
+option go_package = "github.com/Yelp/nrtsearch";
+
 package luceneserver;
 
 message NameAndParams {

--- a/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
@@ -15,6 +15,8 @@ option java_package = "com.yelp.nrtsearch.server.grpc";
 option java_outer_classname = "LuceneServerProto";
 option objc_class_prefix = "HLW";
 
+option go_package = "github.com/Yelp/nrtsearch";
+
 package luceneserver;
 
 // The LuceneServer service definition.

--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -10,6 +10,8 @@ option java_package = "com.yelp.nrtsearch.server.grpc";
 option java_outer_classname = "SearchResponseProto";
 option objc_class_prefix = "HLW";
 
+option go_package = "github.com/Yelp/nrtsearch";
+
 package luceneserver;
 
 // A clause in a BooleanQuery.

--- a/clientlib/src/main/proto/yelp/nrtsearch/suggest.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/suggest.proto
@@ -6,6 +6,8 @@ option java_package = "com.yelp.nrtsearch.server.grpc";
 option java_outer_classname = "SuggestResponseProto";
 option objc_class_prefix = "HLW";
 
+option go_package = "github.com/Yelp/nrtsearch";
+
 package luceneserver;
 
 

--- a/grpc-gateway/Dockerfile
+++ b/grpc-gateway/Dockerfile
@@ -34,13 +34,15 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 #use go modules to pin module versions
 ENV GO111MODULE=on
 ENV GRPC_GATEWAY_VERSION=1.15.2
+ENV PROTOC_GEN_GO_VERSION=1.5.1
+ENV GRPC_VERSION=1.36.0
 
 #install required go protoc plugins to build grpc-gateway server
 RUN go get \
     github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v${GRPC_GATEWAY_VERSION} \
     github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v${GRPC_GATEWAY_VERSION} \
-    github.com/golang/protobuf/protoc-gen-go \
-    google.golang.org/grpc
+    github.com/golang/protobuf/protoc-gen-go@v${PROTOC_GEN_GO_VERSION} \
+    google.golang.org/grpc@v${GRPC_VERSION}
 
 ENV PROTO_PATH=/code/clientlib/src/main/proto
 ENV PROTO_BUILD_PATH=/code/clientlib/build


### PR DESCRIPTION
We were seeing build failures where the grpc-gateway build failed with:
```
protoc-gen-go: unable to determine Go import path for "yelp/nrtsearch/analysis.proto"

Please specify either:
        • a "go_package" option in the .proto source file, or
        • a "M" argument on the command line.

See https://developers.google.com/protocol-buffers/docs/reference/go-generated#package for more information.

--go_out: protoc-gen-go: Plugin failed with status code 1.
```

Added go package for all proto files to fix this. Not sure why it suddenly started failing, but I'm guessing that we haven't pinned a version somewhere. Also added a check to fail build if the docker build for grpc-gateway throws an error.