### PR TITLE
IllegalStateException when adding documents to an index on a replica …

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/AddDocumentHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/AddDocumentHandler.java
@@ -314,6 +314,10 @@ public class AddDocumentHandler implements Handler<AddDocumentRequest, Any> {
     }
 
     private void addDocuments(Queue<Document> documents, ShardState shardState) throws IOException {
+      if (shardState.isReplica()) {
+        throw new IllegalStateException(
+            "Adding documents to an index on a replica node is not supported");
+      }
       shardState.writer.addDocuments(
           (Iterable<Document>)
               () ->

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/GrpcServer.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/GrpcServer.java
@@ -345,7 +345,9 @@ public class GrpcServer {
         throws IOException, InterruptedException {
       Stream<AddDocumentRequest> addDocumentRequestStream = getAddDocumentRequestStream(fileName);
       addDocumentsFromStream(addDocumentRequestStream);
-      refresh();
+      if (addDocumentResponse != null) {
+        refresh();
+      }
       return addDocumentResponse;
     }
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/GrpcServer.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/GrpcServer.java
@@ -317,6 +317,7 @@ public class GrpcServer {
     public AddDocumentResponse addDocumentResponse;
     public boolean completed = false;
     public boolean error = false;
+    public Throwable throwable = null;
 
     public TestServer(
         GrpcServer grpcServer, boolean startIndex, Mode mode, int primaryGen, boolean startOldIndex)
@@ -345,7 +346,7 @@ public class GrpcServer {
         throws IOException, InterruptedException {
       Stream<AddDocumentRequest> addDocumentRequestStream = getAddDocumentRequestStream(fileName);
       addDocumentsFromStream(addDocumentRequestStream);
-      if (addDocumentResponse != null) {
+      if (!error) {
         refresh();
       }
       return addDocumentResponse;
@@ -365,6 +366,7 @@ public class GrpcServer {
             @Override
             public void onError(Throwable t) {
               error = true;
+              throwable = t;
               finishLatch.countDown();
             }
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
@@ -492,4 +492,18 @@ public class ReplicationServerTest {
     SearchResponse.Hit secondHit = searchResponse.getHits(1);
     LuceneServerTest.checkHits(secondHit);
   }
+
+  @Test
+  public void testAddDocumentsOnReplicaFailure() throws IOException, InterruptedException {
+    // startIndex primary
+    GrpcServer.TestServer testServerPrimary =
+        new GrpcServer.TestServer(luceneServerPrimary, true, Mode.PRIMARY);
+
+    // startIndex replica
+    GrpcServer.TestServer testServerReplica =
+        new GrpcServer.TestServer(luceneServerSecondary, true, Mode.REPLICA);
+    testServerReplica.addDocuments();
+    assertEquals(testServerReplica.error, true);
+    assertEquals(testServerReplica.completed, false);
+  }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
@@ -503,7 +503,12 @@ public class ReplicationServerTest {
     GrpcServer.TestServer testServerReplica =
         new GrpcServer.TestServer(luceneServerSecondary, true, Mode.REPLICA);
     testServerReplica.addDocuments();
-    assertEquals(testServerReplica.error, true);
-    assertEquals(testServerReplica.completed, false);
+    assertEquals(false, testServerReplica.completed);
+    assertEquals(true, testServerReplica.error);
+    assertTrue(
+        testServerReplica
+            .throwable
+            .getMessage()
+            .contains("Adding documents to an index on a replica node is not supported"));
   }
 }


### PR DESCRIPTION
Error:
```
[WARN ] 2021-12-06 09:31:12.246 [LuceneIndexingExecutor-4-thread-1] LuceneServer - error while trying to addDocuments
java.lang.IllegalStateException: Adding documents to an index on a replica node is not supported
	at com.yelp.nrtsearch.server.luceneserver.AddDocumentHandler$DocumentIndexer.addDocuments(AddDocumentHandler.java:318) ~[main/:?]
	at com.yelp.nrtsearch.server.luceneserver.AddDocumentHandler$DocumentIndexer.runIndexingJob(AddDocumentHandler.java:238) ~[main/:?]
	at com.yelp.nrtsearch.server.grpc.LuceneServer$LuceneServerImpl$1.onCompletedForIndex(LuceneServer.java:703) ~[main/:?]
	at com.yelp.nrtsearch.server.grpc.LuceneServer$LuceneServerImpl$1.lambda$onCompleted$0(LuceneServer.java:748) ~[main/:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) [?:?]
	at java.lang.Thread.run(Thread.java:832) [?:?]
```