### PR TITLE
include building grpc gateway step on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Note: This code has been tested on *Java14*
 ./build/install/nrtsearch/bin/lucene-server
 ```
 
+# Build gRPC Gateway
+
+```
+./gradlew buildGrpcGateway
+```
+
 # Run REST Server (use the appropriate binary for your platform e.g. for mac os)
 
 ```


### PR DESCRIPTION
Hi there,

following the steps on the readme file to run the example I realized that building the gRPC gateway was not included. Just added that.

Thanks for sharing :)