### PR TITLE
Fix race condition in gateway docker build script

### DIFF
--- a/build_grpc_gateway.sh
+++ b/build_grpc_gateway.sh
@@ -1,6 +1,7 @@
 set -euxo pipefail
 docker build -t grpc-gateway -f grpc-gateway/Dockerfile .
-docker run grpc-gateway
-docker cp $(docker ps -alq):/code/output/yelp/nrtsearch/. ./grpc-gateway/
-docker cp $(docker ps -alq):/code/output/github.com/Yelp/nrtsearch/. ./grpc-gateway/
-docker cp $(docker ps -alq):/code/bin/. ./build/install/nrtsearch/bin
+CID=$(docker run -d grpc-gateway)
+docker cp $CID:/code/output/yelp/nrtsearch/. ./grpc-gateway/
+docker cp $CID:/code/output/github.com/Yelp/nrtsearch/. ./grpc-gateway/
+docker cp $CID:/code/bin/. ./build/install/nrtsearch/bin
+docker container rm $CID


### PR DESCRIPTION
The grpc-gateway build script runs a series of docker commands to copy files out of the gateway container. These commands get the container id of the last container executed. The is a race condition, and will fail if another container is run between the command executions.

Fixed script to save container id from the run command, and use that id for all subsequent commands.

Also now removes the container when the command finishes.