### PR TITLE
Use better toString for ExecutorWithParams

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/MyIndexSearcher.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/MyIndexSearcher.java
@@ -75,6 +75,13 @@ public class MyIndexSearcher extends IndexSearcher {
     public void execute(Runnable command) {
       wrapped.execute(command);
     }
+
+    @Override
+    public String toString() {
+      return String.format(
+          "ExecutorWithParams(sliceMaxDocs=%d, sliceMaxSegments=%d, virtualShards=%d, wrapped=%s)",
+          sliceMaxDocs, sliceMaxSegments, virtualShards, wrapped);
+    }
   }
 
   /**


### PR DESCRIPTION
The search executor gets printed as part of the `IndexSearcher` in the response of some of the index status endpoints. Adds a toString implementation that includes the parameters and wrapped executor.