### PR TITLE
Don't throw an error if nodes are not found initially

### DIFF
--- a/clientlib/src/main/java/com/yelp/nrtsearch/clientlib/NodeAddressFileNameResolver.java
+++ b/clientlib/src/main/java/com/yelp/nrtsearch/clientlib/NodeAddressFileNameResolver.java
@@ -77,7 +77,7 @@ public class NodeAddressFileNameResolver extends NameResolver {
   private void loadNodes() {
     List<Node> nodes = readNodesFromFile();
     if (nodes == null || nodes.size() == 0) {
-      throw new IllegalStateException("No nodes found in file: " + nodeAddressesFile);
+      return;
     }
     updateNodes(nodes);
   }
@@ -96,7 +96,7 @@ public class NodeAddressFileNameResolver extends NameResolver {
     try {
       return objectMapper.readValue(nodeAddressesFile, new TypeReference<List<Node>>() {});
     } catch (IOException e) {
-      logger.error("Unable to read file: {}", nodeAddressesFile, e);
+      logger.warn("Unable to read file: {}", nodeAddressesFile, e);
       return Collections.emptyList();
     }
   }


### PR DESCRIPTION
It is possible that there won't be any primary nodes in the file when the primary restarts. We should still continue in this case as the primary will eventually come back up and the timer thread can then read the file and update it. 