### PR TITLE
Add action to create a release

### DIFF
--- a/.github/workflows/tagged_release.yml
+++ b/.github/workflows/tagged_release.yml
@@ -1,0 +1,18 @@
+---
+name: "tagged-release"
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  tagged-release:
+    name: "Tagged Release"
+    runs-on: "ubuntu-latest"
+
+    steps:     
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false


### PR DESCRIPTION
This action will run whenever a version tag is pushed. It will then create a release for the tag using all of the commit messages from the commits since the previous release. This uses [marvenpinto/action-automatic-releases](https://github.com/marvinpinto/action-automatic-releases).
Proposed workflow with this:
1. Make changes and send PR
2. Once PR is approved, squash-and-merge to master with a new commit message describing the changes in one line
3. Repeat steps 1 and 2 until all changes for release are in master
4. If the version was not bumped in one of the above PRs, bump it via another PR
5. Create and push a tag with the new version, e.g. "v0.9".
After step 5 this workflow will run and release the tag, using the commit messages to generate the release.

If this workflow seems fine, we can merge this PR and also update this in the README.