### PR TITLE
Improve global state handling, use configurable backend

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -87,6 +87,7 @@ public class LuceneServerConfiguration {
   private final FileCopyConfig fileCopyConfig;
   private final ScriptCacheConfig scriptCacheConfig;
   private final boolean deadlineCancellation;
+  private final StateConfig stateConfig;
 
   private final YamlConfigReader configReader;
   private final long maxConnectionAgeForReplication;
@@ -146,6 +147,7 @@ public class LuceneServerConfiguration {
     threadPoolConfiguration = new ThreadPoolConfiguration(configReader);
     scriptCacheConfig = ScriptCacheConfig.fromConfig(configReader);
     deadlineCancellation = configReader.getBoolean("deadlineCancellation", false);
+    stateConfig = StateConfig.fromConfig(configReader);
   }
 
   public ThreadPoolConfiguration getThreadPoolConfiguration() {
@@ -274,6 +276,10 @@ public class LuceneServerConfiguration {
 
   public boolean getDeadlineCancellation() {
     return deadlineCancellation;
+  }
+
+  public StateConfig getStateConfig() {
+    return stateConfig;
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/config/StateConfig.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/StateConfig.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.config;
+
+import java.util.Objects;
+
+/** Configuration class for state managment. */
+public class StateConfig {
+  public static final String CONFIG_PREFIX = "stateConfig.";
+
+  public enum StateBackendType {
+    LEGACY,
+    LOCAL,
+    REMOTE
+  }
+
+  private final StateBackendType backendType;
+
+  /**
+   * Create instance from provided configuration reader.
+   *
+   * @param configReader config reader
+   * @return class instance
+   */
+  public static StateConfig fromConfig(YamlConfigReader configReader) {
+    Objects.requireNonNull(configReader);
+    StateBackendType backendType =
+        StateBackendType.valueOf(configReader.getString(CONFIG_PREFIX + "backendType", "LEGACY"));
+    return new StateConfig(backendType);
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param backendType type of backend to used for storing/loading state
+   */
+  public StateConfig(StateBackendType backendType) {
+    Objects.requireNonNull(backendType);
+    this.backendType = backendType;
+  }
+
+  /** Get if state management should be consistent with the legacy state system. */
+  public boolean useLegacyStateManagement() {
+    return StateBackendType.LEGACY.equals(backendType);
+  }
+
+  /** Get the type of backend that should be used for storing/loading server state. */
+  public StateBackendType getBackendType() {
+    return backendType;
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/BackupIndexRequestHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/BackupIndexRequestHandler.java
@@ -329,7 +329,9 @@ public class BackupIndexRequestHandler implements Handler<BackupIndexRequest, Ba
     }
     backupIndexResponseBuilder.setDataVersionHash(versionHash);
 
-    uploadMetadata(serviceName, resourceName, indexState, backupIndexResponseBuilder, stream);
+    if (indexState.globalState.getConfiguration().getStateConfig().useLegacyStateManagement()) {
+      uploadMetadata(serviceName, resourceName, indexState, backupIndexResponseBuilder, stream);
+    }
   }
 
   public void uploadMetadata(
@@ -346,7 +348,7 @@ public class BackupIndexRequestHandler implements Handler<BackupIndexRequest, Ba
           archiver.upload(
               serviceName,
               resourceMetadata,
-              indexState.globalState.stateDir,
+              indexState.globalState.getStateDir(),
               Collections.emptyList(),
               Collections.emptyList(),
               stream);
@@ -357,7 +359,7 @@ public class BackupIndexRequestHandler implements Handler<BackupIndexRequest, Ba
           incrementalArchiver.upload(
               serviceName,
               resourceMetadata,
-              indexState.globalState.stateDir,
+              indexState.globalState.getStateDir(),
               Collections.emptyList(),
               Collections.emptyList(),
               stream);

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/GlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/GlobalState.java
@@ -15,27 +15,19 @@
  */
 package com.yelp.nrtsearch.server.luceneserver;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonParser;
 import com.yelp.nrtsearch.server.backup.Archiver;
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.config.ThreadPoolConfiguration;
+import com.yelp.nrtsearch.server.luceneserver.state.BackendGlobalState;
+import com.yelp.nrtsearch.server.luceneserver.state.LegacyGlobalState;
 import com.yelp.nrtsearch.server.utils.ThreadPoolExecutorFactory;
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.channels.SeekableByteChannel;
-import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.util.*;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -46,54 +38,54 @@ import org.apache.lucene.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class GlobalState implements Closeable, Restorable {
-  public static final String NULL = "NULL";
+public abstract class GlobalState implements Closeable {
+  private static final Logger logger = LoggerFactory.getLogger(GlobalState.class);
   private final String hostName;
   private final int port;
   private final int replicationPort;
   private final ThreadPoolConfiguration threadPoolConfiguration;
-  private Optional<Archiver> incArchiver;
+  private final Archiver incArchiver;
   private int replicaReplicationPortPingInterval;
-
-  Logger logger = LoggerFactory.getLogger(GlobalState.class);
-  private long lastIndicesGen;
-  private final JsonParser jsonParser = new JsonParser();
   private final String ephemeralId = UUID.randomUUID().toString();
 
-  public final String nodeName;
+  private final String nodeName;
 
-  public final List<RemoteNodeConnection> remoteNodes = new CopyOnWriteArrayList<>();
+  private final List<RemoteNodeConnection> remoteNodes = new CopyOnWriteArrayList<>();
 
-  public final LuceneServerConfiguration configuration;
-
-  /** Current indices. */
-  final Map<String, IndexState> indices = new ConcurrentHashMap<String, IndexState>();
+  private final LuceneServerConfiguration configuration;
 
   /** Server shuts down once this latch is decremented. */
-  public final CountDownLatch shutdownNow = new CountDownLatch(1);
+  private final CountDownLatch shutdownNow = new CountDownLatch(1);
 
-  final Path stateDir;
-  final Path indexDirBase;
-
-  /** This is persisted so on restart we know about all previously created indices. */
-  private final JsonObject indexNames = new JsonObject();
+  private final Path stateDir;
+  private final Path indexDirBase;
 
   private final ExecutorService indexService;
   private final ExecutorService fetchService;
   private final ThreadPoolExecutor searchThreadPoolExecutor;
 
-  public Optional<Archiver> getIncArchiver() {
-    return incArchiver;
-  }
-
-  public GlobalState(LuceneServerConfiguration luceneServerConfiguration, Archiver incArchiver)
+  public static GlobalState createState(LuceneServerConfiguration luceneServerConfiguration)
       throws IOException {
-    this(luceneServerConfiguration);
-    this.incArchiver = Optional.ofNullable(incArchiver);
+    return createState(luceneServerConfiguration, null);
   }
 
-  public GlobalState(LuceneServerConfiguration luceneServerConfiguration) throws IOException {
-    this.incArchiver = Optional.empty();
+  public static GlobalState createState(
+      LuceneServerConfiguration luceneServerConfiguration, Archiver incArchiver)
+      throws IOException {
+    if (luceneServerConfiguration.getStateConfig().useLegacyStateManagement()) {
+      return new LegacyGlobalState(luceneServerConfiguration, incArchiver);
+    } else {
+      return new BackendGlobalState(luceneServerConfiguration, incArchiver);
+    }
+  }
+
+  public Optional<Archiver> getIncArchiver() {
+    return Optional.ofNullable(incArchiver);
+  }
+
+  protected GlobalState(LuceneServerConfiguration luceneServerConfiguration, Archiver incArchiver)
+      throws IOException {
+    this.incArchiver = incArchiver;
     this.nodeName = luceneServerConfiguration.getNodeName();
     this.stateDir = Paths.get(luceneServerConfiguration.getStateDir());
     this.indexDirBase = Paths.get(luceneServerConfiguration.getIndexDir());
@@ -119,7 +111,14 @@ public class GlobalState implements Closeable, Restorable {
             ThreadPoolExecutorFactory.ExecutorType.FETCH,
             luceneServerConfiguration.getThreadPoolConfiguration());
     this.configuration = luceneServerConfiguration;
-    loadIndexNames();
+  }
+
+  public LuceneServerConfiguration getConfiguration() {
+    return configuration;
+  }
+
+  public String getNodeName() {
+    return nodeName;
   }
 
   public String getHostName() {
@@ -142,76 +141,14 @@ public class GlobalState implements Closeable, Restorable {
     return stateDir;
   }
 
-  public synchronized void setStateDir(Path source) throws IOException {
-    restoreDir(source, stateDir);
-    loadIndexNames();
-  }
-
-  // need to call this first time LuceneServer comes up and upon StartIndex with restore
-  private void loadIndexNames() throws IOException {
-    long gen = IndexState.getLastGen(stateDir, "indices");
-    lastIndicesGen = gen;
-    if (gen != -1) {
-      Path path = stateDir.resolve("indices." + gen);
-      byte[] bytes;
-      try (SeekableByteChannel channel = Files.newByteChannel(path, StandardOpenOption.READ)) {
-        bytes = new byte[(int) channel.size()];
-        ByteBuffer buffer = ByteBuffer.wrap(bytes);
-        int count = channel.read(buffer);
-        if (count != bytes.length) {
-          throw new AssertionError("fix me!");
-        }
-      }
-      JsonObject o;
-      try {
-        o = jsonParser.parse(IndexState.fromUTF8(bytes)).getAsJsonObject();
-      } catch (JsonParseException pe) {
-        // Something corrupted the save state since we last
-        // saved it ...
-        throw new RuntimeException(
-            "index state file \"" + path + "\" cannot be parsed: " + pe.getMessage());
-      }
-      for (Map.Entry<String, JsonElement> ent : o.entrySet()) {
-        indexNames.add(ent.getKey(), ent.getValue());
-      }
-    }
-  }
-
-  private void saveIndexNames() throws IOException {
-    synchronized (indices) {
-      lastIndicesGen++;
-      byte[] bytes = IndexState.toUTF8(indexNames.toString());
-      Path f = stateDir.resolve("indices." + lastIndicesGen);
-      try (FileChannel channel =
-          FileChannel.open(f, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW)) {
-        int count = channel.write(ByteBuffer.wrap(bytes));
-        if (count != bytes.length) {
-          throw new AssertionError("fix me");
-        }
-        channel.force(true);
-      }
-
-      // remove old gens
-      try (DirectoryStream<Path> stream = Files.newDirectoryStream(stateDir)) {
-        for (Path sub : stream) {
-          String filename = sub.getFileName().toString();
-          if (filename.startsWith("indices.")) {
-            long gen = Long.parseLong(filename.substring(8));
-            if (gen != lastIndicesGen) {
-              Files.delete(sub);
-            }
-          }
-        }
-      }
-    }
+  public CountDownLatch getShutdownLatch() {
+    return shutdownNow;
   }
 
   @Override
   public void close() throws IOException {
-    logger.info("GlobalState.close: indices=" + indices);
     // searchThread.interrupt();
     IOUtils.close(remoteNodes);
-    IOUtils.close(indices.values());
     indexService.shutdown();
     TimeLimitingCollector.getGlobalTimerThread().stopTimer();
     try {
@@ -225,81 +162,29 @@ public class GlobalState implements Closeable, Restorable {
     return Paths.get(indexDirBase.toString(), indexName);
   }
 
-  /** Create a new index. */
-  public IndexState createIndex(String name) throws IllegalArgumentException, IOException {
-    synchronized (indices) {
-      Path rootDir = getIndexDir(name);
-      if (indexNames.get(name) != null) {
-        throw new IllegalArgumentException("index \"" + name + "\" already exists");
-      }
-      if (rootDir == null) {
-        indexNames.addProperty(name, NULL);
-      } else {
-        if (Files.exists(rootDir)) {
-          throw new IllegalArgumentException("rootDir \"" + rootDir + "\" already exists");
-        }
-        indexNames.addProperty(name, name);
-      }
-      saveIndexNames();
-      IndexState state = new IndexState(this, name, rootDir, true, false);
-      indices.put(name, state);
-      return state;
-    }
-  }
+  public abstract void setStateDir(Path source) throws IOException;
 
-  public IndexState getIndex(String name, boolean hasRestore) throws IOException {
-    synchronized (indices) {
-      IndexState state = indices.get(name);
-      if (state == null) {
-        String rootPath = null;
-        JsonElement indexJsonName = indexNames.get(name);
-        if (indexJsonName == null) {
-          throw new IllegalArgumentException("index " + name + " was not saved or commited");
-        }
-        String indexName = indexJsonName.getAsString();
-        if (indexName != null) {
-          rootPath = getIndexDir(name).toString();
-        }
-        if (rootPath != null) {
-          if (rootPath.equals(NULL)) {
-            state = new IndexState(this, name, null, false, hasRestore);
-          } else {
-            state = new IndexState(this, name, Paths.get(rootPath), false, hasRestore);
-          }
-          // nocommit we need to also persist which shards are here?
-          state.addShard(0, false);
-          indices.put(name, state);
-        } else {
-          throw new IllegalArgumentException("index \"" + name + "\" was not yet created");
-        }
-      }
-      return state;
-    }
-  }
+  public abstract Set<String> getIndexNames();
+
+  /** Create a new index. */
+  public abstract IndexState createIndex(String name) throws IOException;
+
+  public abstract IndexState getIndex(String name, boolean hasRestore) throws IOException;
 
   /** Get the {@link IndexState} by index name. */
-  public IndexState getIndex(String name) throws IllegalArgumentException, IOException {
-    return getIndex(name, false);
-  }
+  public abstract IndexState getIndex(String name) throws IOException;
+
+  /** Remove the specified index. */
+  public abstract void deleteIndex(String name) throws IOException;
+
+  public abstract void indexClosed(String name);
 
   public Future<Long> submitIndexingTask(Callable job) {
     return indexService.submit(job);
   }
 
-  /** Remove the specified index. */
-  public void deleteIndex(String name) throws IOException {
-    synchronized (indices) {
-      indexNames.remove(name);
-      saveIndexNames();
-    }
-  }
-
   public int getReplicationPort() {
     return replicationPort;
-  }
-
-  public Set<String> getIndexNames() {
-    return Collections.unmodifiableSet(indexNames.keySet());
   }
 
   public ThreadPoolConfiguration getThreadPoolConfiguration() {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexBackupUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexBackupUtils.java
@@ -15,6 +15,8 @@
  */
 package com.yelp.nrtsearch.server.luceneserver;
 
+import com.yelp.nrtsearch.server.luceneserver.state.backend.RemoteStateBackend;
+
 public class IndexBackupUtils {
 
   public static String getResourceMetadata(String resourceName) {
@@ -35,5 +37,9 @@ public class IndexBackupUtils {
 
   public static boolean isMetadata(String resourceName) {
     return resourceName.contains("_metadata");
+  }
+
+  public static boolean isBackendGlobalState(String resourceName) {
+    return RemoteStateBackend.GLOBAL_STATE_RESOURCE.equals(resourceName);
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -492,7 +492,8 @@ public class ShardState implements Closeable {
         indexDirFile = rootDir.resolve("index");
       }
       origIndexDir =
-          indexState.df.open(indexDirFile, indexState.globalState.configuration.getPreloadConfig());
+          indexState.df.open(
+              indexDirFile, indexState.globalState.getConfiguration().getPreloadConfig());
 
       // nocommit don't allow RAMDir
       // nocommit remove NRTCachingDir too?
@@ -530,7 +531,8 @@ public class ShardState implements Closeable {
         taxoDirFile = rootDir.resolve("taxonomy");
       }
       taxoDir =
-          indexState.df.open(taxoDirFile, indexState.globalState.configuration.getPreloadConfig());
+          indexState.df.open(
+              taxoDirFile, indexState.globalState.getConfiguration().getPreloadConfig());
 
       taxoSnapshots =
           new PersistentSnapshotDeletionPolicy(
@@ -581,7 +583,7 @@ public class ShardState implements Closeable {
 
       restartReopenThread();
 
-      startSearcherPruningThread(indexState.globalState.shutdownNow);
+      startSearcherPruningThread(indexState.globalState.getShutdownLatch());
       started = true;
     } finally {
       if (!started) {
@@ -634,7 +636,8 @@ public class ShardState implements Closeable {
         indexDirFile = rootDir.resolve("index");
       }
       origIndexDir =
-          indexState.df.open(indexDirFile, indexState.globalState.configuration.getPreloadConfig());
+          indexState.df.open(
+              indexDirFile, indexState.globalState.getConfiguration().getPreloadConfig());
 
       if ((origIndexDir instanceof MMapDirectory) == false) {
         double maxMergeSizeMB =
@@ -665,7 +668,7 @@ public class ShardState implements Closeable {
 
       // TODO: get facets working!
 
-      boolean verbose = indexState.globalState.configuration.getIndexVerbose();
+      boolean verbose = indexState.globalState.getConfiguration().getIndexVerbose();
 
       writer =
           new IndexWriter(
@@ -725,7 +728,7 @@ public class ShardState implements Closeable {
               });
       restartReopenThread();
 
-      startSearcherPruningThread(indexState.globalState.shutdownNow);
+      startSearcherPruningThread(indexState.globalState.getShutdownLatch());
       started = true;
     } finally {
       if (!started) {
@@ -898,7 +901,8 @@ public class ShardState implements Closeable {
         indexDirFile = rootDir.resolve("index");
       }
       origIndexDir =
-          indexState.df.open(indexDirFile, indexState.globalState.configuration.getPreloadConfig());
+          indexState.df.open(
+              indexDirFile, indexState.globalState.getConfiguration().getPreloadConfig());
       // nocommit don't allow RAMDir
       // nocommit remove NRTCachingDir too?
       if ((origIndexDir instanceof MMapDirectory) == false) {
@@ -917,7 +921,7 @@ public class ShardState implements Closeable {
       manager = null;
       nrtPrimaryNode = null;
 
-      boolean verbose = indexState.globalState.configuration.getIndexVerbose();
+      boolean verbose = indexState.globalState.getConfiguration().getIndexVerbose();
 
       HostPort hostPort =
           new HostPort(
@@ -932,13 +936,13 @@ public class ShardState implements Closeable {
               new ShardSearcherFactory(true, false),
               verbose ? System.out : new PrintStream(OutputStream.nullOutputStream()),
               primaryGen,
-              indexState.globalState.configuration.getFileCopyConfig().getAckedCopy());
+              indexState.globalState.getConfiguration().getFileCopyConfig().getAckedCopy());
 
-      if (indexState.globalState.configuration.getSyncInitialNrtPoint()) {
+      if (indexState.globalState.getConfiguration().getSyncInitialNrtPoint()) {
         nrtReplicaNode.syncFromCurrentPrimary(INITIAL_SYNC_PRIMARY_WAIT_MS);
       }
 
-      startSearcherPruningThread(indexState.globalState.shutdownNow);
+      startSearcherPruningThread(indexState.globalState.getShutdownLatch());
 
       // Necessary so that the replica "hang onto" all versions sent to it, since the version is
       // sent back to the user on writeNRTPoint
@@ -960,7 +964,7 @@ public class ShardState implements Closeable {
       keepAlive = new KeepAlive(this);
       new Thread(keepAlive, "KeepAlive").start();
 
-      WarmerConfig warmerConfig = indexState.globalState.configuration.getWarmerConfig();
+      WarmerConfig warmerConfig = indexState.globalState.getConfiguration().getWarmerConfig();
       if (warmerConfig.isWarmOnStartup() && indexState.getWarmer() != null) {
         indexState.getWarmer().warmFromS3(indexState, warmerConfig.getWarmingParallelism());
       }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/BackendGlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/BackendGlobalState.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.state;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.yelp.nrtsearch.server.backup.Archiver;
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.luceneserver.GlobalState;
+import com.yelp.nrtsearch.server.luceneserver.IndexState;
+import com.yelp.nrtsearch.server.luceneserver.state.PersistentGlobalState.IndexInfo;
+import com.yelp.nrtsearch.server.luceneserver.state.backend.LocalStateBackend;
+import com.yelp.nrtsearch.server.luceneserver.state.backend.RemoteStateBackend;
+import com.yelp.nrtsearch.server.luceneserver.state.backend.StateBackend;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.lucene.util.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of GlobalState that uses a configurable {@link StateBackend} for storing/loading
+ * state.
+ */
+public class BackendGlobalState extends GlobalState {
+  private static final Logger logger = LoggerFactory.getLogger(BackendGlobalState.class);
+
+  /**
+   * State class containing immutable persistent and ephemeral global state, stored together so that
+   * they can be updated atomically.
+   */
+  private static class ImmutableState {
+    public final PersistentGlobalState persistentGlobalState;
+    public final Map<String, IndexState> indexStateMap;
+
+    ImmutableState(
+        PersistentGlobalState persistentGlobalState, Map<String, IndexState> indexStateMap) {
+      this.persistentGlobalState = persistentGlobalState;
+      this.indexStateMap = Collections.unmodifiableMap(indexStateMap);
+    }
+  }
+
+  // volatile for atomic replacement
+  private volatile ImmutableState immutableState;
+  private final StateBackend stateBackend;
+
+  /**
+   * Constructor.
+   *
+   * @param luceneServerConfiguration server config
+   * @param incArchiver archiver for remote backends
+   * @throws IOException on filesystem error
+   */
+  public BackendGlobalState(
+      LuceneServerConfiguration luceneServerConfiguration, Archiver incArchiver)
+      throws IOException {
+    super(luceneServerConfiguration, incArchiver);
+    stateBackend = createStateBackend();
+    immutableState =
+        new ImmutableState(stateBackend.loadOrCreateGlobalState(), Collections.emptyMap());
+  }
+
+  /**
+   * Create {@link StateBackend} based on the current configuration. Protected to allow injection
+   * for testing.
+   */
+  protected StateBackend createStateBackend() {
+    switch (getConfiguration().getStateConfig().getBackendType()) {
+      case LOCAL:
+        return new LocalStateBackend(this);
+      case REMOTE:
+        return new RemoteStateBackend(this);
+      default:
+        throw new IllegalArgumentException(
+            "Unsupported state backend type: "
+                + getConfiguration().getStateConfig().getBackendType());
+    }
+  }
+
+  @VisibleForTesting
+  StateBackend getStateBackend() {
+    return stateBackend;
+  }
+
+  @Override
+  public void setStateDir(Path source) throws IOException {
+    // only called by legacy restore
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Set<String> getIndexNames() {
+    return immutableState.persistentGlobalState.getIndices().keySet();
+  }
+
+  @Override
+  public synchronized IndexState createIndex(String name) throws IOException {
+    Path rootDir = getIndexDir(name);
+    if (immutableState.persistentGlobalState.getIndices().containsKey(name)) {
+      throw new IllegalArgumentException("index \"" + name + "\" already exists");
+    }
+    if (Files.exists(rootDir)) {
+      throw new IllegalArgumentException("rootDir \"" + rootDir + "\" already exists");
+    }
+    IndexState state = new IndexState(this, name, rootDir, true, false);
+
+    Map<String, IndexInfo> updatedIndexInfoMap =
+        new HashMap<>(immutableState.persistentGlobalState.getIndices());
+    updatedIndexInfoMap.put(name, new IndexInfo());
+    PersistentGlobalState updatedState =
+        immutableState.persistentGlobalState.asBuilder().withIndices(updatedIndexInfoMap).build();
+    stateBackend.commitGlobalState(updatedState);
+
+    Map<String, IndexState> updatedIndexStateMap = new HashMap<>(immutableState.indexStateMap);
+    updatedIndexStateMap.put(name, state);
+    immutableState = new ImmutableState(updatedState, updatedIndexStateMap);
+
+    return state;
+  }
+
+  @Override
+  public IndexState getIndex(String name, boolean hasRestore) throws IOException {
+    IndexState state = immutableState.indexStateMap.get(name);
+    if (state != null) {
+      return state;
+    }
+    synchronized (this) {
+      state = immutableState.indexStateMap.get(name);
+      if (state == null) {
+        if (!immutableState.persistentGlobalState.getIndices().containsKey(name)) {
+          throw new IllegalArgumentException("index \"" + name + "\" was not saved or committed");
+        }
+        Path rootPath = getIndexDir(name);
+        state = new IndexState(this, name, rootPath, false, hasRestore);
+        // nocommit we need to also persist which shards are here?
+        state.addShard(0, false);
+
+        Map<String, IndexState> updatedIndexStateMap = new HashMap<>(immutableState.indexStateMap);
+        updatedIndexStateMap.put(name, state);
+        immutableState =
+            new ImmutableState(immutableState.persistentGlobalState, updatedIndexStateMap);
+      }
+      return state;
+    }
+  }
+
+  @Override
+  public IndexState getIndex(String name) throws IOException {
+    return getIndex(name, false);
+  }
+
+  @Override
+  public synchronized void deleteIndex(String name) throws IOException {
+    Map<String, IndexInfo> updatedIndexInfoMap =
+        new HashMap<>(immutableState.persistentGlobalState.getIndices());
+    updatedIndexInfoMap.remove(name);
+    PersistentGlobalState updatedState =
+        immutableState.persistentGlobalState.asBuilder().withIndices(updatedIndexInfoMap).build();
+    stateBackend.commitGlobalState(updatedState);
+
+    immutableState = new ImmutableState(updatedState, new HashMap<>(immutableState.indexStateMap));
+  }
+
+  @Override
+  public synchronized void indexClosed(String name) {
+    Map<String, IndexState> updatedIndexStateMap = new HashMap<>(immutableState.indexStateMap);
+    updatedIndexStateMap.remove(name);
+    immutableState = new ImmutableState(immutableState.persistentGlobalState, updatedIndexStateMap);
+  }
+
+  @Override
+  public void close() throws IOException {
+    synchronized (this) {
+      logger.info("GlobalState.close: indices=" + getIndexNames());
+      IOUtils.close(immutableState.indexStateMap.values());
+    }
+    super.close();
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/LegacyGlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/LegacyGlobalState.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.state;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+import com.yelp.nrtsearch.server.backup.Archiver;
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.luceneserver.GlobalState;
+import com.yelp.nrtsearch.server.luceneserver.IndexState;
+import com.yelp.nrtsearch.server.luceneserver.Restorable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.lucene.util.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * GlobalState implementation that uses legacy state management. Index names are written to an
+ * indices.{#} file, which is restored on startup.
+ */
+public class LegacyGlobalState extends GlobalState implements Restorable {
+  public static final String NULL = "NULL";
+  private static final Logger logger = LoggerFactory.getLogger(LegacyGlobalState.class);
+  private long lastIndicesGen;
+  private final JsonParser jsonParser = new JsonParser();
+
+  /** Current indices. */
+  private final Map<String, IndexState> indices = new ConcurrentHashMap<>();
+
+  /** This is persisted so on restart we know about all previously created indices. */
+  private final JsonObject indexNames = new JsonObject();
+
+  public LegacyGlobalState(
+      LuceneServerConfiguration luceneServerConfiguration, Archiver incArchiver)
+      throws IOException {
+    super(luceneServerConfiguration, incArchiver);
+    loadIndexNames();
+  }
+
+  // need to call this first time LuceneServer comes up and upon StartIndex with restore
+  private void loadIndexNames() throws IOException {
+    long gen = IndexState.getLastGen(getStateDir(), "indices");
+    lastIndicesGen = gen;
+    if (gen != -1) {
+      Path path = getStateDir().resolve("indices." + gen);
+      byte[] bytes;
+      try (SeekableByteChannel channel = Files.newByteChannel(path, StandardOpenOption.READ)) {
+        bytes = new byte[(int) channel.size()];
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        int count = channel.read(buffer);
+        if (count != bytes.length) {
+          throw new AssertionError("fix me!");
+        }
+      }
+      JsonObject o;
+      try {
+        o = jsonParser.parse(IndexState.fromUTF8(bytes)).getAsJsonObject();
+      } catch (JsonParseException pe) {
+        // Something corrupted the save state since we last
+        // saved it ...
+        throw new RuntimeException(
+            "index state file \"" + path + "\" cannot be parsed: " + pe.getMessage());
+      }
+      for (Map.Entry<String, JsonElement> ent : o.entrySet()) {
+        indexNames.add(ent.getKey(), ent.getValue());
+      }
+    }
+  }
+
+  private void saveIndexNames() throws IOException {
+    synchronized (indices) {
+      lastIndicesGen++;
+      byte[] bytes = IndexState.toUTF8(indexNames.toString());
+      Path f = getStateDir().resolve("indices." + lastIndicesGen);
+      try (FileChannel channel =
+          FileChannel.open(f, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW)) {
+        int count = channel.write(ByteBuffer.wrap(bytes));
+        if (count != bytes.length) {
+          throw new AssertionError("fix me");
+        }
+        channel.force(true);
+      }
+
+      // remove old gens
+      try (DirectoryStream<Path> stream = Files.newDirectoryStream(getStateDir())) {
+        for (Path sub : stream) {
+          String filename = sub.getFileName().toString();
+          if (filename.startsWith("indices.")) {
+            long gen = Long.parseLong(filename.substring(8));
+            if (gen != lastIndicesGen) {
+              Files.delete(sub);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    logger.info("GlobalState.close: indices=" + indices);
+    IOUtils.close(indices.values());
+    super.close();
+  }
+
+  @Override
+  public synchronized void setStateDir(Path source) throws IOException {
+    restoreDir(source, getStateDir());
+    loadIndexNames();
+  }
+
+  /** Create a new index. */
+  @Override
+  public IndexState createIndex(String name) throws IOException {
+    synchronized (indices) {
+      Path rootDir = getIndexDir(name);
+      if (indexNames.get(name) != null) {
+        throw new IllegalArgumentException("index \"" + name + "\" already exists");
+      }
+      if (rootDir == null) {
+        indexNames.addProperty(name, NULL);
+      } else {
+        if (Files.exists(rootDir)) {
+          throw new IllegalArgumentException("rootDir \"" + rootDir + "\" already exists");
+        }
+        indexNames.addProperty(name, name);
+      }
+      saveIndexNames();
+      IndexState state = new IndexState(this, name, rootDir, true, false);
+      indices.put(name, state);
+      return state;
+    }
+  }
+
+  @Override
+  public IndexState getIndex(String name, boolean hasRestore) throws IOException {
+    synchronized (indices) {
+      IndexState state = indices.get(name);
+      if (state == null) {
+        String rootPath = null;
+        JsonElement indexJsonName = indexNames.get(name);
+        if (indexJsonName == null) {
+          throw new IllegalArgumentException("index " + name + " was not saved or commited");
+        }
+        String indexName = indexJsonName.getAsString();
+        if (indexName != null) {
+          rootPath = getIndexDir(name).toString();
+        }
+        if (rootPath != null) {
+          if (rootPath.equals(NULL)) {
+            state = new IndexState(this, name, null, false, hasRestore);
+          } else {
+            state = new IndexState(this, name, Paths.get(rootPath), false, hasRestore);
+          }
+          // nocommit we need to also persist which shards are here?
+          state.addShard(0, false);
+          indices.put(name, state);
+        } else {
+          throw new IllegalArgumentException("index \"" + name + "\" was not yet created");
+        }
+      }
+      return state;
+    }
+  }
+
+  /** Get the {@link IndexState} by index name. */
+  @Override
+  public IndexState getIndex(String name) throws IOException {
+    return getIndex(name, false);
+  }
+
+  @Override
+  public void indexClosed(String name) {
+    synchronized (indices) {
+      indices.remove(name);
+    }
+  }
+
+  /** Remove the specified index. */
+  @Override
+  public void deleteIndex(String name) throws IOException {
+    synchronized (indices) {
+      indexNames.remove(name);
+      saveIndexNames();
+    }
+  }
+
+  @Override
+  public Set<String> getIndexNames() {
+    return Collections.unmodifiableSet(indexNames.keySet());
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/PersistentGlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/PersistentGlobalState.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.state;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Json serializable class containing all global state that should persist between server restarts.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class PersistentGlobalState {
+  private final Map<String, IndexInfo> indices;
+
+  /** Constructor to create a new persistent state instance with default values. */
+  public PersistentGlobalState() {
+    this(new HashMap<>());
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param indices global index state for all known indices
+   */
+  @JsonCreator
+  public PersistentGlobalState(@JsonProperty("indices") Map<String, IndexInfo> indices) {
+    Objects.requireNonNull(indices);
+    this.indices = Collections.unmodifiableMap(indices);
+  }
+
+  /** Get global index state for all known indices. Both the map and state are immutable. */
+  public Map<String, IndexInfo> getIndices() {
+    return indices;
+  }
+
+  /**
+   * Get a builder initialized with the current state of this class. Useful when modifying only
+   * specific fields.
+   *
+   * @return class builder
+   */
+  public Builder asBuilder() {
+    return new Builder(this);
+  }
+
+  /** Builder for producing an immutable {@link PersistentGlobalState}. */
+  public static class Builder {
+    private Map<String, IndexInfo> indices;
+
+    Builder(PersistentGlobalState base) {
+      this.indices = base.indices;
+    }
+
+    public Builder withIndices(Map<String, IndexInfo> indices) {
+      this.indices = indices;
+      return this;
+    }
+
+    public PersistentGlobalState build() {
+      return new PersistentGlobalState(this.indices);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof PersistentGlobalState) {
+      PersistentGlobalState p = (PersistentGlobalState) o;
+      return Objects.equals(indices, p.indices);
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Json serializable class containing index specific global state that should persist between
+   * server restarts. This may eventually contain properties such as if the index is open or closed,
+   * or primary discovery configuration.
+   */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonInclude(Include.NON_NULL)
+  public static class IndexInfo {
+
+    @Override
+    public boolean equals(Object o) {
+      if (o instanceof IndexInfo) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/StateUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/StateUtils.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.state;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Objects;
+import org.apache.lucene.util.IOUtils;
+
+/** Utility class containing helper methods for interacting with server state. */
+public class StateUtils {
+  public static final String GLOBAL_STATE_FOLDER = "global_state";
+  public static final String GLOBAL_STATE_FILE = "state.json";
+  public static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private StateUtils() {}
+
+  /**
+   * Ensure that the directory for the given path exists, creating it and any parents if needed.
+   *
+   * @param dirPath path for desired directory
+   * @throws IllegalArgumentException if path exists, but is not a directory
+   */
+  public static void ensureDirectory(Path dirPath) {
+    Objects.requireNonNull(dirPath);
+    File dirFile = dirPath.toFile();
+    if (dirFile.exists() && !dirFile.isDirectory()) {
+      throw new IllegalArgumentException("Path: " + dirFile + " is not a directory");
+    } else {
+      dirFile.mkdirs();
+    }
+  }
+
+  /**
+   * Write the json representation of the given {@link PersistentGlobalState} into a file in the
+   * specified directory. Data is written to a temp file, then moved to replace any existing
+   * version. File is synced for durability.
+   *
+   * @param persistentGlobalState global state to write
+   * @param directory directory to write state file into
+   * @param fileName final name of state file
+   * @throws IOException on filesystem error
+   */
+  public static void writeStateToFile(
+      PersistentGlobalState persistentGlobalState, Path directory, String fileName)
+      throws IOException {
+    Objects.requireNonNull(persistentGlobalState);
+    Objects.requireNonNull(directory);
+    Objects.requireNonNull(fileName);
+
+    String stateStr = MAPPER.writeValueAsString(persistentGlobalState);
+    File tmpStateFile = File.createTempFile(fileName, ".tmp", directory.toFile());
+    FileOutputStream fileOutputStream = new FileOutputStream(tmpStateFile);
+    try (DataOutputStream dataOutputStream = new DataOutputStream(fileOutputStream)) {
+      dataOutputStream.writeUTF(stateStr);
+    }
+
+    Path tmpStatePath = tmpStateFile.toPath();
+    Path destPath = directory.resolve(fileName);
+    IOUtils.fsync(tmpStatePath, false);
+    Files.move(tmpStatePath, destPath, StandardCopyOption.REPLACE_EXISTING);
+
+    IOUtils.fsync(destPath, false);
+    IOUtils.fsync(directory, true);
+  }
+
+  /**
+   * Read {@link PersistentGlobalState} from json representation in the given file.
+   *
+   * @param filePath state json file
+   * @return global state
+   * @throws IOException on filesystem error
+   */
+  public static PersistentGlobalState readStateFromFile(Path filePath) throws IOException {
+    Objects.requireNonNull(filePath);
+    String stateStr;
+    FileInputStream fileInputStream = new FileInputStream(filePath.toFile());
+    try (DataInputStream dataInputStream = new DataInputStream(fileInputStream)) {
+      stateStr = dataInputStream.readUTF();
+    }
+    return MAPPER.readValue(stateStr, PersistentGlobalState.class);
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/backend/LocalStateBackend.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/backend/LocalStateBackend.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.state.backend;
+
+import static com.yelp.nrtsearch.server.luceneserver.state.StateUtils.GLOBAL_STATE_FILE;
+import static com.yelp.nrtsearch.server.luceneserver.state.StateUtils.GLOBAL_STATE_FOLDER;
+import static com.yelp.nrtsearch.server.luceneserver.state.StateUtils.MAPPER;
+
+import com.yelp.nrtsearch.server.luceneserver.GlobalState;
+import com.yelp.nrtsearch.server.luceneserver.state.PersistentGlobalState;
+import com.yelp.nrtsearch.server.luceneserver.state.StateUtils;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** StateBackend implementation that stores state on the local filesystem. */
+public class LocalStateBackend implements StateBackend {
+  private static final Logger logger = LoggerFactory.getLogger(LocalStateBackend.class);
+
+  private final Path globalStatePath;
+
+  /**
+   * Constructor.
+   *
+   * @param globalState global state
+   */
+  public LocalStateBackend(GlobalState globalState) {
+    Objects.requireNonNull(globalState);
+    this.globalStatePath = globalState.getStateDir().resolve(GLOBAL_STATE_FOLDER);
+    StateUtils.ensureDirectory(globalStatePath);
+  }
+
+  @Override
+  public PersistentGlobalState loadOrCreateGlobalState() throws IOException {
+    logger.info("Loading local state");
+    Path statePath = globalStatePath.resolve(GLOBAL_STATE_FILE);
+    File stateFile = statePath.toFile();
+    if (stateFile.isDirectory()) {
+      throw new IllegalStateException("State file: " + stateFile + " is a directory");
+    }
+    if (!stateFile.exists()) {
+      logger.info("Local state not present, initializing default");
+      PersistentGlobalState state = new PersistentGlobalState();
+      commitGlobalState(state);
+      return state;
+    } else {
+      PersistentGlobalState persistentGlobalState = StateUtils.readStateFromFile(statePath);
+      logger.info("Loaded local state: " + MAPPER.writeValueAsString(persistentGlobalState));
+      return persistentGlobalState;
+    }
+  }
+
+  @Override
+  public void commitGlobalState(PersistentGlobalState persistentGlobalState) throws IOException {
+    Objects.requireNonNull(persistentGlobalState);
+    logger.info("Committing global state");
+    StateUtils.writeStateToFile(persistentGlobalState, globalStatePath, GLOBAL_STATE_FILE);
+    logger.info("Committed state: " + MAPPER.writeValueAsString(persistentGlobalState));
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/backend/RemoteStateBackend.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/backend/RemoteStateBackend.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.state.backend;
+
+import static com.yelp.nrtsearch.server.luceneserver.state.StateUtils.GLOBAL_STATE_FILE;
+import static com.yelp.nrtsearch.server.luceneserver.state.StateUtils.GLOBAL_STATE_FOLDER;
+import static com.yelp.nrtsearch.server.luceneserver.state.StateUtils.MAPPER;
+
+import com.yelp.nrtsearch.server.backup.Archiver;
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.StateConfig;
+import com.yelp.nrtsearch.server.luceneserver.GlobalState;
+import com.yelp.nrtsearch.server.luceneserver.state.PersistentGlobalState;
+import com.yelp.nrtsearch.server.luceneserver.state.StateUtils;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Collections;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * StateBackend implementation that persists state to a remote location using an {@link Archiver}.
+ */
+public class RemoteStateBackend implements StateBackend {
+  public static final String GLOBAL_STATE_RESOURCE = "global_state";
+  private static final Logger logger = LoggerFactory.getLogger(RemoteStateBackend.class);
+  private final GlobalState globalState;
+  private final Archiver archiver;
+  private final Path localFilePath;
+  private final RemoteBackendConfig config;
+
+  /** Configuration class for state backend. */
+  public static class RemoteBackendConfig {
+    public static final String CONFIG_PREFIX = StateConfig.CONFIG_PREFIX + "remote.";
+    private final boolean readOnly;
+
+    /**
+     * Read backend config from server config.
+     *
+     * @param luceneServerConfiguration server configuration
+     * @return config for remote backend
+     */
+    public static RemoteBackendConfig fromConfig(
+        LuceneServerConfiguration luceneServerConfiguration) {
+      boolean readOnly =
+          luceneServerConfiguration.getConfigReader().getBoolean(CONFIG_PREFIX + "readOnly", true);
+      return new RemoteBackendConfig(readOnly);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param readOnly is backend read only
+     */
+    public RemoteBackendConfig(boolean readOnly) {
+      this.readOnly = readOnly;
+    }
+
+    /** Get if backend is read only. */
+    public boolean getReadOnly() {
+      return readOnly;
+    }
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param globalState global state
+   */
+  public RemoteStateBackend(GlobalState globalState) {
+    Objects.requireNonNull(globalState);
+    this.globalState = globalState;
+    this.config = RemoteBackendConfig.fromConfig(globalState.getConfiguration());
+    this.archiver =
+        globalState
+            .getIncArchiver()
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "Archiver must be provided for remote state usage"));
+    this.localFilePath = globalState.getStateDir().resolve(GLOBAL_STATE_FOLDER);
+    StateUtils.ensureDirectory(localFilePath);
+  }
+
+  @Override
+  public PersistentGlobalState loadOrCreateGlobalState() throws IOException {
+    logger.info("Loading remote state");
+    Path downloadedPath =
+        archiver.download(globalState.getConfiguration().getServiceName(), GLOBAL_STATE_RESOURCE);
+    if (downloadedPath == null) {
+      PersistentGlobalState state = new PersistentGlobalState();
+      logger.info("Remote state not present, initializing default");
+      commitGlobalState(state);
+      return state;
+    } else {
+      Path downloadedStateFilePath =
+          downloadedPath.resolve(GLOBAL_STATE_FOLDER).resolve(GLOBAL_STATE_FILE);
+      if (!downloadedStateFilePath.toFile().exists()) {
+        throw new IllegalStateException("No state file present in downloaded directory");
+      }
+      // copy restored state to local state directory, not strictly required but ensures a
+      // current copy of the state is always in the local directory
+      Files.copy(
+          downloadedStateFilePath,
+          localFilePath.resolve(GLOBAL_STATE_FILE),
+          StandardCopyOption.REPLACE_EXISTING);
+      PersistentGlobalState persistentGlobalState =
+          StateUtils.readStateFromFile(downloadedStateFilePath);
+      logger.info("Loaded remote state: " + MAPPER.writeValueAsString(persistentGlobalState));
+      return persistentGlobalState;
+    }
+  }
+
+  @Override
+  public void commitGlobalState(PersistentGlobalState persistentGlobalState) throws IOException {
+    Objects.requireNonNull(persistentGlobalState);
+    logger.info("Committing global state");
+    if (config.getReadOnly()) {
+      throw new IllegalStateException("Cannot update remote state when configured as read only");
+    }
+    StateUtils.writeStateToFile(persistentGlobalState, localFilePath, GLOBAL_STATE_FILE);
+    String version =
+        archiver.upload(
+            globalState.getConfiguration().getServiceName(),
+            GLOBAL_STATE_RESOURCE,
+            localFilePath,
+            Collections.singletonList(GLOBAL_STATE_FILE),
+            Collections.emptyList(),
+            true);
+    archiver.blessVersion(
+        globalState.getConfiguration().getServiceName(), GLOBAL_STATE_RESOURCE, version);
+    logger.info("Committed state: " + MAPPER.writeValueAsString(persistentGlobalState));
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/backend/StateBackend.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/backend/StateBackend.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.state.backend;
+
+import com.yelp.nrtsearch.server.luceneserver.state.PersistentGlobalState;
+import java.io.IOException;
+
+/**
+ * Interface for a backend managing the loading/storing of {@link PersistentGlobalState}. It can be
+ * assumed that external synchronization will prevent interface methods from being called
+ * concurrently.
+ */
+public interface StateBackend {
+
+  /**
+   * Load the current state value from the backend. If no state exists, create a new one, persisting
+   * it before returning.
+   *
+   * @return current state value
+   * @throws IOException
+   */
+  PersistentGlobalState loadOrCreateGlobalState() throws IOException;
+
+  /**
+   * Commit the given state value to the backend.
+   *
+   * @param persistentGlobalState state value to commit
+   * @throws IOException
+   */
+  void commitGlobalState(PersistentGlobalState persistentGlobalState) throws IOException;
+}

--- a/src/test/java/com/yelp/nrtsearch/clientlib/NodeNameResolverAndLoadBalancingTests.java
+++ b/src/test/java/com/yelp/nrtsearch/clientlib/NodeNameResolverAndLoadBalancingTests.java
@@ -109,7 +109,7 @@ public class NodeNameResolverAndLoadBalancingTests {
   private GrpcServer createGrpcServer() throws IOException {
     LuceneServerConfiguration luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
-    GlobalState globalState = new GlobalState(luceneServerConfiguration);
+    GlobalState globalState = GlobalState.createState(luceneServerConfiguration);
     return new GrpcServer(
         grpcCleanup,
         luceneServerConfiguration,

--- a/src/test/java/com/yelp/nrtsearch/server/config/StateConfigTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/StateConfigTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.yelp.nrtsearch.server.config.StateConfig.StateBackendType;
+import java.io.ByteArrayInputStream;
+import org.junit.Test;
+
+public class StateConfigTest {
+  private static StateConfig getConfig(String configFile) {
+    return StateConfig.fromConfig(
+        new YamlConfigReader(new ByteArrayInputStream(configFile.getBytes())));
+  }
+
+  @Test
+  public void testDefaultConfig() {
+    String configFile = "nodeName: \"lucene_server_foo\"";
+    StateConfig stateConfig = getConfig(configFile);
+    assertEquals(StateBackendType.LEGACY, stateConfig.getBackendType());
+    assertTrue(stateConfig.useLegacyStateManagement());
+  }
+
+  @Test
+  public void testValidConfig() {
+    String configFile = String.join("\n", "stateConfig:", "  backendType: LOCAL");
+    StateConfig stateConfig = getConfig(configFile);
+    assertEquals(StateBackendType.LOCAL, stateConfig.getBackendType());
+    assertFalse(stateConfig.useLegacyStateManagement());
+  }
+
+  @Test
+  public void testInvalidBackendType() {
+    String configFile = String.join("\n", "stateConfig:", "  backendType: INVALID");
+    try {
+      getConfig(configFile);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("No enum constant"));
+    }
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNullConfigReader() {
+    StateConfig.fromConfig(null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNullBackendType() {
+    new StateConfig(null);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/AckedCopyTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/AckedCopyTest.java
@@ -96,7 +96,7 @@ public class AckedCopyTest {
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerPrimaryConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.PRIMARY, folder.getRoot(), extraConfig);
-    GlobalState globalStatePrimary = new GlobalState(luceneServerPrimaryConfiguration);
+    GlobalState globalStatePrimary = GlobalState.createState(luceneServerPrimaryConfiguration);
     luceneServerPrimary =
         new GrpcServer(
             grpcCleanup,
@@ -122,7 +122,7 @@ public class AckedCopyTest {
     // set up secondary servers
     LuceneServerConfiguration luceneServerSecondaryConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.REPLICA, folder.getRoot(), extraConfig);
-    GlobalState globalStateSecondary = new GlobalState(luceneServerSecondaryConfiguration);
+    GlobalState globalStateSecondary = GlobalState.createState(luceneServerSecondaryConfiguration);
 
     luceneServerSecondary =
         new GrpcServer(

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/BackupRestoreIndexRequestHandlerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/BackupRestoreIndexRequestHandlerTest.java
@@ -86,7 +86,7 @@ public class BackupRestoreIndexRequestHandlerTest {
   private GrpcServer setUpGrpcServer() throws IOException {
     LuceneServerConfiguration luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
-    GlobalState globalState = new GlobalState(luceneServerConfiguration);
+    GlobalState globalState = GlobalState.createState(luceneServerConfiguration);
     return new GrpcServer(
         grpcCleanup,
         luceneServerConfiguration,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/CustomFieldTypeTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/CustomFieldTypeTest.java
@@ -83,7 +83,7 @@ public class CustomFieldTypeTest {
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
-    GlobalState globalState = new GlobalState(luceneServerConfiguration);
+    GlobalState globalState = GlobalState.createState(luceneServerConfiguration);
     return new GrpcServer(
         collectorRegistry,
         grpcCleanup,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/FailedBackupCleanupTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/FailedBackupCleanupTest.java
@@ -83,7 +83,7 @@ public class FailedBackupCleanupTest {
   }
 
   private GrpcServer setUpGrpcServer() throws IOException {
-    GlobalState globalState = new GlobalState(luceneServerConfiguration);
+    GlobalState globalState = GlobalState.createState(luceneServerConfiguration);
     return new GrpcServer(
         grpcCleanup,
         luceneServerConfiguration,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerIdFieldTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerIdFieldTest.java
@@ -77,7 +77,7 @@ public class LuceneServerIdFieldTest {
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
-    GlobalState globalState = new GlobalState(luceneServerConfiguration);
+    GlobalState globalState = GlobalState.createState(luceneServerConfiguration);
     return new GrpcServer(
         collectorRegistry,
         grpcCleanup,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -188,7 +188,7 @@ public class LuceneServerTest {
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
-    GlobalState globalState = new GlobalState(luceneServerConfiguration);
+    GlobalState globalState = GlobalState.createState(luceneServerConfiguration);
     return new GrpcServer(
         collectorRegistry,
         grpcCleanup,
@@ -209,7 +209,7 @@ public class LuceneServerTest {
     LuceneServerConfiguration luceneServerReplicaConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(
             Mode.REPLICA, folder.getRoot(), getExtraConfig());
-    GlobalState globalStateSecondary = new GlobalState(luceneServerReplicaConfiguration);
+    GlobalState globalStateSecondary = GlobalState.createState(luceneServerReplicaConfiguration);
 
     return new GrpcServer(
         grpcCleanup,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/MergeBehaviorTests.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/MergeBehaviorTests.java
@@ -86,7 +86,7 @@ public class MergeBehaviorTests {
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
-    GlobalState globalState = new GlobalState(luceneServerConfiguration);
+    GlobalState globalState = GlobalState.createState(luceneServerConfiguration);
     return new GrpcServer(
         collectorRegistry,
         grpcCleanup,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
@@ -78,7 +78,7 @@ public class QueryTest {
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
-    GlobalState globalState = new GlobalState(luceneServerConfiguration);
+    GlobalState globalState = GlobalState.createState(luceneServerConfiguration);
     return new GrpcServer(
         grpcCleanup,
         luceneServerConfiguration,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
@@ -95,7 +95,7 @@ public class ReplicationServerTest {
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerPrimaryConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.PRIMARY, folder.getRoot());
-    GlobalState globalStatePrimary = new GlobalState(luceneServerPrimaryConfiguration);
+    GlobalState globalStatePrimary = GlobalState.createState(luceneServerPrimaryConfiguration);
     luceneServerPrimary =
         new GrpcServer(
             grpcCleanup,
@@ -121,7 +121,7 @@ public class ReplicationServerTest {
     // set up secondary servers
     LuceneServerConfiguration luceneServerSecondaryConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.REPLICA, folder.getRoot());
-    GlobalState globalStateSecondary = new GlobalState(luceneServerSecondaryConfiguration);
+    GlobalState globalStateSecondary = GlobalState.createState(luceneServerSecondaryConfiguration);
 
     luceneServerSecondary =
         new GrpcServer(

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationTestFailureScenarios.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationTestFailureScenarios.java
@@ -99,7 +99,7 @@ public class ReplicationTestFailureScenarios {
   public void startPrimaryServer() throws IOException {
     LuceneServerConfiguration luceneServerPrimaryConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.PRIMARY, folder.getRoot());
-    GlobalState globalStatePrimary = new GlobalState(luceneServerPrimaryConfiguration);
+    GlobalState globalStatePrimary = GlobalState.createState(luceneServerPrimaryConfiguration);
     luceneServerPrimary =
         new GrpcServer(
             grpcCleanup,
@@ -127,7 +127,7 @@ public class ReplicationTestFailureScenarios {
   public void startSecondaryServer() throws IOException {
     LuceneServerConfiguration luceneSecondaryConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.REPLICA, folder.getRoot());
-    GlobalState globalStateSecondary = new GlobalState(luceneSecondaryConfiguration);
+    GlobalState globalStateSecondary = GlobalState.createState(luceneSecondaryConfiguration);
 
     luceneServerSecondary =
         new GrpcServer(

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/SuggestTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/SuggestTest.java
@@ -81,7 +81,7 @@ public class SuggestTest {
   public void setUp() throws IOException {
     LuceneServerConfiguration luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
-    GlobalState globalState = new GlobalState(luceneServerConfiguration);
+    GlobalState globalState = GlobalState.createState(luceneServerConfiguration);
     grpcServer =
         new GrpcServer(
             grpcCleanup,

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/GlobalStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/GlobalStateTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver;
+
+import static org.junit.Assert.assertTrue;
+
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.luceneserver.state.BackendGlobalState;
+import com.yelp.nrtsearch.server.luceneserver.state.LegacyGlobalState;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class GlobalStateTest {
+
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  private LuceneServerConfiguration getConfig(String config) {
+    return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+  }
+
+  @Test
+  public void testCreateLegacyGlobalState() throws IOException {
+    String configFile = String.join("\n", "stateConfig:", "  backendType: LEGACY");
+    LuceneServerConfiguration configuration = getConfig(configFile);
+    GlobalState globalState = GlobalState.createState(configuration);
+    assertTrue(globalState instanceof LegacyGlobalState);
+  }
+
+  @Test
+  public void testCreateBackendGlobalState() throws IOException {
+    String configFile =
+        String.join(
+            "\n",
+            "stateConfig:",
+            "  backendType: LOCAL",
+            "stateDir: " + folder.getRoot().getAbsolutePath());
+    LuceneServerConfiguration configuration = getConfig(configFile);
+    GlobalState globalState = GlobalState.createState(configuration);
+    assertTrue(globalState instanceof BackendGlobalState);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/IndexStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/IndexStateTest.java
@@ -669,7 +669,7 @@ public class IndexStateTest {
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     FieldDefCreator.initialize(luceneServerConfiguration, Collections.emptyList());
     SimilarityCreator.initialize(luceneServerConfiguration, Collections.emptyList());
-    return new GlobalState(luceneServerConfiguration);
+    return GlobalState.createState(luceneServerConfiguration);
   }
 
   public GlobalState getInitStateVirtualSharding() throws IOException {
@@ -678,6 +678,6 @@ public class IndexStateTest {
             Mode.STANDALONE, folder.getRoot(), "virtualSharding: true");
     FieldDefCreator.initialize(luceneServerConfiguration, Collections.emptyList());
     SimilarityCreator.initialize(luceneServerConfiguration, Collections.emptyList());
-    return new GlobalState(luceneServerConfiguration);
+    return GlobalState.createState(luceneServerConfiguration);
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/RestoreStateHandlerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/RestoreStateHandlerTest.java
@@ -65,7 +65,7 @@ public class RestoreStateHandlerTest {
             s3, BUCKET_NAME, archiverDirectory, new TarImpl(TarImpl.CompressionMode.LZ4));
     LuceneServerConfiguration luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
-    globalState = new GlobalState(luceneServerConfiguration);
+    globalState = GlobalState.createState(luceneServerConfiguration);
   }
 
   @After

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/ServerTestCase.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/ServerTestCase.java
@@ -204,7 +204,7 @@ public class ServerTestCase {
     LuceneServerConfiguration luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(
             Mode.STANDALONE, folder.getRoot(), getExtraConfig());
-    globalState = new GlobalState(luceneServerConfiguration);
+    globalState = GlobalState.createState(luceneServerConfiguration);
     return new GrpcServer(
         collectorRegistry,
         grpcCleanup,

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
@@ -100,7 +100,7 @@ public class ScoreScriptTest {
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
-    GlobalState globalState = new GlobalState(luceneServerConfiguration);
+    GlobalState globalState = GlobalState.createState(luceneServerConfiguration);
     return new GrpcServer(
         collectorRegistry,
         grpcCleanup,

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/state/BackendGlobalStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/state/BackendGlobalStateTest.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.state;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.yelp.nrtsearch.server.backup.Archiver;
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.luceneserver.IndexState;
+import com.yelp.nrtsearch.server.luceneserver.field.FieldDefCreator;
+import com.yelp.nrtsearch.server.luceneserver.similarity.SimilarityCreator;
+import com.yelp.nrtsearch.server.luceneserver.state.PersistentGlobalState.IndexInfo;
+import com.yelp.nrtsearch.server.luceneserver.state.backend.LocalStateBackend;
+import com.yelp.nrtsearch.server.luceneserver.state.backend.RemoteStateBackend;
+import com.yelp.nrtsearch.server.luceneserver.state.backend.StateBackend;
+import com.yelp.nrtsearch.server.plugins.Plugin;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.ArgumentCaptor;
+
+public class BackendGlobalStateTest {
+
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  @BeforeClass
+  public static void setup() {
+    String configFile = "nodeName: \"lucene_server_foo\"";
+    LuceneServerConfiguration dummyConfig =
+        new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+    List<Plugin> dummyPlugins = Collections.emptyList();
+    // these must be initialized to create an IndexState
+    FieldDefCreator.initialize(dummyConfig, dummyPlugins);
+    SimilarityCreator.initialize(dummyConfig, dummyPlugins);
+  }
+
+  static class MockBackendGlobalState extends BackendGlobalState {
+    public static StateBackend stateBackend;
+
+    /**
+     * Constructor.
+     *
+     * @param luceneServerConfiguration server config
+     * @param incArchiver archiver for remote backends
+     * @throws IOException on filesystem error
+     */
+    public MockBackendGlobalState(
+        LuceneServerConfiguration luceneServerConfiguration, Archiver incArchiver)
+        throws IOException {
+      super(luceneServerConfiguration, incArchiver);
+    }
+
+    @Override
+    public StateBackend createStateBackend() {
+      return stateBackend;
+    }
+  }
+
+  private LuceneServerConfiguration getConfig() throws IOException {
+    String configFile =
+        String.join(
+            "\n",
+            "stateConfig:",
+            "  backendType: LOCAL",
+            "stateDir: " + folder.newFolder("state").getAbsolutePath(),
+            "indexDir: " + folder.newFolder("index").getAbsolutePath());
+    return new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+  }
+
+  @Test
+  public void testCreateNewIndex() throws IOException {
+    StateBackend mockBackend = mock(StateBackend.class);
+    PersistentGlobalState initialState = new PersistentGlobalState();
+    when(mockBackend.loadOrCreateGlobalState()).thenReturn(initialState);
+
+    MockBackendGlobalState.stateBackend = mockBackend;
+    BackendGlobalState backendGlobalState = new MockBackendGlobalState(getConfig(), null);
+    backendGlobalState.createIndex("test_index");
+
+    assertEquals(1, backendGlobalState.getIndexNames().size());
+    assertTrue(backendGlobalState.getIndexNames().contains("test_index"));
+    assertNotNull(backendGlobalState.getIndex("test_index"));
+
+    verify(mockBackend, times(1)).loadOrCreateGlobalState();
+
+    ArgumentCaptor<PersistentGlobalState> stateArgumentCaptor =
+        ArgumentCaptor.forClass(PersistentGlobalState.class);
+    verify(mockBackend, times(1)).commitGlobalState(stateArgumentCaptor.capture());
+    PersistentGlobalState committedState = stateArgumentCaptor.getValue();
+    assertEquals(1, committedState.getIndices().size());
+    assertNotNull(committedState.getIndices().get("test_index"));
+
+    verifyNoMoreInteractions(mockBackend);
+  }
+
+  @Test
+  public void testCreateIndexMultiple() throws IOException {
+    StateBackend mockBackend = mock(StateBackend.class);
+    PersistentGlobalState initialState = new PersistentGlobalState();
+    when(mockBackend.loadOrCreateGlobalState()).thenReturn(initialState);
+
+    MockBackendGlobalState.stateBackend = mockBackend;
+    BackendGlobalState backendGlobalState = new MockBackendGlobalState(getConfig(), null);
+    backendGlobalState.createIndex("test_index");
+    backendGlobalState.createIndex("test_index_2");
+
+    assertEquals(2, backendGlobalState.getIndexNames().size());
+    assertTrue(backendGlobalState.getIndexNames().contains("test_index"));
+    assertTrue(backendGlobalState.getIndexNames().contains("test_index_2"));
+    assertNotNull(backendGlobalState.getIndex("test_index"));
+    assertNotNull(backendGlobalState.getIndex("test_index_2"));
+
+    verify(mockBackend, times(1)).loadOrCreateGlobalState();
+
+    ArgumentCaptor<PersistentGlobalState> stateArgumentCaptor =
+        ArgumentCaptor.forClass(PersistentGlobalState.class);
+    verify(mockBackend, times(2)).commitGlobalState(stateArgumentCaptor.capture());
+    PersistentGlobalState committedState = stateArgumentCaptor.getAllValues().get(0);
+    assertEquals(1, committedState.getIndices().size());
+    assertNotNull(committedState.getIndices().get("test_index"));
+    committedState = stateArgumentCaptor.getAllValues().get(1);
+    assertEquals(2, committedState.getIndices().size());
+    assertNotNull(committedState.getIndices().get("test_index"));
+    assertNotNull(committedState.getIndices().get("test_index_2"));
+
+    verifyNoMoreInteractions(mockBackend);
+  }
+
+  @Test
+  public void testCreateIndexFails() throws IOException {
+    StateBackend mockBackend = mock(StateBackend.class);
+    PersistentGlobalState initialState = new PersistentGlobalState();
+    when(mockBackend.loadOrCreateGlobalState()).thenReturn(initialState);
+
+    MockBackendGlobalState.stateBackend = mockBackend;
+    BackendGlobalState backendGlobalState = new MockBackendGlobalState(getConfig(), null);
+    backendGlobalState.createIndex("test_index");
+    try {
+      backendGlobalState.createIndex("test_index");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("index \"test_index\" already exists", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testCreateIndexFailsFromLoadedState() throws IOException {
+    StateBackend mockBackend = mock(StateBackend.class);
+    Map<String, IndexInfo> initialIndices = new HashMap<>();
+    initialIndices.put("test_index", new IndexInfo());
+    PersistentGlobalState initialState = new PersistentGlobalState(initialIndices);
+    when(mockBackend.loadOrCreateGlobalState()).thenReturn(initialState);
+
+    MockBackendGlobalState.stateBackend = mockBackend;
+    BackendGlobalState backendGlobalState = new MockBackendGlobalState(getConfig(), null);
+    try {
+      backendGlobalState.createIndex("test_index");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("index \"test_index\" already exists", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testGetCreatedIndex() throws IOException {
+    StateBackend mockBackend = mock(StateBackend.class);
+    PersistentGlobalState initialState = new PersistentGlobalState();
+    when(mockBackend.loadOrCreateGlobalState()).thenReturn(initialState);
+
+    MockBackendGlobalState.stateBackend = mockBackend;
+    BackendGlobalState backendGlobalState = new MockBackendGlobalState(getConfig(), null);
+    backendGlobalState.createIndex("test_index");
+
+    assertEquals(1, backendGlobalState.getIndexNames().size());
+    assertTrue(backendGlobalState.getIndexNames().contains("test_index"));
+    IndexState createdState = backendGlobalState.getIndex("test_index");
+    assertNotNull(createdState);
+
+    IndexState getIndexState = backendGlobalState.getIndex("test_index");
+    assertSame(createdState, getIndexState);
+
+    verify(mockBackend, times(1)).loadOrCreateGlobalState();
+
+    ArgumentCaptor<PersistentGlobalState> stateArgumentCaptor =
+        ArgumentCaptor.forClass(PersistentGlobalState.class);
+    verify(mockBackend, times(1)).commitGlobalState(stateArgumentCaptor.capture());
+    PersistentGlobalState committedState = stateArgumentCaptor.getValue();
+    assertEquals(1, committedState.getIndices().size());
+    assertNotNull(committedState.getIndices().get("test_index"));
+
+    verifyNoMoreInteractions(mockBackend);
+  }
+
+  @Test
+  public void testGetRestoredStateIndex() throws IOException {
+    StateBackend mockBackend = mock(StateBackend.class);
+    Map<String, IndexInfo> initialIndices = new HashMap<>();
+    initialIndices.put("test_index", new IndexInfo());
+    PersistentGlobalState initialState = new PersistentGlobalState(initialIndices);
+    when(mockBackend.loadOrCreateGlobalState()).thenReturn(initialState);
+
+    MockBackendGlobalState.stateBackend = mockBackend;
+    BackendGlobalState backendGlobalState = new MockBackendGlobalState(getConfig(), null);
+    assertNotNull(backendGlobalState.getIndex("test_index"));
+
+    verify(mockBackend, times(1)).loadOrCreateGlobalState();
+
+    verifyNoMoreInteractions(mockBackend);
+  }
+
+  @Test
+  public void testGetIndexNotExists() throws IOException {
+    StateBackend mockBackend = mock(StateBackend.class);
+    PersistentGlobalState initialState = new PersistentGlobalState();
+    when(mockBackend.loadOrCreateGlobalState()).thenReturn(initialState);
+
+    MockBackendGlobalState.stateBackend = mockBackend;
+    BackendGlobalState backendGlobalState = new MockBackendGlobalState(getConfig(), null);
+    try {
+      backendGlobalState.getIndex("test_index");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("index \"test_index\" was not saved or committed", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testDeleteCreatedIndex() throws IOException {
+    StateBackend mockBackend = mock(StateBackend.class);
+    PersistentGlobalState initialState = new PersistentGlobalState();
+    when(mockBackend.loadOrCreateGlobalState()).thenReturn(initialState);
+
+    MockBackendGlobalState.stateBackend = mockBackend;
+    BackendGlobalState backendGlobalState = new MockBackendGlobalState(getConfig(), null);
+    backendGlobalState.createIndex("test_index");
+    backendGlobalState.createIndex("test_index_2");
+
+    assertEquals(2, backendGlobalState.getIndexNames().size());
+    assertTrue(backendGlobalState.getIndexNames().contains("test_index"));
+    assertTrue(backendGlobalState.getIndexNames().contains("test_index_2"));
+    assertNotNull(backendGlobalState.getIndex("test_index"));
+    assertNotNull(backendGlobalState.getIndex("test_index_2"));
+
+    backendGlobalState.deleteIndex("test_index");
+    assertEquals(1, backendGlobalState.getIndexNames().size());
+    assertNotNull(backendGlobalState.getIndex("test_index_2"));
+
+    verify(mockBackend, times(1)).loadOrCreateGlobalState();
+
+    ArgumentCaptor<PersistentGlobalState> stateArgumentCaptor =
+        ArgumentCaptor.forClass(PersistentGlobalState.class);
+    verify(mockBackend, times(3)).commitGlobalState(stateArgumentCaptor.capture());
+    PersistentGlobalState committedState = stateArgumentCaptor.getAllValues().get(0);
+    assertEquals(1, committedState.getIndices().size());
+    assertNotNull(committedState.getIndices().get("test_index"));
+    committedState = stateArgumentCaptor.getAllValues().get(1);
+    assertEquals(2, committedState.getIndices().size());
+    assertNotNull(committedState.getIndices().get("test_index"));
+    assertNotNull(committedState.getIndices().get("test_index_2"));
+    committedState = stateArgumentCaptor.getAllValues().get(2);
+    assertEquals(1, committedState.getIndices().size());
+    assertNotNull(committedState.getIndices().get("test_index_2"));
+
+    verifyNoMoreInteractions(mockBackend);
+  }
+
+  @Test
+  public void testDeleteRestoredStateIndex() throws IOException {
+    StateBackend mockBackend = mock(StateBackend.class);
+    Map<String, IndexInfo> initialIndices = new HashMap<>();
+    initialIndices.put("test_index", new IndexInfo());
+    initialIndices.put("test_index_2", new IndexInfo());
+    PersistentGlobalState initialState = new PersistentGlobalState(initialIndices);
+    when(mockBackend.loadOrCreateGlobalState()).thenReturn(initialState);
+
+    MockBackendGlobalState.stateBackend = mockBackend;
+    BackendGlobalState backendGlobalState = new MockBackendGlobalState(getConfig(), null);
+
+    backendGlobalState.deleteIndex("test_index_2");
+    assertEquals(Set.of("test_index"), backendGlobalState.getIndexNames());
+
+    verify(mockBackend, times(1)).loadOrCreateGlobalState();
+
+    ArgumentCaptor<PersistentGlobalState> stateArgumentCaptor =
+        ArgumentCaptor.forClass(PersistentGlobalState.class);
+    verify(mockBackend, times(1)).commitGlobalState(stateArgumentCaptor.capture());
+    PersistentGlobalState committedState = stateArgumentCaptor.getValue();
+    assertEquals(1, committedState.getIndices().size());
+    assertNotNull(committedState.getIndices().get("test_index"));
+
+    verifyNoMoreInteractions(mockBackend);
+  }
+
+  @Test
+  public void testIndexClosed() throws IOException {
+    StateBackend mockBackend = mock(StateBackend.class);
+    PersistentGlobalState initialState = new PersistentGlobalState();
+    when(mockBackend.loadOrCreateGlobalState()).thenReturn(initialState);
+
+    MockBackendGlobalState.stateBackend = mockBackend;
+    BackendGlobalState backendGlobalState = new MockBackendGlobalState(getConfig(), null);
+    backendGlobalState.createIndex("test_index");
+
+    IndexState state1 = backendGlobalState.getIndex("test_index");
+    IndexState state2 = backendGlobalState.getIndex("test_index");
+    assertSame(state1, state2);
+
+    backendGlobalState.indexClosed("test_index");
+    IndexState state3 = backendGlobalState.getIndex("test_index");
+    assertNotSame(state1, state3);
+
+    verify(mockBackend, times(1)).loadOrCreateGlobalState();
+
+    ArgumentCaptor<PersistentGlobalState> stateArgumentCaptor =
+        ArgumentCaptor.forClass(PersistentGlobalState.class);
+    verify(mockBackend, times(1)).commitGlobalState(stateArgumentCaptor.capture());
+    PersistentGlobalState committedState = stateArgumentCaptor.getValue();
+    assertEquals(1, committedState.getIndices().size());
+    assertNotNull(committedState.getIndices().get("test_index"));
+
+    verifyNoMoreInteractions(mockBackend);
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testSetStateDir() throws IOException {
+    StateBackend mockBackend = mock(StateBackend.class);
+    PersistentGlobalState initialState = new PersistentGlobalState();
+    when(mockBackend.loadOrCreateGlobalState()).thenReturn(initialState);
+
+    MockBackendGlobalState.stateBackend = mockBackend;
+    BackendGlobalState backendGlobalState = new MockBackendGlobalState(getConfig(), null);
+    backendGlobalState.setStateDir(folder.getRoot().toPath());
+  }
+
+  @Test
+  public void testUseLocalBackend() throws IOException {
+    String configFile =
+        String.join(
+            "\n",
+            "stateConfig:",
+            "  backendType: LOCAL",
+            "stateDir: " + folder.newFolder("state").getAbsolutePath(),
+            "indexDir: " + folder.newFolder("index").getAbsolutePath());
+    LuceneServerConfiguration config =
+        new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+    BackendGlobalState backendGlobalState = new BackendGlobalState(config, null);
+    assertTrue(backendGlobalState.getStateBackend() instanceof LocalStateBackend);
+  }
+
+  @Test
+  public void testUseRemoteBackend() throws IOException {
+    String configFile =
+        String.join(
+            "\n",
+            "stateConfig:",
+            "  backendType: REMOTE",
+            "stateDir: " + folder.newFolder("state").getAbsolutePath(),
+            "indexDir: " + folder.newFolder("index").getAbsolutePath());
+    LuceneServerConfiguration config =
+        new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+
+    Path tmpStateFolder =
+        Paths.get(folder.getRoot().getAbsolutePath(), StateUtils.GLOBAL_STATE_FOLDER);
+    StateUtils.ensureDirectory(tmpStateFolder);
+    StateUtils.writeStateToFile(
+        new PersistentGlobalState(), tmpStateFolder, StateUtils.GLOBAL_STATE_FILE);
+    Archiver archiver = mock(Archiver.class);
+    when(archiver.download(any(), any())).thenReturn(Paths.get(folder.getRoot().getAbsolutePath()));
+
+    BackendGlobalState backendGlobalState = new BackendGlobalState(config, archiver);
+    assertTrue(backendGlobalState.getStateBackend() instanceof RemoteStateBackend);
+  }
+
+  @Test
+  public void testInvalidBackend() throws IOException {
+    String configFile =
+        String.join(
+            "\n",
+            "stateConfig:",
+            "  backendType: LEGACY",
+            "stateDir: " + folder.newFolder("state").getAbsolutePath(),
+            "indexDir: " + folder.newFolder("index").getAbsolutePath());
+    LuceneServerConfiguration config =
+        new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+    try {
+      new BackendGlobalState(config, null);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("Unsupported state backend type: LEGACY", e.getMessage());
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/state/PersistentGlobalStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/state/PersistentGlobalStateTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.state;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+
+import com.yelp.nrtsearch.server.luceneserver.state.PersistentGlobalState.IndexInfo;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class PersistentGlobalStateTest {
+
+  @Test
+  public void testDefaultGlobalState() {
+    PersistentGlobalState state = new PersistentGlobalState();
+    assertEquals(0, state.getIndices().size());
+  }
+
+  @Test
+  public void testGlobalState() {
+    Map<String, IndexInfo> indicesMap = new HashMap<>();
+    indicesMap.put("test_index", new IndexInfo());
+    indicesMap.put("test_index_2", new IndexInfo());
+    PersistentGlobalState state = new PersistentGlobalState(indicesMap);
+    assertEquals(indicesMap, state.getIndices());
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testUnmodifiableIndices() {
+    PersistentGlobalState state = new PersistentGlobalState();
+    state.getIndices().put("test_index", new IndexInfo());
+  }
+
+  @Test
+  public void testBuilder() {
+    Map<String, IndexInfo> indicesMap = new HashMap<>();
+    indicesMap.put("test_index", new IndexInfo());
+    indicesMap.put("test_index_2", new IndexInfo());
+    PersistentGlobalState state = new PersistentGlobalState(indicesMap);
+
+    PersistentGlobalState rebuilt = state.asBuilder().build();
+    assertNotSame(state, rebuilt);
+    assertEquals(state, rebuilt);
+
+    indicesMap = new HashMap<>();
+    indicesMap.put("test_index_3", new IndexInfo());
+    indicesMap.put("test_index_4", new IndexInfo());
+    PersistentGlobalState updated = state.asBuilder().withIndices(indicesMap).build();
+    assertNotEquals(state, updated);
+    assertEquals(indicesMap, updated.getIndices());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNullIndices() {
+    new PersistentGlobalState(null);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/state/StateUtilsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/state/StateUtilsTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.state;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.yelp.nrtsearch.server.luceneserver.state.PersistentGlobalState.IndexInfo;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class StateUtilsTest {
+
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  @Test
+  public void testEnsureDirectoryCreatesDirs() {
+    Path dirPath = Paths.get(folder.getRoot().getAbsolutePath(), "dir1", "dir2");
+    assertFalse(dirPath.toFile().exists());
+
+    StateUtils.ensureDirectory(dirPath);
+    assertTrue(dirPath.toFile().exists());
+    assertTrue(dirPath.toFile().isDirectory());
+  }
+
+  @Test
+  public void testEnsureDirectoryExistsNoop() {
+    Path dirPath = Paths.get(folder.getRoot().getAbsolutePath());
+    assertTrue(dirPath.toFile().exists());
+
+    StateUtils.ensureDirectory(dirPath);
+    assertTrue(dirPath.toFile().exists());
+    assertTrue(dirPath.toFile().isDirectory());
+  }
+
+  @Test
+  public void testEnsureDirectoryFailsOnFile() throws IOException {
+    Path filePath = Paths.get(folder.getRoot().getAbsolutePath(), "file");
+    assertTrue(filePath.toFile().createNewFile());
+
+    try {
+      StateUtils.ensureDirectory(filePath);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("is not a directory"));
+    }
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testEnsureDirectoryNull() {
+    StateUtils.ensureDirectory(null);
+  }
+
+  @Test
+  public void testWriteNewStateFile() throws IOException {
+    Path expectedStateFilePath =
+        Paths.get(folder.getRoot().getAbsolutePath(), StateUtils.GLOBAL_STATE_FILE);
+    assertFalse(expectedStateFilePath.toFile().exists());
+
+    Map<String, IndexInfo> testIndices = new HashMap<>();
+    testIndices.put("test_index", new IndexInfo());
+    testIndices.put("test_index_2", new IndexInfo());
+    PersistentGlobalState persistentGlobalState = new PersistentGlobalState(testIndices);
+
+    StateUtils.writeStateToFile(
+        persistentGlobalState,
+        Paths.get(folder.getRoot().getAbsolutePath()),
+        StateUtils.GLOBAL_STATE_FILE);
+    assertTrue(expectedStateFilePath.toFile().exists());
+
+    PersistentGlobalState readState = StateUtils.readStateFromFile(expectedStateFilePath);
+    assertEquals(persistentGlobalState, readState);
+  }
+
+  @Test
+  public void testReWriteStateFile() throws IOException {
+    Path expectedStateFilePath =
+        Paths.get(folder.getRoot().getAbsolutePath(), StateUtils.GLOBAL_STATE_FILE);
+    assertFalse(expectedStateFilePath.toFile().exists());
+
+    Map<String, IndexInfo> testIndices = new HashMap<>();
+    testIndices.put("test_index_3", new IndexInfo());
+    testIndices.put("test_index_4", new IndexInfo());
+    PersistentGlobalState persistentGlobalState = new PersistentGlobalState(testIndices);
+
+    StateUtils.writeStateToFile(
+        persistentGlobalState,
+        Paths.get(folder.getRoot().getAbsolutePath()),
+        StateUtils.GLOBAL_STATE_FILE);
+    assertTrue(expectedStateFilePath.toFile().exists());
+
+    PersistentGlobalState readState = StateUtils.readStateFromFile(expectedStateFilePath);
+    assertEquals(persistentGlobalState, readState);
+
+    testIndices = new HashMap<>();
+    testIndices.put("test_index_5", new IndexInfo());
+    testIndices.put("test_index_6", new IndexInfo());
+    testIndices.put("test_index_7", new IndexInfo());
+    PersistentGlobalState persistentGlobalState2 = new PersistentGlobalState(testIndices);
+
+    StateUtils.writeStateToFile(
+        persistentGlobalState2,
+        Paths.get(folder.getRoot().getAbsolutePath()),
+        StateUtils.GLOBAL_STATE_FILE);
+    assertTrue(expectedStateFilePath.toFile().exists());
+
+    PersistentGlobalState readState2 = StateUtils.readStateFromFile(expectedStateFilePath);
+    assertEquals(persistentGlobalState2, readState2);
+    assertNotEquals(readState, readState2);
+  }
+
+  @Test
+  public void testWriteNullFile() throws IOException {
+    try {
+      StateUtils.writeStateToFile(
+          null, Paths.get(folder.getRoot().getAbsolutePath()), StateUtils.GLOBAL_STATE_FILE);
+      fail();
+    } catch (NullPointerException ignore) {
+
+    }
+    try {
+      StateUtils.writeStateToFile(new PersistentGlobalState(), null, StateUtils.GLOBAL_STATE_FILE);
+      fail();
+    } catch (NullPointerException ignore) {
+
+    }
+    try {
+      StateUtils.writeStateToFile(
+          new PersistentGlobalState(), Paths.get(folder.getRoot().getAbsolutePath()), null);
+      fail();
+    } catch (NullPointerException ignore) {
+
+    }
+  }
+
+  @Test(expected = FileNotFoundException.class)
+  public void testReadStateFileNotFound() throws IOException {
+    Path expectedStateFilePath =
+        Paths.get(folder.getRoot().getAbsolutePath(), StateUtils.GLOBAL_STATE_FILE);
+    assertFalse(expectedStateFilePath.toFile().exists());
+    StateUtils.readStateFromFile(expectedStateFilePath);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testReadNullFile() throws IOException {
+    StateUtils.readStateFromFile(null);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/state/backend/LocalStateBackendTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/state/backend/LocalStateBackendTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.state.backend;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.luceneserver.GlobalState;
+import com.yelp.nrtsearch.server.luceneserver.state.PersistentGlobalState;
+import com.yelp.nrtsearch.server.luceneserver.state.PersistentGlobalState.IndexInfo;
+import com.yelp.nrtsearch.server.luceneserver.state.StateUtils;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class LocalStateBackendTest {
+
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  private LuceneServerConfiguration getConfig() throws IOException {
+    String configFile =
+        String.join(
+            "\n",
+            "stateConfig:",
+            "  backendType: LOCAL",
+            "stateDir: " + folder.getRoot().getAbsolutePath());
+    return new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+  }
+
+  private GlobalState getMockGlobalState() throws IOException {
+    GlobalState mockState = mock(GlobalState.class);
+    LuceneServerConfiguration serverConfiguration = getConfig();
+    when(mockState.getConfiguration()).thenReturn(serverConfiguration);
+    when(mockState.getStateDir()).thenReturn(Paths.get(serverConfiguration.getStateDir()));
+    return mockState;
+  }
+
+  private Path getStateFilePath() {
+    return Paths.get(
+        folder.getRoot().getAbsolutePath(),
+        StateUtils.GLOBAL_STATE_FOLDER,
+        StateUtils.GLOBAL_STATE_FILE);
+  }
+
+  @Test
+  public void testCreatesGlobalStateDir() throws IOException {
+    Path stateDir = Paths.get(folder.getRoot().getAbsolutePath(), StateUtils.GLOBAL_STATE_FOLDER);
+    assertFalse(stateDir.toFile().exists());
+
+    new LocalStateBackend(getMockGlobalState());
+    assertTrue(stateDir.toFile().exists());
+    assertTrue(stateDir.toFile().isDirectory());
+  }
+
+  @Test
+  public void testCreatesDefaultState() throws IOException {
+    StateBackend stateBackend = new LocalStateBackend(getMockGlobalState());
+    Path filePath = getStateFilePath();
+    assertFalse(filePath.toFile().exists());
+
+    PersistentGlobalState globalState = stateBackend.loadOrCreateGlobalState();
+    assertEquals(globalState, new PersistentGlobalState());
+
+    assertTrue(filePath.toFile().exists());
+    assertTrue(filePath.toFile().isFile());
+
+    PersistentGlobalState loadedState = StateUtils.readStateFromFile(filePath);
+    assertEquals(globalState, loadedState);
+  }
+
+  @Test
+  public void testLoadsSavedState() throws IOException {
+    StateBackend stateBackend = new LocalStateBackend(getMockGlobalState());
+    Path filePath = getStateFilePath();
+
+    Map<String, IndexInfo> indicesMap = new HashMap<>();
+    indicesMap.put("test_index", new IndexInfo());
+    indicesMap.put("test_index_2", new IndexInfo());
+    PersistentGlobalState initialState = new PersistentGlobalState(indicesMap);
+    StateUtils.writeStateToFile(
+        initialState,
+        Paths.get(folder.getRoot().getAbsolutePath(), StateUtils.GLOBAL_STATE_FOLDER),
+        StateUtils.GLOBAL_STATE_FILE);
+    assertTrue(filePath.toFile().exists());
+    assertTrue(filePath.toFile().isFile());
+
+    PersistentGlobalState loadedState = stateBackend.loadOrCreateGlobalState();
+    assertEquals(initialState, loadedState);
+  }
+
+  @Test
+  public void testCommitGlobalState() throws IOException {
+    StateBackend stateBackend = new LocalStateBackend(getMockGlobalState());
+    Path filePath = getStateFilePath();
+    PersistentGlobalState initialState = stateBackend.loadOrCreateGlobalState();
+
+    Map<String, IndexInfo> indicesMap = new HashMap<>();
+    indicesMap.put("test_index", new IndexInfo());
+    indicesMap.put("test_index_2", new IndexInfo());
+    PersistentGlobalState updatedState = new PersistentGlobalState(indicesMap);
+    assertNotEquals(initialState, updatedState);
+
+    stateBackend.commitGlobalState(updatedState);
+    PersistentGlobalState loadedState = StateUtils.readStateFromFile(filePath);
+    assertEquals(updatedState, loadedState);
+
+    indicesMap = new HashMap<>();
+    indicesMap.put("test_index_3", new IndexInfo());
+    PersistentGlobalState updatedState2 = new PersistentGlobalState(indicesMap);
+    assertNotEquals(updatedState, updatedState2);
+    stateBackend.commitGlobalState(updatedState2);
+
+    loadedState = StateUtils.readStateFromFile(filePath);
+    assertEquals(updatedState2, loadedState);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testCommitNullState() throws IOException {
+    StateBackend stateBackend = new LocalStateBackend(getMockGlobalState());
+    stateBackend.loadOrCreateGlobalState();
+    stateBackend.commitGlobalState(null);
+  }
+
+  @Test
+  public void testStateFileIsDirectory() throws IOException {
+    StateBackend stateBackend = new LocalStateBackend(getMockGlobalState());
+    StateUtils.ensureDirectory(
+        Paths.get(
+            folder.getRoot().getAbsolutePath(),
+            StateUtils.GLOBAL_STATE_FOLDER,
+            StateUtils.GLOBAL_STATE_FILE));
+    try {
+      stateBackend.loadOrCreateGlobalState();
+      fail();
+    } catch (IllegalStateException e) {
+      assertTrue(e.getMessage().contains("state.json is a directory"));
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/state/backend/RemoteStateBackendTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/state/backend/RemoteStateBackendTest.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.state.backend;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
+import com.yelp.nrtsearch.server.backup.Archiver;
+import com.yelp.nrtsearch.server.backup.BackupDiffManager;
+import com.yelp.nrtsearch.server.backup.ContentDownloader;
+import com.yelp.nrtsearch.server.backup.ContentDownloaderImpl;
+import com.yelp.nrtsearch.server.backup.FileCompressAndUploader;
+import com.yelp.nrtsearch.server.backup.IndexArchiver;
+import com.yelp.nrtsearch.server.backup.TarImpl;
+import com.yelp.nrtsearch.server.backup.VersionManager;
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.luceneserver.GlobalState;
+import com.yelp.nrtsearch.server.luceneserver.state.PersistentGlobalState;
+import com.yelp.nrtsearch.server.luceneserver.state.PersistentGlobalState.IndexInfo;
+import com.yelp.nrtsearch.server.luceneserver.state.StateUtils;
+import io.findify.s3mock.S3Mock;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import net.jpountz.lz4.LZ4FrameInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class RemoteStateBackendTest {
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  private static final String TEST_BUCKET = "remote-state-test";
+  private static final String TEST_SERVICE_NAME = "test-service-name";
+  private S3Mock api;
+  private VersionManager versionManager;
+  private Archiver archiver;
+
+  @Before
+  public void setup() throws IOException {
+    Path s3Directory = folder.newFolder("s3").toPath();
+    Path archiverDirectory = folder.newFolder("archiver").toPath();
+
+    api = S3Mock.create(8011, s3Directory.toAbsolutePath().toString());
+    api.start();
+    AmazonS3 s3 = new AmazonS3Client(new AnonymousAWSCredentials());
+    s3.setEndpoint("http://127.0.0.1:8011");
+    s3.createBucket(TEST_BUCKET);
+    TransferManager transferManager =
+        TransferManagerBuilder.standard().withS3Client(s3).withShutDownThreadPools(false).build();
+
+    ContentDownloader contentDownloader =
+        new ContentDownloaderImpl(
+            new TarImpl(TarImpl.CompressionMode.LZ4), transferManager, TEST_BUCKET, true);
+    FileCompressAndUploader fileCompressAndUploader =
+        new FileCompressAndUploader(
+            new TarImpl(TarImpl.CompressionMode.LZ4), transferManager, TEST_BUCKET);
+    versionManager = new VersionManager(s3, TEST_BUCKET);
+    archiver =
+        new IndexArchiver(
+            mock(BackupDiffManager.class),
+            fileCompressAndUploader,
+            contentDownloader,
+            versionManager,
+            archiverDirectory);
+  }
+
+  @After
+  public void teardown() {
+    api.shutdown();
+  }
+
+  private LuceneServerConfiguration getConfig(boolean readOnly) throws IOException {
+    String configFile =
+        String.join(
+            "\n",
+            "stateConfig:",
+            "  backendType: REMOTE",
+            "  remote:",
+            "    readOnly: " + readOnly,
+            "stateDir: " + folder.getRoot().getAbsolutePath(),
+            "serviceName: " + TEST_SERVICE_NAME);
+    return new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+  }
+
+  private GlobalState getMockGlobalState(boolean readOnly) throws IOException {
+    GlobalState mockState = mock(GlobalState.class);
+    LuceneServerConfiguration serverConfiguration = getConfig(readOnly);
+    when(mockState.getConfiguration()).thenReturn(serverConfiguration);
+    when(mockState.getStateDir()).thenReturn(Paths.get(serverConfiguration.getStateDir()));
+    when(mockState.getIncArchiver()).thenReturn(Optional.of(archiver));
+    return mockState;
+  }
+
+  private Path getLocalStateFilePath() {
+    return Paths.get(
+        folder.getRoot().getAbsolutePath(),
+        StateUtils.GLOBAL_STATE_FOLDER,
+        StateUtils.GLOBAL_STATE_FILE);
+  }
+
+  private Path getS3FilePath(String versionHash) {
+    return Paths.get(
+        folder.getRoot().getAbsolutePath(),
+        "s3",
+        TEST_BUCKET,
+        TEST_SERVICE_NAME,
+        RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+        versionHash);
+  }
+
+  private PersistentGlobalState getS3State() throws IOException {
+    long currentVersion =
+        versionManager.getLatestVersionNumber(
+            TEST_SERVICE_NAME, RemoteStateBackend.GLOBAL_STATE_RESOURCE);
+    if (currentVersion < 0) {
+      return null;
+    }
+    String versionHash =
+        versionManager.getVersionString(
+            TEST_SERVICE_NAME,
+            RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            String.valueOf(currentVersion));
+    Path s3FilePath = getS3FilePath(versionHash);
+    assertTrue(s3FilePath.toFile().exists());
+    assertTrue(s3FilePath.toFile().isFile());
+
+    TarArchiveInputStream tarArchiveInputStream =
+        new TarArchiveInputStream(
+            new LZ4FrameInputStream(new FileInputStream(s3FilePath.toFile())));
+    PersistentGlobalState stateFromTar = null;
+    for (TarArchiveEntry tarArchiveEntry = tarArchiveInputStream.getNextTarEntry();
+        tarArchiveEntry != null;
+        tarArchiveEntry = tarArchiveInputStream.getNextTarEntry()) {
+      if (tarArchiveEntry.getName().endsWith(StateUtils.GLOBAL_STATE_FILE)) {
+        String stateStr;
+        try (DataInputStream dataInputStream = new DataInputStream(tarArchiveInputStream)) {
+          stateStr = dataInputStream.readUTF();
+        }
+        stateFromTar = StateUtils.MAPPER.readValue(stateStr, PersistentGlobalState.class);
+        break;
+      }
+    }
+    return stateFromTar;
+  }
+
+  private void writeStateToS3(PersistentGlobalState state) throws IOException {
+    File tmpFolderFile = folder.newFolder();
+    Path tmpGlobalStatePath =
+        Paths.get(tmpFolderFile.getAbsolutePath(), StateUtils.GLOBAL_STATE_FOLDER);
+    StateUtils.ensureDirectory(tmpGlobalStatePath);
+    StateUtils.writeStateToFile(state, tmpGlobalStatePath, StateUtils.GLOBAL_STATE_FILE);
+    String version =
+        archiver.upload(
+            TEST_SERVICE_NAME,
+            RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            tmpGlobalStatePath,
+            Collections.singletonList(StateUtils.GLOBAL_STATE_FILE),
+            Collections.emptyList(),
+            true);
+    archiver.blessVersion(TEST_SERVICE_NAME, RemoteStateBackend.GLOBAL_STATE_RESOURCE, version);
+  }
+
+  @Test
+  public void testCreatesLocalStateDir() throws IOException {
+    Path stateDir = Paths.get(folder.getRoot().getAbsolutePath(), StateUtils.GLOBAL_STATE_FOLDER);
+    assertFalse(stateDir.toFile().exists());
+
+    new RemoteStateBackend(getMockGlobalState(false));
+    assertTrue(stateDir.toFile().exists());
+    assertTrue(stateDir.toFile().isDirectory());
+  }
+
+  @Test
+  public void testCreatesDefaultState() throws IOException {
+    StateBackend stateBackend = new RemoteStateBackend(getMockGlobalState(false));
+    Path localFilePath = getLocalStateFilePath();
+    assertFalse(localFilePath.toFile().exists());
+    assertNull(getS3State());
+
+    PersistentGlobalState globalState = stateBackend.loadOrCreateGlobalState();
+    assertEquals(globalState, new PersistentGlobalState());
+
+    assertTrue(localFilePath.toFile().exists());
+    assertTrue(localFilePath.toFile().isFile());
+
+    PersistentGlobalState loadedLocalState = StateUtils.readStateFromFile(localFilePath);
+    assertEquals(globalState, loadedLocalState);
+
+    PersistentGlobalState stateFromTar = getS3State();
+    assertNotNull(stateFromTar);
+    assertEquals(globalState, stateFromTar);
+  }
+
+  @Test
+  public void testLoadsSavedState() throws IOException {
+    StateBackend stateBackend = new RemoteStateBackend(getMockGlobalState(false));
+    Path localFilePath = getLocalStateFilePath();
+    assertFalse(localFilePath.toFile().exists());
+
+    Map<String, IndexInfo> indicesMap = new HashMap<>();
+    indicesMap.put("test_index", new IndexInfo());
+    indicesMap.put("test_index_2", new IndexInfo());
+    PersistentGlobalState initialState = new PersistentGlobalState(indicesMap);
+
+    writeStateToS3(initialState);
+
+    PersistentGlobalState loadedState = stateBackend.loadOrCreateGlobalState();
+    assertEquals(initialState, loadedState);
+
+    assertTrue(localFilePath.toFile().exists());
+    assertTrue(localFilePath.toFile().isFile());
+
+    PersistentGlobalState loadedLocalState = StateUtils.readStateFromFile(localFilePath);
+    assertEquals(initialState, loadedLocalState);
+  }
+
+  @Test
+  public void testCommitGlobalState() throws IOException {
+    StateBackend stateBackend = new RemoteStateBackend(getMockGlobalState(false));
+    Path localFilePath = getLocalStateFilePath();
+    PersistentGlobalState initialState = stateBackend.loadOrCreateGlobalState();
+
+    Map<String, IndexInfo> indicesMap = new HashMap<>();
+    indicesMap.put("test_index", new IndexInfo());
+    indicesMap.put("test_index_2", new IndexInfo());
+    PersistentGlobalState updatedState = new PersistentGlobalState(indicesMap);
+    assertNotEquals(initialState, updatedState);
+
+    stateBackend.commitGlobalState(updatedState);
+    PersistentGlobalState loadedState = getS3State();
+    assertEquals(updatedState, loadedState);
+    PersistentGlobalState loadedLocalState = StateUtils.readStateFromFile(localFilePath);
+    assertEquals(updatedState, loadedLocalState);
+
+    indicesMap = new HashMap<>();
+    indicesMap.put("test_index_3", new IndexInfo());
+    PersistentGlobalState updatedState2 = new PersistentGlobalState(indicesMap);
+    assertNotEquals(updatedState, updatedState2);
+    stateBackend.commitGlobalState(updatedState2);
+
+    loadedState = getS3State();
+    assertEquals(updatedState2, loadedState);
+    loadedLocalState = StateUtils.readStateFromFile(localFilePath);
+    assertEquals(updatedState2, loadedLocalState);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testCommitNullState() throws IOException {
+    StateBackend stateBackend = new RemoteStateBackend(getMockGlobalState(false));
+    stateBackend.loadOrCreateGlobalState();
+    stateBackend.commitGlobalState(null);
+  }
+
+  @Test
+  public void testReadOnlyNoInitialState() throws IOException {
+    StateBackend stateBackend = new RemoteStateBackend(getMockGlobalState(true));
+    assertNull(getS3State());
+    try {
+      stateBackend.loadOrCreateGlobalState();
+      fail();
+    } catch (IllegalStateException e) {
+      assertEquals("Cannot update remote state when configured as read only", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testReadOnlyWithInitialState() throws IOException {
+    StateBackend stateBackend = new RemoteStateBackend(getMockGlobalState(true));
+
+    Map<String, IndexInfo> indicesMap = new HashMap<>();
+    indicesMap.put("test_index", new IndexInfo());
+    indicesMap.put("test_index_2", new IndexInfo());
+    PersistentGlobalState initialState = new PersistentGlobalState(indicesMap);
+
+    writeStateToS3(initialState);
+    PersistentGlobalState loadedState = stateBackend.loadOrCreateGlobalState();
+    assertEquals(initialState, loadedState);
+  }
+
+  @Test
+  public void testReadOnlyCommit() throws IOException {
+    StateBackend stateBackend = new RemoteStateBackend(getMockGlobalState(true));
+
+    Map<String, IndexInfo> indicesMap = new HashMap<>();
+    indicesMap.put("test_index", new IndexInfo());
+    indicesMap.put("test_index_2", new IndexInfo());
+    PersistentGlobalState initialState = new PersistentGlobalState(indicesMap);
+
+    writeStateToS3(initialState);
+    PersistentGlobalState loadedState = stateBackend.loadOrCreateGlobalState();
+    assertEquals(initialState, loadedState);
+
+    indicesMap = new HashMap<>();
+    indicesMap.put("test_index_3", new IndexInfo());
+    indicesMap.put("test_index_4", new IndexInfo());
+    indicesMap.put("test_index_5", new IndexInfo());
+    PersistentGlobalState updatedState = new PersistentGlobalState(indicesMap);
+    try {
+      stateBackend.commitGlobalState(updatedState);
+      fail();
+    } catch (IllegalStateException e) {
+      assertEquals("Cannot update remote state when configured as read only", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testArchiverRequired() throws IOException {
+    GlobalState mockState = mock(GlobalState.class);
+    LuceneServerConfiguration serverConfiguration = getConfig(false);
+    when(mockState.getConfiguration()).thenReturn(serverConfiguration);
+    when(mockState.getStateDir()).thenReturn(Paths.get(serverConfiguration.getStateDir()));
+    try {
+      new RemoteStateBackend(mockState);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("Archiver must be provided for remote state usage", e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
Adds improvements an configurability to the handling of global cluster state.

For backwards compatibility, the `GlobalState` class is now abstract, allowing for different implementations of state mutating methods.

The config now allows for specifying a state backend type with the `stateConfig.backendType` key. There are three valid values:

### `LEGACY` (default)
Equivalent functionality to before this change. Uses `LegacyGlobalState` implementation, and writes out `indices.x` files as needed. Uses `RestoreStateHandler` to load indices names from index backup metadata.

### `LOCAL`
Uses `BackendGlobalState` implementation with `LocalStateBackend`. Uses local filesystem to store global state in a json file: `<state_dir>/global_state/state.json`.

### `REMOTE`
Uses `BackendGlobalState` implementation with `RemoteStateBackend`. Uses incremental `Archiver` to store current state in s3, with the `global_state` resource name. A local copy is maintained in the local state directory for debug purposes, but the remote copy is the source of truth. The `stateConfig.remote.readOnly` config values controls if the server instance can modify the remote state.

Global state highlights:
- State automatically loaded during startup
- State changes are durably committed to the backend before being visible locally
- State information is built into an immutable object, which is atomically replaced when changed
- Indices can now have a map of properties (`IndexInfo`) in global state, instead of just the name