### PR TITLE
Call fetch task for hits grouped by leaves and in order of doc ids

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ sourceCompatibility = 1.14
 targetCompatibility = 1.14
 
 allprojects {
-    version = '0.6.12'
+    version = '0.6.13'
     group = 'com.yelp.nrtsearch'
 }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
@@ -44,6 +44,7 @@ import com.yelp.nrtsearch.server.utils.StructJsonUtils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -179,11 +180,17 @@ public class SearchHandler implements Handler<SearchRequest, SearchResponse> {
       // fill all other needed fields into each Hit.Builder
       List<Hit.Builder> hitBuilders = searchContext.getResponseBuilder().getHitsBuilderList();
       List<LeafReaderContext> leaves = s.searcher.getIndexReader().leaves();
+
+      Map<LeafReaderContext, List<Hit.Builder>> leafToHits = new HashMap<>();
+
       for (int hitIndex = 0; hitIndex < hitBuilders.size(); ++hitIndex) {
         var hitResponse = hitBuilders.get(hitIndex);
 
         LeafReaderContext leaf =
             leaves.get(ReaderUtil.subIndex(hitResponse.getLuceneDocId(), leaves));
+        List<Hit.Builder> hitsForLeaf =
+            leafToHits.computeIfAbsent(leaf, leafReaderContext -> new ArrayList<>());
+        hitsForLeaf.add(hitResponse);
 
         if (!searchContext.getRetrieveFields().isEmpty()) {
           var fieldValueMap =
@@ -199,8 +206,15 @@ public class SearchHandler implements Handler<SearchRequest, SearchResponse> {
                   searchContext.getRetrieveFields());
           hitResponse.putAllFields(fieldValueMap);
         }
+      }
 
-        searchContext.getFetchTasks().processHit(searchContext, leaf, hitResponse);
+      for (Map.Entry<LeafReaderContext, List<Hit.Builder>> entry : leafToHits.entrySet()) {
+        LeafReaderContext leaf = entry.getKey();
+        List<Hit.Builder> hitsForLeaf = entry.getValue();
+        hitsForLeaf.sort(Comparator.comparing(Hit.Builder::getLuceneDocId));
+        for (Hit.Builder hit : hitsForLeaf) {
+          searchContext.getFetchTasks().processHit(searchContext, leaf, hit);
+        }
       }
 
       searchContext

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/FetchTasks.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/FetchTasks.java
@@ -52,7 +52,8 @@ public class FetchTasks {
 
     /**
      * Process each hit individually. Hits will already have lucene doc id and scoring info
-     * populated, as well as all requested query fields.
+     * populated, as well as all requested query fields. The method will be called in order of
+     * lucene doc ID of the hits.
      *
      * @param searchContext search context
      * @param hitLeaf lucene segment for hit


### PR DESCRIPTION
Jprofiling shows that creating a scorer for every hit in the fetch task is expensive especially when we have a large number of top hits. This change should allow the fetch task to create one scorer per leaf instead of creating one per hit.