### PR TITLE
fix an issue causing replica cannot startIndex without primary

### DIFF
--- a/src/test/java/com/yelp/nrtsearch/server/LuceneServerTestConfigurationFactory.java
+++ b/src/test/java/com/yelp/nrtsearch/server/LuceneServerTestConfigurationFactory.java
@@ -24,23 +24,25 @@ import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class LuceneServerTestConfigurationFactory {
-  static AtomicLong atomicLong = new AtomicLong();
+  private AtomicLong atomicLong;
 
-  public static LuceneServerConfiguration getConfig(Mode mode, File dataRootDir) {
+  public LuceneServerTestConfigurationFactory() {
+    this.atomicLong = new AtomicLong();
+  }
+
+  public LuceneServerConfiguration getConfig(Mode mode, File dataRootDir) {
     return getConfig(mode, dataRootDir, Paths.get(dataRootDir.toString(), "archiver"), "");
   }
 
-  public static LuceneServerConfiguration getConfig(
-      Mode mode, File dataRootDir, String extraConfig) {
+  public LuceneServerConfiguration getConfig(Mode mode, File dataRootDir, String extraConfig) {
     return getConfig(mode, dataRootDir, Paths.get(dataRootDir.toString(), "archiver"), extraConfig);
   }
 
-  public static LuceneServerConfiguration getConfig(
-      Mode mode, File dataRootDir, Path archiverDirectory) {
+  public LuceneServerConfiguration getConfig(Mode mode, File dataRootDir, Path archiverDirectory) {
     return getConfig(mode, dataRootDir, archiverDirectory, "");
   }
 
-  public static LuceneServerConfiguration getConfig(
+  public LuceneServerConfiguration getConfig(
       Mode mode, File dataRootDir, Path archiverDirectory, String extraConfig) {
     String dirNum = String.valueOf(atomicLong.addAndGet(1));
     if (mode.equals(Mode.STANDALONE)) {
@@ -76,6 +78,8 @@ public class LuceneServerTestConfigurationFactory {
               extraConfig);
       return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
     } else if (mode.equals(Mode.REPLICA)) {
+      // allow creating more than one replica without collision
+      long portOffset = atomicLong.addAndGet(2);
       String stateDir =
           Paths.get(dataRootDir.getAbsolutePath(), "replica", dirNum, "state").toString();
       String indexDir =
@@ -86,8 +90,8 @@ public class LuceneServerTestConfigurationFactory {
               "nodeName: replica",
               "stateDir: " + stateDir,
               "indexDir: " + indexDir,
-              "port: " + 9902,
-              "replicationPort: " + 9003,
+              "port: " + (9902 + portOffset),
+              "replicationPort: " + (9003 + portOffset),
               extraConfig);
       return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
     }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/AckedCopyTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/AckedCopyTest.java
@@ -61,6 +61,7 @@ public class AckedCopyTest {
   private AmazonS3 s3;
   private Path s3Directory;
   private Path archiverDirectory;
+  private LuceneServerTestConfigurationFactory luceneServerTestConfigurationFactory;
 
   @After
   public void tearDown() throws IOException {
@@ -94,8 +95,9 @@ public class AckedCopyTest {
 
     // set up primary servers
     String testIndex = "test_index";
+    luceneServerTestConfigurationFactory = new LuceneServerTestConfigurationFactory();
     LuceneServerConfiguration luceneServerPrimaryConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.PRIMARY, folder.getRoot(), extraConfig);
+        luceneServerTestConfigurationFactory.getConfig(Mode.PRIMARY, folder.getRoot(), extraConfig);
     GlobalState globalStatePrimary = new GlobalState(luceneServerPrimaryConfiguration);
     luceneServerPrimary =
         new GrpcServer(
@@ -121,7 +123,7 @@ public class AckedCopyTest {
             archiver);
     // set up secondary servers
     LuceneServerConfiguration luceneServerSecondaryConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.REPLICA, folder.getRoot(), extraConfig);
+        luceneServerTestConfigurationFactory.getConfig(Mode.REPLICA, folder.getRoot(), extraConfig);
     GlobalState globalStateSecondary = new GlobalState(luceneServerSecondaryConfiguration);
 
     luceneServerSecondary =

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/BackupRestoreIndexRequestHandlerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/BackupRestoreIndexRequestHandlerTest.java
@@ -84,8 +84,10 @@ public class BackupRestoreIndexRequestHandlerTest {
   }
 
   private GrpcServer setUpGrpcServer() throws IOException {
+    LuceneServerTestConfigurationFactory luceneServerTestConfigurationFactory =
+        new LuceneServerTestConfigurationFactory();
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
+        luceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     GlobalState globalState = new GlobalState(luceneServerConfiguration);
     return new GrpcServer(
         grpcCleanup,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/CustomFieldTypeTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/CustomFieldTypeTest.java
@@ -81,8 +81,10 @@ public class CustomFieldTypeTest {
 
   private GrpcServer setUpGrpcServer(CollectorRegistry collectorRegistry) throws IOException {
     String testIndex = "test_index";
+    LuceneServerTestConfigurationFactory luceneServerTestConfigurationFactory =
+        new LuceneServerTestConfigurationFactory();
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
+        luceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     GlobalState globalState = new GlobalState(luceneServerConfiguration);
     return new GrpcServer(
         collectorRegistry,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/FailedBackupCleanupTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/FailedBackupCleanupTest.java
@@ -17,9 +17,7 @@ package com.yelp.nrtsearch.server.grpc;
 
 import static com.yelp.nrtsearch.server.grpc.GrpcServer.rmDir;
 import static com.yelp.nrtsearch.server.grpc.LuceneServerTest.RETRIEVED_VALUES;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
@@ -52,6 +50,9 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public class FailedBackupCleanupTest {
+  private static LuceneServerTestConfigurationFactory luceneServerTestConfigurationFactory =
+      new LuceneServerTestConfigurationFactory();
+
   private final String BUCKET_NAME = "archiver-unittest";
   private Archiver archiver;
   private AmazonS3 s3;
@@ -77,7 +78,7 @@ public class FailedBackupCleanupTest {
     archiver =
         new ArchiverImpl(s3, BUCKET_NAME, archiverDirectory, new TarImpl(Tar.CompressionMode.LZ4));
     luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(
+        luceneServerTestConfigurationFactory.getConfig(
             Mode.PRIMARY, folder.getRoot(), archiverDirectory);
     grpcServer = setUpGrpcServer();
   }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerIdFieldTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerIdFieldTest.java
@@ -16,9 +16,7 @@
 package com.yelp.nrtsearch.server.grpc;
 
 import static com.yelp.nrtsearch.server.grpc.GrpcServer.rmDir;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import com.yelp.nrtsearch.server.LuceneServerTestConfigurationFactory;
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
@@ -75,8 +73,10 @@ public class LuceneServerIdFieldTest {
 
   private GrpcServer setUpGrpcServer(CollectorRegistry collectorRegistry) throws IOException {
     String testIndex = "test_index";
+    LuceneServerTestConfigurationFactory luceneServerTestConfigurationFactory =
+        new LuceneServerTestConfigurationFactory();
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
+        luceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     GlobalState globalState = new GlobalState(luceneServerConfiguration);
     return new GrpcServer(
         collectorRegistry,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -44,13 +44,7 @@ import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -181,8 +175,10 @@ public class LuceneServerTest {
 
   private GrpcServer setUpGrpcServer(CollectorRegistry collectorRegistry) throws IOException {
     String testIndex = "test_index";
+    LuceneServerTestConfigurationFactory luceneServerTestConfigurationFactory =
+        new LuceneServerTestConfigurationFactory();
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
+        luceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     GlobalState globalState = new GlobalState(luceneServerConfiguration);
     return new GrpcServer(
         collectorRegistry,
@@ -201,8 +197,10 @@ public class LuceneServerTest {
   private GrpcServer setUpReplicaGrpcServer(CollectorRegistry collectorRegistry)
       throws IOException {
     String testIndex = "test_index";
+    LuceneServerTestConfigurationFactory luceneServerTestConfigurationFactory =
+        new LuceneServerTestConfigurationFactory();
     LuceneServerConfiguration luceneServerReplicaConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(
+        luceneServerTestConfigurationFactory.getConfig(
             Mode.REPLICA, folder.getRoot(), getExtraConfig());
     GlobalState globalStateSecondary = new GlobalState(luceneServerReplicaConfiguration);
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/MergeBehaviorTests.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/MergeBehaviorTests.java
@@ -84,8 +84,10 @@ public class MergeBehaviorTests {
 
   private GrpcServer setUpGrpcServer(CollectorRegistry collectorRegistry) throws IOException {
     String testIndex = "test_index";
+    LuceneServerTestConfigurationFactory luceneServerTestConfigurationFactory =
+        new LuceneServerTestConfigurationFactory();
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
+        luceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     GlobalState globalState = new GlobalState(luceneServerConfiguration);
     return new GrpcServer(
         collectorRegistry,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
@@ -76,8 +76,10 @@ public class QueryTest {
 
   private GrpcServer setUpGrpcServer() throws IOException {
     String testIndex = "test_index";
+    LuceneServerTestConfigurationFactory luceneServerTestConfigurationFactory =
+        new LuceneServerTestConfigurationFactory();
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
+        luceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     GlobalState globalState = new GlobalState(luceneServerConfiguration);
     return new GrpcServer(
         grpcCleanup,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationTestFailureScenarios.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationTestFailureScenarios.java
@@ -97,8 +97,10 @@ public class ReplicationTestFailureScenarios {
   }
 
   public void startPrimaryServer() throws IOException {
+    LuceneServerTestConfigurationFactory luceneServerTestConfigurationFactory =
+        new LuceneServerTestConfigurationFactory();
     LuceneServerConfiguration luceneServerPrimaryConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.PRIMARY, folder.getRoot());
+        luceneServerTestConfigurationFactory.getConfig(Mode.PRIMARY, folder.getRoot());
     GlobalState globalStatePrimary = new GlobalState(luceneServerPrimaryConfiguration);
     luceneServerPrimary =
         new GrpcServer(
@@ -125,8 +127,10 @@ public class ReplicationTestFailureScenarios {
   }
 
   public void startSecondaryServer() throws IOException {
+    LuceneServerTestConfigurationFactory luceneServerTestConfigurationFactory =
+        new LuceneServerTestConfigurationFactory();
     LuceneServerConfiguration luceneSecondaryConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.REPLICA, folder.getRoot());
+        luceneServerTestConfigurationFactory.getConfig(Mode.REPLICA, folder.getRoot());
     GlobalState globalStateSecondary = new GlobalState(luceneSecondaryConfiguration);
 
     luceneServerSecondary =

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/SuggestTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/SuggestTest.java
@@ -25,11 +25,7 @@ import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.luceneserver.GlobalState;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
-import java.io.BufferedWriter;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
+import java.io.*;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -79,8 +75,10 @@ public class SuggestTest {
 
   @Before
   public void setUp() throws IOException {
+    LuceneServerTestConfigurationFactory luceneServerTestConfigurationFactory =
+        new LuceneServerTestConfigurationFactory();
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
+        luceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     GlobalState globalState = new GlobalState(luceneServerConfiguration);
     grpcServer =
         new GrpcServer(

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/IndexStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/IndexStateTest.java
@@ -665,16 +665,20 @@ public class IndexStateTest {
   }
 
   public GlobalState getInitState() throws IOException {
+    LuceneServerTestConfigurationFactory luceneServerTestConfigurationFactory =
+        new LuceneServerTestConfigurationFactory();
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
+        luceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     FieldDefCreator.initialize(luceneServerConfiguration, Collections.emptyList());
     SimilarityCreator.initialize(luceneServerConfiguration, Collections.emptyList());
     return new GlobalState(luceneServerConfiguration);
   }
 
   public GlobalState getInitStateVirtualSharding() throws IOException {
+    LuceneServerTestConfigurationFactory luceneServerTestConfigurationFactory =
+        new LuceneServerTestConfigurationFactory();
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(
+        luceneServerTestConfigurationFactory.getConfig(
             Mode.STANDALONE, folder.getRoot(), "virtualSharding: true");
     FieldDefCreator.initialize(luceneServerConfiguration, Collections.emptyList());
     SimilarityCreator.initialize(luceneServerConfiguration, Collections.emptyList());

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/RestoreStateHandlerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/RestoreStateHandlerTest.java
@@ -32,11 +32,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 
 public class RestoreStateHandlerTest {
@@ -63,8 +59,10 @@ public class RestoreStateHandlerTest {
     archiver =
         new ArchiverImpl(
             s3, BUCKET_NAME, archiverDirectory, new TarImpl(TarImpl.CompressionMode.LZ4));
+    LuceneServerTestConfigurationFactory luceneServerTestConfigurationFactory =
+        new LuceneServerTestConfigurationFactory();
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
+        luceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     globalState = new GlobalState(luceneServerConfiguration);
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/ServerTestCase.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/ServerTestCase.java
@@ -21,26 +21,12 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import com.yelp.nrtsearch.server.LuceneServerTestConfigurationFactory;
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
-import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
-import com.yelp.nrtsearch.server.grpc.AddDocumentResponse;
-import com.yelp.nrtsearch.server.grpc.CreateIndexRequest;
-import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
-import com.yelp.nrtsearch.server.grpc.GrpcServer;
-import com.yelp.nrtsearch.server.grpc.LiveSettingsRequest;
-import com.yelp.nrtsearch.server.grpc.LuceneServerClientBuilder;
-import com.yelp.nrtsearch.server.grpc.LuceneServerGrpc;
-import com.yelp.nrtsearch.server.grpc.Mode;
-import com.yelp.nrtsearch.server.grpc.RefreshRequest;
-import com.yelp.nrtsearch.server.grpc.StartIndexRequest;
+import com.yelp.nrtsearch.server.grpc.*;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import io.prometheus.client.CollectorRegistry;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -201,8 +187,10 @@ public class ServerTestCase {
 
   private GrpcServer setUpGrpcServer(CollectorRegistry collectorRegistry) throws IOException {
     String testIndex = "test_index";
+    LuceneServerTestConfigurationFactory luceneServerTestConfigurationFactory =
+        new LuceneServerTestConfigurationFactory();
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(
+        luceneServerTestConfigurationFactory.getConfig(
             Mode.STANDALONE, folder.getRoot(), getExtraConfig());
     globalState = new GlobalState(luceneServerConfiguration);
     return new GrpcServer(

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
@@ -16,25 +16,11 @@
 package com.yelp.nrtsearch.server.luceneserver.script;
 
 import static com.yelp.nrtsearch.server.grpc.GrpcServer.rmDir;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import com.yelp.nrtsearch.server.LuceneServerTestConfigurationFactory;
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
-import com.yelp.nrtsearch.server.grpc.AddDocumentResponse;
-import com.yelp.nrtsearch.server.grpc.FunctionScoreQuery;
-import com.yelp.nrtsearch.server.grpc.GrpcServer;
-import com.yelp.nrtsearch.server.grpc.MatchQuery;
-import com.yelp.nrtsearch.server.grpc.Mode;
-import com.yelp.nrtsearch.server.grpc.Query;
-import com.yelp.nrtsearch.server.grpc.RefreshRequest;
-import com.yelp.nrtsearch.server.grpc.Script;
-import com.yelp.nrtsearch.server.grpc.SearchRequest;
-import com.yelp.nrtsearch.server.grpc.SearchResponse;
-import com.yelp.nrtsearch.server.grpc.VirtualField;
+import com.yelp.nrtsearch.server.grpc.*;
 import com.yelp.nrtsearch.server.luceneserver.GlobalState;
 import com.yelp.nrtsearch.server.luceneserver.doc.DocLookup;
 import com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues;
@@ -49,11 +35,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DoubleValues;
 import org.junit.After;
@@ -95,8 +77,10 @@ public class ScoreScriptTest {
 
   private GrpcServer setUpGrpcServer(CollectorRegistry collectorRegistry) throws IOException {
     String testIndex = "test_index";
+    LuceneServerTestConfigurationFactory luceneServerTestConfigurationFactory =
+        new LuceneServerTestConfigurationFactory();
     LuceneServerConfiguration luceneServerConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
+        luceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     GlobalState globalState = new GlobalState(luceneServerConfiguration);
     return new GrpcServer(
         collectorRegistry,


### PR DESCRIPTION
The luecene abstract replica node initiates with pull delta from the primary. We set the primaryGen to be -1 if the primary is down to allow the replica to start alone.

RP-5477