### PR TITLE
support java 16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id "com.diffplug.gradle.spotless" version "4.3.0"
+    id 'java-library'
 }
 
 repositories {
@@ -105,7 +106,7 @@ dependencies {
     testImplementation "io.findify:s3mock_2.12:${s3mockVersion}"
     testImplementation "org.assertj:assertj-core:3.19.0"
 
-    compile project(':clientlib')
+    api project(':clientlib')
 }
 
 startScripts.enabled = false

--- a/clientlib/build.gradle
+++ b/clientlib/build.gradle
@@ -9,6 +9,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id "com.diffplug.gradle.spotless"
+    id 'java-library'
 }
 
 repositories {
@@ -32,7 +33,7 @@ def protocVersion = protobufVersion
 
 dependencies {
     //grpc deps
-    compile "io.grpc:grpc-protobuf:${rootProject.grpcVersion}"
+    implementation "io.grpc:grpc-protobuf:${rootProject.grpcVersion}"
     implementation "io.grpc:grpc-stub:${rootProject.grpcVersion}"
     implementation "io.grpc:grpc-okhttp:${rootProject.grpcVersion}"
     implementation "javax.annotation:javax.annotation-api:1.2"
@@ -40,12 +41,12 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
 
     // examples/advanced need this for JsonFormat
-    compile "com.google.protobuf:protobuf-java-util:${protobufVersion}"
+    api "com.google.protobuf:protobuf-java-util:${protobufVersion}"
 
     runtimeOnly "io.grpc:grpc-netty-shaded:${rootProject.grpcVersion}"
 
     //test deps
-    compile "io.grpc:grpc-testing:${rootProject.grpcVersion}"
+    api "io.grpc:grpc-testing:${rootProject.grpcVersion}"
 
     testImplementation "org.mockito:mockito-core:${rootProject.mockitoVersion}"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Wed Dec 18 15:47:22 PST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
This allows us to build with java 16. It still maintains backwards compatibility with Java 14 (ran build on java 14).
- needed to upgrade to gradle 7.0
- fix api and implementation as per gradle recommendations: https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal