### PR TITLE
Add search phase profiling stats

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -276,6 +276,8 @@ message SearchRequest {
     bool disallowPartialResults = 16; //Should partial result be a failure condition. Applies when a search request times out. If false, the top documents ranking at the point of timeout are used and the request continues. Also, hitTimeout is set to true in the response.
     string queryNestedPath = 17; //nested path we want to query by if we want to query child documents.
     repeated Rescorer rescorers = 18; // Rescorers which are executed in-order after the first pass
+    //If detailed request execution profiling should be included in the response
+    bool profile = 19;
 }
 
 /* Virtual field used during search */
@@ -424,6 +426,8 @@ message SearchResponse {
     repeated Hit hits = 4;
     SearchState searchState = 5;
     repeated FacetResult facetResult = 6; ////Counts or aggregates for a single dimension
+    // Detailed stats returned when profile=true in request
+    ProfileResult profileResult = 7;
 }
 
 message NumericRangeType {
@@ -487,4 +491,36 @@ message Rescorer {
         QueryRescorer queryRescorer = 2;
         PluginRescorer pluginRescorer = 3;
     }
+}
+
+// Defines detailed profiling stats for queries that set profile=true
+message ProfileResult {
+    message CollectorStats {
+        // If collection for this index slice was terminated early, such as by a timeout.
+        bool terminated = 1;
+        repeated SegmentStats segmentStats = 2;
+    }
+
+    message SegmentStats {
+        // Total docs in segment
+        int32 maxDoc = 1;
+        // Total live docs in segment
+        int32 numDocs = 2;
+        // How many docs were collected
+        int32 collectedCount = 3;
+        // Start time of segment processing in relation to the start of the search phase
+        double relativeStartTimeMs = 4;
+        // Collection duration
+        double collectTimeMs = 5;
+    }
+
+    message SearchStats {
+        // Total time for all document collection
+        double totalCollectTimeMs = 1;
+        // Total time to reduce results from all parallel search slices
+        double totalReduceTimeMs = 2;
+        repeated CollectorStats collectorStats = 3;
+    }
+
+    SearchStats searchStats = 1;
 }

--- a/grpc-gateway/luceneserver.swagger.json
+++ b/grpc-gateway/luceneserver.swagger.json
@@ -1188,6 +1188,72 @@
       ],
       "default": "NONE"
     },
+    "ProfileResultCollectorStats": {
+      "type": "object",
+      "properties": {
+        "terminated": {
+          "type": "boolean",
+          "description": "If collection for this index slice was terminated early, such as by a timeout."
+        },
+        "segmentStats": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ProfileResultSegmentStats"
+          }
+        }
+      }
+    },
+    "ProfileResultSearchStats": {
+      "type": "object",
+      "properties": {
+        "totalCollectTimeMs": {
+          "type": "number",
+          "format": "double",
+          "title": "Total time for all document collection"
+        },
+        "totalReduceTimeMs": {
+          "type": "number",
+          "format": "double",
+          "title": "Total time to reduce results from all parallel search slices"
+        },
+        "collectorStats": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ProfileResultCollectorStats"
+          }
+        }
+      }
+    },
+    "ProfileResultSegmentStats": {
+      "type": "object",
+      "properties": {
+        "maxDoc": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Total docs in segment"
+        },
+        "numDocs": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Total live docs in segment"
+        },
+        "collectedCount": {
+          "type": "integer",
+          "format": "int32",
+          "title": "How many docs were collected"
+        },
+        "relativeStartTimeMs": {
+          "type": "number",
+          "format": "double",
+          "title": "Start time of segment processing in relation to the start of the search phase"
+        },
+        "collectTimeMs": {
+          "type": "number",
+          "format": "double",
+          "title": "Collection duration"
+        }
+      }
+    },
     "ScriptParamListValue": {
       "type": "object",
       "properties": {
@@ -2826,6 +2892,15 @@
       },
       "title": "Point representation"
     },
