### PR TITLE
Allow additional dependencies in classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,8 @@ task luceneServer(type: CreateStartScripts) {
     applicationName = 'lucene-server'
     outputDir = new File(project.buildDir, 'tmp')
     classpath = startScripts.classpath
+    // Add additional dependencies, e.g. custom loggers
+    classpath += files('$APP_HOME/additional_libs')
 }
 
 task luceneServerClient(type: CreateStartScripts) {


### PR DESCRIPTION
# Changes
- Include jars from `$APP_HOME/additional_libs` if presents to the classpath
- should not cause any issues with existing deps in `lib` folder

# Verification

Generated classpath in `bin/lucene-server` looks as follows, the extra directory is appended at the end:

```
CLASSPATH=$APP_HOME/lib/nrtsearch-0.6.17.jar: (...) :$APP_HOME/lib/j2objc-annotations-1.3.jar:$APP_HOME/lib/additional_libs
```
