### PR TITLE
Give GeoPoint a fastutils pair view

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ sourceCompatibility = 1.14
 targetCompatibility = 1.14
 
 allprojects {
-    version = '0.10.1'
+    version = '0.10.2'
     group = 'com.yelp.nrtsearch'
 }
 
@@ -46,6 +46,7 @@ def awsJavaSdkVersion = '1.11.695'
 def guicedeeVersion = '1.1.1.3-jre14'
 def lz4Version = '1.7.0'
 def prometheusClientVersion = '0.8.0'
+def fastutilVersion = '8.5.6'
 
 dependencies {
 
@@ -98,6 +99,8 @@ dependencies {
 
     // gRPC deps
     implementation "io.grpc:grpc-services:${project.ext.grpcVersion}"
+
+    implementation "it.unimi.dsi:fastutil:${fastutilVersion}"
 
     testImplementation "junit:junit:4.12"
     testImplementation "org.mockito:mockito-core:${project.ext.mockitoVersion}"

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/geo/GeoPoint.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/geo/GeoPoint.java
@@ -15,13 +15,15 @@
  */
 package com.yelp.nrtsearch.server.luceneserver.geo;
 
+import it.unimi.dsi.fastutil.doubles.DoubleDoublePair;
 import org.apache.lucene.util.SloppyMath;
 
 /**
  * Class to encapsulate a geo location loaded out of a doc value. Currently represents a lat/lon
- * value.
+ * value. Also provides point with a {@link DoubleDoublePair} view, with left/first being latitude
+ * and right/second being longitude.
  */
-public final class GeoPoint {
+public final class GeoPoint implements DoubleDoublePair {
   private final double latitude;
   private final double longitude;
 
@@ -66,5 +68,15 @@ public final class GeoPoint {
         .append(longitude)
         .append(")")
         .toString();
+  }
+
+  @Override
+  public double leftDouble() {
+    return latitude;
+  }
+
+  @Override
+  public double rightDouble() {
+    return longitude;
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
@@ -407,6 +407,16 @@ public class ScoreScriptTest {
         assertEquals(fieldName + " latitude", expectedPoint.getLat(), loadedPoint.getLat(), 0.0001);
         assertEquals(
             fieldName + " longitude", expectedPoint.getLon(), loadedPoint.getLon(), 0.0001);
+        assertEquals(
+            fieldName + " latitude (left)",
+            expectedPoint.getLat(),
+            loadedPoint.leftDouble(),
+            0.0001);
+        assertEquals(
+            fieldName + " longitude (right)",
+            expectedPoint.getLon(),
+            loadedPoint.rightDouble(),
+            0.0001);
 
         fieldName = "lat_lon_multi";
         docValues = getDoc().get(fieldName);


### PR DESCRIPTION
Have GeoPoint implement the fastutil `DoubleDoublePair`. Allows interaction without a direct dependency on the nrtsearch core.