### PR TITLE
Add virtual sharding

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
@@ -377,6 +377,8 @@ message LiveSettingsRequest {
     int32 sliceMaxDocs = 7;
     //Maximum number of segments allowed in a parallel search slice.
     int32 sliceMaxSegments = 8;
+    //Number of virtual shards to use for this index.
+    int32 virtualShards = 9;
 }
 
 /* Response from Server to liveSettings */

--- a/grpc-gateway/luceneserver.swagger.json
+++ b/grpc-gateway/luceneserver.swagger.json
@@ -2650,6 +2650,11 @@
           "type": "integer",
           "format": "int32",
           "description": "Maximum number of segments allowed in a parallel search slice."
+        },
+        "virtualShards": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of virtual shards to use for this index."
         }
       },
       "title": "Input to liveSettings"

--- a/src/main/java/com/yelp/nrtsearch/server/cli/LiveSettingsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/server/cli/LiveSettingsCommand.java
@@ -79,6 +79,13 @@ public class LiveSettingsCommand implements Callable<Integer> {
       defaultValue = "0")
   private int sliceMaxSegments;
 
+  @CommandLine.Option(
+      names = {"--virtualShards"},
+      description =
+          "Number of virtual shards to partition index into, or 0 to keep current value. (default: ${DEFAULT-VALUE})",
+      defaultValue = "0")
+  private int virtualShards;
+
   public String getIndexName() {
     return indexName;
   }
@@ -111,6 +118,10 @@ public class LiveSettingsCommand implements Callable<Integer> {
     return sliceMaxSegments;
   }
 
+  public int getVirtualShards() {
+    return virtualShards;
+  }
+
   @Override
   public Integer call() throws Exception {
     LuceneServerClient client = baseCmd.getClient();
@@ -123,7 +134,8 @@ public class LiveSettingsCommand implements Callable<Integer> {
           getIndexRamBufferSizeMB(),
           getAddDocumentsMaxBufferLen(),
           getSliceMaxDocs(),
-          getSliceMaxSegments());
+          getSliceMaxSegments(),
+          getVirtualShards());
     } finally {
       client.shutdown();
     }

--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -67,6 +67,7 @@ public class LuceneServerConfiguration {
   private final IndexPreloadConfig preloadConfig;
   private final boolean downloadAsStream;
   private final boolean fileSendDelay;
+  private final boolean virtualSharding;
 
   private final YamlConfigReader configReader;
 
@@ -105,6 +106,7 @@ public class LuceneServerConfiguration {
     preloadConfig = IndexPreloadConfig.fromConfig(configReader);
     downloadAsStream = configReader.getBoolean("downloadAsStream", false);
     fileSendDelay = configReader.getBoolean("fileSendDelay", true);
+    virtualSharding = configReader.getBoolean("virtualSharding", false);
     threadPoolConfiguration = new ThreadPoolConfiguration(configReader);
   }
 
@@ -186,6 +188,10 @@ public class LuceneServerConfiguration {
 
   public boolean getFileSendDelay() {
     return fileSendDelay;
+  }
+
+  public boolean getVirtualSharding() {
+    return virtualSharding;
   }
 
   public YamlConfigReader getConfigReader() {

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
@@ -97,12 +97,13 @@ public class LuceneServerClient {
       double indexRamBufferSizeMB,
       int addDocumentsMaxBufferLen,
       int sliceMaxDocs,
-      int sliceMaxSegments) {
+      int sliceMaxSegments,
+      int virtualShards) {
     logger.info(
         String.format(
             "will try to update liveSettings for indexName: %s, "
                 + "maxRefreshSec: %s, minRefreshSec: %s, maxSearcherAgeSec: %s, "
-                + "indexRamBufferSizeMB: %s, addDocumentsMaxBufferLen: %s, sliceMaxDocs: %s, sliceMaxSegments: %s ",
+                + "indexRamBufferSizeMB: %s, addDocumentsMaxBufferLen: %s, sliceMaxDocs: %s, sliceMaxSegments: %s, virtualShards: %s ",
             indexName,
             maxRefreshSec,
             minRefreshSec,
@@ -110,7 +111,8 @@ public class LuceneServerClient {
             indexRamBufferSizeMB,
             addDocumentsMaxBufferLen,
             sliceMaxDocs,
-            sliceMaxSegments));
+            sliceMaxSegments,
+            virtualShards));
     LiveSettingsRequest request =
         LiveSettingsRequest.newBuilder()
             .setIndexName(indexName)
@@ -121,6 +123,7 @@ public class LuceneServerClient {
             .setAddDocumentsMaxBufferLen(addDocumentsMaxBufferLen)
             .setSliceMaxDocs(sliceMaxDocs)
             .setSliceMaxSegments(sliceMaxSegments)
+            .setVirtualShards(virtualShards)
             .build();
     LiveSettingsResponse response;
     try {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/LiveSettingsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/LiveSettingsHandler.java
@@ -63,6 +63,10 @@ public class LiveSettingsHandler implements Handler<LiveSettingsRequest, LiveSet
       logger.info(
           String.format("set sliceMaxSegments: %s", liveSettingsRequest.getSliceMaxSegments()));
     }
+    if (liveSettingsRequest.getVirtualShards() != 0) {
+      indexState.setVirtualShards(liveSettingsRequest.getVirtualShards());
+      logger.info(String.format("set virtualShards: %s", liveSettingsRequest.getVirtualShards()));
+    }
     String response = indexState.getLiveSettingsJSON();
     LiveSettingsResponse reply = LiveSettingsResponse.newBuilder().setResponse(response).build();
     return reply;

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
@@ -504,7 +504,8 @@ public class SearchHandler implements Handler<SearchRequest, SearchResponse> {
                   new MyIndexSearcher.ExecutorWithParams(
                       threadPoolExecutor,
                       state.indexState.getSliceMaxDocs(),
-                      state.indexState.getSliceMaxSegments())),
+                      state.indexState.getSliceMaxSegments(),
+                      state.indexState.getVirtualShards())),
               s.taxonomyReader);
       state.slm.record(result.searcher);
       long t1 = System.nanoTime();

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -457,7 +457,10 @@ public class ShardState implements Closeable {
           new MyIndexSearcher(
               reader,
               new MyIndexSearcher.ExecutorWithParams(
-                  searchExecutor, indexState.getSliceMaxDocs(), indexState.getSliceMaxSegments()));
+                  searchExecutor,
+                  indexState.getSliceMaxDocs(),
+                  indexState.getSliceMaxSegments(),
+                  indexState.getVirtualShards()));
       searcher.setSimilarity(indexState.sim);
       if (loadEagerOrdinals) {
         loadEagerGlobalOrdinals(reader);
@@ -732,7 +735,8 @@ public class ShardState implements Closeable {
                           new MyIndexSearcher.ExecutorWithParams(
                               searchExecutor,
                               indexState.getSliceMaxDocs(),
-                              indexState.getSliceMaxSegments()));
+                              indexState.getSliceMaxSegments(),
+                              indexState.getVirtualShards()));
                   searcher.setSimilarity(indexState.sim);
                   return searcher;
                 }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/BucketedTieredMergePolicy.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/BucketedTieredMergePolicy.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.index;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.function.IntSupplier;
