### PR TITLE
api to update MaxMergedSegmentMB

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
@@ -379,6 +379,8 @@ message LiveSettingsRequest {
     int32 sliceMaxSegments = 8;
     //Number of virtual shards to use for this index.
     int32 virtualShards = 9;
+    //Maximum sized segment to produce during normal merging
+    int32 maxMergedSegmentMB = 10;
 }
 
 /* Response from Server to liveSettings */

--- a/grpc-gateway/luceneserver.swagger.json
+++ b/grpc-gateway/luceneserver.swagger.json
@@ -2655,6 +2655,11 @@
           "type": "integer",
           "format": "int32",
           "description": "Number of virtual shards to use for this index."
+        },
+        "maxMergedSegmentMB": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Maximum sized segment to produce during normal merging"
         }
       },
       "title": "Input to liveSettings"

--- a/src/main/java/com/yelp/nrtsearch/server/cli/LiveSettingsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/server/cli/LiveSettingsCommand.java
@@ -86,6 +86,13 @@ public class LiveSettingsCommand implements Callable<Integer> {
       defaultValue = "0")
   private int virtualShards;
 
+  @CommandLine.Option(
+      names = {"--maxMergedSegmentMB"},
+      description =
+          "Max sized segment to produce during normal merging (default: ${DEFAULT-VALUE})",
+      defaultValue = "0")
+  private int maxMergedSegmentMB;
+
   public String getIndexName() {
     return indexName;
   }
@@ -122,6 +129,10 @@ public class LiveSettingsCommand implements Callable<Integer> {
     return virtualShards;
   }
 
+  public int getMaxMergedSegmentMB() {
+    return maxMergedSegmentMB;
+  }
+
   @Override
   public Integer call() throws Exception {
     LuceneServerClient client = baseCmd.getClient();
@@ -135,7 +146,8 @@ public class LiveSettingsCommand implements Callable<Integer> {
           getAddDocumentsMaxBufferLen(),
           getSliceMaxDocs(),
           getSliceMaxSegments(),
-          getVirtualShards());
+          getVirtualShards(),
+          getMaxMergedSegmentMB());
     } finally {
       client.shutdown();
     }

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
@@ -98,12 +98,13 @@ public class LuceneServerClient {
       int addDocumentsMaxBufferLen,
       int sliceMaxDocs,
       int sliceMaxSegments,
-      int virtualShards) {
+      int virtualShards,
+      int maxMergedSegmentMB) {
     logger.info(
         String.format(
             "will try to update liveSettings for indexName: %s, "
                 + "maxRefreshSec: %s, minRefreshSec: %s, maxSearcherAgeSec: %s, "
-                + "indexRamBufferSizeMB: %s, addDocumentsMaxBufferLen: %s, sliceMaxDocs: %s, sliceMaxSegments: %s, virtualShards: %s ",
+                + "indexRamBufferSizeMB: %s, addDocumentsMaxBufferLen: %s, sliceMaxDocs: %s, sliceMaxSegments: %s, virtualShards: %s, maxMergedSegmentMB: %s ",
             indexName,
             maxRefreshSec,
             minRefreshSec,
@@ -112,7 +113,8 @@ public class LuceneServerClient {
             addDocumentsMaxBufferLen,
             sliceMaxDocs,
             sliceMaxSegments,
-            virtualShards));
+            virtualShards,
+            maxMergedSegmentMB));
     LiveSettingsRequest request =
         LiveSettingsRequest.newBuilder()
             .setIndexName(indexName)
@@ -124,6 +126,7 @@ public class LuceneServerClient {
             .setSliceMaxDocs(sliceMaxDocs)
             .setSliceMaxSegments(sliceMaxSegments)
             .setVirtualShards(virtualShards)
+            .setMaxMergedSegmentMB(maxMergedSegmentMB)
             .build();
     LiveSettingsResponse response;
     try {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/LiveSettingsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/LiveSettingsHandler.java
@@ -67,6 +67,11 @@ public class LiveSettingsHandler implements Handler<LiveSettingsRequest, LiveSet
       indexState.setVirtualShards(liveSettingsRequest.getVirtualShards());
       logger.info(String.format("set virtualShards: %s", liveSettingsRequest.getVirtualShards()));
     }
+    if (liveSettingsRequest.getMaxMergedSegmentMB() != 0) {
+      indexState.setMaxMergedSegmentMB(liveSettingsRequest.getMaxMergedSegmentMB());
+      logger.info(
+          String.format("set maxMergedSegmentMB: %s", liveSettingsRequest.getMaxMergedSegmentMB()));
+    }
     String response = indexState.getLiveSettingsJSON();
     LiveSettingsResponse reply = LiveSettingsResponse.newBuilder().setResponse(response).build();
     return reply;


### PR DESCRIPTION
pretty much same as the recent prs to update index state.

This config only applies to cluster without virtual sharding

https://lucene.apache.org/core/4_6_0/core/org/apache/lucene/index/TieredMergePolicy.html#setMaxMergedSegmentMB(double)