### PR TITLE
Add timeoutCheckEvery option for search timeout

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -278,6 +278,8 @@ message SearchRequest {
     repeated Rescorer rescorers = 18; // Rescorers which are executed in-order after the first pass
     //If detailed request execution profiling should be included in the response
     bool profile = 19;
+    //Check the search timeout condition after each collection of n documents in a segment. If 0, timeout is only checked on the segment boundary.
+    int32 timeoutCheckEvery = 20;
 }
 
 /* Virtual field used during search */

--- a/grpc-gateway/luceneserver.swagger.json
+++ b/grpc-gateway/luceneserver.swagger.json
@@ -3218,6 +3218,11 @@
         "profile": {
           "type": "boolean",
           "title": "If detailed request execution profiling should be included in the response"
+        },
+        "timeoutCheckEvery": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Check the search timeout condition after each collection of n documents in a segment. If 0, timeout is only checked on the segment boundary."
         }
       }
     },

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/DocCollector.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/DocCollector.java
@@ -135,6 +135,7 @@ public abstract class DocCollector {
           new SearchCutoffWrapper<>(
               wrapped,
               request.getTimeoutSec(),
+              request.getTimeoutCheckEvery(),
               request.getDisallowPartialResults(),
               () -> hadTimeout = true);
     }


### PR DESCRIPTION
Adds a `checkEvery` option for the search timeout. If specified, after every n documents are collected in a segment, the timeout condition is checked. This allows for collection to be terminated without needing to finish processing the current segment, providing a better bounds on maximum search time.