### PR TITLE
Dockerfile for Server and Client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM azul/zulu-openjdk-debian:14
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN mkdir /usr/app/
+COPY . /user/app/ 
+WORKDIR /user/app/ 
+
+RUN ./gradlew clean installDist 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -50,18 +50,30 @@ Below is a depiction of how the system works in regards to Near-real-time (NRT) 
 Build Server and Client
 ---------------------------
 
-In the home directory.
+In the home directory is a Dockerfile that will build a base image that can be used for the client and server.
+This Dockerfile is based off of a Java-14 image, installs the distribution via gradle, and can be built like this:
 
 .. code-block::
-  ./gradlew clean installDist test
-
-Note: This code has been tested on *Java14*.
+  shell% docker build --tag nrtsearch .
 
 Run gRPC Server
 ---------------------------
 
+The server can be run via the base image created in the step above. 
 .. code-block::
-  ./build/install/nrtsearch/bin/lucene-server
+  shell% docker run -d --network host nrtsearch /user/app/build/install/nrtsearch/bin/lucene-server
+
+Run gRPC Slient
+---------------------------
+
+The client can be accessed via a running Docker image built and run in the steps above.  For example, if one 
+wants to create an index, this command would work:
+.. code-block::
+  shell% CONTAINER_ID=$(docker ps -a | grep nrtsearch | awk '{print $1}')
+  shell% docker exec $CONTAINER_ID /user/app/build/install/nrtsearch/bin/lucene-client createIndex --indexName  testIdx
+  [INFO ] 2021-10-24 16:39:40.047 [main] LuceneServerClient - Will try to create index: testIdx
+  [INFO ] 2021-10-24 16:39:40.713 [main] LuceneServerClient - Server returned : Created Index name: testIdx
+
 
 Run REST Server
 ---------------------------

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -50,7 +50,17 @@ Below is a depiction of how the system works in regards to Near-real-time (NRT) 
 Build Server and Client
 ---------------------------
 
-The home directory contains a Dockerfile that will build a base image, which can be used for both the client and server.
+In the home directory, one can build nrtSearch locally like this:
+
+.. code-block::
+  ./gradlew clean installDist test
+
+Note: This code has been tested on *Java14*.
+
+Build Server and Client (Docker Version)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The home directory also contains a Dockerfile that will build a base image, which can be used for both the client and server.
 This Dockerfile is based off of a Java-14 image, installs the distribution via gradle, and can be built like this:
 
 .. code-block::
@@ -59,15 +69,25 @@ This Dockerfile is based off of a Java-14 image, installs the distribution via g
 Run gRPC Server
 ---------------------------
 
-The server can be run via the base image created in the step above. 
+The server can be run locally like this:
+
+.. code-block::
+  ./build/install/nrtsearch/bin/lucene-server
+
+Run gRPC Server (Docker Version)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Dockerized server can be run via the base image created in the step above like this:
+
 .. code-block::
   shell% docker run -d --network host nrtsearch /user/app/build/install/nrtsearch/bin/lucene-server
 
-Run gRPC Client 
+Run gRPC Client (Docker Version)
 ---------------------------
 
 The client can be accessed via a running Docker image built and run in the steps above.  For example, if one 
 wants to create an index, this command would work:
+
 .. code-block::
   shell% CONTAINER_ID=$(docker ps -a | grep nrtsearch | awk '{print $1}')
   shell% docker exec $CONTAINER_ID /user/app/build/install/nrtsearch/bin/lucene-client createIndex --indexName  testIdx

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -61,7 +61,7 @@ Build Server and Client (Docker Version)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The home directory also contains a Dockerfile that will build a base image, which can be used for both the client and server.
-This Dockerfile is based off of a Java-14 image, installs the distribution via gradle, and can be built like this:
+This Dockerfile is based off of a *Java14* image, installs the distribution via gradle, and can be built like this:
 
 .. code-block::
   shell% docker build --tag nrtsearch .

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -50,7 +50,7 @@ Below is a depiction of how the system works in regards to Near-real-time (NRT) 
 Build Server and Client
 ---------------------------
 
-In the home directory is a Dockerfile that will build a base image that can be used for the client and server.
+The home directory contains a Dockerfile that will build a base image, which can be used for both the client and server.
 This Dockerfile is based off of a Java-14 image, installs the distribution via gradle, and can be built like this:
 
 .. code-block::
@@ -63,7 +63,7 @@ The server can be run via the base image created in the step above.
 .. code-block::
   shell% docker run -d --network host nrtsearch /user/app/build/install/nrtsearch/bin/lucene-server
 
