### PR TITLE
Use the year variable in license header

### DIFF
--- a/license_header
+++ b/license_header
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Yelp Inc.
+ * Copyright $YEAR Yelp Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This should format new files with the right year in the copyright header while not reformatting older files.