+    "luceneserverProfileResult": {
+      "type": "object",
+      "properties": {
+        "searchStats": {
+          "$ref": "#/definitions/ProfileResultSearchStats"
+        }
+      },
+      "title": "Defines detailed profiling stats for queries that set profile=true"
+    },
     "luceneserverQuery": {
       "type": "object",
       "properties": {
@@ -3129,6 +3204,10 @@
           "items": {
             "$ref": "#/definitions/luceneserverRescorer"
           }
+        },
+        "profile": {
+          "type": "boolean",
+          "title": "If detailed request execution profiling should be included in the response"
         }
       }
     },
@@ -3158,6 +3237,10 @@
           "items": {
             "$ref": "#/definitions/luceneserverFacetResult"
           }
+        },
+        "profileResult": {
+          "$ref": "#/definitions/luceneserverProfileResult",
+          "title": "Detailed stats returned when profile=true in request"
         }
       }
     },

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchStatsWrapper.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchStatsWrapper.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.search;
+
+import com.yelp.nrtsearch.server.grpc.ProfileResult;
+import com.yelp.nrtsearch.server.grpc.ProfileResult.CollectorStats;
+import com.yelp.nrtsearch.server.grpc.ProfileResult.SearchStats;
+import com.yelp.nrtsearch.server.grpc.ProfileResult.SegmentStats;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.CollectionTerminatedException;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.TopDocs;
+
+/**
+ * CollectorManager that wraps another manager and collects timing stats for the search execution.
+ * Records timing for collection and reduce operations, as well as detailed stats for each processed
+ * segment.
+ *
+ * @param <C> collector type of wrapped manager
+ * @param <T> <T> top docs type of wrapped manager
+ */
+public class SearchStatsWrapper<C extends Collector, T extends TopDocs>
+    implements CollectorManager<SearchStatsWrapper<C, T>.SearchStatsCollectorWrapper, T> {
+
+  private Collection<SearchStatsCollectorWrapper> collectors;
+  private final CollectorManager<C, T> in;
+  long collectStartNano = -1;
+  long collectEndNano = -1;
+  long reduceStartNano = -1;
+  long reduceEndNano = -1;
+
+  /**
+   * Constructor
+   *
+   * @param in manager to wrap
+   */
+  public SearchStatsWrapper(CollectorManager<C, T> in) {
+    this.in = in;
+  }
+
+  @Override
+  public SearchStatsCollectorWrapper newCollector() throws IOException {
+    if (collectStartNano < 0) {
+      collectStartNano = System.nanoTime();
+      collectEndNano = collectStartNano;
+    }
+    return new SearchStatsCollectorWrapper(in.newCollector());
+  }
+
+  @Override
+  public T reduce(Collection<SearchStatsWrapper<C, T>.SearchStatsCollectorWrapper> collectors)
+      throws IOException {
+    this.collectors = collectors;
+    collectEndNano = System.nanoTime();
+
+    List<C> innerCollectors = new ArrayList<>(collectors.size());
+    for (SearchStatsCollectorWrapper collector : collectors) {
+      innerCollectors.add(collector.collector);
+    }
+
+    reduceStartNano = System.nanoTime();
+    try {
+      return in.reduce(innerCollectors);
+    } finally {
+      reduceEndNano = System.nanoTime();
+    }
+  }
+
+  /** Get the collector manager being wrapped. */
+  public CollectorManager<C, T> getWrapped() {
+    return in;
+  }
+
+  /**
+   * Add search profiling stats to profile results builder.
+   *
+   * @param profileResultBuilder profile results builder
+   * @throws NullPointerException if builder is null
+   */
+  public void addProfiling(ProfileResult.Builder profileResultBuilder) {
+    Objects.requireNonNull(profileResultBuilder);
+
+    // stats collection is incomplete
+    if (collectStartNano == -1
+        || collectEndNano == -1
+        || reduceStartNano == -1
+        || reduceEndNano == -1
+        || this.collectors == null) {
+      return;
+    }
+
+    SearchStats.Builder searchStatsBuilder = SearchStats.newBuilder();
+    searchStatsBuilder.setTotalCollectTimeMs((collectEndNano - collectStartNano) / 1000000.0);
+    searchStatsBuilder.setTotalReduceTimeMs((reduceEndNano - reduceStartNano) / 1000000.0);
+    for (SearchStatsCollectorWrapper collector : collectors) {
+      CollectorStats.Builder collectorStatsBuilder = CollectorStats.newBuilder();
+      collectorStatsBuilder.setTerminated(collector.terminated);
+      for (SearchStatsLeafCollectorWrapper leafCollector : collector.leafCollectors) {
+        SegmentStats.Builder segmentStatsBuilder = SegmentStats.newBuilder();
+        segmentStatsBuilder.setMaxDoc(leafCollector.context.reader().maxDoc());
+        segmentStatsBuilder.setNumDocs(leafCollector.context.reader().numDocs());
+        segmentStatsBuilder.setCollectedCount(leafCollector.collectedCount);
+        segmentStatsBuilder.setRelativeStartTimeMs(
+            (leafCollector.leafStartNano - collectStartNano) / 1000000.0);
+        segmentStatsBuilder.setCollectTimeMs(
+            (leafCollector.leafEndNano - leafCollector.leafStartNano) / 1000000.0);
+        collectorStatsBuilder.addSegmentStats(segmentStatsBuilder.build());
+      }
+      searchStatsBuilder.addCollectorStats(collectorStatsBuilder.build());
+    }
+    profileResultBuilder.setSearchStats(searchStatsBuilder);
+  }
+
+  /**
+   * Stats collector that wraps another collector. Records if collection was gracefully terminated.
+   */
+  class SearchStatsCollectorWrapper implements Collector {
+
+    private final C collector;
+    private final List<SearchStatsLeafCollectorWrapper> leafCollectors = new ArrayList<>();
+    boolean terminated = false;
+
+    public SearchStatsCollectorWrapper(C collector) {
+      this.collector = collector;
+    }
+
+    @Override
+    public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+      SearchStatsLeafCollectorWrapper leafCollector;
+      try {
+        leafCollector =
+            new SearchStatsLeafCollectorWrapper(collector.getLeafCollector(context), context);
+      } catch (CollectionTerminatedException e) {
+        terminated = true;
+        throw e;
+      }
+
+      leafCollectors.add(leafCollector);
+      return leafCollector;
+    }
+
+    @Override
+    public ScoreMode scoreMode() {
+      return collector.scoreMode();
+    }
+  }
+
+  /**
+   * Leaf collector that wraps another leaf collector. Records the start and end of collection, and
+   * the total collected documents.
+   */
+  static class SearchStatsLeafCollectorWrapper implements LeafCollector {
+
+    private final LeafCollector in;
+    private final LeafReaderContext context;
+    int collectedCount = 0;
+    final long leafStartNano;
+    long leafEndNano;
+
+    public SearchStatsLeafCollectorWrapper(LeafCollector in, LeafReaderContext context) {
+      this.in = in;
+      this.context = context;
+      leafStartNano = System.nanoTime();
+      leafEndNano = leafStartNano;
+    }
+
+    @Override
+    public void setScorer(Scorable scorer) throws IOException {
+      in.setScorer(scorer);
+    }
+
+    @Override
+    public void collect(int doc) throws IOException {
+      collectedCount++;
+      in.collect(doc);
+      // update end time after each collection, since we don't know when it will be the last one
+      leafEndNano = System.nanoTime();
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/SearchStatsWrapperTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/SearchStatsWrapperTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.search;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
+import com.yelp.nrtsearch.server.grpc.ProfileResult;
+import com.yelp.nrtsearch.server.grpc.ProfileResult.CollectorStats;
+import com.yelp.nrtsearch.server.grpc.ProfileResult.SegmentStats;
+import com.yelp.nrtsearch.server.grpc.Query;
+import com.yelp.nrtsearch.server.grpc.SearchRequest;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.search.CollectionTerminatedException;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.TopDocs;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class SearchStatsWrapperTest extends ServerTestCase {
+  private static final String TEST_INDEX = "test_index";
+  private static final int NUM_DOCS = 100;
+  private static final int SEGMENT_CHUNK = 10;
+
+  @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  @Override
+  public List<String> getIndices() {
+    return Collections.singletonList(TEST_INDEX);
+  }
+
+  @Override
+  public FieldDefRequest getIndexDef(String name) throws IOException {
+    return getFieldsFromResourceFile("/search/StatsWrapperRegisterFields.json");
+  }
+
+  @Override
+  public void initIndex(String name) throws Exception {
+    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    // don't want any merges for these tests
+    writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
+
+    // create a shuffled list of ids
+    List<Integer> idList = new ArrayList<>();
+    for (int i = 0; i < NUM_DOCS; ++i) {
+      idList.add(i);
+    }
+    Collections.shuffle(idList);
+
+    // add documents one chunk at a time to ensure multiple index segments
+    List<AddDocumentRequest> requestChunk = new ArrayList<>();
+    for (Integer id : idList) {
+      requestChunk.add(
+          AddDocumentRequest.newBuilder()
+              .setIndexName(name)
+              .putFields(
+                  "doc_id",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(id))
+                      .build())
+              .putFields(
+                  "int_score",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(NUM_DOCS - id))
+                      .build())
+              .putFields(
+                  "int_field",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(id))
+                      .build())
+              .build());
+
+      if (requestChunk.size() == SEGMENT_CHUNK) {
+        addDocuments(requestChunk.stream());
+        requestChunk.clear();
+        writer.commit();
+      }
+    }
+  }
+
+  @Test
+  public void testHasSearchStats() {
+    SearchResponse searchResponse =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(TEST_INDEX)
+                    .setStartHit(0)
+                    .setTopHits(5)
+                    .addRetrieveFields("doc_id")
+                    .addRetrieveFields("int_score")
+                    .addRetrieveFields("int_field")
+                    .setQuery(Query.newBuilder())
+                    .setProfile(true)
+                    .build());
+    assertTrue(searchResponse.getProfileResult().getSearchStats().getCollectorStatsCount() > 1);
+    assertTrue(searchResponse.getProfileResult().getSearchStats().getTotalCollectTimeMs() > 0.0);
+    assertTrue(searchResponse.getProfileResult().getSearchStats().getTotalReduceTimeMs() > 0.0);
+    for (CollectorStats collectorStats :
+        searchResponse.getProfileResult().getSearchStats().getCollectorStatsList()) {
+      assertFalse(collectorStats.getTerminated());
+      for (SegmentStats segmentStats : collectorStats.getSegmentStatsList()) {
+        assertEquals(10, segmentStats.getMaxDoc());
+        assertEquals(10, segmentStats.getNumDocs());
+        assertEquals(10, segmentStats.getCollectedCount());
+        assertTrue(segmentStats.getCollectTimeMs() > 0.0);
+        assertTrue(segmentStats.getRelativeStartTimeMs() > 0.0);
+      }
+    }
+  }
+
+  public static class MockTerminateCollectorManager
+      implements CollectorManager<Collector, TopDocs> {
+
+    @Override
+    public Collector newCollector() throws IOException {
+      return new MockTerminateCollector();
+    }
+
+    @Override
+    public TopDocs reduce(Collection<Collector> collectors) throws IOException {
+      return null;
+    }
+
+    public static class MockTerminateCollector implements Collector {
+
+      @Override
+      public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+        throw new CollectionTerminatedException();
+      }
+
+      @Override
+      public ScoreMode scoreMode() {
+        return null;
+      }
+    }
+  }
+
+  @Test
+  public void testTerminateFlag() throws IOException {
+    SearchStatsWrapper searchStatsWrapper =
+        new SearchStatsWrapper(new MockTerminateCollectorManager());
+    List<Collector> collectors = new ArrayList<>();
+    for (int i = 0; i < 3; ++i) {
+      Collector c = searchStatsWrapper.newCollector();
+      collectors.add(c);
+      try {
+        c.getLeafCollector(null);
+        assert false;
+      } catch (CollectionTerminatedException ignored) {
+      }
+    }
+    searchStatsWrapper.reduce(collectors);
+    ProfileResult.Builder builder = ProfileResult.newBuilder();
+    searchStatsWrapper.addProfiling(builder);
+    ProfileResult result = builder.build();
+    assertEquals(3, result.getSearchStats().getCollectorStatsCount());
+    for (CollectorStats collectorStats : result.getSearchStats().getCollectorStatsList()) {
+      assertTrue(collectorStats.getTerminated());
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/DocCollectorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/DocCollectorTest.java
@@ -25,6 +25,7 @@ import com.yelp.nrtsearch.server.grpc.SearchRequest;
 import com.yelp.nrtsearch.server.grpc.SearchResponse.Hit.Builder;
 import com.yelp.nrtsearch.server.grpc.SearchResponse.SearchState;
 import com.yelp.nrtsearch.server.luceneserver.search.SearchCutoffWrapper;
+import com.yelp.nrtsearch.server.luceneserver.search.SearchStatsWrapper;
 import java.io.IOException;
 import java.util.Collection;
 import org.apache.lucene.search.Collector;
@@ -83,6 +84,30 @@ public class DocCollectorTest {
     assertTrue(docCollector.getManager() instanceof TestDocCollector.TestCollectorManager);
     assertTrue(docCollector.getWrappedManager() instanceof SearchCutoffWrapper);
     assertNotSame(docCollector.getManager(), docCollector.getWrappedManager());
+  }
+
+  @Test
+  public void testHasStatsWrapper() {
+    SearchRequest request = SearchRequest.newBuilder().setTopHits(10).setProfile(true).build();
+    TestDocCollector docCollector = new TestDocCollector(request);
+    assertTrue(docCollector.getManager() instanceof TestDocCollector.TestCollectorManager);
+    assertTrue(docCollector.getWrappedManager() instanceof SearchStatsWrapper);
+    assertSame(
+        docCollector.getManager(),
+        ((SearchStatsWrapper<?, ?>) docCollector.getWrappedManager()).getWrapped());
+    assertNotSame(docCollector.getManager(), docCollector.getWrappedManager());
+  }
+
+  @Test
+  public void testHasStatsAndTimeoutWrapper() {
+    SearchRequest request =
+        SearchRequest.newBuilder().setTopHits(10).setTimeoutSec(5).setProfile(true).build();
+    TestDocCollector docCollector = new TestDocCollector(request);
+    assertTrue(docCollector.getManager() instanceof TestDocCollector.TestCollectorManager);
+    assertTrue(docCollector.getWrappedManager() instanceof SearchStatsWrapper);
+    assertTrue(
+        ((SearchStatsWrapper<?, ?>) docCollector.getWrappedManager()).getWrapped()
+            instanceof SearchCutoffWrapper);
   }
 
   @Test

--- a/src/test/resources/search/StatsWrapperRegisterFields.json
+++ b/src/test/resources/search/StatsWrapperRegisterFields.json
@@ -1,0 +1,21 @@
+{
+  "indexName": "test_index",
+  "field": [
+    {
+      "name": "doc_id",
+      "type": "ATOM",
+      "storeDocValues": true
+    },
+    {
+      "name": "int_score",
+      "type": "INT",
+      "storeDocValues": true
+    },
+    {
+      "name": "int_field",
+      "type": "INT",
+      "search": true,
+      "storeDocValues": true
+    }
+  ]
+}


### PR DESCRIPTION
Add the option to request detailed profiling output for a request.

Currently only contains search stats, which provides info on parallel search execution.

Search Stats:
- collect timing
- reduce timing
- stats per collector

Collector Stats:
- if terminated early
- stats per segment

Segment Stats:
- maxDocs
- num live docs
- num docs collected
- relative start time
- collection duration