### PR TITLE
Log errors during guice injector creation

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -268,9 +268,9 @@ public class LuceneServer {
 
     @Override
     public Integer call() throws Exception {
-      Injector injector = Guice.createInjector(new LuceneServerModule(this));
       LuceneServer luceneServer;
       try {
+        Injector injector = Guice.createInjector(new LuceneServerModule(this));
         luceneServer = injector.getInstance(LuceneServer.class);
         luceneServer.start();
       } catch (Throwable t) {


### PR DESCRIPTION
The `Guice.createInjector()` call can fail and throw an exception, which would not be logged.

Put injector creation inside the catch-all try block around server start, so that uncaught exceptions will be logged.