### PR TITLE
Fix Long field retrieval from doc values

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/doc/LoadedDocValues.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/doc/LoadedDocValues.java
@@ -262,7 +262,7 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
 
     @Override
     public SearchResponse.Hit.FieldValue toFieldValue(int index) {
-      return SearchResponse.Hit.FieldValue.newBuilder().setLongValue(index).build();
+      return SearchResponse.Hit.FieldValue.newBuilder().setLongValue(get(index)).build();
     }
   }
 


### PR DESCRIPTION
This is fixed as part of https://github.com/Yelp/nrtsearch/pull/387 but I want to take some time to run more benchmarks. This is a pretty obvious bug that will cause incorrect data to be returned for multi value long fields. Better to fix it sooner rather than later.