### PR TITLE
Fix delete index data restore

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/StartIndexHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/StartIndexHandler.java
@@ -21,11 +21,10 @@ import com.yelp.nrtsearch.server.grpc.RestoreIndex;
 import com.yelp.nrtsearch.server.grpc.StartIndexRequest;
 import com.yelp.nrtsearch.server.grpc.StartIndexResponse;
 import com.yelp.nrtsearch.server.utils.Archiver;
+import com.yelp.nrtsearch.server.utils.FileUtil;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import com.yelp.nrtsearch.server.utils.FileUtil;
 import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager;
 import org.apache.lucene.index.IndexReader;
 import org.slf4j.Logger;

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/StartIndexHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/StartIndexHandler.java
@@ -64,7 +64,7 @@ public class StartIndexHandler implements Handler<StartIndexRequest, StartIndexR
         try {
           if (!shardState.isRestored()) {
             RestoreIndex restoreIndex = startIndexRequest.getRestore();
-            if (startIndexRequest.getRestore().getDeleteExistingData()) {
+            if (restoreIndex.getDeleteExistingData()) {
               indexState.deleteIndexRootDir();
               deleteDownloadedBackupDirectories(restoreIndex.getResourceName());
             }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/BackupRestoreIndexRequestHandlerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/BackupRestoreIndexRequestHandlerTest.java
@@ -214,6 +214,10 @@ public class BackupRestoreIndexRequestHandlerTest {
     restartIndexWithRestoreAndVerify(true, true);
   }
 
+  /**
+   * When a backup is downloaded we just point the index directory the downloaded files. This test verifies
+   * that if deleteExistingData is set during restore it deletes the directories from the backup as well.
+   */
   @Test
   public void testRestoreHandler_indexInitiallyStartedFromBackup_deleteExistingDataAndRestoreIndexWithDeleteExistingDataOption()
           throws IOException, InterruptedException {

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/BackupRestoreIndexRequestHandlerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/BackupRestoreIndexRequestHandlerTest.java
@@ -209,6 +209,23 @@ public class BackupRestoreIndexRequestHandlerTest {
     backupIndex(false);
     testAddDocs.addDocuments();
 
+
+
+    restartIndexWithRestoreAndVerify(true, true);
+  }
+
+  @Test
+  public void testRestoreHandler_indexInitiallyStartedFromBackup_deleteExistingDataAndRestoreIndexWithDeleteExistingDataOption()
+          throws IOException, InterruptedException {
+    GrpcServer.TestServer testAddDocs =
+            new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
+    testAddDocs.addDocuments();
+
+    backupIndex(false);
+    testAddDocs.addDocuments();
+
+    restartIndexWithRestoreAndVerify(true, true);
+
     restartIndexWithRestoreAndVerify(true, true);
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/BackupRestoreIndexRequestHandlerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/BackupRestoreIndexRequestHandlerTest.java
@@ -209,20 +209,20 @@ public class BackupRestoreIndexRequestHandlerTest {
     backupIndex(false);
     testAddDocs.addDocuments();
 
-
-
     restartIndexWithRestoreAndVerify(true, true);
   }
 
   /**
-   * When a backup is downloaded we just point the index directory the downloaded files. This test verifies
-   * that if deleteExistingData is set during restore it deletes the directories from the backup as well.
+   * When a backup is downloaded we just point the index directory the downloaded files. This test
+   * verifies that if deleteExistingData is set during restore it deletes the directories from the
+   * backup as well.
    */
   @Test
-  public void testRestoreHandler_indexInitiallyStartedFromBackup_deleteExistingDataAndRestoreIndexWithDeleteExistingDataOption()
+  public void
+      testRestoreHandler_indexInitiallyStartedFromBackup_deleteExistingDataAndRestoreIndexWithDeleteExistingDataOption()
           throws IOException, InterruptedException {
     GrpcServer.TestServer testAddDocs =
-            new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
+        new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
     testAddDocs.addDocuments();
 
     backupIndex(false);


### PR DESCRIPTION
#349 enabled deleting existing index data before doing a restore, but it didn't work correctly if the existing index was started from a backup. This was because an index started from backup doesn't have the files in the root directory, but the root directory is pointed to the backup. So the backup directory was not deleted, and the Archiver determined that it didn't need to download the backup since the directory was already present.
This PR fixes the issue by deleting the data directory for the index in Archiver directory.