### PR TITLE
Include stacktrace for failing tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,6 +151,10 @@ test {
         }
     }
     systemProperties System.properties
+    testLogging {
+        events "failed"
+        exceptionFormat "full"
+    }
 }
 
 task javadocs(type: Javadoc) {

--- a/build.gradle
+++ b/build.gradle
@@ -154,6 +154,7 @@ test {
     testLogging {
         events "failed"
         exceptionFormat "full"
+        showStackTraces true
     }
 }
 


### PR DESCRIPTION
Proposal to be discussed.

Currently when a test fails when running `./gradlew test` we get a very little information what went wrong e.g. 
```
> Task :test                                     

com.yelp.nrtsearch.server.grpc.ReplicationTestFailureScenarios > primaryDurabilitySyncWithReplica FAILED                                                                                             
    io.grpc.StatusRuntimeException at ReplicationTestFailureScenarios.java:453                    

com.yelp.nrtsearch.server.grpc.ReplicationTestFailureScenarios > primaryStoppedAndRestartedWithNoPreviousIndex FAILED                                                                                
    io.grpc.StatusRuntimeException at ReplicationTestFailureScenarios.java:453                    

6 tests completed, 2 failed                      
```

This gradle option will add stacktrace for every failing test, so it will be easier to debug what's wrong. It should not produce any extra output for passing tests. For the failing tests we will get a following output:
```
> Task :test                                                                                                                                                                                         
                                                                                                                                                                                                     
com.yelp.nrtsearch.server.grpc.ReplicationTestFailureScenarios > primaryDurabilitySyncWithReplica FAILED                                                                                             
    io.grpc.StatusRuntimeException: UNKNOWN: error while trying to execute search for index test_index. check logs for full searchRequest.                                                           
    searcher: This searcher has expired version=6 vs currentVersion=10                                                                                                                               
        at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:244)                                                                                                                   
        at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:225)                                                                                                                               
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:142)                                                                                                                          
        at com.yelp.nrtsearch.server.grpc.LuceneServerGrpc$LuceneServerBlockingStub.search(LuceneServerGrpc.java:2239)                                                                               
        at com.yelp.nrtsearch.server.grpc.ReplicationTestFailureScenarios.publishNRTAndValidateSearchResults(ReplicationTestFailureScenarios.java:453)                                               
        at com.yelp.nrtsearch.server.grpc.ReplicationTestFailureScenarios.primaryDurabilitySyncWithReplica(ReplicationTestFailureScenarios.java:354)                                                 
                                                                                                                                                                                                     
com.yelp.nrtsearch.server.grpc.ReplicationTestFailureScenarios > primaryStoppedAndRestartedWithNoPreviousIndex FAILED                                                                                
    io.grpc.StatusRuntimeException: UNKNOWN: error while trying to execute search for index test_index. check logs for full searchRequest.                                                           
    searcher: This searcher has expired version=3 vs currentVersion=5                                                                                                                                
        at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:244)                                                                                                                   
        at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:225)                                                                                                                               
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:142)                                                                                                                          
        at com.yelp.nrtsearch.server.grpc.LuceneServerGrpc$LuceneServerBlockingStub.search(LuceneServerGrpc.java:2239)                                                                               
        at com.yelp.nrtsearch.server.grpc.ReplicationTestFailureScenarios.publishNRTAndValidateSearchResults(ReplicationTestFailureScenarios.java:453)                                               
        at com.yelp.nrtsearch.server.grpc.ReplicationTestFailureScenarios.primaryStoppedAndRestartedWithNoPreviousIndex(ReplicationTestFailureScenarios.java:243)                                    
                                                                                                                                                                                                     
6 tests completed, 2 failed  
```

For reference linking [Gradle docs](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.logging.TestLogging.html) with more info about testLogging settings.