-Run gRPC Slient
+Run gRPC Client 
 ---------------------------
 
 The client can be accessed via a running Docker image built and run in the steps above.  For example, if one 


### PR DESCRIPTION
## Motivation
As reported in [issue-381](https://github.com/Yelp/nrtsearch/issues/381), we would like to start to dockerize nrtSearch.  This PR attempts to keep each change small, and add a simple Dockerfile.  

## Implementation
A single Dockerfile is included in this branch.  The same base image ( `azul/zulu-openjdk-debian:14` ) is used here as in the grpc_gateway image for simplicity later on when we want to build both images.  Gradle does not run the tests in the Dockerfile, but only runs the build. I would assume a CICD pipeline would run tests later.

Note that this build will not run a command. The command can be included later in docker run bash command (see below), docker-compose YAML, or K8s config YAML files.

## Questions
1. Should this PR include a build and/or start BASH scripts?
2. Should I provide more tests, such as a docker-compose run?
3. Should we run the gradle tests while building the container?

## Testing
The gradle tests are green.  

Below are some manual tests I did to show the container working.
```
shell% docker -v
Docker version 20.10.8, build 3967b7d28e

###########################
# build image
###########################
shell% docker build --tag nrtsearch .
Downloading https://services.gradle.org/distributions/gradle-7.0-bin.zip
..........10%...........20%...........30%..........40%...........50%...........60%...........70%..........80%...........90%...........100%

Welcome to Gradle 7.0!
...
BUILD SUCCESSFUL in 2m 1s
16 actionable tasks: 16 executed
Removing intermediate container cba694cc19c0
 ---> b95288748e37


###########################
# run the server
###########################
shell% docker run -d --network host nrtsearch /user/app/build/install/nrtsearch/bin/lucene-server
[INFO ] 2021-10-24 16:30:12.229 [main] ThreadPoolExecutorFactory - Creating LuceneIndexingExecutor of size 9
[INFO ] 2021-10-24 16:30:12.235 [main] ThreadPoolExecutorFactory - Creating LuceneSearchExecutor of size 13
[INFO ] 2021-10-24 16:30:12.236 [main] ThreadPoolExecutorFactory - Creating LuceneFetchExecutor of size 1
[INFO ] 2021-10-24 16:30:12.252 [main] Plugin - Loading plugins: []
[INFO ] 2021-10-24 16:30:12.470 [main] ThreadPoolExecutorFactory - Creating GrpcLuceneServerExecutor of size 9
[INFO ] 2021-10-24 16:30:12.606 [main] LuceneServer - Server started, listening on 6000 for messages
[INFO ] 2021-10-24 16:30:12.619 [main] ThreadPoolExecutorFactory - Creating GrpcReplicationServerExecutor of size 9
[INFO ] 2021-10-24 16:30:12.621 [main] LuceneServer - Server started, listening on 6001 for replication messages

###########################
# get container ID
###########################
CONTAINER_ID=$(docker ps -a | grep nrtsearch | awk '{print $1}')

###########################
# Create Index
###########################
shell% docker exec $CONTAINER_ID /user/app/build/install/nrtsearch/bin/lucene-client createIndex --indexName  testIdx
[INFO ] 2021-10-24 16:39:40.047 [main] LuceneServerClient - Will try to create index: testIdx
[INFO ] 2021-10-24 16:39:40.713 [main] LuceneServerClient - Server returned : Created Index name: testIdx

###########################
# add files to container
###########################
shell% docker ps
CONTAINER ID   IMAGE       COMMAND                  CREATED         STATUS         PORTS     NAMES
8e140d55c2f2   nrtsearch   "/user/app/build/ins…"   3 minutes ago   Up 3 minutes             objective_lichterman
shell% docker cp startIndex.json $CONTAINER_ID:/tmp/
shell% docker cp registerFields.json $CONTAINER_ID:/tmp/
shell% docker cp docs.csv $CONTAINER_ID:/tmp/
shell% docker cp search.json $CONTAINER_ID:/tmp/

###########################
# start Index
###########################
shell% docker exec $CONTAINER_ID /user/app/build/install/nrtsearch/bin/lucene-client startIndex -f /tmp/startIndex.json
[INFO ] 2021-10-24 16:51:41.339 [main] LuceneServerClientBuilder$StartIndexClientBuilder - Converting fields {
  "indexName" : "testIdx"
}
 to proto StartIndexRequest
[INFO ] 2021-10-24 16:51:41.520 [main] LuceneServerClientBuilder$StartIndexClientBuilder - jsonStr converted to proto StartIndexRequest: 
indexName: "testIdx"

[INFO ] 2021-10-24 16:51:42.037 [main] LuceneServerClient - Server returned : segments: "StandardDirectoryReader(segments:1:nrt)"
startTimeMS: 241.398372

###########################
# RegisterFields
###########################
shell% docker exec $CONTAINER_ID  /user/app/build/install/nrtsearch/bin/lucene-client registerFields -f /tmp/registerFields.json
[INFO ] 2021-10-25 18:50:19.083 [main] LuceneServerClient - Converting fields {             "indexName": "testIdx",
              "field":
              [
                      { "name": "doc_id", "type": "ATOM", "storeDocValues": true},
                      { "name": "vendor_name", "type": "TEXT" , "search": true, "store": true, "tokenize": true},
                      { "name": "license_no",  "type": "INT", "multiValued": true, "storeDocValues": true}
              ]
}
 to proto FieldDefRequest
[INFO ] 2021-10-25 18:50:19.274 [main] LuceneServerClient - jsonStr converted to proto FieldDefRequest indexName: "testIdx"
field {
  name: "doc_id"
  storeDocValues: true
}
field {
  name: "vendor_name"
  type: TEXT
  search: true
  store: true
  tokenize: true
}
field {
  name: "license_no"
  type: INT
  storeDocValues: true
  multiValued: true
}

[INFO ] 2021-10-25 18:50:19.505 [main] LuceneServerClient - Server returned : {"license_no":{"name":"license_no","type":"INT","storeDocValues":true,"multiValued":true},"vendor_name":{"name":"vendor_name","type":"TEXT","search":true,"store":true,"tokenize":true},"doc_id":{"name":"doc_id","storeDocValues":true}}

###########################
# Add Documents
###########################
shell% docker exec $CONTAINER_ID /user/app/build/install/nrtsearch/bin/lucene-client addDocuments -i testIdx -f /tmp/docs.csv -t csv
[INFO ] 2021-10-25 18:52:12.407 [main] LuceneServerClientBuilder$AddDocumentsClientBuilder - Read row 0
[INFO ] 2021-10-25 18:52:12.411 [main] LuceneServerClientBuilder$AddDocumentsClientBuilder - Read row 1
[INFO ] 2021-10-25 18:52:12.459 [main] LuceneServerClient - sent async addDocumentsRequest to server...
[INFO ] 2021-10-25 18:52:12.685 [grpc-default-executor-0] LuceneServerClient - Received response for genId: genId: "3"
primaryId: "3623a867-9948-4ab1-9e70-66fff98b0e63"

[INFO ] 2021-10-25 18:52:12.686 [grpc-default-executor-0] LuceneServerClient - Received final response from server

###########################
# Search
###########################
shell% docker exec $CONTAINER_ID /user/app/build/install/nrtsearch/bin/lucene-client search -f /tmp/search.json
[INFO ] 2021-10-25 18:53:08.265 [main] LuceneServerClientBuilder$SearchClientBuilder - Converting fields {
        "indexName": "testIdx",
        "startHit": 0,
        "topHits": 100,
        "retrieveFields": ["doc_id", "license_no", "vendor_name"],
         "queryText": "vendor_name:first vendor"
}
 to proto SearchRequest
[INFO ] 2021-10-25 18:53:08.399 [main] LuceneServerClientBuilder$SearchClientBuilder - jsonStr converted to proto SearchRequest: 
indexName: "testIdx"
topHits: 100
retrieveFields: "doc_id"
retrieveFields: "license_no"
retrieveFields: "vendor_name"
queryText: "vendor_name:first vendor"

[INFO ] 2021-10-25 18:53:08.748 [main] LuceneServerClient - Server returned : diagnostics {
  firstPassSearchTimeMs: 48.561708
  getFieldsTimeMs: 20.366334
}
totalHits {
  value: 2
}
hits {
  score: 0.3979403078556061
  fields {
    key: "doc_id"
    value {
      fieldValue {
        textValue: "0"
      }
    }
  }
  fields {
    key: "license_no"
    value {
      fieldValue {
        intValue: 100
      }
      fieldValue {
        intValue: 200
      }
    }
  }
  fields {
    key: "vendor_name"
    value {
      fieldValue {
        textValue: "first vendor"
      }
    }
  }
}
hits {
  luceneDocId: 1
  score: 0.08287343382835388
  fields {
    key: "doc_id"
    value {
      fieldValue {
        textValue: "1"
      }
    }
  }
  fields {
    key: "license_no"
    value {
      fieldValue {
        intValue: 111
      }
      fieldValue {
        intValue: 222
      }
    }
  }
  fields {
    key: "vendor_name"
    value {
      fieldValue {
        textValue: "second vendor"
      }
    }
  }
}
searchState {
}

```