### PR TITLE
Add searcher slice params to live settings

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
@@ -373,6 +373,10 @@ message LiveSettingsRequest {
     double indexRamBufferSizeMB = 5;
     //Max number of documents to add at a time.
     int32 addDocumentsMaxBufferLen = 6;
+    //Maximum number of documents allowed in a parallel search slice.
+    int32 sliceMaxDocs = 7;
+    //Maximum number of segments allowed in a parallel search slice.
+    int32 sliceMaxSegments = 8;
 }
 
 /* Response from Server to liveSettings */

--- a/grpc-gateway/luceneserver.swagger.json
+++ b/grpc-gateway/luceneserver.swagger.json
@@ -2640,6 +2640,16 @@
           "type": "integer",
           "format": "int32",
           "description": "Max number of documents to add at a time."
+        },
+        "sliceMaxDocs": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of documents allowed in a parallel search slice."
+        },
+        "sliceMaxSegments": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of segments allowed in a parallel search slice."
         }
       },
       "title": "Input to liveSettings"

--- a/src/main/java/com/yelp/nrtsearch/server/cli/LiveSettingsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/server/cli/LiveSettingsCommand.java
@@ -65,6 +65,20 @@ public class LiveSettingsCommand implements Callable<Integer> {
       defaultValue = "100")
   private int addDocumentsMaxBufferLen;
 
+  @CommandLine.Option(
+      names = {"--sliceMaxDocs"},
+      description =
+          "Max documents per index slice, or 0 to keep current value. (default: ${DEFAULT-VALUE})",
+      defaultValue = "0")
+  private int sliceMaxDocs;
+
+  @CommandLine.Option(
+      names = {"--sliceMaxSegments"},
+      description =
+          "Max segments per index slice, or 0 to keep current value. (default: ${DEFAULT-VALUE})",
+      defaultValue = "0")
+  private int sliceMaxSegments;
+
   public String getIndexName() {
     return indexName;
   }
@@ -89,6 +103,14 @@ public class LiveSettingsCommand implements Callable<Integer> {
     return addDocumentsMaxBufferLen;
   }
 
+  public int getSliceMaxDocs() {
+    return sliceMaxDocs;
+  }
+
+  public int getSliceMaxSegments() {
+    return sliceMaxSegments;
+  }
+
   @Override
   public Integer call() throws Exception {
     LuceneServerClient client = baseCmd.getClient();
@@ -99,7 +121,9 @@ public class LiveSettingsCommand implements Callable<Integer> {
           getMinRefreshSec(),
           getMaxSearcherAgeSec(),
           getIndexRamBufferSizeMB(),
-          getAddDocumentsMaxBufferLen());
+          getAddDocumentsMaxBufferLen(),
+          getSliceMaxDocs(),
+          getSliceMaxSegments());
     } finally {
       client.shutdown();
     }

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
@@ -95,18 +95,22 @@ public class LuceneServerClient {
       double minRefreshSec,
       double maxSearcherAgeSec,
       double indexRamBufferSizeMB,
-      int addDocumentsMaxBufferLen) {
+      int addDocumentsMaxBufferLen,
+      int sliceMaxDocs,
+      int sliceMaxSegments) {
     logger.info(
         String.format(
             "will try to update liveSettings for indexName: %s, "
                 + "maxRefreshSec: %s, minRefreshSec: %s, maxSearcherAgeSec: %s, "
-                + "indexRamBufferSizeMB: %s, addDocumentsMaxBufferLen: %s ",
+                + "indexRamBufferSizeMB: %s, addDocumentsMaxBufferLen: %s, sliceMaxDocs: %s, sliceMaxSegments: %s ",
             indexName,
             maxRefreshSec,
             minRefreshSec,
             maxSearcherAgeSec,
             indexRamBufferSizeMB,
-            addDocumentsMaxBufferLen));
+            addDocumentsMaxBufferLen,
+            sliceMaxDocs,
+            sliceMaxSegments));
     LiveSettingsRequest request =
         LiveSettingsRequest.newBuilder()
             .setIndexName(indexName)
@@ -115,6 +119,8 @@ public class LuceneServerClient {
             .setMaxSearcherAgeSec(maxSearcherAgeSec)
             .setIndexRamBufferSizeMB(indexRamBufferSizeMB)
             .setAddDocumentsMaxBufferLen(addDocumentsMaxBufferLen)
+            .setSliceMaxDocs(sliceMaxDocs)
+            .setSliceMaxSegments(sliceMaxSegments)
             .build();
     LiveSettingsResponse response;
     try {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/LiveSettingsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/LiveSettingsHandler.java
@@ -54,6 +54,15 @@ public class LiveSettingsHandler implements Handler<LiveSettingsRequest, LiveSet
               "set addDocumentsMaxBufferLen: %s",
               liveSettingsRequest.getAddDocumentsMaxBufferLen()));
     }
