### PR TITLE
Add deadline based cancellation for search requests

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -86,6 +86,7 @@ public class LuceneServerConfiguration {
   private final boolean indexVerbose;
   private final FileCopyConfig fileCopyConfig;
   private final ScriptCacheConfig scriptCacheConfig;
+  private final boolean deadlineCancellation;
 
   private final YamlConfigReader configReader;
   private final long maxConnectionAgeForReplication;
@@ -144,6 +145,7 @@ public class LuceneServerConfiguration {
     fileCopyConfig = FileCopyConfig.fromConfig(configReader);
     threadPoolConfiguration = new ThreadPoolConfiguration(configReader);
     scriptCacheConfig = ScriptCacheConfig.fromConfig(configReader);
+    deadlineCancellation = configReader.getBoolean("deadlineCancellation", false);
   }
 
   public ThreadPoolConfiguration getThreadPoolConfiguration() {
@@ -268,6 +270,10 @@ public class LuceneServerConfiguration {
 
   public ScriptCacheConfig getScriptCacheConfig() {
     return scriptCacheConfig;
+  }
+
+  public boolean getDeadlineCancellation() {
+    return deadlineCancellation;
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/DeadlineUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/DeadlineUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.grpc;
+
+import com.yelp.nrtsearch.server.monitoring.DeadlineMetrics;
+import io.grpc.Context;
+import io.grpc.Deadline;
+import io.grpc.Status;
+
+/** Utility class for functionality related to gRPC request deadlines. */
+public class DeadlineUtils {
+  private static boolean cancellationEnabled = false;
+
+  /** Set if deadline based request cancellation is enabled. */
+  public static void setCancellationEnabled(boolean enabled) {
+    cancellationEnabled = enabled;
+  }
+
+  /** Get if deadline based request cancellation is enabled. */
+  public static boolean getCancellationEnabled() {
+    return cancellationEnabled;
+  }
+
+  /**
+   * Check if the deadline for the current request is expired, and cancel the request if needed.
+   * This method is a noop if cancellation is disabled by {@link #setCancellationEnabled(boolean)},
+   * or if the request has no deadline.
+   *
+   * @param message context to add to exception message
+   * @param operation operation label for metrics collection
+   * @throws io.grpc.StatusRuntimeException with CANCELLED status if deadline is expired
+   */
+  public static void checkDeadline(String message, String operation) {
+    if (cancellationEnabled) {
+      Deadline deadline = Context.current().getDeadline();
+      if (deadline != null && deadline.isExpired()) {
+        DeadlineMetrics.nrtDeadlineCancelCount.labels(operation).inc();
+        throw Status.CANCELLED
+            .withDescription("Request deadline exceeded: " + message)
+            .asRuntimeException();
+      }
+    }
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
@@ -18,6 +18,7 @@ package com.yelp.nrtsearch.server.luceneserver;
 import com.google.common.collect.Lists;
 import com.google.protobuf.Struct;
 import com.google.protobuf.util.JsonFormat;
+import com.yelp.nrtsearch.server.grpc.DeadlineUtils;
 import com.yelp.nrtsearch.server.grpc.FacetResult;
 import com.yelp.nrtsearch.server.grpc.ProfileResult;
 import com.yelp.nrtsearch.server.grpc.SearchRequest;
@@ -93,6 +94,9 @@ public class SearchHandler implements Handler<SearchRequest, SearchResponse> {
   @Override
   public SearchResponse handle(IndexState indexState, SearchRequest searchRequest)
       throws SearchHandlerException {
+    // this request may have been waiting in the grpc queue too long
+    DeadlineUtils.checkDeadline("SearchHandler: start", "SEARCH");
+
     ShardState shardState = indexState.getShard(0);
 
     // Index won't be started if we are currently warming
@@ -180,6 +184,8 @@ public class SearchHandler implements Handler<SearchRequest, SearchResponse> {
 
       diagnostics.setFirstPassSearchTimeMs(((System.nanoTime() - searchStartTime) / 1000000.0));
 
+      DeadlineUtils.checkDeadline("SearchHandler: post recall", "SEARCH");
+
       // add detailed timing metrics for query execution
       if (profileResultBuilder != null) {
         searchContext.getCollector().maybeAddProfiling(profileResultBuilder);
@@ -193,6 +199,7 @@ public class SearchHandler implements Handler<SearchRequest, SearchResponse> {
           hits = rescorer.rescore(hits, searchContext);
           long endNS = System.nanoTime();
           diagnostics.putRescorersTimeMs(rescorer.getName(), (endNS - startNS) / 1000000.0);
+          DeadlineUtils.checkDeadline("SearchHandler: post " + rescorer.getName(), "SEARCH");
         }
         diagnostics.setRescoreTimeMs(((System.nanoTime() - rescoreStartTime) / 1000000.0));
       }
@@ -258,6 +265,8 @@ public class SearchHandler implements Handler<SearchRequest, SearchResponse> {
       logger.error("Unable to add warming query", e);
     }
 
+    // if we are out of time, don't bother with serialization
+    DeadlineUtils.checkDeadline("SearchHandler: end", "SEARCH");
     return searchContext.getResponseBuilder().build();
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/DeadlineMetrics.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/DeadlineMetrics.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.monitoring;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Counter;
+
+public class DeadlineMetrics {
+
+  public static final Counter nrtDeadlineCancelCount =
+      Counter.build()
+          .name("nrt_deadline_cancel_count")
+          .help("Number of requests canceled from expired deadlines.")
+          .labelNames("operation")
+          .create();
+
+  /**
+   * Add all deadline metrics to the collector registry.
+   *
+   * @param registry collector registry
+   */
+  public static void register(CollectorRegistry registry) {
+    registry.register(nrtDeadlineCancelCount);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/DeadLineUtilsEnableTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/DeadLineUtilsEnableTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.grpc;
+
+import static org.junit.Assert.assertTrue;
+
+import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
+import io.grpc.testing.GrpcCleanupRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class DeadLineUtilsEnableTest extends ServerTestCase {
+  @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  public String getExtraConfig() {
+    return "deadlineCancellation: true";
+  }
+
+  @Test
+  public void testDeadlineCancellationEnabled() {
+    assertTrue(DeadlineUtils.getCancellationEnabled());
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/DeadlineUtilsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/DeadlineUtilsTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.grpc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import com.yelp.nrtsearch.server.monitoring.DeadlineMetrics;
+import io.grpc.Context;
+import io.grpc.Context.CancellableContext;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+public class DeadlineUtilsTest {
+  private static final ScheduledExecutorService executorService =
+      new ScheduledThreadPoolExecutor(1);
+
+  @Test
+  public void testOutOfContextNoop() {
+    DeadlineUtils.setCancellationEnabled(false);
+    DeadlineUtils.checkDeadline("test", "TEST");
+    DeadlineUtils.setCancellationEnabled(true);
+    DeadlineUtils.checkDeadline("test", "TEST");
+  }
+
+  @Test
+  public void testInContextNoDeadline() {
+    DeadlineUtils.setCancellationEnabled(false);
+    Context.current().run(() -> DeadlineUtils.checkDeadline("test", "TEST"));
+    DeadlineUtils.setCancellationEnabled(true);
+    Context.current().run(() -> DeadlineUtils.checkDeadline("test", "TEST"));
+  }
+
+  @Test
+  public void testWithDeadlineNotReached() {
+    DeadlineUtils.setCancellationEnabled(false);
+    CancellableContext context =
+        Context.current().withDeadlineAfter(100, TimeUnit.SECONDS, executorService);
+    try {
+      context.run(() -> DeadlineUtils.checkDeadline("test", "TEST"));
+    } finally {
+      context.cancel(null);
+    }
+    DeadlineUtils.setCancellationEnabled(true);
+    context = Context.current().withDeadlineAfter(100, TimeUnit.SECONDS, executorService);
+    try {
+      context.run(() -> DeadlineUtils.checkDeadline("test", "TEST"));
+    } finally {
+      context.cancel(null);
+    }
+  }
+
+  @Test
+  public void testWithDeadlineReached() {
+    DeadlineUtils.setCancellationEnabled(false);
+    CancellableContext context =
+        Context.current().withDeadlineAfter(1, TimeUnit.MILLISECONDS, executorService);
+    try {
+      context.run(
+          () -> {
+            try {
+              Thread.sleep(5);
+            } catch (InterruptedException ignored) {
+            }
+            DeadlineUtils.checkDeadline("test", "TEST");
+          });
+    } finally {
+      context.cancel(null);
+    }
+    DeadlineUtils.setCancellationEnabled(true);
+    context = Context.current().withDeadlineAfter(1, TimeUnit.MILLISECONDS, executorService);
+    try {
+      context.run(
+          () -> {
+            try {
+              Thread.sleep(5);
+            } catch (InterruptedException ignored) {
+            }
+            DeadlineUtils.checkDeadline("test", "TEST");
+          });
+      fail();
+    } catch (StatusRuntimeException e) {
+      assertEquals(Status.CANCELLED.getCode(), e.getStatus().getCode());
+      assertEquals("Request deadline exceeded: test", e.getStatus().getDescription());
+    } finally {
+      context.cancel(null);
+    }
+  }
+
+  @Test
+  public void testMetricsCounter() {
+    int initialCount = getCancelMetricCount();
+    DeadlineUtils.setCancellationEnabled(true);
+    CancellableContext context =
+        Context.current().withDeadlineAfter(1, TimeUnit.MILLISECONDS, executorService);
+    try {
+      context.run(
+          () -> {
+            try {
+              Thread.sleep(5);
+            } catch (InterruptedException ignored) {
+            }
+            DeadlineUtils.checkDeadline("test", "TEST");
+          });
+      fail();
+    } catch (StatusRuntimeException e) {
+      assertEquals(Status.CANCELLED.getCode(), e.getStatus().getCode());
+      assertEquals("Request deadline exceeded: test", e.getStatus().getDescription());
+    } finally {
+      context.cancel(null);
+    }
+    int newCount = getCancelMetricCount();
+    assertEquals(initialCount + 1, newCount);
+  }
+
+  private int getCancelMetricCount() {
+    return (int) DeadlineMetrics.nrtDeadlineCancelCount.labels("TEST").get();
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -1269,6 +1269,11 @@ public class LuceneServerTest {
     return fields;
   }
 
+  @Test
+  public void testCancellationDefaultDisabled() {
+    assertFalse(DeadlineUtils.getCancellationEnabled());
+  }
+
   public static void checkHits(SearchResponse.Hit hit) {
     Map<String, CompositeFieldValue> fields = hit.getFieldsMap();
     checkFieldNames(RETRIEVED_VALUES, fields);


### PR DESCRIPTION
Add deadline based cancellation for search requests. At several points during request processing, check if the gRPC deadline has already expired. This will help avoid wasted work on requests when the client has already given up.

Check points:
- Processing start
- After first pass recall
- After each rescorer runs
- After fetch operations

This functionality is disabled by default, and enabled with the `deadlineCancellation` config flag.

Adds a new metric counter `nrt_deadline_cancel_count` to monitor how many requests are canceled by deadline expiration. This metric has a label for the operation type (`SEARCH` in this case).

If this works well for search, the plan is to add something similar to indexing/commit.