### PR TITLE
Refactor Rescorer interface to use RescoreContext

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ sourceCompatibility = 1.14
 targetCompatibility = 1.14
 
 allprojects {
-    version = '0.9.0'
+    version = '0.10.0'
     group = 'com.yelp.nrtsearch'
 }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
@@ -190,7 +190,7 @@ public class SearchHandler implements Handler<SearchRequest, SearchResponse> {
       if (!searchContext.getRescorers().isEmpty()) {
         for (RescoreTask rescorer : searchContext.getRescorers()) {
           long startNS = System.nanoTime();
-          hits = rescorer.rescore(s.searcher, hits);
+          hits = rescorer.rescore(hits, searchContext);
           long endNS = System.nanoTime();
           diagnostics.putRescorersTimeMs(rescorer.getName(), (endNS - startNS) / 1000000.0);
         }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/rescore/QueryRescore.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/rescore/QueryRescore.java
@@ -15,18 +15,20 @@
  */
 package com.yelp.nrtsearch.server.luceneserver.rescore;
 
+import java.io.IOException;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryRescorer;
+import org.apache.lucene.search.TopDocs;
 
 /**
  * A implementation of {@link QueryRescorer} that uses a provided Query to assign scores to the
  * first-pass hits. The final score is defined by the combine function and is calculated as follows:
  * <i>final_score = queryWeight * firstPassScore + rescoreQueryWeight * secondPassScore</i>
  */
-public final class QueryRescore extends QueryRescorer {
+public final class QueryRescore extends QueryRescorer implements RescoreOperation {
 
-  private double queryWeight;
-  private double rescoreQueryWeight;
+  private final double queryWeight;
+  private final double rescoreQueryWeight;
 
   private QueryRescore(Builder builder) {
     super(builder.query);
@@ -44,6 +46,14 @@ public final class QueryRescore extends QueryRescorer {
 
   public static Builder newBuilder() {
     return new Builder();
+  }
+
+  @Override
+  public TopDocs rescore(TopDocs hits, RescoreContext context) throws IOException {
+    return rescore(
+        context.getSearchContext().getSearcherAndTaxonomy().searcher,
+        hits,
+        context.getWindowSize());
   }
 
   public static class Builder {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/rescore/RescoreContext.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/rescore/RescoreContext.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.rescore;
+
+import com.yelp.nrtsearch.server.luceneserver.search.SearchContext;
+
+/** Class containing additional information a {@link RescoreOperation} can use for rescoring. */
+public class RescoreContext {
+  private final int windowSize;
+  private final SearchContext searchContext;
+
+  /**
+   * Constructor.
+   *
+   * @param windowSize rescore window size
+   * @param searchContext search context
+   */
+  public RescoreContext(int windowSize, SearchContext searchContext) {
+    this.windowSize = windowSize;
+    this.searchContext = searchContext;
+  }
+
+  /** Get rescore window size. */
+  public int getWindowSize() {
+    return windowSize;
+  }
+
+  /** Get query search context. */
+  public SearchContext getSearchContext() {
+    return searchContext;
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/rescore/RescoreOperation.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/rescore/RescoreOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Yelp Inc.
+ * Copyright 2021 Yelp Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,22 @@
  */
 package com.yelp.nrtsearch.server.luceneserver.rescore;
 
-import java.util.Map;
+import java.io.IOException;
+import org.apache.lucene.search.TopDocs;
 
 /**
- * Interface for getting a {@link RescoreOperation} implementation initialized with the given
- * parameters map.
- *
- * @param <T> rescorer type
+ * Interface for implementation of a rescore operation that produces {@link TopDocs} given the
+ * {@link TopDocs} from a previous search/rescore operation.
  */
-public interface RescorerProvider<T extends RescoreOperation> {
+public interface RescoreOperation {
 
   /**
-   * Get a {@link RescoreOperation} implementation initialized with the given parameters.
+   * Rescore the given hits to produce a new set of {@link TopDocs}.
    *
-   * @param params rescorer parameters decoded from {@link
-   *     com.yelp.nrtsearch.server.grpc.PluginRescorer}
-   * @return {@link RescoreOperation} instance
+   * @param hits {@link TopDocs} from a previous search/rescore operation
+   * @param context additional context for rescoring
+   * @return new hits ranking
+   * @throws IOException on error loading index data
    */
-  T get(Map<String, Object> params);
+  TopDocs rescore(TopDocs hits, RescoreContext context) throws IOException;
 }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/rescore/RescoreTask.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/rescore/RescoreTask.java
@@ -15,39 +15,38 @@
  */
 package com.yelp.nrtsearch.server.luceneserver.rescore;
 
+import com.yelp.nrtsearch.server.luceneserver.search.SearchContext;
 import java.io.IOException;
-import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.Rescorer;
 import org.apache.lucene.search.TopDocs;
 
 /**
- * A wrapper component for {@link Rescorer} and <i>int windowSize</i>. It has a public
+ * A wrapper component for {@link RescoreOperation} and <i>int windowSize</i>. It has a public
  * <i>rescore</i> method which is called by the {@link
  * com.yelp.nrtsearch.server.luceneserver.SearchHandler} to rescore the first-pass hits.
  */
 public class RescoreTask {
 
-  private final Rescorer rescorer;
+  private final RescoreOperation rescoreOperation;
   private final int windowSize;
   private final String name;
 
   private RescoreTask(Builder builder) {
-    rescorer = builder.rescorer;
+    rescoreOperation = builder.rescoreOperation;
     windowSize = builder.windowSize;
     name = builder.name;
   }
 
   /**
-   * This wrapper method calls {@link Rescorer} <i>rescore</i> method with <i>windowSize</i>
-   * parameter passed from {@link RescoreTask} class field.
+   * This wrapper method calls {@link RescoreOperation} <i>rescore</i> method with a {@link
+   * RescoreContext} to pass additional information.
    *
-   * @param searcher index searcher instance
    * @param hits results from the previous search pass
    * @return rescored documents
-   * @throws IOException
+   * @throws IOException on error loading index data
    */
-  public TopDocs rescore(IndexSearcher searcher, TopDocs hits) throws IOException {
-    return rescorer.rescore(searcher, hits, windowSize);
+  public TopDocs rescore(TopDocs hits, SearchContext searchContext) throws IOException {
+    RescoreContext context = new RescoreContext(windowSize, searchContext);
+    return rescoreOperation.rescore(hits, context);
   }
 
   public String getName() {
@@ -59,14 +58,14 @@ public class RescoreTask {
   }
 
   public static class Builder {
-    private Rescorer rescorer;
+    private RescoreOperation rescoreOperation;
     private int windowSize;
     private String name;
 
     private Builder() {}
 
-    public Builder setRescorer(Rescorer rescorer) {
-      this.rescorer = rescorer;
+    public Builder setRescoreOperation(RescoreOperation rescoreOperation) {
+      this.rescoreOperation = rescoreOperation;
       return this;
     }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/rescore/RescorerCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/rescore/RescorerCreator.java
@@ -22,28 +22,28 @@ import com.yelp.nrtsearch.server.plugins.RescorerPlugin;
 import com.yelp.nrtsearch.server.utils.StructValueTransformer;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.lucene.search.Rescorer;
 
 /**
- * Class to handle the creation of {@link Rescorer} instances. Type strings are mapped to {@link
- * RescorerProvider}s to produce concrete {@link Rescorer}s.
+ * Class to handle the creation of {@link RescoreOperation} instances. Type strings are mapped to
+ * {@link RescorerProvider}s to produce concrete {@link RescoreOperation}s.
  */
 public class RescorerCreator {
 
   private static RescorerCreator instance;
 
-  private final Map<String, RescorerProvider<? extends Rescorer>> rescorersMap = new HashMap<>();
+  private final Map<String, RescorerProvider<? extends RescoreOperation>> rescorersMap =
+      new HashMap<>();
 
   public RescorerCreator(LuceneServerConfiguration configuration) {}
 
   /**
-   * Get a {@link Rescorer} implementation by name, and with the given parameters. Valid names are
-   * any custom type registered by a {@link RescorerPlugin}.
+   * Get a {@link RescoreOperation} implementation by name, and with the given parameters. Valid
+   * names are any custom type registered by a {@link RescorerPlugin}.
    *
    * @param grpcPluginRescorer grpc message with plugin name and params map
    * @return rescorer instance
    */
-  public Rescorer createRescorer(PluginRescorer grpcPluginRescorer) {
+  public RescoreOperation createRescorer(PluginRescorer grpcPluginRescorer) {
     RescorerProvider<?> provider = rescorersMap.get(grpcPluginRescorer.getName());
     if (provider == null) {
       throw new IllegalArgumentException(
@@ -55,11 +55,11 @@ public class RescorerCreator {
     return provider.get(StructValueTransformer.transformStruct(grpcPluginRescorer.getParams()));
   }
 
-  private void register(Map<String, RescorerProvider<? extends Rescorer>> rescorers) {
+  private void register(Map<String, RescorerProvider<? extends RescoreOperation>> rescorers) {
     rescorers.forEach(this::register);
   }
 
-  private void register(String name, RescorerProvider<? extends Rescorer> rescorer) {
+  private void register(String name, RescorerProvider<? extends RescoreOperation> rescorer) {
     if (rescorersMap.containsKey(name)) {
       throw new IllegalArgumentException("Rescorer " + name + " already exists");
     }
@@ -68,7 +68,7 @@ public class RescorerCreator {
 
   /**
    * Initialize singleton instance of {@link RescorerCreator}. Registers any additional {@link
-   * Rescorer} implementations provided by {@link RescorerPlugin}s.
+   * RescoreOperation} implementations provided by {@link RescorerPlugin}s.
    *
    * @param configuration service configuration
    * @param plugins list of loaded plugins

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
@@ -29,6 +29,7 @@ import com.yelp.nrtsearch.server.luceneserver.field.FieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.IndexableFieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.VirtualFieldDef;
 import com.yelp.nrtsearch.server.luceneserver.rescore.QueryRescore;
+import com.yelp.nrtsearch.server.luceneserver.rescore.RescoreOperation;
 import com.yelp.nrtsearch.server.luceneserver.rescore.RescoreTask;
 import com.yelp.nrtsearch.server.luceneserver.rescore.RescorerCreator;
 import com.yelp.nrtsearch.server.luceneserver.script.ScoreScript;
@@ -56,7 +57,6 @@ import org.apache.lucene.queryparser.simple.SimpleQueryParser;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.Rescorer;
 import org.apache.lucene.util.QueryBuilder;
 
 /**
@@ -334,14 +334,14 @@ public class SearchRequestProcessor {
     for (int i = 0; i < searchRequest.getRescorersList().size(); ++i) {
       com.yelp.nrtsearch.server.grpc.Rescorer rescorer = searchRequest.getRescorers(i);
       String rescorerName = rescorer.getName();
-      Rescorer thisRescorer;
+      RescoreOperation thisRescoreOperation;
 
       if (rescorer.hasQueryRescorer()) {
         QueryRescorer queryRescorer = rescorer.getQueryRescorer();
         Query query = QUERY_NODE_MAPPER.getQuery(queryRescorer.getRescoreQuery(), indexState);
         query = searcher.rewrite(query);
 
-        thisRescorer =
+        thisRescoreOperation =
             QueryRescore.newBuilder()
                 .setQuery(query)
                 .setQueryWeight(queryRescorer.getQueryWeight())
@@ -349,7 +349,7 @@ public class SearchRequestProcessor {
                 .build();
       } else if (rescorer.hasPluginRescorer()) {
         PluginRescorer plugin = rescorer.getPluginRescorer();
-        thisRescorer = RescorerCreator.getInstance().createRescorer(plugin);
+        thisRescoreOperation = RescorerCreator.getInstance().createRescorer(plugin);
       } else {
         throw new IllegalArgumentException(
             "Rescorer should define either QueryRescorer or PluginRescorer");
@@ -357,7 +357,7 @@ public class SearchRequestProcessor {
 
       rescorers.add(
           RescoreTask.newBuilder()
-              .setRescorer(thisRescorer)
+              .setRescoreOperation(thisRescoreOperation)
               .setWindowSize(rescorer.getWindowSize())
               .setName(
                   rescorerName != null && !rescorerName.equals("")

--- a/src/main/java/com/yelp/nrtsearch/server/plugins/RescorerPlugin.java
+++ b/src/main/java/com/yelp/nrtsearch/server/plugins/RescorerPlugin.java
@@ -15,14 +15,20 @@
  */
 package com.yelp.nrtsearch.server.plugins;
 
+import com.yelp.nrtsearch.server.luceneserver.rescore.RescoreOperation;
 import com.yelp.nrtsearch.server.luceneserver.rescore.RescorerProvider;
 import java.util.Collections;
 import java.util.Map;
-import org.apache.lucene.search.Rescorer;
 
+/**
+ * Plugin interface for providing custom {@link RescoreOperation}s. Provides info for registration
+ * of rescorers by name. These rescorers can be invoked by sending {@link
+ * com.yelp.nrtsearch.server.grpc.Rescorer} messages as part of the {@link
+ * com.yelp.nrtsearch.server.grpc.SearchRequest}.
+ */
 public interface RescorerPlugin {
-
-  default Map<String, RescorerProvider<? extends Rescorer>> getRescorers() {
+  /** Get map of rescorer name to {@link RescorerProvider} for registration. */
+  default Map<String, RescorerProvider<? extends RescoreOperation>> getRescorers() {
     return Collections.emptyMap();
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/rescore/RescorerCreatorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/rescore/RescorerCreatorTest.java
@@ -30,9 +30,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.lucene.search.Explanation;
-import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.Rescorer;
 import org.apache.lucene.search.TopDocs;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,13 +53,14 @@ public class RescorerCreatorTest {
   public static class TestRescorerPlugin extends Plugin implements RescorerPlugin {
 
     @Override
-    public Map<String, RescorerProvider<? extends Rescorer>> getRescorers() {
-      Map<String, RescorerProvider<? extends Rescorer>> rescorerProviderMap = new HashMap<>();
+    public Map<String, RescorerProvider<? extends RescoreOperation>> getRescorers() {
+      Map<String, RescorerProvider<? extends RescoreOperation>> rescorerProviderMap =
+          new HashMap<>();
       rescorerProviderMap.put("plugin_rescorer", CustomRescorer::new);
       return rescorerProviderMap;
     }
 
-    public static class CustomRescorer extends Rescorer {
+    public static class CustomRescorer implements RescoreOperation {
 
       public final Map<String, Object> params;
 
@@ -71,14 +69,7 @@ public class RescorerCreatorTest {
       }
 
       @Override
-      public TopDocs rescore(IndexSearcher searcher, TopDocs firstPassTopDocs, int topN)
-          throws IOException {
-        return null;
-      }
-
-      @Override
-      public Explanation explain(
-          IndexSearcher searcher, Explanation firstPassExplanation, int docID) throws IOException {
+      public TopDocs rescore(TopDocs hits, RescoreContext context) throws IOException {
         return null;
       }
     }
@@ -93,7 +84,7 @@ public class RescorerCreatorTest {
   @Test
   public void testPluginProvidesRescorer() {
     init(Collections.singletonList(new TestRescorerPlugin()));
-    Rescorer rescorer =
+    RescoreOperation rescorer =
         RescorerCreator.getInstance()
             .createRescorer(PluginRescorer.newBuilder().setName("plugin_rescorer").build());
     assertTrue(rescorer instanceof TestRescorerPlugin.CustomRescorer);
@@ -102,7 +93,7 @@ public class RescorerCreatorTest {
   @Test
   public void testRescorerParams() {
     init(Collections.singletonList(new TestRescorerPlugin()));
-    Rescorer rescorer =
+    RescoreOperation rescorer =
         RescorerCreator.getInstance()
             .createRescorer(
                 PluginRescorer.newBuilder()

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/rescore/RescorerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/rescore/RescorerTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2021 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.rescore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
+import com.yelp.nrtsearch.server.grpc.PluginRescorer;
+import com.yelp.nrtsearch.server.grpc.Query;
+import com.yelp.nrtsearch.server.grpc.RangeQuery;
+import com.yelp.nrtsearch.server.grpc.Rescorer;
+import com.yelp.nrtsearch.server.grpc.SearchRequest;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
+import com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues;
+import com.yelp.nrtsearch.server.luceneserver.field.IndexableFieldDef;
+import com.yelp.nrtsearch.server.plugins.Plugin;
+import com.yelp.nrtsearch.server.plugins.RescorerPlugin;
+import io.grpc.StatusRuntimeException;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.ReaderUtil;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.TotalHits.Relation;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class RescorerTest extends ServerTestCase {
+  private static final String TEST_INDEX = "test_index";
+  private static final int NUM_DOCS = 100;
+  private static final int SEGMENT_CHUNK = 10;
+
+  @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  @Override
+  public List<String> getIndices() {
+    return Collections.singletonList(TEST_INDEX);
+  }
+
+  @Override
+  public FieldDefRequest getIndexDef(String name) throws IOException {
+    return getFieldsFromResourceFile("/rescore/RescoreRegisterFields.json");
+  }
+
+  @Override
+  public void initIndex(String name) throws Exception {
+    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    // don't want any merges for these tests
+    writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
+
+    // create a shuffled list of ids
+    List<Integer> idList = new ArrayList<>();
+    for (int i = 0; i < NUM_DOCS; ++i) {
+      idList.add(i);
+    }
+    Collections.shuffle(idList);
+
+    // add documents one chunk at a time to ensure multiple index segments
+    List<AddDocumentRequest> requestChunk = new ArrayList<>();
+    for (Integer id : idList) {
+      requestChunk.add(
+          AddDocumentRequest.newBuilder()
+              .setIndexName(name)
+              .putFields(
+                  "doc_id",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(id))
+                      .build())
+              .putFields(
+                  "int_score",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(NUM_DOCS - id))
+                      .build())
+              .putFields(
+                  "int_field",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(id))
+                      .build())
+              .build());
+
+      if (requestChunk.size() == SEGMENT_CHUNK) {
+        addDocuments(requestChunk.stream());
+        requestChunk.clear();
+        writer.commit();
+      }
+    }
+  }
+
+  static class TestRescorerPlugin extends Plugin implements RescorerPlugin {
+    TestRescorerPlugin() {}
+
+    public Map<String, RescorerProvider<? extends RescoreOperation>> getRescorers() {
+      Map<String, RescorerProvider<? extends RescoreOperation>> rescorers = new HashMap<>();
+      rescorers.put("test_rescorer", TestRescoreOperation::new);
+      return rescorers;
+    }
+
+    static class TestRescoreOperation implements RescoreOperation {
+      public TestRescoreOperation(Map<String, Object> params) {}
+
+      @Override
+      public TopDocs rescore(TopDocs hits, RescoreContext context) throws IOException {
+        List<DocAndScore> docAndScores = new ArrayList<>();
+        for (ScoreDoc doc : hits.scoreDocs) {
+          List<LeafReaderContext> leaves =
+              context
+                  .getSearchContext()
+                  .getSearcherAndTaxonomy()
+                  .searcher
+                  .getIndexReader()
+                  .leaves();
+          int leafIndex = ReaderUtil.subIndex(doc.doc, leaves);
+          LeafReaderContext leaf = leaves.get(leafIndex);
+          @SuppressWarnings("unchecked")
+          LoadedDocValues<Integer> docValues =
+              ((LoadedDocValues<Integer>)
+                  ((IndexableFieldDef)
+                          context.getSearchContext().getIndexState().getField("int_score"))
+                      .getDocValues(leaf));
+          docValues.setDocId(doc.doc - leaf.docBase);
+          int score = docValues.get(0);
+          docAndScores.add(new DocAndScore(score, doc));
+        }
+        docAndScores.sort(Comparator.comparingInt(d -> d.score));
+        ScoreDoc[] newOrder = new ScoreDoc[context.getWindowSize()];
+        int docIndex = 0;
+        for (int i = 0; i < context.getWindowSize(); i++) {
+          newOrder[i] = docAndScores.get(docIndex).doc;
+          docIndex += 2;
+        }
+        return new TopDocs(new TotalHits(context.getWindowSize(), Relation.EQUAL_TO), newOrder);
+      }
+
+      static class DocAndScore {
+        final int score;
+        final ScoreDoc doc;
+
+        DocAndScore(int score, ScoreDoc doc) {
+          this.score = score;
+          this.doc = doc;
+        }
+      }
+    }
+  }
+
+  protected List<Plugin> getPlugins() {
+    return Collections.singletonList(new TestRescorerPlugin());
+  }
+
+  @Test
+  public void testUnknownRescorer() {
+    SearchRequest request =
+        SearchRequest.newBuilder()
+            .setTopHits(10)
+            .setStartHit(0)
+            .setIndexName(DEFAULT_TEST_INDEX)
+            .addRetrieveFields("int_score")
+            .setQuery(
+                Query.newBuilder()
+                    .setRangeQuery(
+                        RangeQuery.newBuilder()
+                            .setField("int_field")
+                            .setLower("5")
+                            .setUpper("10")
+                            .build())
+                    .build())
+            .addRescorers(
+                Rescorer.newBuilder()
+                    .setPluginRescorer(PluginRescorer.newBuilder().setName("invalid").build())
+                    .build())
+            .build();
+    try {
+      getGrpcServer().getBlockingStub().search(request);
+      fail();
+    } catch (StatusRuntimeException e) {
+      String expectedMessage = "Invalid rescorer name: invalid, must be one of: [test_rescorer]";
+      assertTrue(e.getMessage().contains(expectedMessage));
+    }
+  }
+
+  @Test
+  public void testCustomRescorer() {
+    SearchRequest request =
+        SearchRequest.newBuilder()
+            .setTopHits(10)
+            .setStartHit(0)
+            .setIndexName(DEFAULT_TEST_INDEX)
+            .addRetrieveFields("int_score")
+            .setQuery(
+                Query.newBuilder()
+                    .setRangeQuery(
+                        RangeQuery.newBuilder()
+                            .setField("int_field")
+                            .setLower("5")
+                            .setUpper("10")
+                            .build())
+                    .build())
+            .addRescorers(
+                Rescorer.newBuilder()
+                    .setWindowSize(3)
+                    .setPluginRescorer(PluginRescorer.newBuilder().setName("test_rescorer").build())
+                    .build())
+            .build();
+    SearchResponse response = getGrpcServer().getBlockingStub().search(request);
+    assertEquals(3, response.getHitsCount());
+    assertEquals(
+        90, response.getHits(0).getFieldsOrThrow("int_score").getFieldValue(0).getIntValue());
+    assertEquals(
+        92, response.getHits(1).getFieldsOrThrow("int_score").getFieldValue(0).getIntValue());
+    assertEquals(
+        94, response.getHits(2).getFieldsOrThrow("int_score").getFieldValue(0).getIntValue());
+  }
+}

--- a/src/test/resources/rescore/RescoreRegisterFields.json
+++ b/src/test/resources/rescore/RescoreRegisterFields.json
@@ -1,0 +1,21 @@
+{
+  "indexName": "test_index",
+  "field": [
+    {
+      "name": "doc_id",
+      "type": "ATOM",
+      "storeDocValues": true
+    },
+    {
+      "name": "int_score",
+      "type": "INT",
+      "storeDocValues": true
+    },
+    {
+      "name": "int_field",
+      "type": "INT",
+      "search": true,
+      "storeDocValues": true
+    }
+  ]
+}


### PR DESCRIPTION
Change the Rescorer interfaces to allow passing of context information from nrtsearch. Previously, all rescorers needed to be a lucene `Rescorer`, which only received the `IndexSearcher` and window size. Now, all rescorers must implement the `RescoreOperation` interface, which passes a `RescoreContext`.

The `RescoreContext` provides the query `SearchContext`, which has access to field definitions and doc value accessors.

Existing rescorers and plugins will need to be updated to use the new interface, but it should be a pretty simple change (see `QueryRescore` below).