+import java.util.stream.Collectors;
+import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.MergeTrigger;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.index.TieredMergePolicy;
+
+/**
+ * Merge policy that tries to divide the index into even sized buckets. Prior to any merge
+ * decisions, the index segments are divided into n buckets as evenly as possible. Merges are found
+ * for each segment set independently as if it were its own index, managed by a {@link
+ * TieredMergePolicy}.
+ */
+public class BucketedTieredMergePolicy extends TieredMergePolicy {
+  private final IntSupplier bucketCountSupplier;
+  final LinkedList<Set<String>> pendingMerges = new LinkedList<>();
+
+  /** Class to hold a bucket's segment set and current live document count. */
+  private static class MergeBucket {
+    SegmentInfos bucketInfos;
+    long liveDocCount;
+
+    MergeBucket(int majorVersion) {
+      bucketInfos = new SegmentInfos(majorVersion);
+      liveDocCount = 0;
+    }
+
+    void add(SegmentCommitInfo sci, long liveDocs) {
+      bucketInfos.add(sci);
+      liveDocCount += liveDocs;
+    }
+
+    void addAll(Iterable<SegmentCommitInfo> infos, long totalLiveDocs) {
+      bucketInfos.addAll(infos);
+      liveDocCount += totalLiveDocs;
+    }
+  }
+
+  /**
+   * Interface for a single unit of index segments. This could be an individual segment, or a set of
+   * segments that are part of a pending merge.
+   */
+  private interface MergeUnit {
+    /** Get the total number of live documents in the index unit. */
+    long getLiveDocCount();
+
+    /** Add the segments this unit represents into a MergeBucket. */
+    void addToBucket(MergeBucket bucket);
+  }
+
+  /** MergeUnit representing a single index segment. */
+  private static class SingleSegment implements MergeUnit {
+    final SegmentCommitInfo info;
+    final long liveDocCount;
+
+    SingleSegment(SegmentCommitInfo sci) {
+      info = sci;
+      liveDocCount = (sci.info.maxDoc() - sci.getDelCount());
+    }
+
+    @Override
+    public long getLiveDocCount() {
+      return liveDocCount;
+    }
+
+    @Override
+    public void addToBucket(MergeBucket bucket) {
+      bucket.add(info, liveDocCount);
+    }
+  }
+
+  /** MergeUnit representing a collection of index segments. */
+  private static class MultiSegment implements MergeUnit {
+    List<SegmentCommitInfo> infos = new ArrayList<>();
+    long liveDocCount = 0;
+
+    void add(SegmentCommitInfo sci) {
+      infos.add(sci);
+      liveDocCount += (sci.info.maxDoc() - sci.getDelCount());
+    }
+
+    @Override
+    public long getLiveDocCount() {
+      return liveDocCount;
+    }
+
+    @Override
+    public void addToBucket(MergeBucket bucket) {
+      bucket.addAll(infos, liveDocCount);
+    }
+  }
+
+  /**
+   * Interface to run a super class merge function. Like a standard {@link
+   * java.util.function.Function}, but throws a checked {@link IOException}.
+   */
+  @FunctionalInterface
+  interface BucketMergeFunc<T, R> {
+    R apply(T t) throws IOException;
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param bucketCountSupplier provides the current number of buckets for the index, this value may
+   *     change between calls
+   */
+  public BucketedTieredMergePolicy(IntSupplier bucketCountSupplier) {
+    this.bucketCountSupplier = bucketCountSupplier;
+  }
+
+  @Override
+  public MergePolicy.MergeSpecification findMerges(
+      MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergePolicy.MergeContext mergeContext)
+      throws IOException {
+
+    final int buckets = bucketCountSupplier.getAsInt();
+    if (buckets > 1) {
+      return findForSegmentInfos(
+          buckets, segmentInfos, infos -> super.findMerges(mergeTrigger, infos, mergeContext));
+    } else {
+      return super.findMerges(mergeTrigger, segmentInfos, mergeContext);
+    }
+  }
+
+  @Override
+  public MergePolicy.MergeSpecification findForcedMerges(
+      SegmentInfos segmentInfos,
+      int maxSegmentCount,
+      Map<SegmentCommitInfo, Boolean> segmentsToMerge,
+      MergePolicy.MergeContext mergeContext)
+      throws IOException {
+
+    final int buckets = bucketCountSupplier.getAsInt();
+    if (buckets > 1) {
+      return findForSegmentInfos(
+          buckets,
+          segmentInfos,
+          infos -> super.findForcedMerges(infos, maxSegmentCount, segmentsToMerge, mergeContext));
+    } else {
+      return super.findForcedMerges(segmentInfos, maxSegmentCount, segmentsToMerge, mergeContext);
+    }
+  }
+
+  @Override
+  public MergePolicy.MergeSpecification findForcedDeletesMerges(
+      SegmentInfos segmentInfos, MergePolicy.MergeContext mergeContext) throws IOException {
+    final int buckets = bucketCountSupplier.getAsInt();
+
+    if (buckets > 1) {
+      return findForSegmentInfos(
+          buckets, segmentInfos, infos -> super.findForcedDeletesMerges(infos, mergeContext));
+    } else {
+      return super.findForcedDeletesMerges(segmentInfos, mergeContext);
+    }
+  }
+
+  MergePolicy.MergeSpecification findForSegmentInfos(
+      int buckets,
+      SegmentInfos segmentInfos,
+      BucketMergeFunc<SegmentInfos, MergeSpecification> bucketFunc)
+      throws IOException {
+    // sort index merge units in descending order
+    List<MergeUnit> sortedMergeUnits = getMergeUnits(segmentInfos);
+    sortedMergeUnits.sort(Comparator.comparingLong(MergeUnit::getLiveDocCount).reversed());
+
+    // create buckets
+    PriorityQueue<MergeBucket> bucketQueue =
+        new PriorityQueue<>(buckets, Comparator.comparingLong(mb -> mb.liveDocCount));
+    for (int i = 0; i < buckets; ++i) {
+      bucketQueue.add(new MergeBucket(segmentInfos.getIndexCreatedVersionMajor()));
+    }
+
+    // add each merge unit in sequence to the bucket with the lowest live documents
+    for (MergeUnit mu : sortedMergeUnits) {
+      MergeBucket mb = bucketQueue.poll();
+      mu.addToBucket(mb);
+      bucketQueue.add(mb);
+    }
+
+    // find merges for each bucket and aggregate them
+    MergeSpecification aggregateMerges = new MergeSpecification();
+    while (!bucketQueue.isEmpty()) {
+      MergeBucket mb = bucketQueue.poll();
+      if (mb.bucketInfos.size() > 0) {
+        MergeSpecification bucketMerges = bucketFunc.apply(mb.bucketInfos);
+        if (bucketMerges != null) {
+          for (OneMerge om : bucketMerges.merges) {
+            aggregateMerges.add(om);
+            addPendingMerge(om);
+          }
+        }
+      }
+    }
+    if (aggregateMerges.merges.size() > 0) {
+      return aggregateMerges;
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Group the current index segments into merge units.
+   *
+   * @param infos current index segments info
+   * @return unsorted list of merge units
+   */
+  private List<MergeUnit> getMergeUnits(SegmentInfos infos) {
+    // create mapping of segment name to meta data
+    Map<String, SegmentCommitInfo> infoMap = new HashMap<>();
+    for (SegmentCommitInfo sci : infos) {
+      infoMap.put(sci.info.name, sci);
+    }
+
+    List<MergeUnit> unitList = new ArrayList<>();
+
+    // group segments that are part of a pending merge
+    ListIterator<Set<String>> pendingIterator = pendingMerges.listIterator();
+    while (pendingIterator.hasNext()) {
+      Set<String> mergeSegments = pendingIterator.next();
+      MultiSegment multiSegment = new MultiSegment();
+      boolean skip = false;
+      for (String name : mergeSegments) {
+        SegmentCommitInfo mergeSegmentInfo = infoMap.get(name);
+        if (mergeSegmentInfo == null) {
+          // this merge is done
+          pendingIterator.remove();
+          skip = true;
+          break;
+        }
+        multiSegment.add(mergeSegmentInfo);
+      }
+      if (skip) {
+        continue;
+      }
+      for (String name : mergeSegments) {
+        infoMap.remove(name);
+      }
+      unitList.add(multiSegment);
+    }
+    // add remaining segments a single merge units
+    for (Map.Entry<String, SegmentCommitInfo> entry : infoMap.entrySet()) {
+      unitList.add(new SingleSegment(entry.getValue()));
+    }
+    return unitList;
+  }
+
+  /** Add info for this merge to the pendingMerge list. */
+  private void addPendingMerge(OneMerge merge) {
+    // add to the start of the list, so it will be looked at first when bucketing
+    pendingMerges.addFirst(
+        merge.segments.stream().map(sci -> sci.info.name).collect(Collectors.toSet()));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/MyIndexSearcherTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/MyIndexSearcherTest.java
@@ -186,6 +186,6 @@ public class MyIndexSearcherTest extends ServerTestCase {
 
   @Test(expected = NullPointerException.class)
   public void testNullWrappedExecutor() throws IOException {
-    new ExecutorWithParams(null, 10, 10);
+    new ExecutorWithParams(null, 10, 10, 1);
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/MyIndexSearcherVirtualShardsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/MyIndexSearcherVirtualShardsTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager.SearcherAndTaxonomy;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.search.IndexSearcher.LeafSlice;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class MyIndexSearcherVirtualShardsTest extends ServerTestCase {
+
+  @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  @Override
+  public FieldDefRequest getIndexDef(String name) throws IOException {
+    return getFieldsFromResourceFile("/search/VirtualShardsRegisterFields.json");
+  }
+
+  @Override
+  public void initIndex(String name) throws Exception {
+    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    // don't want any merges for these tests
+    writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
+  }
+
+  @Override
+  public String getExtraConfig() {
+    return "virtualSharding: true";
+  }
+
+  @Before
+  public void clearIndex() throws Exception {
+    IndexWriter writer = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).writer;
+    writer.deleteAll();
+  }
+
+  @Test
+  public void testVirtualShards() throws Exception {
+    setLiveSettings(4, 10000, 100);
+    addSegments(Arrays.asList(10, 10, 10, 10, 10, 10, 10));
+    assertSlices(Arrays.asList(20, 20, 20, 10), Arrays.asList(2, 2, 2, 1));
+  }
+
+  @Test
+  public void testLessVirtualShards() throws Exception {
+    setLiveSettings(4, 10000, 100);
+    addSegments(Arrays.asList(10, 10));
+    assertSlices(Arrays.asList(10, 10), Arrays.asList(1, 1));
+  }
+
+  @Test
+  public void testNoVirtualShards() throws Exception {
+    setLiveSettings(4, 10000, 100);
+    addSegments(Collections.emptyList());
+    assertSlices(Collections.emptyList(), Collections.emptyList());
+  }
+
+  @Test
+  public void testUnevenSegments() throws Exception {
+    setLiveSettings(3, 10000, 100);
+    addSegments(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
+    assertSlices(Arrays.asList(16, 15, 14), Arrays.asList(3, 3, 3));
+  }
+
+  @Test
+  public void testMaxDocs() throws Exception {
+    setLiveSettings(2, 25, 100);
+    addSegments(Arrays.asList(10, 10, 10, 10, 10, 10, 10, 10, 10));
+    assertSlices(Arrays.asList(30, 30, 20, 10), Arrays.asList(3, 3, 2, 1));
+  }
+
+  @Test
+  public void testMaxSegments() throws Exception {
+    setLiveSettings(3, 10000, 2);
+    addSegments(Arrays.asList(10, 10, 10, 10, 10, 10, 5, 4, 3));
+    assertSlices(Arrays.asList(20, 20, 20, 5, 4, 3), Arrays.asList(2, 2, 2, 1, 1, 1));
+  }
+
+  @Test
+  public void testHasVirtualShards() throws Exception {
+    setLiveSettings(111, 10000, 2);
+    addSegments(Collections.emptyList());
+    SearcherAndTaxonomy s = null;
+    ShardState shardState = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0);
+    try {
+      s = shardState.acquire();
+      assertTrue(s.searcher instanceof MyIndexSearcher);
+      MyIndexSearcher searcher = (MyIndexSearcher) s.searcher;
+      assertTrue(searcher.getExecutor() instanceof MyIndexSearcher.ExecutorWithParams);
+      MyIndexSearcher.ExecutorWithParams params =
+          (MyIndexSearcher.ExecutorWithParams) searcher.getExecutor();
+      assertEquals(111, params.virtualShards);
+    } finally {
+      if (s != null) {
+        shardState.release(s);
+      }
+    }
+  }
+
+  private void setLiveSettings(int virtualShards, int maxDocs, int maxSegments) throws IOException {
+    IndexState indexState = getGlobalState().getIndex(DEFAULT_TEST_INDEX);
+    indexState.setVirtualShards(virtualShards);
+    indexState.setSliceMaxDocs(maxDocs);
+    indexState.setSliceMaxSegments(maxSegments);
+  }
+
+  private void addSegments(Iterable<Integer> sizes) throws Exception {
+    IndexWriter writer = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).writer;
+
+    int currentVal = 0;
+    for (Integer size : sizes) {
+      List<AddDocumentRequest> requestChunk = new ArrayList<>();
+      for (int i = 0; i < size; ++i) {
+        requestChunk.add(
+            AddDocumentRequest.newBuilder()
+                .setIndexName(DEFAULT_TEST_INDEX)
+                .putFields(
+                    "doc_id",
+                    AddDocumentRequest.MultiValuedField.newBuilder()
+                        .addValue(String.valueOf(currentVal))
+                        .build())
+                .putFields(
+                    "int_score",
+                    AddDocumentRequest.MultiValuedField.newBuilder()
+                        .addValue(String.valueOf(currentVal + 1))
+                        .build())
+                .putFields(
+                    "int_field",
+                    AddDocumentRequest.MultiValuedField.newBuilder()
+                        .addValue(String.valueOf(currentVal + 2))
+                        .build())
+                .build());
+        currentVal++;
+      }
+      addDocuments(requestChunk.stream());
+      writer.commit();
+    }
+    getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).maybeRefreshBlocking();
+  }
+
+  private void assertSlices(List<Integer> docCounts, List<Integer> segmentCounts)
+      throws IOException {
+    assertEquals(docCounts.size(), segmentCounts.size());
+
+    SearcherAndTaxonomy s = null;
+    ShardState shardState = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0);
+    try {
+      s = shardState.acquire();
+      LeafSlice[] slices = s.searcher.getSlices();
+      assertEquals(docCounts.size(), slices.length);
+      for (int i = 0; i < docCounts.size(); ++i) {
+        assertEquals(segmentCounts.get(i), Integer.valueOf(slices[i].leaves.length));
+
+        int totalDocs = 0;
+        for (int j = 0; j < slices[i].leaves.length; ++j) {
+          totalDocs += slices[i].leaves[j].reader().numDocs();
+        }
+        assertEquals(docCounts.get(i), Integer.valueOf(totalDocs));
+      }
+    } finally {
+      if (s != null) {
+        shardState.release(s);
+      }
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/index/BucketedTieredMergePolicyTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/index/BucketedTieredMergePolicyTest.java
@@ -1,0 +1,473 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.index;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
+import com.yelp.nrtsearch.server.grpc.Query;
+import com.yelp.nrtsearch.server.grpc.SearchRequest;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import com.yelp.nrtsearch.server.grpc.SearchResponse.Hit;
+import com.yelp.nrtsearch.server.luceneserver.IndexState;
+import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
+import com.yelp.nrtsearch.server.luceneserver.ShardState;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager.SearcherAndTaxonomy;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.MergePolicy.MergeSpecification;
+import org.apache.lucene.index.MergePolicy.OneMerge;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.search.IndexSearcher.LeafSlice;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.Version;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class BucketedTieredMergePolicyTest extends ServerTestCase {
+
+  @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  @Override
+  public FieldDefRequest getIndexDef(String name) throws IOException {
+    return getFieldsFromResourceFile("/search/VirtualShardsRegisterFields.json");
+  }
+
+  @Override
+  public String getExtraConfig() {
+    return "virtualSharding: true";
+  }
+
+  @Before
+  public void clearIndex() throws Exception {
+    IndexWriter writer = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).writer;
+    writer.deleteAll();
+  }
+
+  @Test
+  public void testFindMerges() throws Exception {
+    setLiveSettings(5, 10000, 100);
+    addData(500);
+
+    ShardState shardState = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0);
+    MergePolicy policy = shardState.writer.getConfig().getMergePolicy();
+    assertTrue(policy instanceof BucketedTieredMergePolicy);
+
+    waitForMerges(shardState);
+    shardState.maybeRefreshBlocking();
+
+    SearcherAndTaxonomy s = null;
+    try {
+      s = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).acquire();
+      assertEquals(5, s.searcher.getSlices().length);
+      for (LeafSlice slice : s.searcher.getSlices()) {
+        assertTrue(slice.leaves.length < 100);
+        int totalDocs = 0;
+        for (LeafReaderContext context : slice.leaves) {
+          totalDocs += context.reader().numDocs();
+        }
+        assertEquals(100, totalDocs);
+      }
+    } finally {
+      if (s != null) {
+        shardState.release(s);
+      }
+    }
+    verifyData(500);
+  }
+
+  @Test
+  public void testFindForcedMerges() throws Exception {
+    setLiveSettings(10, 10000, 100);
+    addData(600);
+
+    ShardState shardState = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0);
+    shardState.writer.forceMerge(1, true);
+    waitForMerges(shardState);
+    shardState.maybeRefreshBlocking();
+
+    SearcherAndTaxonomy s = null;
+    try {
+      s = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).acquire();
+      assertEquals(10, s.searcher.getSlices().length);
+      for (LeafSlice slice : s.searcher.getSlices()) {
+        assertEquals(1, slice.leaves.length);
+        int totalDocs = 0;
+        for (LeafReaderContext context : slice.leaves) {
+          totalDocs += context.reader().numDocs();
+        }
+        assertEquals(60, totalDocs);
+      }
+    } finally {
+      if (s != null) {
+        shardState.release(s);
+      }
+    }
+    verifyData(600);
+
+    // cut virtual shards in half and re-merge
+    setLiveSettings(5, 10000, 100);
+    shardState.writer.forceMerge(1, true);
+    waitForMerges(shardState);
+    shardState.maybeRefreshBlocking();
+
+    s = null;
+    try {
+      s = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).acquire();
+      assertEquals(5, s.searcher.getSlices().length);
+      for (LeafSlice slice : s.searcher.getSlices()) {
+        assertEquals(1, slice.leaves.length);
+        int totalDocs = 0;
+        for (LeafReaderContext context : slice.leaves) {
+          totalDocs += context.reader().numDocs();
+        }
+        assertEquals(120, totalDocs);
+      }
+    } finally {
+      if (s != null) {
+        shardState.release(s);
+      }
+    }
+    verifyData(600);
+  }
+
+  private void waitForMerges(ShardState shardState) throws IOException {
+    shardState.writer.maybeMerge();
+    int tries = 600;
+    int count = 0;
+    while (shardState.writer.hasPendingMerges()) {
+      count++;
+      if (count == tries) {
+        throw new RuntimeException("Timed out waiting for merges");
+      }
+      try {
+        Thread.sleep(100);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    // for ConcurrentMergeScheduler this just forces a sync
+    shardState.writer.getConfig().getMergeScheduler().close();
+  }
+
+  private void setLiveSettings(int virtualShards, int maxDocs, int maxSegments) throws IOException {
+    IndexState indexState = getGlobalState().getIndex(DEFAULT_TEST_INDEX);
+    indexState.setVirtualShards(virtualShards);
+    indexState.setSliceMaxDocs(maxDocs);
+    indexState.setSliceMaxSegments(maxSegments);
+  }
+
+  private void addData(int count) throws Exception {
+    IndexWriter writer = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).writer;
+
+    for (int i = 0; i < count; ++i) {
+      AddDocumentRequest request =
+          AddDocumentRequest.newBuilder()
+              .setIndexName(DEFAULT_TEST_INDEX)
+              .putFields(
+                  "doc_id",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(i))
+                      .build())
+              .putFields(
+                  "int_score",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(i + 1))
+                      .build())
+              .putFields(
+                  "int_field",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(i + 2))
+                      .build())
+              .build();
+      addDocuments(Stream.of(request));
+      writer.flush();
+    }
+    getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).maybeRefreshBlocking();
+  }
+
+  private void verifyData(int docs) {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(DEFAULT_TEST_INDEX)
+                    .setTopHits(docs + 100)
+                    .setQuery(Query.newBuilder().build())
+                    .addRetrieveFields("doc_id")
+                    .addRetrieveFields("int_score")
+                    .addRetrieveFields("int_field")
+                    .build());
+    assertEquals(docs, response.getHitsCount());
+    Set<String> seenIds = new HashSet<>();
+    for (Hit hit : response.getHitsList()) {
+      String id = hit.getFieldsOrThrow("doc_id").getFieldValue(0).getTextValue();
+      seenIds.add(id);
+      assertEquals(
+          Integer.parseInt(id) + 1,
+          hit.getFieldsOrThrow("int_score").getFieldValue(0).getIntValue());
+      assertEquals(
+          Integer.parseInt(id) + 2,
+          hit.getFieldsOrThrow("int_field").getFieldValue(0).getIntValue());
+    }
+    assertEquals(docs, seenIds.size());
+    for (int i = 0; i < docs; ++i) {
+      assertTrue(seenIds.contains(String.valueOf(i)));
+    }
+  }
+
+  @Test
+  public void testBucketsForMerges() throws IOException {
+    SegmentInfos infos = getInfos(Arrays.asList(10, 10, 10, 10, 10));
+    checkBucketing(2, infos, Arrays.asList(20, 30), Arrays.asList(2, 3));
+    checkBucketing(3, infos, Arrays.asList(10, 20, 20), Arrays.asList(1, 2, 2));
+    checkBucketing(4, infos, Arrays.asList(10, 10, 10, 20), Arrays.asList(1, 1, 1, 2));
+    checkBucketing(5, infos, Arrays.asList(10, 10, 10, 10, 10), Arrays.asList(1, 1, 1, 1, 1));
+    checkBucketing(6, infos, Arrays.asList(10, 10, 10, 10, 10), Arrays.asList(1, 1, 1, 1, 1));
+
+    infos = getInfos(Arrays.asList(3, 5, 6, 7, 9));
+    checkBucketing(2, infos, Arrays.asList(14, 16), Arrays.asList(2, 3));
+    checkBucketing(3, infos, Arrays.asList(9, 10, 11), Arrays.asList(1, 2, 2));
+    checkBucketing(4, infos, Arrays.asList(6, 7, 8, 9), Arrays.asList(1, 1, 2, 1));
+  }
+
+  @Test
+  public void testBucketsByLiveDocs() throws IOException {
+    SegmentInfos infos = getInfos(Arrays.asList(3, 5, 7, 9, 10), Arrays.asList(0, 4, 3, 1, 5));
+    checkBucketing(2, infos, Arrays.asList(10, 11), Arrays.asList(3, 2));
+    checkBucketing(3, infos, Arrays.asList(6, 7, 8), Arrays.asList(2, 2, 1));
+    checkBucketing(5, infos, Arrays.asList(1, 3, 4, 5, 8), Arrays.asList(1, 1, 1, 1, 1));
+  }
+
+  @Test
+  public void testEmptyInfos() throws IOException {
+    SegmentInfos infos = getInfos(Collections.emptyList());
+    checkBucketing(2, infos, Collections.emptyList(), Collections.emptyList());
+  }
+
+  @Test
+  public void testGetsAllMerges() throws IOException {
+    SegmentInfos infos = getInfos(Arrays.asList(9, 8, 7, 6, 5));
+    List<MergeSpecification> bucketMerges = new ArrayList<>();
+
+    bucketMerges.add(new MergeSpecification());
+
+    MergeSpecification mergeSpecification = new MergeSpecification();
+    mergeSpecification.add(new OneMerge(Arrays.asList(infos.info(2), infos.info(3))));
+    bucketMerges.add(mergeSpecification);
+
+    mergeSpecification = new MergeSpecification();
+    mergeSpecification.add(new OneMerge(Arrays.asList(infos.info(1), infos.info(4))));
+    bucketMerges.add(mergeSpecification);
+
+    MergeSpecification aggregatedMerges = applyWithMerges(3, infos, bucketMerges);
+    assertEquals(2, aggregatedMerges.merges.size());
+    assertEquals(
+        bucketMerges.get(1).merges.get(0).segments, aggregatedMerges.merges.get(0).segments);
+    assertEquals(
+        bucketMerges.get(2).merges.get(0).segments, aggregatedMerges.merges.get(1).segments);
+  }
+
+  @Test
+  public void testNoMergesIsNull() throws IOException {
+    SegmentInfos infos = getInfos(Arrays.asList(9, 8, 7, 6, 5));
+    List<MergeSpecification> bucketMerges = new ArrayList<>();
+    bucketMerges.add(new MergeSpecification());
+    bucketMerges.add(new MergeSpecification());
+    bucketMerges.add(new MergeSpecification());
+    MergeSpecification aggregatedMerges = applyWithMerges(3, infos, bucketMerges);
+    assertNull(aggregatedMerges);
+  }
+
+  @Test
+  public void testTracksPendingMerges() throws IOException {
+    SegmentInfos infos = getInfos(Arrays.asList(9, 8, 7, 6, 5));
+    List<MergeSpecification> bucketMerges = new ArrayList<>();
+    BucketedTieredMergePolicy btmp = new BucketedTieredMergePolicy(() -> 3);
+
+    bucketMerges.add(new MergeSpecification());
+    MergeSpecification mergeSpecification = new MergeSpecification();
+    mergeSpecification.add(new OneMerge(Arrays.asList(infos.info(2), infos.info(3))));
+    bucketMerges.add(mergeSpecification);
+    bucketMerges.add(new MergeSpecification());
+
+    MergeSpecification aggregatedMerges = applyWithMerges(btmp, 3, infos, bucketMerges);
+    assertEquals(1, aggregatedMerges.merges.size());
+    assertEquals(
+        bucketMerges.get(1).merges.get(0).segments, aggregatedMerges.merges.get(0).segments);
+    assertEquals(1, btmp.pendingMerges.size());
+    assertEquals(Set.of("2", "3"), btmp.pendingMerges.get(0));
+
+    bucketMerges = new ArrayList<>();
+    bucketMerges.add(new MergeSpecification());
+    bucketMerges.add(new MergeSpecification());
+    mergeSpecification = new MergeSpecification();
+    mergeSpecification.add(new OneMerge(Arrays.asList(infos.info(1), infos.info(4))));
+    bucketMerges.add(mergeSpecification);
+
+    aggregatedMerges = applyWithMerges(btmp, 3, infos, bucketMerges);
+    assertEquals(1, aggregatedMerges.merges.size());
+    assertEquals(
+        bucketMerges.get(2).merges.get(0).segments, aggregatedMerges.merges.get(0).segments);
+    assertEquals(2, btmp.pendingMerges.size());
+    assertEquals(Set.of("1", "4"), btmp.pendingMerges.get(0));
+    assertEquals(Set.of("2", "3"), btmp.pendingMerges.get(1));
+  }
+
+  @Test
+  public void testRemovesCompletedMerges() throws IOException {
+    SegmentInfos infos = getInfos(Arrays.asList(10, 10, 10, 10, 10));
+    BucketedTieredMergePolicy btmp = new BucketedTieredMergePolicy(() -> 3);
+    btmp.pendingMerges.add(Set.of("1", "3"));
+    btmp.pendingMerges.add(Set.of("0", "5"));
+    btmp.pendingMerges.add(Set.of("2", "4"));
+    btmp.pendingMerges.add(Set.of("6", "7"));
+
+    checkBucketing(btmp, 3, infos, Arrays.asList(10, 20, 20), Arrays.asList(1, 2, 2));
+    assertEquals(2, btmp.pendingMerges.size());
+    assertEquals(Set.of("1", "3"), btmp.pendingMerges.get(0));
+    assertEquals(Set.of("2", "4"), btmp.pendingMerges.get(1));
+  }
+
+  @Test
+  public void testGroupsMergingSegments() throws IOException {
+    SegmentInfos infos = getInfos(Arrays.asList(3, 9, 1, 8, 1));
+    BucketedTieredMergePolicy btmp = new BucketedTieredMergePolicy(() -> 3);
+    btmp.pendingMerges.add(Set.of("0", "2", "4"));
+
+    checkBucketing(btmp, 3, infos, Arrays.asList(5, 8, 9), Arrays.asList(3, 1, 1));
+  }
+
+  @Test
+  public void testRemovesShadowedMerges() throws IOException {
+    SegmentInfos infos = getInfos(Arrays.asList(3, 9, 1, 8, 1));
+    BucketedTieredMergePolicy btmp = new BucketedTieredMergePolicy(() -> 3);
+    btmp.pendingMerges.add(Set.of("0", "1", "2"));
+    btmp.pendingMerges.add(Set.of("2", "3", "4"));
+
+    checkBucketing(btmp, 3, infos, Arrays.asList(1, 8, 13), Arrays.asList(1, 1, 3));
+    assertEquals(1, btmp.pendingMerges.size());
+    assertEquals(Set.of("0", "1", "2"), btmp.pendingMerges.get(0));
+  }
+
+  private MergeSpecification applyWithMerges(
+      int buckets, SegmentInfos infos, List<MergeSpecification> bucketMerges) throws IOException {
+    BucketedTieredMergePolicy btmp = new BucketedTieredMergePolicy(() -> buckets);
+    return applyWithMerges(btmp, buckets, infos, bucketMerges);
+  }
+
+  private MergeSpecification applyWithMerges(
+      BucketedTieredMergePolicy btmp,
+      int buckets,
+      SegmentInfos infos,
+      List<MergeSpecification> bucketMerges)
+      throws IOException {
+    AtomicInteger index = new AtomicInteger();
+    return btmp.findForSegmentInfos(
+        buckets, infos, (si) -> bucketMerges.get(index.getAndIncrement()));
+  }
+
+  private void checkBucketing(
+      int buckets, SegmentInfos infos, List<Integer> bucketSizes, List<Integer> segmentCounts)
+      throws IOException {
+    checkBucketing(
+        new BucketedTieredMergePolicy(() -> buckets), buckets, infos, bucketSizes, segmentCounts);
+  }
+
+  private void checkBucketing(
+      BucketedTieredMergePolicy btmp,
+      int buckets,
+      SegmentInfos infos,
+      List<Integer> bucketSizes,
+      List<Integer> segmentCounts)
+      throws IOException {
+    assertEquals(bucketSizes.size(), segmentCounts.size());
+
+    AtomicInteger index = new AtomicInteger();
+    Set<String> seenNames = new HashSet<>();
+
+    btmp.findForSegmentInfos(
+        buckets,
+        infos,
+        (si) -> {
+          int currentIndex = index.getAndIncrement();
+          assertEquals(segmentCounts.get(currentIndex), Integer.valueOf(si.size()));
+          int totalSize = 0;
+          for (SegmentCommitInfo sci : si) {
+            seenNames.add(sci.info.name);
+            totalSize += (sci.info.maxDoc() - sci.getDelCount());
+          }
+          assertEquals(bucketSizes.get(currentIndex), Integer.valueOf(totalSize));
+          return new MergeSpecification();
+        });
+
+    assertEquals(bucketSizes.size(), index.get());
+
+    assertEquals(infos.size(), seenNames.size());
+    for (int i = 0; i < infos.size(); ++i) {
+      assertTrue(seenNames.contains(String.valueOf(i)));
+    }
+  }
+
+  private SegmentInfos getInfos(List<Integer> sizes) {
+    return getInfos(sizes, Collections.nCopies(sizes.size(), 0));
+  }
+
+  private SegmentInfos getInfos(List<Integer> sizes, List<Integer> deletions) {
+    SegmentInfos infos = new SegmentInfos(Version.LATEST.major);
+    Directory mockDir = mock(Directory.class);
+    int id = 0;
+    for (int i = 0; i < sizes.size(); ++i) {
+      SegmentInfo si =
+          new SegmentInfo(
+              mockDir,
+              Version.LATEST,
+              Version.LATEST,
+              String.valueOf(id),
+              sizes.get(i),
+              false,
+              null,
+              Collections.emptyMap(),
+              new byte[StringHelper.ID_LENGTH],
+              Collections.emptyMap(),
+              null);
+      SegmentCommitInfo sci = new SegmentCommitInfo(si, deletions.get(i), 0, 1, 1, 1);
+      infos.add(sci);
+      id++;
+    }
+    return infos;
+  }
+}

