### PR TITLE
Executing onCompleted for addDocuments and commit on separate threadpool

### DIFF
--- a/clientlib/src/main/java/com/yelp/nrtsearch/clientlib/NodeAddressFileNameResolver.java
+++ b/clientlib/src/main/java/com/yelp/nrtsearch/clientlib/NodeAddressFileNameResolver.java
@@ -69,7 +69,9 @@ public class NodeAddressFileNameResolver extends NameResolver {
 
   @Override
   public void shutdown() {
-    fileChangeCheckTimer.cancel();
+    if (fileChangeCheckTimer != null) {
+      fileChangeCheckTimer.cancel();
+    }
   }
 
   private void loadNodes() {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/GlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/GlobalState.java
@@ -265,7 +265,7 @@ public class GlobalState implements Closeable, Restorable {
     return getIndex(name, false);
   }
 
-  public Future<Long> submitIndexingTask(Callable job) throws InterruptedException {
+  public Future<Long> submitIndexingTask(Callable job) {
     return indexService.submit(job);
   }
 

--- a/src/test/java/com/yelp/nrtsearch/clientlib/NodeNameResolverAndLoadBalancingTests.java
+++ b/src/test/java/com/yelp/nrtsearch/clientlib/NodeNameResolverAndLoadBalancingTests.java
@@ -183,7 +183,8 @@ public class NodeNameResolverAndLoadBalancingTests {
     int requestsToEachServer = 20;
     int numServers = 3;
 
-    Map<Integer, Integer> resultCounts = performSearchAndGetResultCounts(stub, requestsToEachServer, numServers);
+    Map<Integer, Integer> resultCounts =
+        performSearchAndGetResultCounts(stub, requestsToEachServer, numServers);
 
     // All servers should get the same number of requests
     assertEquals(requestsToEachServer, resultCounts.get(SERVER_1_ID).intValue());
@@ -231,7 +232,8 @@ public class NodeNameResolverAndLoadBalancingTests {
 
     int requestsToEachServer = 20;
 
-    Map<Integer, Integer> resultCounts = performSearchAndGetResultCounts(stub, requestsToEachServer, 3);
+    Map<Integer, Integer> resultCounts =
+        performSearchAndGetResultCounts(stub, requestsToEachServer, 3);
 
     // Equal number of requests sent to all 3 servers
     assertEquals(resultCounts.get(SERVER_1_ID).intValue(), requestsToEachServer);
@@ -261,7 +263,8 @@ public class NodeNameResolverAndLoadBalancingTests {
 
     int requestsToEachServer = 20;
 
-    Map<Integer, Integer> resultCounts = performSearchAndGetResultCounts(stub, requestsToEachServer, 3);
+    Map<Integer, Integer> resultCounts =
+        performSearchAndGetResultCounts(stub, requestsToEachServer, 3);
 
     // Equal number of requests sent to all 3 servers
     assertEquals(resultCounts.get(SERVER_1_ID).intValue(), requestsToEachServer);
@@ -294,7 +297,8 @@ public class NodeNameResolverAndLoadBalancingTests {
 
     int requestsToEachServer = 20;
 
-    Map<Integer, Integer> resultCounts = performSearchAndGetResultCounts(stub, requestsToEachServer, 2);
+    Map<Integer, Integer> resultCounts =
+        performSearchAndGetResultCounts(stub, requestsToEachServer, 2);
 
     // Requests sent to servers 2 and 3
     assertEquals(resultCounts.get(SERVER_2_ID).intValue(), requestsToEachServer);
@@ -369,7 +373,8 @@ public class NodeNameResolverAndLoadBalancingTests {
     }
   }
 
-  private Map<Integer, Integer> performSearchAndGetResultCounts(LuceneServerGrpc.LuceneServerBlockingStub stub, int requestsToEachServer, int numServers) {
+  private Map<Integer, Integer> performSearchAndGetResultCounts(
+      LuceneServerGrpc.LuceneServerBlockingStub stub, int requestsToEachServer, int numServers) {
     Map<Integer, Integer> resultCounts = new HashMap<>();
     for (int i = 0; i < numServers * requestsToEachServer; i++) {
       int result = performSearch(stub);


### PR DESCRIPTION
With this change the luceneserver grpc threads won't be blocked on long-running onCompleted (of addDocuments) and commit calls when there are merges happening. Reusing the indexing threadpool for this since addDocuments and commit are parts of indexing only. We can separately increase the size of this threadpool if needed.