### PR TITLE
Make random file send delay optional

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -66,6 +66,7 @@ public class LuceneServerConfiguration {
   private final ThreadPoolConfiguration threadPoolConfiguration;
   private final IndexPreloadConfig preloadConfig;
   private final boolean downloadAsStream;
+  private final boolean fileSendDelay;
 
   private final YamlConfigReader configReader;
 
@@ -103,6 +104,7 @@ public class LuceneServerConfiguration {
     restoreState = configReader.getBoolean("restoreState", false);
     preloadConfig = IndexPreloadConfig.fromConfig(configReader);
     downloadAsStream = configReader.getBoolean("downloadAsStream", false);
+    fileSendDelay = configReader.getBoolean("fileSendDelay", true);
     threadPoolConfiguration = new ThreadPoolConfiguration(configReader);
   }
 
@@ -180,6 +182,10 @@ public class LuceneServerConfiguration {
 
   public boolean getDownloadAsStream() {
     return downloadAsStream;
+  }
+
+  public boolean getFileSendDelay() {
+    return fileSendDelay;
   }
 
   public YamlConfigReader getConfigReader() {

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -1545,7 +1545,9 @@ public class LuceneServer {
                     .build();
             rawFileChunkStreamObserver.onNext(rawFileChunk);
             totalRead += chunkSize;
-            randomDelay(random);
+            if (globalState.configuration.getFileSendDelay()) {
+              randomDelay(random);
+            }
           }
           // EOF
           rawFileChunkStreamObserver.onCompleted();


### PR DESCRIPTION
Adds a config option to disable the random delay added between sending file chunks. This should hopefully speed up larger file transfers.