### PR TITLE
Update gradle.yml to disable jacoco code coverage enforcements

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,8 +35,8 @@ jobs:
       uses: cicirello/jacoco-badge-generator@v2.4.1
       with:
         jacoco-csv-file: build/reports/jacoco/test/jacocoTestReport.csv
-        generate-coverage-badge: true
-        generate-branches-badge: true
-        on-missing-report: fail
-        fail-on-coverage-decrease: true
-        fail-on-branches-decrease: true
+        # generate-coverage-badge: true
+        # generate-branches-badge: true
+        # on-missing-report: fail
+        # fail-on-coverage-decrease: true
+        # fail-on-branches-decrease: true


### PR DESCRIPTION
I see https://github.com/Yelp/nrtsearch/pull/393 is failing, because there was no jacoco history. I'm going to disable the restrictions and re-enable them once history is created.