+    if (liveSettingsRequest.getSliceMaxDocs() != 0) {
+      indexState.setSliceMaxDocs(liveSettingsRequest.getSliceMaxDocs());
+      logger.info(String.format("set sliceMaxDocs: %s", liveSettingsRequest.getSliceMaxDocs()));
+    }
+    if (liveSettingsRequest.getSliceMaxSegments() != 0) {
+      indexState.setSliceMaxSegments(liveSettingsRequest.getSliceMaxSegments());
+      logger.info(
+          String.format("set sliceMaxSegments: %s", liveSettingsRequest.getSliceMaxSegments()));
+    }
     String response = indexState.getLiveSettingsJSON();
     LiveSettingsResponse reply = LiveSettingsResponse.newBuilder().setResponse(response).build();
     return reply;

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
@@ -499,7 +499,13 @@ public class SearchHandler implements Handler<SearchRequest, SearchResponse> {
 
       SearcherTaxonomyManager.SearcherAndTaxonomy result =
           new SearcherTaxonomyManager.SearcherAndTaxonomy(
-              new MyIndexSearcher(r, threadPoolExecutor), s.taxonomyReader);
+              new MyIndexSearcher(
+                  r,
+                  new MyIndexSearcher.ExecutorWithParams(
+                      threadPoolExecutor,
+                      state.indexState.getSliceMaxDocs(),
+                      state.indexState.getSliceMaxSegments())),
+              s.taxonomyReader);
       state.slm.record(result.searcher);
       long t1 = System.nanoTime();
       if (diagnostics != null) {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -84,7 +84,7 @@ import org.slf4j.LoggerFactory;
 
 public class ShardState implements Closeable {
   public static final int REPLICA_ID = 0;
-  private final ThreadPoolExecutor searchExecutor;
+  final ThreadPoolExecutor searchExecutor;
   Logger logger = LoggerFactory.getLogger(ShardState.class);
 
   /** {@link IndexState} for the index this shard belongs to */
@@ -453,7 +453,11 @@ public class ShardState implements Closeable {
     @Override
     public IndexSearcher newSearcher(IndexReader reader, IndexReader previousReader)
         throws IOException {
-      IndexSearcher searcher = new MyIndexSearcher(reader, searchExecutor);
+      IndexSearcher searcher =
+          new MyIndexSearcher(
+              reader,
+              new MyIndexSearcher.ExecutorWithParams(
+                  searchExecutor, indexState.getSliceMaxDocs(), indexState.getSliceMaxSegments()));
       searcher.setSimilarity(indexState.sim);
       if (loadEagerOrdinals) {
         loadEagerGlobalOrdinals(reader);
@@ -722,7 +726,13 @@ public class ShardState implements Closeable {
                 @Override
                 public IndexSearcher newSearcher(IndexReader r, IndexReader previousReader)
                     throws IOException {
-                  IndexSearcher searcher = new MyIndexSearcher(r, searchExecutor);
+                  IndexSearcher searcher =
+                      new MyIndexSearcher(
+                          r,
+                          new MyIndexSearcher.ExecutorWithParams(
+                              searchExecutor,
+                              indexState.getSliceMaxDocs(),
+                              indexState.getSliceMaxSegments()));
                   searcher.setSimilarity(indexState.sim);
                   return searcher;
                 }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/IndexStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/IndexStateTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import com.google.gson.JsonObject;
+import com.yelp.nrtsearch.server.LuceneServerTestConfigurationFactory;
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.grpc.LiveSettingsRequest;
+import com.yelp.nrtsearch.server.grpc.Mode;
+import com.yelp.nrtsearch.server.luceneserver.field.FieldDefCreator;
+import com.yelp.nrtsearch.server.luceneserver.similarity.SimilarityCreator;
+import java.io.IOException;
+import java.util.Collections;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class IndexStateTest {
+
+  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+
+  @Test
+  public void testDefaultSliceParams() throws IOException {
+    try (GlobalState globalState = getInitState()) {
+      IndexState indexState = new IndexState(globalState, "testIdx", null, true, false);
+      assertEquals(IndexState.DEFAULT_SLICE_MAX_DOCS, indexState.getSliceMaxDocs());
+      assertEquals(IndexState.DEFAULT_SLICE_MAX_SEGMENTS, indexState.getSliceMaxSegments());
+    }
+  }
+
+  @Test
+  public void testChangeSliceParams() throws IOException {
+    try (GlobalState globalState = getInitState()) {
+      IndexState indexState = new IndexState(globalState, "testIdx", null, true, false);
+      indexState.setSliceMaxDocs(100);
+      indexState.setSliceMaxSegments(50);
+      assertEquals(100, indexState.getSliceMaxDocs());
+      assertEquals(50, indexState.getSliceMaxSegments());
+    }
+  }
+
+  @Test
+  public void testInvalidSliceDocs() throws IOException {
+    String expectedMessage = "Max slice docs must be greater than 0.";
+    try (GlobalState globalState = getInitState()) {
+      IndexState indexState = new IndexState(globalState, "testIdx", null, true, false);
+      try {
+        indexState.setSliceMaxDocs(0);
+        fail();
+      } catch (IllegalArgumentException e) {
+        assertEquals(expectedMessage, e.getMessage());
+      }
+      try {
+        indexState.setSliceMaxDocs(-1);
+        fail();
+      } catch (IllegalArgumentException e) {
+        assertEquals(expectedMessage, e.getMessage());
+      }
+    }
+  }
+
+  @Test
+  public void testInvalidSliceSegments() throws IOException {
+    String expectedMessage = "Max slice segments must be greater than 0.";
+    try (GlobalState globalState = getInitState()) {
+      IndexState indexState = new IndexState(globalState, "testIdx", null, true, false);
+      try {
+        indexState.setSliceMaxSegments(0);
+        fail();
+      } catch (IllegalArgumentException e) {
+        assertEquals(expectedMessage, e.getMessage());
+      }
+      try {
+        indexState.setSliceMaxSegments(-1);
+        fail();
+      } catch (IllegalArgumentException e) {
+        assertEquals(expectedMessage, e.getMessage());
+      }
+    }
+  }
+
+  @Test
+  public void testSliceParamsLoad() throws IOException {
+    try (GlobalState globalState = getInitState()) {
+      IndexState indexState = new IndexState(globalState, "testIdx", null, true, false);
+      indexState.setSliceMaxDocs(200);
+      indexState.setSliceMaxSegments(75);
+
+      JsonObject saveState = indexState.getSaveState();
+      LiveSettingsRequest liveSettingsRequest =
+          indexState.buildLiveSettingsRequest(saveState.get("liveSettings").toString());
+      assertEquals(200, liveSettingsRequest.getSliceMaxDocs());
+      assertEquals(75, liveSettingsRequest.getSliceMaxSegments());
+    }
+  }
+
+  @Test
+  public void testSliceParamsSetByLiveSettingsHandler() throws IOException {
+    try (GlobalState globalState = getInitState()) {
+      IndexState indexState = new IndexState(globalState, "testIdx", null, true, false);
+      LiveSettingsRequest liveSettingsRequest =
+          LiveSettingsRequest.newBuilder().setSliceMaxDocs(300).setSliceMaxSegments(150).build();
+      new LiveSettingsHandler().handle(indexState, liveSettingsRequest);
+
+      assertEquals(300, indexState.getSliceMaxDocs());
+      assertEquals(150, indexState.getSliceMaxSegments());
+    }
+  }
+
+  @Test
+  public void testSliceParamsLiveSettingsHandlerNoop() throws IOException {
+    try (GlobalState globalState = getInitState()) {
+      IndexState indexState = new IndexState(globalState, "testIdx", null, true, false);
+      LiveSettingsRequest liveSettingsRequest = LiveSettingsRequest.newBuilder().build();
+      new LiveSettingsHandler().handle(indexState, liveSettingsRequest);
+
+      assertEquals(IndexState.DEFAULT_SLICE_MAX_DOCS, indexState.getSliceMaxDocs());
+      assertEquals(IndexState.DEFAULT_SLICE_MAX_SEGMENTS, indexState.getSliceMaxSegments());
+    }
+  }
+
+  public GlobalState getInitState() throws IOException {
+    LuceneServerConfiguration luceneServerConfiguration =
+        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
+    FieldDefCreator.initialize(luceneServerConfiguration, Collections.emptyList());
+    SimilarityCreator.initialize(luceneServerConfiguration, Collections.emptyList());
+    return new GlobalState(luceneServerConfiguration);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/MyIndexSearcherTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/MyIndexSearcherTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
+import com.yelp.nrtsearch.server.grpc.LiveSettingsRequest;
+import com.yelp.nrtsearch.server.luceneserver.MyIndexSearcher.ExecutorWithParams;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager.SearcherAndTaxonomy;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.search.IndexSearcher.LeafSlice;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class MyIndexSearcherTest extends ServerTestCase {
+  private static final String DOCS_INDEX = "test_index_docs";
+  private static final String SEGMENTS_INDEX = "test_index_segments";
+  private static final int NUM_DOCS = 100;
+  private static final int SEGMENT_CHUNK = 10;
+
+  @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  @Override
+  public List<String> getIndices() {
+    return Arrays.asList(DOCS_INDEX, SEGMENTS_INDEX);
+  }
+
+  @Override
+  public FieldDefRequest getIndexDef(String name) throws IOException {
+    if (DOCS_INDEX.equals(name)) {
+      return getFieldsFromResourceFile("/search/IndexSearcherDocsRegisterFields.json");
+    } else if (SEGMENTS_INDEX.equals(name)) {
+      return getFieldsFromResourceFile("/search/IndexSearcherSegmentsRegisterFields.json");
+    }
+    throw new IllegalArgumentException("Unknown index: " + name);
+  }
+
+  @Override
+  public void initIndex(String name) throws Exception {
+    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    // don't want any merges for these tests
+    writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
+
+    // create a shuffled list of ids
+    List<Integer> idList = new ArrayList<>();
+    for (int i = 0; i < NUM_DOCS; ++i) {
+      idList.add(i);
+    }
+    Collections.shuffle(idList);
+
+    // add documents one chunk at a time to ensure multiple index segments
+    List<AddDocumentRequest> requestChunk = new ArrayList<>();
+    for (Integer id : idList) {
+      requestChunk.add(
+          AddDocumentRequest.newBuilder()
+              .setIndexName(name)
+              .putFields(
+                  "doc_id",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(id))
+                      .build())
+              .putFields(
+                  "int_score",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(NUM_DOCS - id))
+                      .build())
+              .putFields(
+                  "int_field",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(id))
+                      .build())
+              .build());
+
+      if (requestChunk.size() == SEGMENT_CHUNK) {
+        addDocuments(requestChunk.stream());
+        requestChunk.clear();
+        writer.commit();
+      }
+    }
+  }
+
+  @Override
+  public LiveSettingsRequest getLiveSettings(String name) {
+    if (DOCS_INDEX.equals(name)) {
+      return LiveSettingsRequest.newBuilder()
+          .setIndexName(name)
+          .setSliceMaxDocs(25)
+          .setSliceMaxSegments(10)
+          .build();
+    } else if (SEGMENTS_INDEX.equals(name)) {
+      return LiveSettingsRequest.newBuilder()
+          .setIndexName(name)
+          .setSliceMaxDocs(1000)
+          .setSliceMaxSegments(4)
+          .build();
+    }
+    throw new IllegalArgumentException("Unknown index: " + name);
+  }
+
+  @Test
+  public void testHasSliceParams() throws IOException {
+    assertSliceParams(DOCS_INDEX, 25, 10);
+    assertSliceParams(SEGMENTS_INDEX, 1000, 4);
+  }
+
+  private void assertSliceParams(String index, int maxDocs, int maxSegments) throws IOException {
+    SearcherAndTaxonomy s = null;
+    ShardState shardState = getGlobalState().getIndex(index).getShard(0);
+    try {
+      s = shardState.acquire();
+      assertTrue(s.searcher instanceof MyIndexSearcher);
+      MyIndexSearcher searcher = (MyIndexSearcher) s.searcher;
+      assertTrue(searcher.getExecutor() instanceof MyIndexSearcher.ExecutorWithParams);
+      MyIndexSearcher.ExecutorWithParams params =
+          (MyIndexSearcher.ExecutorWithParams) searcher.getExecutor();
+      assertSame(shardState.searchExecutor, params.wrapped);
+      assertEquals(maxDocs, params.sliceMaxDocs);
+      assertEquals(maxSegments, params.sliceMaxSegments);
+    } finally {
+      if (s != null) {
+        shardState.release(s);
+      }
+    }
+  }
+
+  @Test
+  public void testSliceDocsLimit() throws IOException {
+    SearcherAndTaxonomy s = null;
+    ShardState shardState = getGlobalState().getIndex(DOCS_INDEX).getShard(0);
+    try {
+      s = shardState.acquire();
+      LeafSlice[] slices = s.searcher.getSlices();
+      assertEquals(4, slices.length);
+      assertEquals(3, slices[0].leaves.length);
+      assertEquals(3, slices[1].leaves.length);
+      assertEquals(3, slices[2].leaves.length);
+      assertEquals(1, slices[3].leaves.length);
+    } finally {
+      if (s != null) {
+        shardState.release(s);
+      }
+    }
+  }
+
+  @Test
+  public void testSliceSegmentsLimit() throws IOException {
+    SearcherAndTaxonomy s = null;
+    ShardState shardState = getGlobalState().getIndex(SEGMENTS_INDEX).getShard(0);
+    try {
+      s = shardState.acquire();
+      LeafSlice[] slices = s.searcher.getSlices();
+      assertEquals(3, slices.length);
+      assertEquals(4, slices[0].leaves.length);
+      assertEquals(4, slices[1].leaves.length);
+      assertEquals(2, slices[2].leaves.length);
+    } finally {
+      if (s != null) {
+        shardState.release(s);
+      }
+    }
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNullWrappedExecutor() throws IOException {
+    new ExecutorWithParams(null, 10, 10);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/ServerTestCase.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/ServerTestCase.java
@@ -26,6 +26,7 @@ import com.yelp.nrtsearch.server.grpc.AddDocumentResponse;
 import com.yelp.nrtsearch.server.grpc.CreateIndexRequest;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
 import com.yelp.nrtsearch.server.grpc.GrpcServer;
+import com.yelp.nrtsearch.server.grpc.LiveSettingsRequest;
 import com.yelp.nrtsearch.server.grpc.LuceneServerClientBuilder;
 import com.yelp.nrtsearch.server.grpc.LuceneServerGrpc;
 import com.yelp.nrtsearch.server.grpc.Mode;
@@ -229,6 +230,9 @@ public class ServerTestCase {
       // register fields
       blockingStub.registerFields(getIndexDef(indexName));
 
+      // apply live settings
+      blockingStub.liveSettings(getLiveSettings(indexName));
+
       // start the index
       StartIndexRequest.Builder startIndexBuilder =
           StartIndexRequest.newBuilder().setIndexName(indexName);
@@ -248,6 +252,10 @@ public class ServerTestCase {
 
   protected FieldDefRequest getIndexDef(String name) throws IOException {
     return getFieldsFromResourceFile("/registerFieldsBasic.json");
+  }
+
+  protected LiveSettingsRequest getLiveSettings(String name) {
+    return LiveSettingsRequest.newBuilder().setIndexName(name).build();
   }
 
   protected void initIndex(String name) throws Exception {}

--- a/src/test/resources/search/IndexSearcherDocsRegisterFields.json
+++ b/src/test/resources/search/IndexSearcherDocsRegisterFields.json
@@ -1,0 +1,21 @@
+{
+  "indexName": "test_index_docs",
+  "field": [
+    {
+      "name": "doc_id",
+      "type": "ATOM",
+      "storeDocValues": true
+    },
+    {
+      "name": "int_score",
+      "type": "INT",
+      "storeDocValues": true
+    },
+    {
+      "name": "int_field",
+      "type": "INT",
+      "search": true,
+      "storeDocValues": true
+    }
+  ]
+}

--- a/src/test/resources/search/IndexSearcherSegmentsRegisterFields.json
+++ b/src/test/resources/search/IndexSearcherSegmentsRegisterFields.json
@@ -1,0 +1,21 @@
+{
+  "indexName": "test_index_segments",
+  "field": [
+    {
+      "name": "doc_id",
+      "type": "ATOM",
+      "storeDocValues": true
+    },
+    {
+      "name": "int_score",
+      "type": "INT",
+      "storeDocValues": true
+    },
+    {
+      "name": "int_field",
+      "type": "INT",
+      "search": true,
+      "storeDocValues": true
+    }
+  ]
+}


### PR DESCRIPTION
Makes the max documents/segments for a parallel search index slice configurable through the index live settings.

Making these settings available during slice construction is a little tricky. The slices are build directly from the super class constructor in our IndexSearcher. This happens prior to any instance members being set in the child class. I have worked around it by wrapping the parameters in the search executor, but this is a bit hacky. It might be worth seeing if this interface has/could be improved through a contribution to lucene, at some point.