### PR TITLE
Add a few more query cache metrics

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/QueryCacheCollector.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/QueryCacheCollector.java
@@ -53,9 +53,19 @@ public class QueryCacheCollector extends Collector {
             lruQueryCache.getCacheSize()));
     mfs.add(
         new GaugeMetricFamily(
+            "nrt_query_cache_size_bytes",
+            "Total memory used by query cache.",
+            lruQueryCache.ramBytesUsed()));
+    mfs.add(
+        new GaugeMetricFamily(
             "nrt_query_cache_count",
             "Total number of entries added to the query cache.",
             lruQueryCache.getCacheCount()));
+    mfs.add(
+        new GaugeMetricFamily(
+            "nrt_query_cache_eviction_count",
+            "Total number of query cache evictions.",
+            lruQueryCache.getEvictionCount()));
     return mfs;
   }
 }


### PR DESCRIPTION
Notice a couple of other useful query cache metrics.

`nrt_query_cache_size_bytes` - size of the cache in memory
`nrt_query_cache_eviction_count` - total number of cache evictions