### PR TITLE
Only create one search thread pool

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -292,10 +292,7 @@ public class LuceneServer {
       this.archiver = archiver;
       this.archiveDirectory = configuration.getArchiveDirectory();
       this.collectorRegistry = collectorRegistry;
-      this.searchThreadPoolExecutor =
-          ThreadPoolExecutorFactory.getThreadPoolExecutor(
-              ThreadPoolExecutorFactory.ExecutorType.SEARCH,
-              globalState.getThreadPoolConfiguration());
+      this.searchThreadPoolExecutor = globalState.getSearchThreadPoolExecutor();
 
       initExtendableComponents(configuration, plugins);
     }


### PR DESCRIPTION
We are creating the search thread pool in two different places. One gets used by the searcher, the other is used for parallel faceting.

I think this is why the search thread pool metrics don't look right.