### PR TITLE
Bump to v0.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ sourceCompatibility = 1.14
 targetCompatibility = 1.14
 
 allprojects {
-    version = '0.7.1'
+    version = '0.8.0'
     group = 'com.yelp.nrtsearch'
 }
 


### PR DESCRIPTION
Bump to v0.8.0 for terminate_after and per-rescorer diagnostic timing.