### PR TITLE
Make query cache configurable

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -65,6 +65,7 @@ public class LuceneServerConfiguration {
   private final boolean restoreState;
   private final ThreadPoolConfiguration threadPoolConfiguration;
   private final IndexPreloadConfig preloadConfig;
+  private final QueryCacheConfig queryCacheConfig;
   private final boolean downloadAsStream;
   private final boolean fileSendDelay;
   private final boolean virtualSharding;
@@ -104,6 +105,7 @@ public class LuceneServerConfiguration {
     serviceName = configReader.getString("serviceName", DEFAULT_SERVICE_NAME);
     restoreState = configReader.getBoolean("restoreState", false);
     preloadConfig = IndexPreloadConfig.fromConfig(configReader);
+    queryCacheConfig = QueryCacheConfig.fromConfig(configReader);
     downloadAsStream = configReader.getBoolean("downloadAsStream", false);
     fileSendDelay = configReader.getBoolean("fileSendDelay", true);
     virtualSharding = configReader.getBoolean("virtualSharding", false);
@@ -180,6 +182,10 @@ public class LuceneServerConfiguration {
 
   public IndexPreloadConfig getPreloadConfig() {
     return preloadConfig;
+  }
+
+  public QueryCacheConfig getQueryCacheConfig() {
+    return queryCacheConfig;
   }
 
   public boolean getDownloadAsStream() {

--- a/src/main/java/com/yelp/nrtsearch/server/config/QueryCacheConfig.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/QueryCacheConfig.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.config;
+
+import java.util.function.Predicate;
+import org.apache.lucene.index.IndexReaderContext;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.ReaderUtil;
+
+/** Class containing configuration for the global lucene query cache */
+public class QueryCacheConfig {
+  private static final String CONFIG_PREFIX = "queryCache.";
+  static final int DEFAULT_MAX_QUERIES = 1000;
+  static final String DEFAULT_MAX_MEMORY = "32MB";
+  static final int DEFAULT_MIN_DOCS = 10000;
+  static final float DEFAULT_MIN_SIZE_RATIO = 0.03f;
+  static final float DEFAULT_SKIP_CACHE_FACTOR = 250.0f;
+
+  private final int maxQueries;
+  private final long maxMemoryBytes;
+  private final Predicate<LeafReaderContext> leafPredicate;
+  private final float skipCacheFactor;
+
+  /**
+   * Create instance from provided configuration reader.
+   *
+   * @param configReader config reader
+   * @return class instance
+   */
+  public static QueryCacheConfig fromConfig(YamlConfigReader configReader) {
+    int maxQueries = configReader.getInteger(CONFIG_PREFIX + "maxQueries", DEFAULT_MAX_QUERIES);
+    String maxMemory = configReader.getString(CONFIG_PREFIX + "maxMemory", DEFAULT_MAX_MEMORY);
+    long maxMemoryBytes = sizeStrToBytes(maxMemory);
+    int minDocs = configReader.getInteger(CONFIG_PREFIX + "minDocs", DEFAULT_MIN_DOCS);
+    float minSizeRatio =
+        configReader.getFloat(CONFIG_PREFIX + "minSizeRatio", DEFAULT_MIN_SIZE_RATIO);
+    float skipCacheFactor =
+        configReader.getFloat(CONFIG_PREFIX + "skipCacheFactor", DEFAULT_SKIP_CACHE_FACTOR);
+    return new QueryCacheConfig(maxQueries, maxMemoryBytes, minDocs, minSizeRatio, skipCacheFactor);
+  }
+
+  /**
+   * Convert a size string into an absolute number of bytes. The string may be specified with a
+   * units label, or as a percentage of the heap. For example ('100mb', '50kb', '2gb', '10%').
+   * Unlabeled values are assumed to be bytes.
+   */
+  static long sizeStrToBytes(String sizeStr) {
+    if (sizeStr.endsWith("%")) {
+      String percentStr = sizeStr.substring(0, sizeStr.length() - 1);
+      if (percentStr.isEmpty()) {
+        throw new IllegalArgumentException("Cannot convert empty percentage");
+      }
+      double percentValue = Double.parseDouble(percentStr);
+      return (long) (Runtime.getRuntime().maxMemory() * (percentValue / 100.0));
+    }
+    String baseStr = sizeStr;
+    long multiplier = 1;
+    if (baseStr.length() > 2) {
+      String suffix = baseStr.substring(baseStr.length() - 2).toLowerCase();
+      if ("kb".equals(suffix)) {
+        baseStr = baseStr.substring(0, baseStr.length() - 2);
+        multiplier = 1024;
+      } else if ("mb".equals(suffix)) {
+        baseStr = baseStr.substring(0, baseStr.length() - 2);
+        multiplier = 1024 * 1024;
+      } else if ("gb".equals(suffix)) {
+        baseStr = baseStr.substring(0, baseStr.length() - 2);
+        multiplier = 1024 * 1024 * 1024;
+      }
+    }
+    if (baseStr.isEmpty()) {
+      throw new IllegalArgumentException("Cannot convert size string: " + sizeStr);
+    }
+    double baseValue = Double.parseDouble(baseStr);
+    return (long) (baseValue * multiplier);
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param maxQueries max queries the cache will hold
+   * @param maxMemoryBytes maximum cache memory size
+   * @param minDocs min docs needed to consider caching for a segment
+   * @param minSizeRatio min portion of index a segment must have to use caching
+   * @param skipCacheFactor skip caching clauses this many times as expensive as top-level query
+   */
+  public QueryCacheConfig(
+      int maxQueries, long maxMemoryBytes, int minDocs, float minSizeRatio, float skipCacheFactor) {
+    this.maxQueries = maxQueries;
+    this.maxMemoryBytes = maxMemoryBytes;
+    this.leafPredicate = new MinSegmentSizePredicate(minDocs, minSizeRatio);
+    this.skipCacheFactor = skipCacheFactor;
+  }
+
+  /** Get maximum queries to cache. */
+  public int getMaxQueries() {
+    return maxQueries;
+  }
+
+  /** Get maximum memory to use for cache. */
+  public long getMaxMemoryBytes() {
+    return maxMemoryBytes;
+  }
+
+  /** Get predicate to determine if caching should be used for a segment. */
+  public Predicate<LeafReaderContext> getLeafPredicate() {
+    return leafPredicate;
+  }
+
+  /** Get skip cache factor. */
+  public float getSkipCacheFactor() {
+    return skipCacheFactor;
+  }
+
+  /**
+   * Predicate that accepts segments that have more that minSize docs, and contain at least
+   * minSizeRatio portion of the index docs. This was copied out or {@link
+   * org.apache.lucene.search.LRUQueryCache}, since it was package private.
+   */
+  static class MinSegmentSizePredicate implements Predicate<LeafReaderContext> {
+    final int minSize;
+    final float minSizeRatio;
+
+    MinSegmentSizePredicate(int minSize, float minSizeRatio) {
+      this.minSize = minSize;
+      this.minSizeRatio = minSizeRatio;
+    }
+
+    @Override
+    public boolean test(LeafReaderContext context) {
+      final int maxDoc = context.reader().maxDoc();
+      if (maxDoc < minSize) {
+        return false;
+      }
+      final IndexReaderContext topLevelContext = ReaderUtil.getTopLevelContext(context);
+      final float sizeRatio = (float) context.reader().maxDoc() / topLevelContext.reader().maxDoc();
+      return sizeRatio >= minSizeRatio;
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/config/QueryCacheConfigTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/QueryCacheConfigTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.yelp.nrtsearch.server.config.QueryCacheConfig.MinSegmentSizePredicate;
+import java.io.ByteArrayInputStream;
+import java.util.function.Predicate;
+import org.apache.lucene.index.LeafReaderContext;
+import org.junit.Test;
+
+public class QueryCacheConfigTest {
+
+  private static QueryCacheConfig getConfig(String configFile) {
+    return QueryCacheConfig.fromConfig(
+        new YamlConfigReader(new ByteArrayInputStream(configFile.getBytes())));
+  }
+
+  @Test
+  public void testDefault() {
+    String configFile = "nodeName: \"lucene_server_foo\"";
+    QueryCacheConfig config = getConfig(configFile);
+    assertEquals(config.getMaxQueries(), QueryCacheConfig.DEFAULT_MAX_QUERIES);
+    assertEquals(config.getMaxMemoryBytes(), (32L * 1024 * 1024));
+    assertEquals(config.getSkipCacheFactor(), QueryCacheConfig.DEFAULT_SKIP_CACHE_FACTOR, 0.0);
+    Predicate<LeafReaderContext> leafPredicate = config.getLeafPredicate();
+    assertTrue(leafPredicate instanceof QueryCacheConfig.MinSegmentSizePredicate);
+    MinSegmentSizePredicate minSegmentSizePredicate = (MinSegmentSizePredicate) leafPredicate;
+    assertEquals(minSegmentSizePredicate.minSize, QueryCacheConfig.DEFAULT_MIN_DOCS);
+    assertEquals(
+        minSegmentSizePredicate.minSizeRatio, QueryCacheConfig.DEFAULT_MIN_SIZE_RATIO, 0.0);
+  }
+
+  @Test
+  public void testSetConfig() {
+    String configFile =
+        String.join(
+            "\n",
+            "nodeName: \"lucene_server_foo\"",
+            "queryCache:",
+            "  maxQueries: 5000",
+            "  maxMemory: '128MB'",
+            "  minDocs: 7000",
+            "  minSizeRatio: 0.05",
+            "  skipCacheFactor: 400");
+    QueryCacheConfig config = getConfig(configFile);
+    assertEquals(config.getMaxQueries(), 5000);
+    assertEquals(config.getMaxMemoryBytes(), (128L * 1024 * 1024));
+    assertEquals(config.getSkipCacheFactor(), 400.0, 0.0);
+    Predicate<LeafReaderContext> leafPredicate = config.getLeafPredicate();
+    assertTrue(leafPredicate instanceof QueryCacheConfig.MinSegmentSizePredicate);
+    MinSegmentSizePredicate minSegmentSizePredicate = (MinSegmentSizePredicate) leafPredicate;
+    assertEquals(minSegmentSizePredicate.minSize, 7000);
+    assertEquals(minSegmentSizePredicate.minSizeRatio, 0.05, 0.0001);
+  }
+
+  @Test
+  public void testConvertSizeStrAbsolute() {
+    assertEquals(QueryCacheConfig.sizeStrToBytes("1111"), 1111L);
+    assertEquals(QueryCacheConfig.sizeStrToBytes("222KB"), 222L * 1024);
+    assertEquals(QueryCacheConfig.sizeStrToBytes("333kB"), 333L * 1024);
+    assertEquals(QueryCacheConfig.sizeStrToBytes("444kb"), 444L * 1024);
+    assertEquals(QueryCacheConfig.sizeStrToBytes("44MB"), 44L * 1024 * 1024);
+    assertEquals(QueryCacheConfig.sizeStrToBytes("55mB"), 55L * 1024 * 1024);
+    assertEquals(QueryCacheConfig.sizeStrToBytes("66mb"), 66L * 1024 * 1024);
+    assertEquals(QueryCacheConfig.sizeStrToBytes("7GB"), 7L * 1024 * 1024 * 1024);
+    assertEquals(QueryCacheConfig.sizeStrToBytes("8gB"), 8L * 1024 * 1024 * 1024);
+    assertEquals(QueryCacheConfig.sizeStrToBytes("9gb"), 9L * 1024 * 1024 * 1024);
+
+    assertEquals(QueryCacheConfig.sizeStrToBytes("1234.5KB"), (long) (1234.5 * 1024));
+    assertEquals(QueryCacheConfig.sizeStrToBytes("55.5MB"), (long) (55.5 * 1024 * 1024));
+  }
+
+  @Test
+  public void testConvertSizeStrPercentage() {
+    long heapSize = Runtime.getRuntime().maxMemory();
+    assertEquals(QueryCacheConfig.sizeStrToBytes("10%"), (long) (0.1 * heapSize));
+    assertEquals(QueryCacheConfig.sizeStrToBytes("5.5%"), (long) (0.055 * heapSize));
+  }
+
+  @Test
+  public void testConvertEmptySizeStr() {
+    try {
+      QueryCacheConfig.sizeStrToBytes("");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("Cannot convert size string: ", e.getMessage());
+    }
+
+    try {
+      QueryCacheConfig.sizeStrToBytes("%");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("Cannot convert empty percentage", e.getMessage());
+    }
+
+    try {
+      QueryCacheConfig.sizeStrToBytes("mb");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("For input string: \"mb\"", e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
Add configuration for the QueryCache used globally by all IndexSearchers.

`maxQueries` - max number of queries that can be stored
`maxMemory` - max amount of memory the cache can use. Specifiable with units or as a percentage of the heap, ('128MB', '5%')
`minDocs` - min documents a segment must have to be eligible for caching
`minSizeRatio` - min portion of index docs must be in a segment for it to be eligible for caching
`skipCacheFactor` - skip caching clauses this many times as expensive as top-level query