### PR TITLE
Allow missing files in index stats handling

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/StatsRequestHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/StatsRequestHandler.java
@@ -71,7 +71,11 @@ public class StatsRequestHandler implements Handler<StatsRequest, StatsResponse>
       String[] fNames = shardState.indexDir.listAll();
       long dirSize = 0;
       for (int i = 0; i < fNames.length; i++) {
-        dirSize += shardState.indexDir.fileLength(fNames[i]);
+        try {
+          dirSize += shardState.indexDir.fileLength(fNames[i]);
+        } catch (IOException ignored) {
+          // files may be deleted from merging, don't fail the request
+        }
       }
       statsResponseBuilder.setDirSize(dirSize);
       // TODO: snapshots


### PR DESCRIPTION
Saw a file not found error pop up when using the stats endpoint. Added handling to ignore exceptions when getting the sizes of all files in the directory, as merged files may be deleted after getting the files list. 