### PR TITLE
Close index reader after backup

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -421,7 +421,7 @@ message SearchResponse {
     }
 
     Diagnostics diagnostics = 1;
-    bool hitTimeout = 2;
+    bool hitTimeout = 2; // Set to true if search times out and a degraded response is returned
     TotalHits totalHits = 3;
     repeated Hit hits = 4;
     SearchState searchState = 5;

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/BackupIndexRequestHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/BackupIndexRequestHandler.java
@@ -154,9 +154,10 @@ public class BackupIndexRequestHandler implements Handler<BackupIndexRequest, Ba
     }
     ShardState state = indexState.shards.entrySet().iterator().next().getValue();
     SearcherTaxonomyManager.SearcherAndTaxonomy searcherAndTaxonomy = null;
+    IndexReader indexReader = null;
     try {
       searcherAndTaxonomy = state.acquire();
-      IndexReader indexReader =
+      indexReader =
           DirectoryReader.openIfChanged(
               (DirectoryReader) searcherAndTaxonomy.searcher.getIndexReader(),
               state.snapshots.getIndexCommit(snapshot.indexGen));
@@ -168,6 +169,9 @@ public class BackupIndexRequestHandler implements Handler<BackupIndexRequest, Ba
     } finally {
       if (searcherAndTaxonomy != null) {
         state.release(searcherAndTaxonomy);
+      }
+      if (indexReader != null) {
+        indexReader.close();
       }
     }
   }

--- a/src/test/resources/yelp_reviews/primary/lucene_server_configuration.yaml
+++ b/src/test/resources/yelp_reviews/primary/lucene_server_configuration.yaml
@@ -6,4 +6,5 @@ stateDir: "primary_state"
 indexDir: "primary_index_base"
 threadPoolConfiguration:
   maxSearchingThreads: 4
-  maxIndexingThreads: 16
+  maxIndexingThreads: 18
+fileSendDelay: false


### PR DESCRIPTION
We suspect that this IndexReader not being closed is responsible for hanging deleted file handles.

There is a second commit which is unrelated, just adds a comment and changes the config for YelpReviewsTest.