### PR TITLE
Add virtual sharding

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
@@ -373,6 +373,12 @@ message LiveSettingsRequest {
     double indexRamBufferSizeMB = 5;
     //Max number of documents to add at a time.
     int32 addDocumentsMaxBufferLen = 6;
+    //Number of virtual shards to use for this index.
+    int32 virtualShards = 7;
+    //Maximum number of documents allowed in a parallel search slice.
+    int32 sliceMaxDocs = 8;
+    //Maximum number of segments allowed in a parallel search slice.
+    int32 sliceMaxSegments = 9;
 }
 
 /* Response from Server to liveSettings */

--- a/grpc-gateway/luceneserver.swagger.json
+++ b/grpc-gateway/luceneserver.swagger.json
@@ -2574,6 +2574,21 @@
           "type": "integer",
           "format": "int32",
           "description": "Max number of documents to add at a time."
+        },
+        "virtualShards": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of virtual shards to use for this index."
+        },
+        "sliceMaxDocs": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of documents allowed in a parallel search slice."
+        },
+        "sliceMaxSegments": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of segments allowed in a parallel search slice."
         }
       },
       "title": "Input to liveSettings"

--- a/src/main/java/com/yelp/nrtsearch/server/cli/LiveSettingsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/server/cli/LiveSettingsCommand.java
@@ -65,6 +65,27 @@ public class LiveSettingsCommand implements Callable<Integer> {
       defaultValue = "100")
   private int addDocumentsMaxBufferLen;
 
+  @CommandLine.Option(
+      names = {"--virtualShards"},
+      description =
+          "Number of virtual shards to partition index into, or 0 to keep current value.  (default: ${DEFAULT-VALUE})",
+      defaultValue = "0")
+  private int virtualShards;
+
+  @CommandLine.Option(
+      names = {"--sliceMaxDocs"},
+      description =
+          "Max documents per index slice, or 0 to keep current value. (default: ${DEFAULT-VALUE})",
+      defaultValue = "0")
+  private int sliceMaxDocs;
+
+  @CommandLine.Option(
+      names = {"--sliceMaxSegments"},
+      description =
+          "Max segments per index slice, or 0 to keep current value. (default: ${DEFAULT-VALUE})",
+      defaultValue = "0")
+  private int sliceMaxSegments;
+
   public String getIndexName() {
     return indexName;
   }
@@ -89,6 +110,18 @@ public class LiveSettingsCommand implements Callable<Integer> {
     return addDocumentsMaxBufferLen;
   }
 
+  public int getVirtualShards() {
+    return virtualShards;
+  }
+
+  public int getSliceMaxDocs() {
+    return sliceMaxDocs;
+  }
+
+  public int getSliceMaxSegments() {
+    return sliceMaxSegments;
+  }
+
   @Override
   public Integer call() throws Exception {
     LuceneServerClient client = baseCmd.getClient();
@@ -99,7 +132,10 @@ public class LiveSettingsCommand implements Callable<Integer> {
           getMinRefreshSec(),
           getMaxSearcherAgeSec(),
           getIndexRamBufferSizeMB(),
-          getAddDocumentsMaxBufferLen());
+          getAddDocumentsMaxBufferLen(),
+          getVirtualShards(),
+          getSliceMaxDocs(),
+          getSliceMaxSegments());
     } finally {
       client.shutdown();
     }

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
@@ -95,18 +95,24 @@ public class LuceneServerClient {
       double minRefreshSec,
       double maxSearcherAgeSec,
       double indexRamBufferSizeMB,
-      int addDocumentsMaxBufferLen) {
+      int addDocumentsMaxBufferLen,
+      int virtualShards,
+      int sliceMaxDocs,
+      int sliceMaxSegments) {
     logger.info(
         String.format(
             "will try to update liveSettings for indexName: %s, "
                 + "maxRefreshSec: %s, minRefreshSec: %s, maxSearcherAgeSec: %s, "
-                + "indexRamBufferSizeMB: %s, addDocumentsMaxBufferLen: %s ",
+                + "indexRamBufferSizeMB: %s, addDocumentsMaxBufferLen: %s , virtualShards: %s, sliceMaxDocs: %s, sliceMaxSegments: %s",
             indexName,
             maxRefreshSec,
             minRefreshSec,
             maxSearcherAgeSec,
             indexRamBufferSizeMB,
-            addDocumentsMaxBufferLen));
+            addDocumentsMaxBufferLen,
+            virtualShards,
+            sliceMaxDocs,
+            sliceMaxSegments));
     LiveSettingsRequest request =
         LiveSettingsRequest.newBuilder()
             .setIndexName(indexName)
