### PR TITLE
Fix issues when changing min/max refresh seconds

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/cli/LiveSettingsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/server/cli/LiveSettingsCommand.java
@@ -36,15 +36,15 @@ public class LiveSettingsCommand implements Callable<Integer> {
   @CommandLine.Option(
       names = {"--maxRefreshSec"},
       description =
-          "Longest time to wait before reopening IndexSearcher (i.e., periodic background reopen). (default: ${DEFAULT-VALUE})",
-      defaultValue = "1.0")
+          "Longest time to wait before reopening IndexSearcher (i.e., periodic background reopen), or 0 to keep current value. (default: ${DEFAULT-VALUE})",
+      defaultValue = "0")
   private double maxRefreshSec;
 
   @CommandLine.Option(
       names = {"--minRefreshSec"},
       description =
-          "Shortest time to wait before reopening IndexSearcher (i.e., when a search is waiting for a specific indexGen). (default: ${DEFAULT-VALUE})",
-      defaultValue = "0.5")
+          "Shortest time to wait before reopening IndexSearcher (i.e., when a search is waiting for a specific indexGen), or 0 to keep current value. (default: ${DEFAULT-VALUE})",
+      defaultValue = "0")
   private double minRefreshSec;
 
   @CommandLine.Option(

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
@@ -813,24 +813,19 @@ public class IndexState implements Closeable, Restorable {
   }
 
   /**
-   * Live setting: set the mininum refresh time (seconds), which is the longest amount of time a
-   * client may wait for a searcher to reopen.
+   * Live setting: set the minimum and maximum refresh time (seconds), which is the longest amount
+   * of time a client may wait for a searcher to reopen.
    */
-  public synchronized void setMinRefreshSec(double min) {
-    minRefreshSec = min;
-    saveState.getLiveSettings().addProperty("minRefreshSec", min);
-    for (ShardState shardState : shards.values()) {
-      shardState.restartReopenThread();
+  public synchronized void setRefreshSec(double min, double max) {
+    if (min <= 0.0 || max <= 0.0) {
+      throw new IllegalArgumentException("Min and Max refresh seconds must be > 0");
     }
-  }
-
-  /**
-   * Live setting: set the maximum refresh time (seconds), which is the amount of time before we
-   * reopen the searcher proactively (when no search client is waiting for a specific index
-   * generation).
-   */
-  public synchronized void setMaxRefreshSec(double max) {
+    if (max < min) {
+      throw new IllegalArgumentException("Max refresh seconds must be >= Min refresh seconds");
+    }
+    minRefreshSec = min;
     maxRefreshSec = max;
+    saveState.getLiveSettings().addProperty("minRefreshSec", min);
     saveState.getLiveSettings().addProperty("maxRefreshSec", max);
     for (ShardState shardState : shards.values()) {
       shardState.restartReopenThread();

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/LiveSettingsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/LiveSettingsHandler.java
@@ -28,13 +28,18 @@ public class LiveSettingsHandler implements Handler<LiveSettingsRequest, LiveSet
       IndexState indexState, LiveSettingsRequest liveSettingsRequest) {
     logger.info(
         String.format("update liveSettings for index:  %s", liveSettingsRequest.getIndexName()));
-    if (liveSettingsRequest.getMaxRefreshSec() != 0) {
-      indexState.setMaxRefreshSec(liveSettingsRequest.getMaxRefreshSec());
-      logger.info(String.format("set maxRefreshSec: %s", liveSettingsRequest.getMaxRefreshSec()));
-    }
-    if (liveSettingsRequest.getMinRefreshSec() != 0) {
-      indexState.setMinRefreshSec(liveSettingsRequest.getMinRefreshSec());
-      logger.info(String.format("set minRefreshSec: %s", liveSettingsRequest.getMinRefreshSec()));
+    if (liveSettingsRequest.getMaxRefreshSec() != 0
+        || liveSettingsRequest.getMinRefreshSec() != 0) {
+      double maxSec =
+          liveSettingsRequest.getMaxRefreshSec() != 0
+              ? liveSettingsRequest.getMaxRefreshSec()
+              : indexState.maxRefreshSec;
+      double minSec =
+          liveSettingsRequest.getMinRefreshSec() != 0
+              ? liveSettingsRequest.getMinRefreshSec()
+              : indexState.minRefreshSec;
+      indexState.setRefreshSec(minSec, maxSec);
+      logger.info(String.format("set minRefreshSec: %s, maxRefreshSec: %s", minSec, maxSec));
     }
     if (liveSettingsRequest.getMaxSearcherAgeSec() != 0) {
       indexState.setMaxSearcherAgeSec(liveSettingsRequest.getMaxSearcherAgeSec());


### PR DESCRIPTION
Makes some improvements for changing min/max refresh seconds
- cli command defaults to noop
- min and max are set in a single method call
- validation done up front
- tests added