### PR TITLE
Index's Root Directory removal on deleteIndex operation

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -977,7 +977,7 @@ public class LuceneServer {
       try {
         IndexState indexState = globalState.getIndex(deleteIndexRequest.getIndexName());
         DeleteIndexResponse reply = new DeleteIndexHandler().handle(indexState, deleteIndexRequest);
-        logger.info("DeleteAllDocumentsHandler returned " + reply.toString());
+        logger.info("DeleteIndexHandler returned " + reply.toString());
         responseObserver.onNext(reply);
         responseObserver.onCompleted();
       } catch (Exception e) {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/GlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/GlobalState.java
@@ -178,8 +178,9 @@ public class GlobalState implements Closeable, Restorable {
       // remove old gens
       try (DirectoryStream<Path> stream = Files.newDirectoryStream(stateDir)) {
         for (Path sub : stream) {
-          if (sub.toString().startsWith("indices.")) {
-            long gen = Long.parseLong(sub.toString().substring(8));
+          String filename = sub.getFileName().toString();
+          if (filename.startsWith("indices.")) {
+            long gen = Long.parseLong(filename.substring(8));
             if (gen != lastIndicesGen) {
               Files.delete(sub);
             }
@@ -270,9 +271,10 @@ public class GlobalState implements Closeable, Restorable {
   }
 
   /** Remove the specified index. */
-  public void deleteIndex(String name) {
+  public void deleteIndex(String name) throws IOException {
     synchronized (indices) {
       indexNames.remove(name);
+      saveIndexNames();
     }
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
@@ -40,6 +40,7 @@ import com.yelp.nrtsearch.server.luceneserver.field.IndexableFieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.ObjectFieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.TextBaseFieldDef;
 import com.yelp.nrtsearch.server.luceneserver.index.BucketedTieredMergePolicy;
+import com.yelp.nrtsearch.server.utils.FileUtil;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -195,7 +196,19 @@ public class IndexState implements Closeable, Restorable {
     for (ShardState shardState : shards.values()) {
       shardState.deleteShard();
     }
+    deleteIndexRootDir();
     globalState.deleteIndex(name);
+  }
+
+  /**
+   * Deletes the Index's root directory
+   *
+   * @throws IOException
+   */
+  private void deleteIndexRootDir() throws IOException {
+    if (rootDir != null) {
+      FileUtil.deleteAllFiles(rootDir);
+    }
   }
 
   /** True if this index has at least one commit. */

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -20,6 +20,7 @@ import com.yelp.nrtsearch.server.grpc.ReplicationServerClient;
 import com.yelp.nrtsearch.server.luceneserver.field.FieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.IndexableFieldDef.FacetValueType;
 import com.yelp.nrtsearch.server.monitoring.IndexMetrics;
+import com.yelp.nrtsearch.server.utils.FileUtil;
 import com.yelp.nrtsearch.server.utils.HostPort;
 import io.grpc.StatusRuntimeException;
 import java.io.Closeable;
@@ -28,8 +29,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.InetAddress;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -225,26 +224,7 @@ public class ShardState implements Closeable {
   /** Delete this shard. */
   public void deleteShard() throws IOException {
     if (rootDir != null) {
-      deleteAllFiles(rootDir);
-    }
-  }
-
-  private static void deleteAllFiles(Path dir) throws IOException {
-    if (Files.exists(dir)) {
-      if (Files.isRegularFile(dir)) {
-        Files.delete(dir);
-      } else {
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
-          for (Path path : stream) {
-            if (Files.isDirectory(path)) {
-              deleteAllFiles(path);
-            } else {
-              Files.delete(path);
-            }
-          }
-        }
-        Files.delete(dir);
-      }
+      FileUtil.deleteAllFiles(rootDir);
     }
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/utils/FileUtil.java
+++ b/src/main/java/com/yelp/nrtsearch/server/utils/FileUtil.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.utils;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** Util class for filesystem operations */
+public class FileUtil {
+
+  /**
+   * Deletes a directory recursively.
+   *
+   * @param dir directory to delete
+   * @throws IOException in case deletion is unsuccessful
+   */
+  public static void deleteAllFiles(Path dir) throws IOException {
+    if (Files.exists(dir)) {
+      if (Files.isRegularFile(dir)) {
+        Files.delete(dir);
+      } else {
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
+          for (Path path : stream) {
+            if (Files.isDirectory(path)) {
+              deleteAllFiles(path);
+            } else {
+              Files.delete(path);
+            }
+          }
+        }
+        Files.delete(dir);
+      }
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -28,6 +28,8 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.testing.GrpcCleanupRule;
 import io.prometheus.client.CollectorRegistry;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -604,11 +606,15 @@ public class LuceneServerTest {
     assertEquals(2, statsResponse.getNumDocs());
     assertEquals(2, statsResponse.getMaxDoc());
 
+    String indexName = "test_index";
     // deleteIndex
     DeleteIndexRequest deleteIndexRequest =
-        DeleteIndexRequest.newBuilder().setIndexName("test_index").build();
+        DeleteIndexRequest.newBuilder().setIndexName(indexName).build();
     DeleteIndexResponse deleteIndexResponse =
         grpcServer.getBlockingStub().deleteIndex(deleteIndexRequest);
+
+    Path indexRootDir = Paths.get(grpcServer.getIndexDir(), indexName);
+    assertEquals(false, Files.exists(indexRootDir));
 
     assertEquals("ok", deleteIndexResponse.getOk());
   }


### PR DESCRIPTION
Relates : https://github.com/Yelp/nrtsearch/issues/232

Changes included:
* New helper class (FileUtil) for filesystem operations
* ShardState utilizes FileUtil for deleting Shard dirs
* IndexState deletes the root index directory using FileUtil
* Assert for verifying the index root directory being deleted
* log message update for DeleteIndexHandler's reply
* Fix for Removing the old gens files (`indices.*`)
* Flush the updated globalState to disk once an index is deleted