--- a/src/test/resources/search/VirtualShardsRegisterFields.json
+++ b/src/test/resources/search/VirtualShardsRegisterFields.json
@@ -1,0 +1,21 @@
+{
+  "indexName": "test_index",
+  "field": [
+    {
+      "name": "doc_id",
+      "type": "ATOM",
+      "storeDocValues": true
+    },
+    {
+      "name": "int_score",
+      "type": "INT",
+      "storeDocValues": true
+    },
+    {
+      "name": "int_field",
+      "type": "INT",
+      "search": true,
+      "storeDocValues": true
+    }
+  ]
+}


### PR DESCRIPTION
Adds configuration for virtual sharding. This attempts to make the index data divisible into a number of equal buckets, and thus ~equal units of work. There are two places the value is used.

The `BucketedTieredMergePolicy` divides the index segments as evenly as possible into the specified number of buckets. Each of these buckets is evaluated for merges independently using the TieredMergePolicy. This maintains the ability to divide the index data evenly. Note that this also applies to force merge, i.e. force merging down to 1 segment actually merges to 1 per bucket.

The `MyIndexSearcher` has similar modifications. It divides the index segments into even shards and computes parallel search slices independently for each shard. This should maintain a minimum parallelism and more consistent units of work.

The virtual shard configuration is part of the index live settings. Though it is possible to change the virtual sharding config, it is best to set it before any indexing. Otherwise, it will take time and organic indexing to eventually balance with the new value.

Note that there is a global config boolean parameter `virtualSharding` (default false) that serves as a toggle for this functionality. This should help isolate the change from existing clusters.