@@ -115,6 +121,9 @@ public class LuceneServerClient {
             .setMaxSearcherAgeSec(maxSearcherAgeSec)
             .setIndexRamBufferSizeMB(indexRamBufferSizeMB)
             .setAddDocumentsMaxBufferLen(addDocumentsMaxBufferLen)
+            .setVirtualShards(virtualShards)
+            .setSliceMaxDocs(sliceMaxDocs)
+            .setSliceMaxSegments(sliceMaxSegments)
             .build();
     LiveSettingsResponse response;
     try {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/LiveSettingsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/LiveSettingsHandler.java
@@ -54,6 +54,20 @@ public class LiveSettingsHandler implements Handler<LiveSettingsRequest, LiveSet
               "set addDocumentsMaxBufferLen: %s",
               liveSettingsRequest.getAddDocumentsMaxBufferLen()));
     }
+    if (liveSettingsRequest.getVirtualShards() != 0) {
+      System.out.println("Setting virtual shards: " + liveSettingsRequest.getVirtualShards());
+      indexState.setVirtualShards(liveSettingsRequest.getVirtualShards());
+      logger.info(String.format("set virtualShards: %s", liveSettingsRequest.getVirtualShards()));
+    }
+    if (liveSettingsRequest.getSliceMaxDocs() != 0) {
+      indexState.setSliceMaxDocs(liveSettingsRequest.getSliceMaxDocs());
+      logger.info(String.format("set sliceMaxDocs: %s", liveSettingsRequest.getSliceMaxDocs()));
+    }
+    if (liveSettingsRequest.getSliceMaxSegments() != 0) {
+      indexState.setSliceMaxSegments(liveSettingsRequest.getSliceMaxSegments());
+      logger.info(
+          String.format("set sliceMaxSegments: %s", liveSettingsRequest.getSliceMaxSegments()));
+    }
     String response = indexState.getLiveSettingsJSON();
     LiveSettingsResponse reply = LiveSettingsResponse.newBuilder().setResponse(response).build();
     return reply;

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
@@ -484,7 +484,14 @@ public class SearchHandler implements Handler<SearchRequest, SearchResponse> {
 
       SearcherTaxonomyManager.SearcherAndTaxonomy result =
           new SearcherTaxonomyManager.SearcherAndTaxonomy(
-              new MyIndexSearcher(r, threadPoolExecutor), s.taxonomyReader);
+              new MyIndexSearcher(
+                  r,
+                  new MyIndexSearcher.ExecutorWithParams(
+                      threadPoolExecutor,
+                      state.indexState.getVirtualShards(),
+                      state.indexState.getSliceMaxDocs(),
+                      state.indexState.getSliceMaxSegments())),
+              s.taxonomyReader);
       state.slm.record(result.searcher);
       long t1 = System.nanoTime();
       if (diagnostics != null) {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -453,7 +453,14 @@ public class ShardState implements Closeable {
     @Override
     public IndexSearcher newSearcher(IndexReader reader, IndexReader previousReader)
         throws IOException {
-      IndexSearcher searcher = new MyIndexSearcher(reader, searchExecutor);
+      IndexSearcher searcher =
+          new MyIndexSearcher(
+              reader,
+              new MyIndexSearcher.ExecutorWithParams(
+                  searchExecutor,
+                  indexState.getVirtualShards(),
+                  indexState.getSliceMaxDocs(),
+                  indexState.getSliceMaxSegments()));
       searcher.setSimilarity(indexState.sim);
       if (loadEagerOrdinals) {
         loadEagerGlobalOrdinals(reader);
@@ -722,7 +729,14 @@ public class ShardState implements Closeable {
                 @Override
                 public IndexSearcher newSearcher(IndexReader r, IndexReader previousReader)
                     throws IOException {
-                  IndexSearcher searcher = new MyIndexSearcher(r, searchExecutor);
+                  IndexSearcher searcher =
+                      new MyIndexSearcher(
+                          r,
+                          new MyIndexSearcher.ExecutorWithParams(
+                              searchExecutor,
+                              indexState.getVirtualShards(),
+                              indexState.getSliceMaxDocs(),
+                              indexState.getSliceMaxSegments()));
                   searcher.setSimilarity(indexState.sim);
                   return searcher;
                 }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/BucketedTieredMergePolicy.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/BucketedTieredMergePolicy.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.index;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.function.IntSupplier;
+import java.util.stream.Collectors;
+import org.apache.lucene.index.*;
+
+/**
+ * Merge policy that tries to divide the index into even sized buckets. Prior to any merge
+ * decisions, the index segments are divided into n buckets as evenly as possible. Merges are found
+ * for each segment set independently as if it were its own index, managed by a {@link
+ * TieredMergePolicy}.
+ */
+public class BucketedTieredMergePolicy extends TieredMergePolicy {
+  private final IntSupplier bucketCountSupplier;
+  private final LinkedList<Set<String>> pendingMerges = new LinkedList<>();
+
+  /** Class to hold a bucket's segment set and current live document count. */
+  private static class MergeBucket {
+    SegmentInfos bucketInfos;
+    long liveDocCount;
+
+    MergeBucket(int majorVersion) {
+      bucketInfos = new SegmentInfos(majorVersion);
+      liveDocCount = 0;
+    }
+
+    void add(SegmentCommitInfo sci, long liveDocs) {
+      bucketInfos.add(sci);
+      liveDocCount += liveDocs;
+    }
+
+    void addAll(Iterable<SegmentCommitInfo> infos, long totalLiveDocs) {
+      bucketInfos.addAll(infos);
+      liveDocCount += totalLiveDocs;
+    }
+  }
+
+  /**
+   * Interface for a single unit of index segments. This could be an individual segment, or a set of
+   * segments that are part of a pending merge.
+   */
+  private interface MergeUnit {
+    /** Get the total number of live documents in the index unit. */
+    long getLiveDocCount();
+
+    /** Add the segments this unit represents into a MergeBucket. */
+    void addToBucket(MergeBucket bucket);
+  }
+
+  /** MergeUnit representing a single index segment. */
+  private static class SingleSegment implements MergeUnit {
+    final SegmentCommitInfo info;
+    final long liveDocCount;
+
+    SingleSegment(SegmentCommitInfo sci) {
+      info = sci;
+      liveDocCount = (sci.info.maxDoc() - sci.getDelCount());
+    }
+
+    @Override
+    public long getLiveDocCount() {
+      return liveDocCount;
+    }
+
+    @Override
+    public void addToBucket(MergeBucket bucket) {
+      bucket.add(info, liveDocCount);
+    }
+  }
+
+  /** MergeUnit representing a collection of index segments. */
+  private static class MultiSegment implements MergeUnit {
+    List<SegmentCommitInfo> infos = new ArrayList<>();
+    long liveDocCount = 0;
+
+    void add(SegmentCommitInfo sci) {
+      infos.add(sci);
+      liveDocCount += (sci.info.maxDoc() - sci.getDelCount());
+    }
+
+    @Override
+    public long getLiveDocCount() {
+      return liveDocCount;
+    }
+
+    @Override
+    public void addToBucket(MergeBucket bucket) {
+      bucket.addAll(infos, liveDocCount);
+    }
+  }
+
+  /**
+   * Interface to run a super class merge function. Like a standard {@link
+   * java.util.function.Function}, but throws a checked {@link IOException}.
+   */
+  @FunctionalInterface
+  private interface BucketMergeFunc<T, R> {
+    R apply(T t) throws IOException;
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param bucketCountSupplier provides the current number of buckets for the index, this value may
+   *     change between calls
+   */
+  public BucketedTieredMergePolicy(IntSupplier bucketCountSupplier) {
+    this.bucketCountSupplier = bucketCountSupplier;
+  }
+
+  @Override
+  public MergePolicy.MergeSpecification findMerges(
+      MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergePolicy.MergeContext mergeContext)
+      throws IOException {
+
+    final int buckets = bucketCountSupplier.getAsInt();
+    if (buckets > 1) {
+      return findForSegmentInfos(
+          buckets, segmentInfos, infos -> super.findMerges(mergeTrigger, infos, mergeContext));
+    } else {
+      return super.findMerges(mergeTrigger, segmentInfos, mergeContext);
+    }
+  }
+
+  @Override
+  public MergePolicy.MergeSpecification findForcedMerges(
+      SegmentInfos segmentInfos,
+      int maxSegmentCount,
+      Map<SegmentCommitInfo, Boolean> segmentsToMerge,
+      MergePolicy.MergeContext mergeContext)
+      throws IOException {
+
+    final int buckets = bucketCountSupplier.getAsInt();
+    if (buckets > 1) {
+      return findForSegmentInfos(
+          buckets,
+          segmentInfos,
+          infos -> super.findForcedMerges(infos, maxSegmentCount, segmentsToMerge, mergeContext));
+    } else {
+      return super.findForcedMerges(segmentInfos, maxSegmentCount, segmentsToMerge, mergeContext);
+    }
+  }
+
+  @Override
+  public MergePolicy.MergeSpecification findForcedDeletesMerges(
+      SegmentInfos segmentInfos, MergePolicy.MergeContext mergeContext) throws IOException {
+    final int buckets = bucketCountSupplier.getAsInt();
+
+    if (buckets > 1) {
+      return findForSegmentInfos(
+          buckets, segmentInfos, infos -> super.findForcedDeletesMerges(infos, mergeContext));
+    } else {
+      return super.findForcedDeletesMerges(segmentInfos, mergeContext);
+    }
+  }
+
+  private MergePolicy.MergeSpecification findForSegmentInfos(
+      int buckets,
+      SegmentInfos segmentInfos,
+      BucketMergeFunc<SegmentInfos, MergeSpecification> bucketFunc)
+      throws IOException {
+    // sort index merge units in descending order
+    List<MergeUnit> sortedMergeUnits = getMergeUnits(segmentInfos);
+    sortedMergeUnits.sort(Comparator.comparingLong(MergeUnit::getLiveDocCount).reversed());
+
+    // create buckets
+    PriorityQueue<MergeBucket> bucketQueue =
+        new PriorityQueue<>(buckets, Comparator.comparingLong(mb -> mb.liveDocCount));
+    for (int i = 0; i < buckets; ++i) {
+      bucketQueue.add(new MergeBucket(segmentInfos.getIndexCreatedVersionMajor()));
+    }
+
+    // add each merge unit in sequence to the bucket with the lowest live documents
+    for (MergeUnit mu : sortedMergeUnits) {
+      MergeBucket mb = bucketQueue.poll();
+      mu.addToBucket(mb);
+      bucketQueue.add(mb);
+    }
+
+    // find merges for each bucket and aggregate them
+    MergeSpecification aggregateMerges = new MergeSpecification();
+    while (!bucketQueue.isEmpty()) {
+      MergeBucket mb = bucketQueue.poll();
+      if (mb.bucketInfos.size() > 0) {
+        MergeSpecification bucketMerges = bucketFunc.apply(mb.bucketInfos);
+        if (bucketMerges != null) {
+          for (OneMerge om : bucketMerges.merges) {
+            aggregateMerges.add(om);
+            addPendingMerge(om);
+          }
+        }
+      }
+    }
+    return aggregateMerges;
+  }
+
+  /**
+   * Group the current index segments into merge units.
+   *
+   * @param infos current index segments info
+   * @return unsorted list of merge units
+   */
+  private List<MergeUnit> getMergeUnits(SegmentInfos infos) {
+    // create mapping of segment name to meta data
+    Map<String, SegmentCommitInfo> infoMap = new HashMap<>();
+    for (SegmentCommitInfo sci : infos) {
+      infoMap.put(sci.info.name, sci);
+    }
+
+    List<MergeUnit> unitList = new ArrayList<>();
+
+    // group segments that are part of a pending merge
+    ListIterator<Set<String>> pendingIterator = pendingMerges.listIterator();
+    while (pendingIterator.hasNext()) {
+      Set<String> mergeSegments = pendingIterator.next();
+      MultiSegment multiSegment = new MultiSegment();
+      boolean skip = false;
+      for (String name : mergeSegments) {
+        SegmentCommitInfo mergeSegmentInfo = infoMap.get(name);
+        if (mergeSegmentInfo == null) {
+          // this merge is done
+          pendingIterator.remove();
+          skip = true;
+          break;
+        }
+        multiSegment.add(mergeSegmentInfo);
+      }
+      if (skip) {
+        continue;
+      }
+      for (String name : mergeSegments) {
+        infoMap.remove(name);
+      }
+      unitList.add(multiSegment);
+    }
+    // add remaining segments a single merge units
+    for (Map.Entry<String, SegmentCommitInfo> entry : infoMap.entrySet()) {
+      unitList.add(new SingleSegment(entry.getValue()));
+    }
+    return unitList;
+  }
+
+  /** Add info for this merge to the pendingMerge list. */
+  private void addPendingMerge(OneMerge merge) {
+    // add to the start of the list, so it will be looked at first when bucketing
+    pendingMerges.addFirst(
+        merge.segments.stream().map(sci -> sci.info.name).collect(Collectors.toSet()));
+  }
+}


### PR DESCRIPTION
Looking for some initial feedback on the approach. The goal is to provide better, more consistent bounds on the amount of work that needs to be done per searcher thread. This should hopefully allow us to achieve reasonable tail latencies.

---

Adds configuration for virtual sharding. This attempts to make the index data divisible into a number of equal buckets, and thus equal units of work. There are two places the value is used.

The BucketedTieredMergePolicy divides the index segments as evenly as possible into the specified number of buckets. Each of these buckets is evaluated for merges independently using the TieredMergePolicy. This maintains the ability to divide the index data evenly.

The MyIndexSearcher has similar modifications. It divides the index segments into even shards and computes parallel search slices independently for each shard. This should maintain a minimum parallelism and more consistent units of work.

The slice construction parameters and virtual shard configuration are part of the index live settings. Though it is possible to change the virtual sharding config, it is best to set it before any indexing. Otherwise, it will take time and organic indexing to eventually converge at the new value.