### PR TITLE
Add reflection API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,8 @@ dependencies {
     implementation 'info.picocli:picocli:4.0.4'
     implementation 'org.apache.commons:commons-csv:1.7'
 
+    implementation "io.grpc:grpc-services:1.30.0"
+
     testImplementation "junit:junit:4.12"
     testImplementation "org.mockito:mockito-core:2.25.1"
     testImplementation "org.apache.lucene:lucene-test-framework:${luceneVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ System.setProperty("org.gradle.internal.publish.checksums.insecure", "True")
 
 def luceneVersion = '8.4.0'
 project.ext.slf4jVersion = '2.0.0-alpha0'
+project.ext.grpcVersion = '1.30.0'
 def gsonVersion = '2.8.5'
 def snakeYamlVersion = '1.25'
 def spatial4jVersion = '0.7'
@@ -81,7 +82,8 @@ dependencies {
     implementation 'info.picocli:picocli:4.0.4'
     implementation 'org.apache.commons:commons-csv:1.7'
 
-    implementation "io.grpc:grpc-services:1.30.0"
+    // gRPC deps
+    implementation "io.grpc:grpc-services:${project.ext.grpcVersion}"
 
     testImplementation "junit:junit:4.12"
     testImplementation "org.mockito:mockito-core:2.25.1"

--- a/clientlib/build.gradle
+++ b/clientlib/build.gradle
@@ -42,10 +42,10 @@ dependencies {
     // examples/advanced need this for JsonFormat
     compile "com.google.protobuf:protobuf-java-util:${protobufVersion}"
 
-    runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
+    runtimeOnly "io.grpc:grpc-netty-shaded:${rootProject.grpcVersion}"
 
     //test deps
-    compile "io.grpc:grpc-testing:${grpcVersion}"
+    compile "io.grpc:grpc-testing:${rootProject.grpcVersion}"
 }
 
 // Inform IDEs like IntelliJ IDEA, Eclipse or NetBeans about the generated code.
@@ -61,7 +61,7 @@ sourceSets {
 protobuf {
     protoc { artifact = "com.google.protobuf:protoc:${protocVersion}" }
     plugins {
-        grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" }
+        grpc { artifact = "io.grpc:protoc-gen-grpc-java:${rootProject.grpcVersion}" }
     }
     generateProtoTasks {
         all()*.plugins { grpc {} }

--- a/clientlib/build.gradle
+++ b/clientlib/build.gradle
@@ -27,15 +27,14 @@ startScripts.enabled = false
 def _artifactId = 'clientlib'
 
 // Dependency versions
-def grpcVersion = '1.30.0' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.11.1'
 def protocVersion = protobufVersion
 
 dependencies {
     //grpc deps
-    compile "io.grpc:grpc-protobuf:${grpcVersion}"
-    implementation "io.grpc:grpc-stub:${grpcVersion}"
-    implementation "io.grpc:grpc-okhttp:${grpcVersion}"
+    compile "io.grpc:grpc-protobuf:${rootProject.grpcVersion}"
+    implementation "io.grpc:grpc-stub:${rootProject.grpcVersion}"
+    implementation "io.grpc:grpc-okhttp:${rootProject.grpcVersion}"
     implementation "javax.annotation:javax.annotation-api:1.2"
     implementation "org.slf4j:slf4j-api:${rootProject.slf4jVersion}"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -84,7 +84,9 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptors;
 import io.grpc.Status;
+import io.grpc.protobuf.services.ProtoReflectionService;
 import io.grpc.stub.StreamObserver;
+
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.hotspot.DefaultExports;
 import java.io.File;
@@ -167,6 +169,7 @@ public class LuceneServer {
                         collectorRegistry,
                         plugins),
                     monitoringInterceptor))
+            .addService(ProtoReflectionService.newInstance())
             .executor(
                 ThreadPoolExecutorFactory.getThreadPoolExecutor(
                     ThreadPoolExecutorFactory.ExecutorType.LUCENESERVER,

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -86,7 +86,6 @@ import io.grpc.ServerInterceptors;
 import io.grpc.Status;
 import io.grpc.protobuf.services.ProtoReflectionService;
 import io.grpc.stub.StreamObserver;
-
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.hotspot.DefaultExports;
 import java.io.File;


### PR DESCRIPTION
Enabling reflection API on the server, steps taken from [here](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md#:~:text=To%20enable%20server%20reflection%2C%20you,%2D%2D%2D%20a%2Fexamples%2Fbuild.)

Reflection API is pretty useful for tooling, since it allows for discovery of endpoints and schemas on the server without the need for proto files.