### PR TITLE
Use generated .go files when building gateway wrappers

### DIFF
--- a/grpc-gateway/Dockerfile
+++ b/grpc-gateway/Dockerfile
@@ -83,6 +83,7 @@ $PROTO_PATH/yelp/nrtsearch/search.proto \
 $PROTO_PATH/yelp/nrtsearch/suggest.proto
 
 RUN cp $OUTPATH/yelp/nrtsearch/* grpc-gateway/
+RUN cp $OUTPATH/github.com/Yelp/nrtsearch/* grpc-gateway/
 
 # build go executables for various platforms
 RUN for GOOS in darwin linux windows; do \


### PR DESCRIPTION
Replace local .go files with the ones generated as part of building the grpc-gateway. The go files are used when building the wrappers. If the local files have errors (say from a merge conflict), the gateway build will fail.