### PR TITLE
Add query cache query metrics

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/QueryCacheConfig.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/QueryCacheConfig.java
@@ -29,6 +29,7 @@ public class QueryCacheConfig {
   static final float DEFAULT_MIN_SIZE_RATIO = 0.03f;
   static final float DEFAULT_SKIP_CACHE_FACTOR = 250.0f;
 
+  private final boolean enabled;
   private final int maxQueries;
   private final long maxMemoryBytes;
   private final Predicate<LeafReaderContext> leafPredicate;
@@ -41,6 +42,7 @@ public class QueryCacheConfig {
    * @return class instance
    */
   public static QueryCacheConfig fromConfig(YamlConfigReader configReader) {
+    boolean enabled = configReader.getBoolean(CONFIG_PREFIX + "enabled", true);
     int maxQueries = configReader.getInteger(CONFIG_PREFIX + "maxQueries", DEFAULT_MAX_QUERIES);
     String maxMemory = configReader.getString(CONFIG_PREFIX + "maxMemory", DEFAULT_MAX_MEMORY);
     long maxMemoryBytes = sizeStrToBytes(maxMemory);
@@ -49,7 +51,8 @@ public class QueryCacheConfig {
         configReader.getFloat(CONFIG_PREFIX + "minSizeRatio", DEFAULT_MIN_SIZE_RATIO);
     float skipCacheFactor =
         configReader.getFloat(CONFIG_PREFIX + "skipCacheFactor", DEFAULT_SKIP_CACHE_FACTOR);
-    return new QueryCacheConfig(maxQueries, maxMemoryBytes, minDocs, minSizeRatio, skipCacheFactor);
+    return new QueryCacheConfig(
+        enabled, maxQueries, maxMemoryBytes, minDocs, minSizeRatio, skipCacheFactor);
   }
 
   /**
@@ -91,6 +94,7 @@ public class QueryCacheConfig {
   /**
    * Constructor.
    *
+   * @param enabled toggle for enabling query cache
    * @param maxQueries max queries the cache will hold
    * @param maxMemoryBytes maximum cache memory size
    * @param minDocs min docs needed to consider caching for a segment
@@ -98,11 +102,22 @@ public class QueryCacheConfig {
    * @param skipCacheFactor skip caching clauses this many times as expensive as top-level query
    */
   public QueryCacheConfig(
-      int maxQueries, long maxMemoryBytes, int minDocs, float minSizeRatio, float skipCacheFactor) {
+      boolean enabled,
+      int maxQueries,
+      long maxMemoryBytes,
+      int minDocs,
+      float minSizeRatio,
+      float skipCacheFactor) {
+    this.enabled = enabled;
     this.maxQueries = maxQueries;
     this.maxMemoryBytes = maxMemoryBytes;
     this.leafPredicate = new MinSegmentSizePredicate(minDocs, minSizeRatio);
     this.skipCacheFactor = skipCacheFactor;
+  }
+
+  /** Get if query cache is enabled. */
+  public boolean getEnabled() {
+    return enabled;
   }
 
   /** Get maximum queries to cache. */

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/cache/NrtQueryCache.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/cache/NrtQueryCache.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.search.cache;
+
+import java.util.function.Predicate;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.LRUQueryCache;
+import org.apache.lucene.search.Query;
+
+/**
+ * Query cache implementation that extends the default {@link LRUQueryCache} and exposes additional
+ * metrics.
+ */
+public class NrtQueryCache extends LRUQueryCache {
+
+  // these variables are volatile so that we do not need to sync reads
+  // but increments need to be performed under the lock
+  private volatile long cacheQueryCount;
+  private volatile long cacheQuerySize;
+
+  public NrtQueryCache(
+      int maxSize,
+      long maxRamBytesUsed,
+      Predicate<LeafReaderContext> leavesToCache,
+      float skipCacheFactor) {
+    super(maxSize, maxRamBytesUsed, leavesToCache, skipCacheFactor);
+  }
+
+  public NrtQueryCache(int maxSize, long maxRamBytesUsed) {
+    super(maxSize, maxRamBytesUsed);
+  }
+
+  /** Get count of all queries added to cache. */
+  public long getCacheQueryCount() {
+    return cacheQueryCount;
+  }
+
+  /** Get current number of queries in the cache. */
+  public long getCacheQuerySize() {
+    return cacheQuerySize;
+  }
+
+  @Override
+  protected void onQueryCache(Query query, long ramBytesUsed) {
+    // super method asserts thread holds cache lock
+    super.onQueryCache(query, ramBytesUsed);
+    cacheQueryCount += 1;
+    cacheQuerySize += 1;
+  }
+
+  @Override
+  protected void onQueryEviction(Query query, long ramBytesUsed) {
+    // super method asserts thread holds cache lock
+    super.onQueryEviction(query, ramBytesUsed);
+    cacheQuerySize -= 1;
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/config/QueryCacheConfigTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/QueryCacheConfigTest.java
@@ -16,6 +16,7 @@
 package com.yelp.nrtsearch.server.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -36,6 +37,7 @@ public class QueryCacheConfigTest {
   public void testDefault() {
     String configFile = "nodeName: \"lucene_server_foo\"";
     QueryCacheConfig config = getConfig(configFile);
+    assertTrue(config.getEnabled());
     assertEquals(config.getMaxQueries(), QueryCacheConfig.DEFAULT_MAX_QUERIES);
     assertEquals(config.getMaxMemoryBytes(), (32L * 1024 * 1024));
     assertEquals(config.getSkipCacheFactor(), QueryCacheConfig.DEFAULT_SKIP_CACHE_FACTOR, 0.0);
@@ -54,12 +56,14 @@ public class QueryCacheConfigTest {
             "\n",
             "nodeName: \"lucene_server_foo\"",
             "queryCache:",
+            "  enabled: false",
             "  maxQueries: 5000",
             "  maxMemory: '128MB'",
             "  minDocs: 7000",
             "  minSizeRatio: 0.05",
             "  skipCacheFactor: 400");
     QueryCacheConfig config = getConfig(configFile);
+    assertFalse(config.getEnabled());
     assertEquals(config.getMaxQueries(), 5000);
     assertEquals(config.getMaxMemoryBytes(), (128L * 1024 * 1024));
     assertEquals(config.getSkipCacheFactor(), 400.0, 0.0);


### PR DESCRIPTION
Add metrics for query cache queries. Existing published metrics track the cached id sets, but there is no visibility at the query level (number of queries cached, rate of new queries, etc).

Adds a new `QueryCache` implementation that extends the default and adds tracking for new metrics:
- `nrt_query_cache_query_size` - current number of queries in cache
- `nrt_query_cache_query_count` - count of all queries added to cache
- `nrt_query_cache_query_eviction_count` - count of all queries evicted from cache

Additionally, this adds a global `enabled` option to the cache config to allow disabling of the query cache entirely.