### PR TITLE
Use zulu base docker image for grpc gateway

### DIFF
--- a/grpc-gateway/Dockerfile
+++ b/grpc-gateway/Dockerfile
@@ -1,8 +1,7 @@
-FROM ubuntu:20.04
+FROM azul/zulu-openjdk-debian:14
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y wget unzip htop \
-    openjdk-14-jdk \
     golang-go \
     git
 


### PR DESCRIPTION
Java 14 is no longer available from the package server. Switches to using the zulu base image with java already installed.