### PR TITLE
Add client ChannelConfig

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ System.setProperty("org.gradle.internal.publish.checksums.insecure", "True")
 def luceneVersion = '8.4.0'
 project.ext.slf4jVersion = '2.0.0-alpha1'
 project.ext.grpcVersion = '1.30.0'
+project.ext.mockitoVersion = '2.25.1'
 def log4jVersion = '2.14.1'
 def disruptorVersion = '3.2.1'
 def gsonVersion = '2.8.5'
@@ -97,7 +98,7 @@ dependencies {
     implementation "io.grpc:grpc-services:${project.ext.grpcVersion}"
 
     testImplementation "junit:junit:4.12"
-    testImplementation "org.mockito:mockito-core:2.25.1"
+    testImplementation "org.mockito:mockito-core:${project.ext.mockitoVersion}"
     testImplementation "org.apache.lucene:lucene-test-framework:${luceneVersion}"
     testImplementation "org.locationtech.spatial4j:spatial4j:${spatial4jVersion}"
     testImplementation "io.findify:s3mock_2.12:${s3mockVersion}"

--- a/clientlib/build.gradle
+++ b/clientlib/build.gradle
@@ -46,6 +46,8 @@ dependencies {
 
     //test deps
     compile "io.grpc:grpc-testing:${rootProject.grpcVersion}"
+
+    testImplementation "org.mockito:mockito-core:${rootProject.mockitoVersion}"
 }
 
 // Inform IDEs like IntelliJ IDEA, Eclipse or NetBeans about the generated code.

--- a/clientlib/src/main/java/com/yelp/nrtsearch/server/grpc/ChannelConfig.java
+++ b/clientlib/src/main/java/com/yelp/nrtsearch/server/grpc/ChannelConfig.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2021 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.grpc;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.grpc.ManagedChannelBuilder;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Class for holding configuration information for channel building. Designed to be loadable using
+ * jackson. Unless otherwise specified, all fields may be null to used the default channel values.
+ */
+@JsonInclude(Include.NON_NULL)
+public class ChannelConfig {
+  private Boolean enableRetry;
+  private Integer maxHedgedAttempts;
+  private ServiceConfig serviceConfig;
+
+  // Deserialization constructor
+  public ChannelConfig() {}
+
+  /**
+   * Constructor.
+   *
+   * @param enableRetry if the retry system should be enabled
+   * @param maxHedgedAttempts channel level max for hedge attempts
+   * @param serviceConfig additional service configuration
+   */
+  public ChannelConfig(
+      Boolean enableRetry, Integer maxHedgedAttempts, ServiceConfig serviceConfig) {
+    this.enableRetry = enableRetry;
+    this.maxHedgedAttempts = maxHedgedAttempts;
+    this.serviceConfig = serviceConfig;
+  }
+
+  public Boolean getEnableRetry() {
+    return enableRetry;
+  }
+
+  public Integer getMaxHedgedAttempts() {
+    return maxHedgedAttempts;
+  }
+
+  public ServiceConfig getServiceConfig() {
+    return serviceConfig;
+  }
+
+  /**
+   * Set properties on channel builder based on configuration.
+   *
+   * @param builder input channel builder
+   * @param mapper object mapper
+   * @return builder with properties set
+   */
+  public ManagedChannelBuilder<?> configureChannelBuilder(
+      ManagedChannelBuilder<?> builder, ObjectMapper mapper) {
+    if (enableRetry != null) {
+      if (enableRetry) {
+        builder.enableRetry();
+      } else {
+        builder.disableRetry();
+      }
+    }
+    if (maxHedgedAttempts != null) {
+      builder.maxHedgedAttempts(maxHedgedAttempts);
+    }
+    if (serviceConfig != null) {
+      @SuppressWarnings("unchecked")
+      Map<String, ?> defaultServiceConfig = mapper.convertValue(serviceConfig, Map.class);
+      builder.defaultServiceConfig(defaultServiceConfig);
+    }
+    return builder;
+  }
+
+  /**
+   * Additional service configuration properties. Corresponding to the <a
+   * href="https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto">protobuf</a>
+   * specification. Types must conform to the <a
+   * href="https://developers.google.com/protocol-buffers/docs/proto3#json">json encoded</a>
+   * message. Note that this requires all number values to be doubles.
+   */
+  @JsonInclude(Include.NON_NULL)
+  public static class ServiceConfig {
+    private List<MethodConfig> methodConfig;
+    private RetryThrottlingConfig retryThrottling;
+
+    // Deserialization constructor
+    public ServiceConfig() {}
+
+    /**
+     * Constructor.
+     *
+     * @param methodConfig per method configuration
+     * @param retryThrottling retry throttling configuration
+     */
+    public ServiceConfig(List<MethodConfig> methodConfig, RetryThrottlingConfig retryThrottling) {
+      this.methodConfig = methodConfig;
+      this.retryThrottling = retryThrottling;
+    }
+
+    public List<MethodConfig> getMethodConfig() {
+      return methodConfig;
+    }
+
+    public RetryThrottlingConfig getRetryThrottling() {
+      return retryThrottling;
+    }
+
+    /** Method configuration. */
+    @JsonInclude(Include.NON_NULL)
+    public static class MethodConfig {
+      private List<MethodName> name;
+      private String timeout;
+      private HedgingPolicy hedgingPolicy;
+
+      // Deserialization constructor
+      public MethodConfig() {}
+
+      /**
+       * Constructor.
+       *
+       * @param name method names, this must be specified and contain at least one value
+       * @param timeout method deadline
+       * @param hedgingPolicy hedging config
+       * @throws NullPointerException if name is null
+       * @throws IllegalArgumentException if name is empty
+       */
+      public MethodConfig(List<MethodName> name, String timeout, HedgingPolicy hedgingPolicy) {
+        Objects.requireNonNull(name);
+        if (name.isEmpty()) {
+          throw new IllegalArgumentException("At least one method name must be specified");
+        }
+        this.name = name;
+        this.timeout = timeout;
+        this.hedgingPolicy = hedgingPolicy;
+      }
+
+      public List<MethodName> getName() {
+        return name;
+      }
+
+      public String getTimeout() {
+        return timeout;
+      }
+
+      public HedgingPolicy getHedgingPolicy() {
+        return hedgingPolicy;
+      }
+
+      /**
+       * Request hedging configuration. See <a
+       * href="https://github.com/grpc/proposal/blob/master/A6-client-retries.md#hedging-policy-1">docs</a>.
+       */
+      @JsonInclude(Include.NON_NULL)
+      public static class HedgingPolicy {
+        private Double maxAttempts;
+        private String hedgingDelay;
+        private List<String> nonFatalStatusCodes;
+
+        // Deserialization constructor
+        public HedgingPolicy() {}
+
+        /**
+         * Constructor.
+         *
+         * @param maxAttempts max number of hedging attempts, including the initial attempt
+         * @param hedgingDelay duration delay between attempts
+         * @param nonFatalStatusCodes list of returned status codes that will not cancel the request
+         */
+        public HedgingPolicy(
+            Double maxAttempts, String hedgingDelay, List<String> nonFatalStatusCodes) {
+          this.maxAttempts = maxAttempts;
+          this.hedgingDelay = hedgingDelay;
+          this.nonFatalStatusCodes = nonFatalStatusCodes;
+        }
+
+        public Double getMaxAttempts() {
+          return maxAttempts;
+        }
+
+        public String getHedgingDelay() {
+          return hedgingDelay;
+        }
+
+        public List<String> getNonFatalStatusCodes() {
+          return nonFatalStatusCodes;
+        }
+      }
+    }
+
+    /** Method name identifier. */
+    @JsonInclude(Include.NON_NULL)
+    public static class MethodName {
+      private String service;
+      private String method;
+
+      // Deserialization constructor
+      public MethodName() {}
+
+      /**
+       * Constructor.
+       *
+       * @param service service name
+       * @param method method name
+       */
+      public MethodName(String service, String method) {
+        this.service = service;
+        this.method = method;
+      }
+
+      public String getService() {
+        return service;
+      }
+
+      public String getMethod() {
+        return method;
+      }
+    }
+
+    /**
+     * Retry throttling configuration. See <a
+     * href="https://github.com/grpc/proposal/blob/master/A6-client-retries.md#throttling-retry-attempts-and-hedged-rpcs">docs</a>.
+     */
+    @JsonInclude(Include.NON_NULL)
+    public static class RetryThrottlingConfig {
+      private Double maxTokens;
+      private Double tokenRatio;
+
+      // Deserialization constructor
+      public RetryThrottlingConfig() {}
+
+      /**
+       * Constructor.
+       *
+       * @param maxTokens tokens per backend.
+       * @param tokenRatio ratio for refilling tokens
+       */
+      public RetryThrottlingConfig(Double maxTokens, Double tokenRatio) {
+        this.maxTokens = maxTokens;
+        this.tokenRatio = tokenRatio;
+      }
+
+      public Double getMaxTokens() {
+        return maxTokens;
+      }
+
+      public Double getTokenRatio() {
+        return tokenRatio;
+      }
+    }
+  }
+}

--- a/clientlib/src/test/java/com/yelp/nrtsearch/server/grpc/ChannelConfigTest.java
+++ b/clientlib/src/test/java/com/yelp/nrtsearch/server/grpc/ChannelConfigTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2021 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.grpc;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yelp.nrtsearch.server.grpc.ChannelConfig.ServiceConfig.MethodConfig;
+import io.grpc.ManagedChannelBuilder;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class ChannelConfigTest {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @Test
+  public void testEmptyConfig() throws IOException {
+    String configJson = "{}";
+    ChannelConfig config = OBJECT_MAPPER.readValue(configJson, ChannelConfig.class);
+
+    ManagedChannelBuilder<?> mockBuilder = mock(ManagedChannelBuilder.class);
+    config.configureChannelBuilder(mockBuilder, OBJECT_MAPPER);
+
+    verifyNoMoreInteractions(mockBuilder);
+  }
+
+  @Test
+  public void testEnableRetry() throws IOException {
+    String configJson = "{\"enableRetry\": true}";
+    ChannelConfig config = OBJECT_MAPPER.readValue(configJson, ChannelConfig.class);
+
+    ManagedChannelBuilder<?> mockBuilder = mock(ManagedChannelBuilder.class);
+    config.configureChannelBuilder(mockBuilder, OBJECT_MAPPER);
+
+    verify(mockBuilder, times(1)).enableRetry();
+    verifyNoMoreInteractions(mockBuilder);
+  }
+
+  @Test
+  public void testDisableRetry() throws IOException {
+    String configJson = "{\"enableRetry\": false}";
+    ChannelConfig config = OBJECT_MAPPER.readValue(configJson, ChannelConfig.class);
+
+    ManagedChannelBuilder<?> mockBuilder = mock(ManagedChannelBuilder.class);
+    config.configureChannelBuilder(mockBuilder, OBJECT_MAPPER);
+
+    verify(mockBuilder, times(1)).disableRetry();
+    verifyNoMoreInteractions(mockBuilder);
+  }
+
+  @Test
+  public void testMaxHedgedAttempts() throws IOException {
+    String configJson = "{\"maxHedgedAttempts\": 5}";
+    ChannelConfig config = OBJECT_MAPPER.readValue(configJson, ChannelConfig.class);
+
+    ManagedChannelBuilder<?> mockBuilder = mock(ManagedChannelBuilder.class);
+    config.configureChannelBuilder(mockBuilder, OBJECT_MAPPER);
+
+    verify(mockBuilder, times(1)).maxHedgedAttempts(5);
+    verifyNoMoreInteractions(mockBuilder);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNullMethodName() {
+    new MethodConfig(null, null, null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNoMethodName() {
+    new MethodConfig(Collections.emptyList(), null, null);
+  }
+
+  @Test
+  public void testEmptyName() throws IOException {
+    String configJson = "{\"serviceConfig\": {\"methodConfig\": [{\"name\": [{}]}]}}";
+    ChannelConfig config = OBJECT_MAPPER.readValue(configJson, ChannelConfig.class);
+
+    ManagedChannelBuilder<?> mockBuilder = mock(ManagedChannelBuilder.class);
+    config.configureChannelBuilder(mockBuilder, OBJECT_MAPPER);
+
+    Map<String, Object> expectedServiceConfig = new HashMap<>();
+    Map<String, Object> expectedMethodConfig = new HashMap<>();
+    expectedMethodConfig.put("name", Collections.singletonList(new HashMap<String, Object>()));
+    expectedServiceConfig.put("methodConfig", Collections.singletonList(expectedMethodConfig));
+
+    verify(mockBuilder, times(1)).defaultServiceConfig(expectedServiceConfig);
+    verifyNoMoreInteractions(mockBuilder);
+    verifyServiceConfigSettable(expectedServiceConfig);
+  }
+
+  @Test
+  public void testMultiName() throws IOException {
+    String configJson =
+        "{\"serviceConfig\": {\"methodConfig\": [{\"name\": [{\"service\": \"s1\", \"method\": \"m1\"}, {\"service\": \"s2\", \"method\": \"m2\"}]}]}}";
+    ChannelConfig config = OBJECT_MAPPER.readValue(configJson, ChannelConfig.class);
+
+    ManagedChannelBuilder<?> mockBuilder = mock(ManagedChannelBuilder.class);
+    config.configureChannelBuilder(mockBuilder, OBJECT_MAPPER);
+
+    Map<String, Object> expectedServiceConfig = new HashMap<>();
+    Map<String, Object> expectedMethodConfig = new HashMap<>();
+    Map<String, Object> expectedName1 = new HashMap<>();
+    expectedName1.put("service", "s1");
+    expectedName1.put("method", "m1");
+    Map<String, Object> expectedName2 = new HashMap<>();
+    expectedName2.put("service", "s2");
+    expectedName2.put("method", "m2");
+    expectedMethodConfig.put("name", Arrays.asList(expectedName1, expectedName2));
+    expectedServiceConfig.put("methodConfig", Collections.singletonList(expectedMethodConfig));
+
+    verify(mockBuilder, times(1)).defaultServiceConfig(expectedServiceConfig);
+    verifyNoMoreInteractions(mockBuilder);
+    verifyServiceConfigSettable(expectedServiceConfig);
+  }
+
+  @Test
+  public void testMethodTimeout() throws IOException {
+    String configJson =
+        "{\"serviceConfig\": {\"methodConfig\": [{\"name\": [{}], \"timeout\": \"2s\"}]}}";
+    ChannelConfig config = OBJECT_MAPPER.readValue(configJson, ChannelConfig.class);
+
+    ManagedChannelBuilder<?> mockBuilder = mock(ManagedChannelBuilder.class);
+    config.configureChannelBuilder(mockBuilder, OBJECT_MAPPER);
+
+    Map<String, Object> expectedServiceConfig = new HashMap<>();
+    Map<String, Object> expectedMethodConfig = new HashMap<>();
+    expectedMethodConfig.put("name", Collections.singletonList(new HashMap<String, Object>()));
+    expectedMethodConfig.put("timeout", "2s");
+    expectedServiceConfig.put("methodConfig", Collections.singletonList(expectedMethodConfig));
+
+    verify(mockBuilder, times(1)).defaultServiceConfig(expectedServiceConfig);
+    verifyNoMoreInteractions(mockBuilder);
+    verifyServiceConfigSettable(expectedServiceConfig);
+  }
+
+  @Test
+  public void testMethodHedgingPolicy() throws IOException {
+    String configJson =
+        "{\"serviceConfig\": {\"methodConfig\": [{\"name\": [{}], \"hedgingPolicy\": {\"maxAttempts\": 5, \"hedgingDelay\": \"1s\", \"nonFatalStatusCodes\": [\"UNAVAILABLE\"]}}]}}";
+    ChannelConfig config = OBJECT_MAPPER.readValue(configJson, ChannelConfig.class);
+
+    ManagedChannelBuilder<?> mockBuilder = mock(ManagedChannelBuilder.class);
+    config.configureChannelBuilder(mockBuilder, OBJECT_MAPPER);
+
+    Map<String, Object> expectedServiceConfig = new HashMap<>();
+    Map<String, Object> expectedMethodConfig = new HashMap<>();
+    Map<String, Object> expectedHedgingConfig = new HashMap<>();
+    expectedMethodConfig.put("name", Collections.singletonList(new HashMap<String, Object>()));
+    expectedHedgingConfig.put("maxAttempts", 5.0);
+    expectedHedgingConfig.put("hedgingDelay", "1s");
+    expectedHedgingConfig.put("nonFatalStatusCodes", Collections.singletonList("UNAVAILABLE"));
+    expectedMethodConfig.put("hedgingPolicy", expectedHedgingConfig);
+    expectedServiceConfig.put("methodConfig", Collections.singletonList(expectedMethodConfig));
+
+    verify(mockBuilder, times(1)).defaultServiceConfig(expectedServiceConfig);
+    verifyNoMoreInteractions(mockBuilder);
+    verifyServiceConfigSettable(expectedServiceConfig);
+  }
+
+  @Test
+  public void testRetryThrottling() throws IOException {
+    String configJson =
+        "{\"serviceConfig\": {\"retryThrottling\": {\"maxTokens\": 10, \"tokenRatio\": 0.12}}}";
+    ChannelConfig config = OBJECT_MAPPER.readValue(configJson, ChannelConfig.class);
+
+    ManagedChannelBuilder<?> mockBuilder = mock(ManagedChannelBuilder.class);
+    config.configureChannelBuilder(mockBuilder, OBJECT_MAPPER);
+
+    Map<String, Object> expectedServiceConfig = new HashMap<>();
+    Map<String, Object> expectedThrottlingConfig = new HashMap<>();
+    expectedThrottlingConfig.put("maxTokens", 10.0);
+    expectedThrottlingConfig.put("tokenRatio", 0.12);
+    expectedServiceConfig.put("retryThrottling", expectedThrottlingConfig);
+
+    verify(mockBuilder, times(1)).defaultServiceConfig(expectedServiceConfig);
+    verifyNoMoreInteractions(mockBuilder);
+    verifyServiceConfigSettable(expectedServiceConfig);
+  }
+
+  private void verifyServiceConfigSettable(Map<String, Object> serviceConfig) {
+    // setting service config validates typing
+    ManagedChannelBuilder.forAddress("host", 1111).defaultServiceConfig(serviceConfig);
+  }
+}


### PR DESCRIPTION
Creates classes to hold channel configuration. This info is used to configure the channel builder with the desired properties. The ServiceConfig classes conform to the protobuf specification https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto with its json encoded types https://developers.google.com/protocol-buffers/docs/proto3#json

The config is not currently complete, and mainly holds settings related to retry and hedging.

Classes are annotated to be serialized/deserialized with jackson. This is especially important for the ServiceConfig, since it must be provided as a Map<String,?> to the channel builder.