### PR TITLE
Add per document context accessor to SearchContext

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/doc/DefaultSharedDocContext.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/doc/DefaultSharedDocContext.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.doc;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Default implementation of a {@link SharedDocContext}. Uses a {@link ConcurrentHashMap} for thread
+ * safety.
+ */
+public class DefaultSharedDocContext implements SharedDocContext {
+  private final Map<Integer, Map<String, Object>> contextMap = new ConcurrentHashMap<>();
+
+  @Override
+  public Map<String, Object> getContext(int docId) {
+    return contextMap.computeIfAbsent(docId, k -> new HashMap<>());
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/doc/SharedDocContext.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/doc/SharedDocContext.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.doc;
+
+import java.util.Map;
+
+/**
+ * Interface for access to a per document map that can be used to pass information between different
+ * stages of query processing.
+ */
+public interface SharedDocContext {
+
+  /**
+   * Get the context map for a given lucene document id. This method must at least be thread safe
+   * under the condition that calls with the same docId will not be done concurrently. The resulting
+   * context map is assumed to not be synchronized.
+   *
+   * @param docId lucene global document id
+   * @return mutable context map
+   */
+  Map<String, Object> getContext(int docId);
+}

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchContext.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchContext.java
@@ -18,6 +18,7 @@ package com.yelp.nrtsearch.server.luceneserver.search;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import com.yelp.nrtsearch.server.luceneserver.IndexState;
 import com.yelp.nrtsearch.server.luceneserver.ShardState;
+import com.yelp.nrtsearch.server.luceneserver.doc.SharedDocContext;
 import com.yelp.nrtsearch.server.luceneserver.field.FieldDef;
 import com.yelp.nrtsearch.server.luceneserver.rescore.RescoreTask;
 import com.yelp.nrtsearch.server.luceneserver.search.collectors.DocCollector;
@@ -44,6 +45,7 @@ public class SearchContext {
   private final DocCollector collector;
   private final FetchTasks fetchTasks;
   private final List<RescoreTask> rescorers;
+  private final SharedDocContext sharedDocContext;
 
   private SearchContext(Builder builder, boolean validate) {
     this.indexState = builder.indexState;
@@ -59,6 +61,7 @@ public class SearchContext {
     this.collector = builder.collector;
     this.fetchTasks = builder.fetchTasks;
     this.rescorers = builder.rescorers;
+    this.sharedDocContext = builder.sharedDocContext;
 
     if (validate) {
       validate();
@@ -133,6 +136,11 @@ public class SearchContext {
     return rescorers;
   }
 
+  /** Get shared context accessor for documents */
+  public SharedDocContext getSharedDocContext() {
+    return sharedDocContext;
+  }
+
   /** Get new context builder instance * */
   public static Builder newBuilder() {
     return new Builder();
@@ -149,6 +157,7 @@ public class SearchContext {
     Objects.requireNonNull(collector);
     Objects.requireNonNull(fetchTasks);
     Objects.requireNonNull(rescorers);
+    Objects.requireNonNull(sharedDocContext);
 
     if (timestampSec < 0) {
       throw new IllegalStateException("Invalid timestamp value: " + timestampSec);
@@ -178,6 +187,7 @@ public class SearchContext {
     private DocCollector collector;
     private FetchTasks fetchTasks;
     private List<RescoreTask> rescorers;
+    private SharedDocContext sharedDocContext;
 
     private Builder() {}
 
@@ -259,6 +269,12 @@ public class SearchContext {
     /** Set rescorers that should be executed after the first pass */
     public Builder setRescorers(List<RescoreTask> rescorers) {
       this.rescorers = rescorers;
+      return this;
+    }
+
+    /** Set shared context accessor for documents */
+    public Builder setSharedDocContext(SharedDocContext sharedDocContext) {
+      this.sharedDocContext = sharedDocContext;
       return this;
     }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
@@ -25,6 +25,7 @@ import com.yelp.nrtsearch.server.grpc.VirtualField;
 import com.yelp.nrtsearch.server.luceneserver.IndexState;
 import com.yelp.nrtsearch.server.luceneserver.QueryNodeMapper;
 import com.yelp.nrtsearch.server.luceneserver.ShardState;
+import com.yelp.nrtsearch.server.luceneserver.doc.DefaultSharedDocContext;
 import com.yelp.nrtsearch.server.luceneserver.field.FieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.IndexableFieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.VirtualFieldDef;
@@ -142,6 +143,7 @@ public class SearchRequestProcessor {
 
     contextBuilder.setRescorers(
         getRescorers(indexState, searcherAndTaxonomy.searcher, searchRequest));
+    contextBuilder.setSharedDocContext(new DefaultSharedDocContext());
 
     return contextBuilder.build(true);
   }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/DefaultSharedDocContextTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/DefaultSharedDocContextTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.doc;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import java.util.Map;
+import org.junit.Test;
+
+public class DefaultSharedDocContextTest {
+
+  @Test
+  public void testGetContext() {
+    DefaultSharedDocContext context = new DefaultSharedDocContext();
+    Map<String, Object> map1 = context.getContext(1);
+    Map<String, Object> map2 = context.getContext(1);
+    Map<String, Object> map3 = context.getContext(2);
+    Map<String, Object> map4 = context.getContext(1);
+    Map<String, Object> map5 = context.getContext(2);
+
+    assertSame(map1, map2);
+    assertSame(map2, map4);
+    assertSame(map3, map5);
+    assertNotSame(map1, map3);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SharedDocContextTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SharedDocContextTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2021 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.doc;
+
+import static org.junit.Assert.assertEquals;
+
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
+import com.yelp.nrtsearch.server.grpc.Query;
+import com.yelp.nrtsearch.server.grpc.RangeQuery;
+import com.yelp.nrtsearch.server.grpc.SearchRequest;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import com.yelp.nrtsearch.server.grpc.SearchResponse.Hit;
+import com.yelp.nrtsearch.server.grpc.SearchResponse.Hit.CompositeFieldValue;
+import com.yelp.nrtsearch.server.grpc.SearchResponse.Hit.FieldValue;
+import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
+import com.yelp.nrtsearch.server.luceneserver.search.FetchTaskProvider;
+import com.yelp.nrtsearch.server.luceneserver.search.FetchTasks;
+import com.yelp.nrtsearch.server.luceneserver.search.FetchTasks.FetchTask;
+import com.yelp.nrtsearch.server.luceneserver.search.SearchContext;
+import com.yelp.nrtsearch.server.plugins.FetchTaskPlugin;
+import com.yelp.nrtsearch.server.plugins.Plugin;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.ReaderUtil;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class SharedDocContextTest extends ServerTestCase {
+  private static final String TEST_INDEX = "test_index";
+  private static final int NUM_DOCS = 100;
+  private static final int SEGMENT_CHUNK = 10;
+
+  @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  @Override
+  public List<String> getIndices() {
+    return Collections.singletonList(TEST_INDEX);
+  }
+
+  @Override
+  public FieldDefRequest getIndexDef(String name) throws IOException {
+    return getFieldsFromResourceFile("/doc/SharedContextRegisterFields.json");
+  }
+
+  @Override
+  public void initIndex(String name) throws Exception {
+    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    // don't want any merges for these tests
+    writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
+
+    // create a shuffled list of ids
+    List<Integer> idList = new ArrayList<>();
+    for (int i = 0; i < NUM_DOCS; ++i) {
+      idList.add(i);
+    }
+    Collections.shuffle(idList);
+
+    // add documents one chunk at a time to ensure multiple index segments
+    List<AddDocumentRequest> requestChunk = new ArrayList<>();
+    for (Integer id : idList) {
+      requestChunk.add(
+          AddDocumentRequest.newBuilder()
+              .setIndexName(name)
+              .putFields(
+                  "doc_id",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(id))
+                      .build())
+              .putFields(
+                  "int_score",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(NUM_DOCS - id))
+                      .build())
+              .putFields(
+                  "int_field",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(id))
+                      .build())
+              .build());
+
+      if (requestChunk.size() == SEGMENT_CHUNK) {
+        addDocuments(requestChunk.stream());
+        requestChunk.clear();
+        writer.commit();
+      }
+    }
+  }
+
+  @Override
+  public List<Plugin> getPlugins() {
+    return Collections.singletonList(new TestSharedContextPlugin());
+  }
+
+  static class TestSharedContextPlugin extends Plugin implements FetchTaskPlugin {
+    TestSharedContextPlugin() {}
+
+    @Override
+    public Map<String, FetchTaskProvider<? extends FetchTask>> getFetchTasks() {
+      Map<String, FetchTaskProvider<? extends FetchTasks.FetchTask>> taskMap = new HashMap<>();
+      taskMap.put("phase_1", Phase1Task::new);
+      taskMap.put("phase_2", Phase2Task::new);
+      return taskMap;
+    }
+
+    static class Phase1Task implements FetchTasks.FetchTask {
+      Phase1Task(Map<String, Object> params) {}
+
+      @Override
+      public void processHit(
+          SearchContext searchContext, LeafReaderContext hitLeaf, SearchResponse.Hit.Builder hit)
+          throws IOException {
+        List<LeafReaderContext> leaves =
+            searchContext.getSearcherAndTaxonomy().searcher.getIndexReader().leaves();
+        int leafIndex = ReaderUtil.subIndex(hit.getLuceneDocId(), leaves);
+        LeafReaderContext leaf = leaves.get(leafIndex);
+        SegmentDocLookup segmentDocLookup =
+            searchContext.getIndexState().docLookup.getSegmentLookup(leaf);
+        segmentDocLookup.setDocId(hit.getLuceneDocId() - leaf.docBase);
+        Integer score = (Integer) segmentDocLookup.get("int_score").get(0);
+        searchContext
+            .getSharedDocContext()
+            .getContext(hit.getLuceneDocId())
+            .put("shared_info", score * 2);
+      }
+    }
+
+    static class Phase2Task implements FetchTasks.FetchTask {
+      Phase2Task(Map<String, Object> params) {}
+
+      @Override
+      public void processHit(
+          SearchContext searchContext, LeafReaderContext hitLeaf, SearchResponse.Hit.Builder hit)
+          throws IOException {
+        Integer sharedValue =
+            (Integer)
+                searchContext
+                    .getSharedDocContext()
+                    .getContext(hit.getLuceneDocId())
+                    .get("shared_info");
+        hit.putFields(
+            "_context_value",
+            CompositeFieldValue.newBuilder()
+                .addFieldValue(FieldValue.newBuilder().setIntValue(sharedValue).build())
+                .build());
+      }
+    }
+  }
+
+  @Test
+  public void testSharedDocContext() {
+    SearchRequest request =
+        SearchRequest.newBuilder()
+            .setTopHits(10)
+            .setStartHit(0)
+            .setIndexName(DEFAULT_TEST_INDEX)
+            .addRetrieveFields("int_score")
+            .setQuery(
+                Query.newBuilder()
+                    .setRangeQuery(
+                        RangeQuery.newBuilder()
+                            .setField("int_field")
+                            .setLower("20")
+                            .setUpper("29")
+                            .build())
+                    .build())
+            .addFetchTasks(
+                com.yelp.nrtsearch.server.grpc.FetchTask.newBuilder().setName("phase_1").build())
+            .addFetchTasks(
+                com.yelp.nrtsearch.server.grpc.FetchTask.newBuilder().setName("phase_2").build())
+            .build();
+    SearchResponse response = getGrpcServer().getBlockingStub().search(request);
+    assertEquals(10, response.getHitsCount());
+    for (Hit hit : response.getHitsList()) {
+      assertEquals(
+          hit.getFieldsOrThrow("_context_value").getFieldValue(0).getIntValue(),
+          hit.getFieldsOrThrow("int_score").getFieldValue(0).getIntValue() * 2);
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/SearchContextTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/SearchContextTest.java
@@ -21,6 +21,7 @@ import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import com.yelp.nrtsearch.server.grpc.SearchResponse.Hit.Builder;
 import com.yelp.nrtsearch.server.grpc.SearchResponse.SearchState;
 import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
+import com.yelp.nrtsearch.server.luceneserver.doc.DefaultSharedDocContext;
 import com.yelp.nrtsearch.server.luceneserver.search.collectors.CollectorCreatorContext;
 import com.yelp.nrtsearch.server.luceneserver.search.collectors.DocCollector;
 import io.grpc.testing.GrpcCleanupRule;
@@ -71,9 +72,8 @@ public class SearchContextTest extends ServerTestCase {
     return getFieldsFromResourceFile("/registerFieldsBasic.json");
   }
 
-  @Test
-  public void testValid() throws Exception {
-    SearchContext.newBuilder()
+  private SearchContext.Builder getCompleteBuilder() throws IOException {
+    return SearchContext.newBuilder()
         .setIndexState(getGlobalState().getIndex(DEFAULT_TEST_INDEX))
         .setShardState(getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0))
         .setSearcherAndTaxonomy(new SearcherAndTaxonomy(null, null))
@@ -87,7 +87,12 @@ public class SearchContextTest extends ServerTestCase {
         .setCollector(new DummyCollector())
         .setFetchTasks(new FetchTasks(Collections.emptyList()))
         .setRescorers(Collections.emptyList())
-        .build(true);
+        .setSharedDocContext(new DefaultSharedDocContext());
+  }
+
+  @Test
+  public void testValid() throws Exception {
+    getCompleteBuilder().build(true);
   }
 
   @Test
@@ -102,217 +107,71 @@ public class SearchContextTest extends ServerTestCase {
 
   @Test(expected = NullPointerException.class)
   public void testMissingIndexState() throws Exception {
-    SearchContext.newBuilder()
-        .setShardState(getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0))
-        .setSearcherAndTaxonomy(new SearcherAndTaxonomy(null, null))
-        .setResponseBuilder(SearchResponse.newBuilder())
-        .setTimestampSec(1)
-        .setStartHit(0)
-        .setTopHits(10)
-        .setQueryFields(Collections.emptyMap())
-        .setRetrieveFields(Collections.emptyMap())
-        .setQuery(new MatchAllDocsQuery())
-        .setCollector(new DummyCollector())
-        .setFetchTasks(new FetchTasks(Collections.emptyList()))
-        .setRescorers(Collections.emptyList())
-        .setRescorers(Collections.emptyList())
-        .build(true);
+    getCompleteBuilder().setIndexState(null).build(true);
   }
 
   @Test(expected = NullPointerException.class)
   public void testMissingShardState() throws Exception {
-    SearchContext.newBuilder()
-        .setIndexState(getGlobalState().getIndex(DEFAULT_TEST_INDEX))
-        .setSearcherAndTaxonomy(new SearcherAndTaxonomy(null, null))
-        .setResponseBuilder(SearchResponse.newBuilder())
-        .setTimestampSec(1)
-        .setStartHit(0)
-        .setTopHits(10)
-        .setQueryFields(Collections.emptyMap())
-        .setRetrieveFields(Collections.emptyMap())
-        .setQuery(new MatchAllDocsQuery())
-        .setCollector(new DummyCollector())
-        .setFetchTasks(new FetchTasks(Collections.emptyList()))
-        .setRescorers(Collections.emptyList())
-        .build(true);
+    getCompleteBuilder().setShardState(null).build(true);
   }
 
   @Test(expected = NullPointerException.class)
   public void testMissingSearcher() throws Exception {
-    SearchContext.newBuilder()
-        .setIndexState(getGlobalState().getIndex(DEFAULT_TEST_INDEX))
-        .setShardState(getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0))
-        .setResponseBuilder(SearchResponse.newBuilder())
-        .setTimestampSec(1)
-        .setStartHit(0)
-        .setTopHits(10)
-        .setQueryFields(Collections.emptyMap())
-        .setRetrieveFields(Collections.emptyMap())
-        .setQuery(new MatchAllDocsQuery())
-        .setCollector(new DummyCollector())
-        .setFetchTasks(new FetchTasks(Collections.emptyList()))
-        .setRescorers(Collections.emptyList())
-        .build(true);
+    getCompleteBuilder().setSearcherAndTaxonomy(null).build(true);
   }
 
   @Test(expected = NullPointerException.class)
   public void testMissingResponseBuilder() throws Exception {
-    SearchContext.newBuilder()
-        .setIndexState(getGlobalState().getIndex(DEFAULT_TEST_INDEX))
-        .setShardState(getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0))
-        .setSearcherAndTaxonomy(new SearcherAndTaxonomy(null, null))
-        .setTimestampSec(1)
-        .setStartHit(0)
-        .setTopHits(10)
-        .setQueryFields(Collections.emptyMap())
-        .setRetrieveFields(Collections.emptyMap())
-        .setQuery(new MatchAllDocsQuery())
-        .setCollector(new DummyCollector())
-        .setFetchTasks(new FetchTasks(Collections.emptyList()))
-        .setRescorers(Collections.emptyList())
-        .build(true);
+    getCompleteBuilder().setResponseBuilder(null).build(true);
   }
 
   @Test(expected = IllegalStateException.class)
   public void testMissingTimestamp() throws Exception {
-    SearchContext.newBuilder()
-        .setIndexState(getGlobalState().getIndex(DEFAULT_TEST_INDEX))
-        .setShardState(getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0))
-        .setSearcherAndTaxonomy(new SearcherAndTaxonomy(null, null))
-        .setResponseBuilder(SearchResponse.newBuilder())
-        .setStartHit(0)
-        .setTopHits(10)
-        .setQueryFields(Collections.emptyMap())
-        .setRetrieveFields(Collections.emptyMap())
-        .setQuery(new MatchAllDocsQuery())
-        .setCollector(new DummyCollector())
-        .setFetchTasks(new FetchTasks(Collections.emptyList()))
-        .setRescorers(Collections.emptyList())
-        .build(true);
+    getCompleteBuilder().setTimestampSec(-1).build(true);
   }
 
   @Test(expected = IllegalStateException.class)
   public void testMissingStartHit() throws Exception {
-    SearchContext.newBuilder()
-        .setIndexState(getGlobalState().getIndex(DEFAULT_TEST_INDEX))
-        .setShardState(getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0))
-        .setSearcherAndTaxonomy(new SearcherAndTaxonomy(null, null))
-        .setResponseBuilder(SearchResponse.newBuilder())
-        .setTimestampSec(1)
-        .setTopHits(10)
-        .setQueryFields(Collections.emptyMap())
-        .setRetrieveFields(Collections.emptyMap())
-        .setQuery(new MatchAllDocsQuery())
-        .setCollector(new DummyCollector())
-        .setFetchTasks(new FetchTasks(Collections.emptyList()))
-        .setRescorers(Collections.emptyList())
-        .build(true);
+    getCompleteBuilder().setStartHit(-1).build(true);
   }
 
   @Test(expected = IllegalStateException.class)
   public void testMissingTopHits() throws Exception {
-    SearchContext.newBuilder()
-        .setIndexState(getGlobalState().getIndex(DEFAULT_TEST_INDEX))
-        .setShardState(getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0))
-        .setSearcherAndTaxonomy(new SearcherAndTaxonomy(null, null))
-        .setResponseBuilder(SearchResponse.newBuilder())
-        .setTimestampSec(1)
-        .setStartHit(0)
-        .setQueryFields(Collections.emptyMap())
-        .setRetrieveFields(Collections.emptyMap())
-        .setQuery(new MatchAllDocsQuery())
-        .setCollector(new DummyCollector())
-        .setFetchTasks(new FetchTasks(Collections.emptyList()))
-        .setRescorers(Collections.emptyList())
-        .build(true);
+    getCompleteBuilder().setTopHits(-1).build(true);
   }
 
   @Test(expected = NullPointerException.class)
   public void testMissingQueryFields() throws Exception {
-    SearchContext.newBuilder()
-        .setIndexState(getGlobalState().getIndex(DEFAULT_TEST_INDEX))
-        .setShardState(getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0))
-        .setSearcherAndTaxonomy(new SearcherAndTaxonomy(null, null))
-        .setResponseBuilder(SearchResponse.newBuilder())
-        .setTimestampSec(1)
-        .setStartHit(0)
-        .setTopHits(10)
-        .setRetrieveFields(Collections.emptyMap())
-        .setQuery(new MatchAllDocsQuery())
-        .setCollector(new DummyCollector())
-        .setFetchTasks(new FetchTasks(Collections.emptyList()))
-        .setRescorers(Collections.emptyList())
-        .build(true);
+    getCompleteBuilder().setQueryFields(null).build(true);
   }
 
   @Test(expected = NullPointerException.class)
   public void testMissingRetrieveFields() throws Exception {
-    SearchContext.newBuilder()
-        .setIndexState(getGlobalState().getIndex(DEFAULT_TEST_INDEX))
-        .setShardState(getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0))
-        .setSearcherAndTaxonomy(new SearcherAndTaxonomy(null, null))
-        .setResponseBuilder(SearchResponse.newBuilder())
-        .setTimestampSec(1)
-        .setStartHit(0)
-        .setTopHits(10)
-        .setQueryFields(Collections.emptyMap())
-        .setQuery(new MatchAllDocsQuery())
-        .setCollector(new DummyCollector())
-        .setFetchTasks(new FetchTasks(Collections.emptyList()))
-        .setRescorers(Collections.emptyList())
-        .build(true);
+    getCompleteBuilder().setRetrieveFields(null).build(true);
   }
 
   @Test(expected = NullPointerException.class)
   public void testMissingQuery() throws Exception {
-    SearchContext.newBuilder()
-        .setIndexState(getGlobalState().getIndex(DEFAULT_TEST_INDEX))
-        .setShardState(getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0))
-        .setSearcherAndTaxonomy(new SearcherAndTaxonomy(null, null))
-        .setResponseBuilder(SearchResponse.newBuilder())
-        .setTimestampSec(1)
-        .setStartHit(0)
-        .setTopHits(10)
-        .setQueryFields(Collections.emptyMap())
-        .setRetrieveFields(Collections.emptyMap())
-        .setCollector(new DummyCollector())
-        .setFetchTasks(new FetchTasks(Collections.emptyList()))
-        .setRescorers(Collections.emptyList())
-        .build(true);
+    getCompleteBuilder().setQuery(null).build(true);
   }
 
   @Test(expected = NullPointerException.class)
   public void testMissingCollector() throws Exception {
-    SearchContext.newBuilder()
-        .setIndexState(getGlobalState().getIndex(DEFAULT_TEST_INDEX))
-        .setShardState(getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0))
-        .setSearcherAndTaxonomy(new SearcherAndTaxonomy(null, null))
-        .setResponseBuilder(SearchResponse.newBuilder())
-        .setTimestampSec(1)
-        .setStartHit(0)
-        .setTopHits(10)
-        .setQueryFields(Collections.emptyMap())
-        .setRetrieveFields(Collections.emptyMap())
-        .setQuery(new MatchAllDocsQuery())
-        .setFetchTasks(new FetchTasks(Collections.emptyList()))
-        .setRescorers(Collections.emptyList())
-        .build(true);
+    getCompleteBuilder().setCollector(null).build(true);
   }
 
   @Test(expected = NullPointerException.class)
   public void testMissingFetchTasks() throws Exception {
-    SearchContext.newBuilder()
-        .setIndexState(getGlobalState().getIndex(DEFAULT_TEST_INDEX))
-        .setShardState(getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0))
-        .setSearcherAndTaxonomy(new SearcherAndTaxonomy(null, null))
-        .setResponseBuilder(SearchResponse.newBuilder())
-        .setTimestampSec(1)
-        .setStartHit(0)
-        .setTopHits(10)
-        .setQueryFields(Collections.emptyMap())
-        .setRetrieveFields(Collections.emptyMap())
-        .setQuery(new MatchAllDocsQuery())
-        .setCollector(new DummyCollector())
-        .build(true);
+    getCompleteBuilder().setFetchTasks(null).build(true);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testMissingRescorers() throws Exception {
+    getCompleteBuilder().setRescorers(null).build(true);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testMissingSharedDocContext() throws Exception {
+    getCompleteBuilder().setSharedDocContext(null).build(true);
   }
 }

--- a/src/test/resources/doc/SharedContextRegisterFields.json
+++ b/src/test/resources/doc/SharedContextRegisterFields.json
@@ -1,0 +1,21 @@
+{
+  "indexName": "test_index",
+  "field": [
+    {
+      "name": "doc_id",
+      "type": "ATOM",
+      "storeDocValues": true
+    },
+    {
+      "name": "int_score",
+      "type": "INT",
+      "storeDocValues": true
+    },
+    {
+      "name": "int_field",
+      "type": "INT",
+      "search": true,
+      "storeDocValues": true
+    }
+  ]
+}


### PR DESCRIPTION
Add mechanism to share per document context information between different post recall operations. Uses an accessor class to provide a mutable Map based on the document's lucene id. This accessor is available from the `SearchContext`.

Right now, this would mainly allow sharing between `FetchTask`s, but will also include custom rescorers after https://github.com/Yelp/nrtsearch/pull/357