### PR TITLE
Add periodic commits 

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -53,6 +53,7 @@ public class LuceneServerConfiguration {
   private static final Path DEFAULT_PLUGIN_SEARCH_PATH =
       Paths.get(DEFAULT_USER_DIR.toString(), "plugins");
   private static final String DEFAULT_SERVICE_NAME = "nrtsearch-generic";
+  public static final Long PERIODIC_COMMIT_OFF = -1L;
 
   private final int port;
   private final int replicationPort;
@@ -79,6 +80,7 @@ public class LuceneServerConfiguration {
   private final boolean virtualSharding;
   private final boolean syncInitialNrtPoint;
   private final boolean indexVerbose;
+  private final long periodicCommitDelaySec;
 
   private final YamlConfigReader configReader;
 
@@ -122,6 +124,7 @@ public class LuceneServerConfiguration {
     virtualSharding = configReader.getBoolean("virtualSharding", false);
     syncInitialNrtPoint = configReader.getBoolean("syncInitialNrtPoint", false);
     indexVerbose = configReader.getBoolean("indexVerbose", false);
+    periodicCommitDelaySec = configReader.getLong("periodicCommitDelaySec", PERIODIC_COMMIT_OFF);
     threadPoolConfiguration = new ThreadPoolConfiguration(configReader);
   }
 
@@ -223,6 +226,10 @@ public class LuceneServerConfiguration {
 
   public boolean getIndexVerbose() {
     return indexVerbose;
+  }
+
+  public long getPeriodicCommitDelaySec() {
+    return periodicCommitDelaySec;
   }
 
   public YamlConfigReader getConfigReader() {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
@@ -125,7 +125,7 @@ public class IndexState implements Closeable, Restorable {
   public static final int DEFAULT_SLICE_MAX_DOCS = 250_000;
   public static final int DEFAULT_SLICE_MAX_SEGMENTS = 5;
 
-  Logger logger = LoggerFactory.getLogger(IndexState.class);
+  private static final Logger logger = LoggerFactory.getLogger(IndexState.class);
   public final GlobalState globalState;
 
   /** Which norms format to use for all indexed fields. */
@@ -646,10 +646,10 @@ public class IndexState implements Closeable, Restorable {
   @Override
   public void close() throws IOException {
     logger.info(String.format("IndexState.close name= %s", name));
-    if (isPeriodicCommitEnabled()) {
-      periodicCommit.cancel();
-    }
     List<Closeable> closeables = new ArrayList<>();
+    if (periodicCommit != null) {
+      closeables.add(periodicCommit);
+    }
     closeables.addAll(shards.values());
     closeables.addAll(fields.values());
     for (Lookup suggester : suggesters.values()) {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/PeriodicCommit.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/PeriodicCommit.java
@@ -16,15 +16,16 @@
 package com.yelp.nrtsearch.server.luceneserver;
 
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.Timer;
 import java.util.TimerTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PeriodicCommit {
+public class PeriodicCommit implements Closeable {
 
-  Logger logger = LoggerFactory.getLogger(IndexState.class);
+  private static final Logger logger = LoggerFactory.getLogger(PeriodicCommit.class);
 
   private final IndexState indexState;
   private final TimerTask periodicCommitTask;
@@ -53,7 +54,8 @@ public class PeriodicCommit {
     }
   }
 
-  public void cancel() {
+  @Override
+  public void close() throws IOException {
     timer.cancel();
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/PeriodicCommit.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/PeriodicCommit.java
@@ -47,9 +47,7 @@ public class PeriodicCommit {
         };
   }
 
-  public void schedule() {
-    long delaySec = indexState.globalState.configuration.getPeriodicCommitDelaySec();
-
+  public void schedule(long delaySec) {
     if (delaySec != LuceneServerConfiguration.PERIODIC_COMMIT_OFF && delaySec > 0) {
       timer.scheduleAtFixedRate(periodicCommitTask, 0, delaySec * 1000);
     }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/PeriodicCommit.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/PeriodicCommit.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver;
+
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import java.io.IOException;
+import java.util.Timer;
+import java.util.TimerTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PeriodicCommit {
+
+  Logger logger = LoggerFactory.getLogger(IndexState.class);
+
+  private final IndexState indexState;
+  private final TimerTask periodicCommitTask;
+  private final Timer timer;
+
+  public PeriodicCommit(IndexState indexState) {
+    this.indexState = indexState;
+    timer = new Timer();
+    periodicCommitTask =
+        new TimerTask() {
+          @Override
+          public void run() {
+            try {
+              indexState.commit();
+              logger.error("running periodic commit for index: {}", indexState.name);
+            } catch (IOException e) {
+              logger.warn("error while trying to commit index: {}", indexState.name, e);
+            }
+          }
+        };
+  }
+
+  public void schedule() {
+    long delaySec = indexState.globalState.configuration.getPeriodicCommitDelaySec();
+
+    if (delaySec != LuceneServerConfiguration.PERIODIC_COMMIT_OFF && delaySec > 0) {
+      timer.scheduleAtFixedRate(periodicCommitTask, 0, delaySec * 1000);
+    }
+  }
+
+  public void cancel() {
+    timer.cancel();
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/PeriodicCommit.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/PeriodicCommit.java
@@ -39,7 +39,7 @@ public class PeriodicCommit {
           public void run() {
             try {
               indexState.commit();
-              logger.error("running periodic commit for index: {}", indexState.name);
+              logger.info("running periodic commit for index: {}", indexState.name);
             } catch (IOException e) {
               logger.warn("error while trying to commit index: {}", indexState.name, e);
             }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -319,7 +319,6 @@ public class ShardState implements Closeable {
 
     long gen;
 
-    // nocommit this does nothing on replica?  make a failing test!
     if (writer != null) {
       // nocommit: two phase commit?
       if (taxoWriter != null) {
@@ -327,6 +326,9 @@ public class ShardState implements Closeable {
       }
       gen = writer.commit();
     } else {
+      if (nrtReplicaNode != null) {
+        nrtReplicaNode.commit();
+      }
       gen = -1;
     }
 

--- a/src/main/resources/lucene_server_default_configuration.yaml
+++ b/src/main/resources/lucene_server_default_configuration.yaml
@@ -2,3 +2,4 @@ nodeName: "lucene_server"
 hostName: "localhost"
 port: "6000"
 replicationPort: "6001"
+periodicCommitDelaySec: 2

--- a/src/main/resources/lucene_server_default_configuration.yaml
+++ b/src/main/resources/lucene_server_default_configuration.yaml
@@ -2,4 +2,3 @@ nodeName: "lucene_server"
 hostName: "localhost"
 port: "6000"
 replicationPort: "6001"
-periodicCommitDelaySec: 2


### PR DESCRIPTION
Add periodic commits for all shards.

This can be configured in lucene server configuration with `periodicCommitDelaySec`

## Validation

Set `periodicCommitDelaySec` to `2` and could see commit taking place every 2 seconds after starting the index. Stopping the index cancelled the commit task gracefully.