### PR TITLE
Add globbing to populate links from directory pattern

### DIFF
--- a/docs/querying_nrtsearch.rst
+++ b/docs/querying_nrtsearch.rst
@@ -5,5 +5,6 @@ Nrtsearch mostly exposes the query classes in Lucene along with some other types
 
 .. toctree::
    :maxdepth: 1
+   :glob:
 
    queries/*


### PR DESCRIPTION
I missed adding globbing in the previous PR. This is required so that the links get populated from the directory pattern.

Ref: https://www.sphinx-doc.org/en/1.0/markup/toctree.html