### PR TITLE
Add option to sync nrt point on index start

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -68,6 +68,7 @@ public class LuceneServerConfiguration {
   private final boolean downloadAsStream;
   private final boolean fileSendDelay;
   private final boolean virtualSharding;
+  private final boolean syncInitialNrtPoint;
 
   private final YamlConfigReader configReader;
 
@@ -107,6 +108,7 @@ public class LuceneServerConfiguration {
     downloadAsStream = configReader.getBoolean("downloadAsStream", false);
     fileSendDelay = configReader.getBoolean("fileSendDelay", true);
     virtualSharding = configReader.getBoolean("virtualSharding", false);
+    syncInitialNrtPoint = configReader.getBoolean("syncInitialNrtPoint", false);
     threadPoolConfiguration = new ThreadPoolConfiguration(configReader);
   }
 
@@ -192,6 +194,10 @@ public class LuceneServerConfiguration {
 
   public boolean getVirtualSharding() {
     return virtualSharding;
+  }
+
+  public boolean getSyncInitialNrtPoint() {
+    return syncInitialNrtPoint;
   }
 
   public YamlConfigReader getConfigReader() {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/NRTReplicaNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/NRTReplicaNode.java
@@ -41,6 +41,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class NRTReplicaNode extends ReplicaNode {
+  private static final long NRT_SYNC_WAIT_MS = 2000;
+  private static final long NRT_CONNECT_WAIT_MS = 500;
+
   private final ReplicationServerClient primaryAddress;
   private final String indexName;
   final Jobs jobs;
@@ -217,5 +220,60 @@ public class NRTReplicaNode extends ReplicaNode {
       }
     }
     return false;
+  }
+
+  /**
+   * Sync the next nrt point from the current primary. Attempts to start a new copy job with the
+   * primary, giving up after the specified amount of time. Sync is considered completed when either
+   * the index version has changed, or there is no longer an active copy job.
+   *
+   * @param primaryWaitMs how long to wait for primary to be available
+   * @throws IOException on issue getting searcher version
+   */
+  public void syncFromCurrentPrimary(long primaryWaitMs) throws IOException {
+    long curVersion = getCurrentSearchingVersion();
+    logger.info(
+        "Starting sync of next nrt point from current primary, current version: " + curVersion);
+    CopyJob job = null;
+    long startMS = System.currentTimeMillis();
+    // Attempt to start a new nrt point copy from the current primary, give up if
+    // it is unavailable for too long
+    while (job == null && System.currentTimeMillis() - startMS < primaryWaitMs) {
+      // synchronize read of lastPrimaryGen
+      synchronized (this) {
+        job = newNRTPoint(lastPrimaryGen, Long.MAX_VALUE);
+      }
+      if (job == null) {
+        try {
+          Thread.sleep(NRT_CONNECT_WAIT_MS);
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+    if (job == null) {
+      logger.info("Timed out starting nrt point copy from current primary");
+      return;
+    }
+    while (true) {
+      // we are done when either a new index version has synced, or there is no longer
+      // an active copy
+      if (curVersion < getCurrentSearchingVersion()) {
+        break;
+      }
+      synchronized (this) {
+        if (curNRTCopy == null) {
+          break;
+        }
+      }
+      try {
+        Thread.sleep(NRT_SYNC_WAIT_MS);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    logger.info(
+        "Finished syncing nrt point from current primary, current version: "
+            + getCurrentSearchingVersion());
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -82,6 +82,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ShardState implements Closeable {
+  private static final long INITIAL_SYNC_PRIMARY_WAIT_MS = 30000;
   public static final int REPLICA_ID = 0;
   final ThreadPoolExecutor searchExecutor;
   Logger logger = LoggerFactory.getLogger(ShardState.class);
@@ -932,6 +933,10 @@ public class ShardState implements Closeable {
               new ShardSearcherFactory(true, false),
               verbose ? System.out : new PrintStream(OutputStream.nullOutputStream()),
               primaryGen);
+
+      if (indexState.globalState.configuration.getSyncInitialNrtPoint()) {
+        nrtReplicaNode.syncFromCurrentPrimary(INITIAL_SYNC_PRIMARY_WAIT_MS);
+      }
 
       startSearcherPruningThread(indexState.globalState.shutdownNow);
 


### PR DESCRIPTION
Add the option to sync an initial nrt point while starting the index. This is a best effort operation, if the primary is unavailable for too long (30s), the sync will be skipped.

Once the copy job begins, the sync operation will wait until either there is a new index version, or there is no longer an active copy job.