### PR TITLE
This generalizes test LuceneServerTest.testBackupWarmingQueries()

### DIFF
--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -990,9 +990,7 @@ public class LuceneServerTest {
                   .build());
       fail("Expecting exception on the previous line");
     } catch (StatusRuntimeException e) {
-      assertEquals(
-          "UNKNOWN: Unable to backup warming queries since uptime is 0 minutes, which is less than threshold 1000",
-          e.getMessage());
+      assertEquals("UNKNOWN: Unable to backup warming queries", e.getMessage().substring(0, 41));
     }
 
     // Should fail; does not meet NumQueriesThreshold

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -51,6 +51,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hamcrest.core.IsCollectionContaining;
@@ -990,7 +992,11 @@ public class LuceneServerTest {
                   .build());
       fail("Expecting exception on the previous line");
     } catch (StatusRuntimeException e) {
-      assertEquals("UNKNOWN: Unable to backup warming queries", e.getMessage().substring(0, 41));
+      Pattern pattern =
+          Pattern.compile(
+              "UNKNOWN: Unable to backup warming queries since uptime is [0-9] minutes, which is less than threshold 1000");
+      Matcher m = pattern.matcher(e.getMessage());
+      assertTrue(m.matches());
     }
 
     // Should fail; does not meet NumQueriesThreshold


### PR DESCRIPTION
## Motivation 
It seems that when running tests locally the test LuceneServerTest.testBackupWarmingQueries() fails. This was reported in [issue-382](https://github.com/Yelp/nrtsearch/issues/382).  

## Solution
One solution would be to generalize the test. I noticed that when running the test in different environments the server uptime varied.  So this change is one way of fixing this. 

## Testing
Testing via `./gradlew clean installDist test` is green.

## Note to Reviewers
This may not be the best way of solving this problem. Is there a way of getting the gRPC server uptime?

For example, it would be better to rewrite the test to look like the example below, but I do not see a method for getting the gRPC server uptime.

```
assertEquals(
          "UNKNOWN: Unable to backup warming queries since uptime is "+replicaGrpcServer.getUptime()+" minutes, which is less than threshold 1000",
          e.getMessage());
```
