### PR TITLE
Add query cache metrics

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -75,6 +75,7 @@ import com.yelp.nrtsearch.server.monitoring.Configuration;
 import com.yelp.nrtsearch.server.monitoring.IndexMetrics;
 import com.yelp.nrtsearch.server.monitoring.LuceneServerMonitoringServerInterceptor;
 import com.yelp.nrtsearch.server.monitoring.NrtMetrics;
+import com.yelp.nrtsearch.server.monitoring.QueryCacheCollector;
 import com.yelp.nrtsearch.server.monitoring.ThreadPoolCollector;
 import com.yelp.nrtsearch.server.monitoring.ThreadPoolCollector.RejectionCounterWrapper;
 import com.yelp.nrtsearch.server.plugins.Plugin;
@@ -242,6 +243,8 @@ public class LuceneServer {
     NrtMetrics.register(collectorRegistry);
     // register index metrics
     IndexMetrics.register(collectorRegistry);
+    // register query cache metrics
+    new QueryCacheCollector().register(collectorRegistry);
   }
 
   /** Main launches the server from the command line. */

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/QueryCacheCollector.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/QueryCacheCollector.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.monitoring;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.GaugeMetricFamily;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LRUQueryCache;
+import org.apache.lucene.search.QueryCache;
+
+/** Class to manage collection of metrics related to the query cache. */
+public class QueryCacheCollector extends Collector {
+
+  @Override
+  public List<MetricFamilySamples> collect() {
+    QueryCache queryCache = IndexSearcher.getDefaultQueryCache();
+    if (!(queryCache instanceof LRUQueryCache)) {
+      return Collections.emptyList();
+    }
+    LRUQueryCache lruQueryCache = (LRUQueryCache) queryCache;
+
+    List<MetricFamilySamples> mfs = new ArrayList<>();
+    mfs.add(
+        new GaugeMetricFamily(
+            "nrt_query_cache_hits",
+            "Total number of query cache hits.",
+            lruQueryCache.getHitCount()));
+    mfs.add(
+        new GaugeMetricFamily(
+            "nrt_query_cache_misses",
+            "Total number of query cache misses.",
+            lruQueryCache.getMissCount()));
+    mfs.add(
+        new GaugeMetricFamily(
+            "nrt_query_cache_size",
+            "Total number of entries in query cache.",
+            lruQueryCache.getCacheSize()));
+    mfs.add(
+        new GaugeMetricFamily(
+            "nrt_query_cache_count",
+            "Total number of entries added to the query cache.",
+            lruQueryCache.getCacheCount()));
+    return mfs;
+  }
+}


### PR DESCRIPTION
Adds new metrics for the query cache.

`nrt_query_cache_hits` - number of cache hits
`nrt_query_cache_misses` - number of cache misses
`nrt_query_cache_size` - number of entries currently in the cache
`nrt_query_cache_count` - total entries ever added to cache