### PR TITLE
Formatting corrections to render generated docs correctly

### DIFF
--- a/docs/analysis.rst
+++ b/docs/analysis.rst
@@ -19,7 +19,7 @@ To use a predefined analyzer you need to provide the name of the analyzer in ``p
 Predefined Analyzers
 -----------------------------
 
-Following are the predefined analyzers available in Nrtsearch. These are derived from the analyzer classes available in `Lucene <https://lucene.apache.org/core/8_4_0/analyzers-common/index.html>`.
+Following are the predefined analyzers available in Nrtsearch. These are derived from the analyzer classes available in `Lucene <https://lucene.apache.org/core/8_4_0/analyzers-common/index.html>`_.
 
   * ar.Arabic
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -53,6 +53,7 @@ Build Server and Client
 In the home directory, one can build nrtSearch locally like this:
 
 .. code-block::
+
   ./gradlew clean installDist test
 
 Note: This code has been tested on *Java14*.
@@ -64,6 +65,7 @@ The home directory also contains a Dockerfile that will build a base image, whic
 This Dockerfile is based off of a *Java14* image, installs the distribution via gradle, and can be built like this:
 
 .. code-block::
+
   shell% docker build --tag nrtsearch .
 
 Run gRPC Server
@@ -72,6 +74,7 @@ Run gRPC Server
 The server can be run locally like this:
 
 .. code-block::
+
   ./build/install/nrtsearch/bin/lucene-server
 
 Run gRPC Server (Docker Version)
@@ -80,6 +83,7 @@ Run gRPC Server (Docker Version)
 The Dockerized server can be run via the base image created in the step above like this:
 
 .. code-block::
+
   shell% docker run -d --network host nrtsearch /user/app/build/install/nrtsearch/bin/lucene-server
 
 Run gRPC Client (Docker Version)
@@ -89,6 +93,7 @@ The client can be accessed via a running Docker image built and run in the steps
 wants to create an index, this command would work:
 
 .. code-block::
+
   shell% CONTAINER_ID=$(docker ps -a | grep nrtsearch | awk '{print $1}')
   shell% docker exec $CONTAINER_ID /user/app/build/install/nrtsearch/bin/lucene-client createIndex --indexName  testIdx
   [INFO ] 2021-10-24 16:39:40.047 [main] LuceneServerClient - Will try to create index: testIdx
@@ -101,4 +106,5 @@ Run REST Server
 Use the appropriate binary for your platform e.g. for Mac OS X:
 
 .. code-block::
+
   ./build/install/nrtsearch/bin/http_wrapper-darwin-amd64 <gRPC_PORT> <REST_PORT>


### PR DESCRIPTION
Made some corrections:
1. Add "_" after the link
2. Add empty line after starting code-block