### PR TITLE
Added field name to exception message for multivalued value in single valued field

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/BooleanFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/BooleanFieldDef.java
@@ -94,7 +94,8 @@ public class BooleanFieldDef extends IndexableFieldDef implements TermQueryable 
   public void parseDocumentField(
       Document document, List<String> fieldValues, List<List<String>> facetHierarchyPaths) {
     if (fieldValues.size() > 1 && !isMultiValue()) {
-      throw new IllegalArgumentException("Cannot index multiple values into single value field");
+      throw new IllegalArgumentException(
+          "Cannot index multiple values into single value field: " + getName());
     }
 
     for (String fieldStr : fieldValues) {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/DateTimeFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/DateTimeFieldDef.java
@@ -208,7 +208,8 @@ public class DateTimeFieldDef extends IndexableFieldDef implements Sortable, Ran
   public void parseDocumentField(
       Document document, List<String> fieldValues, List<List<String>> facetHierarchyPaths) {
     if (fieldValues.size() > 1 && !isMultiValue()) {
-      throw new IllegalArgumentException("Cannot index multiple values into single value field");
+      throw new IllegalArgumentException(
+          "Cannot index multiple values into single value field: " + getName());
     }
 
     for (String fieldStr : fieldValues) {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/IdFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/IdFieldDef.java
@@ -85,7 +85,8 @@ public class IdFieldDef extends IndexableFieldDef implements TermQueryable {
   public void parseDocumentField(
       Document document, List<String> fieldValues, List<List<String>> facetHierarchyPaths) {
     if (fieldValues.size() > 1) {
-      throw new IllegalArgumentException("Cannot index multiple values into _id fields");
+      throw new IllegalArgumentException(
+          "Cannot index multiple values into _id fields, field name: " + getName());
     }
     String fieldStr = fieldValues.get(0);
     if (hasDocValues()) {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/NumberFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/NumberFieldDef.java
@@ -195,7 +195,8 @@ public abstract class NumberFieldDef extends IndexableFieldDef
   public void parseDocumentField(
       Document document, List<String> fieldValues, List<List<String>> facetHierarchyPaths) {
     if (fieldValues.size() > 1 && !isMultiValue()) {
-      throw new IllegalArgumentException("Cannot index multiple values into single value field");
+      throw new IllegalArgumentException(
+          "Cannot index multiple values into single value field: " + getName());
     }
     for (String fieldStr : fieldValues) {
       Number fieldValue = parseNumberString(fieldStr);

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/TextBaseFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/TextBaseFieldDef.java
@@ -260,7 +260,8 @@ public abstract class TextBaseFieldDef extends IndexableFieldDef implements Term
   public void parseDocumentField(
       Document document, List<String> fieldValues, List<List<String>> facetHierarchyPaths) {
     if (fieldValues.size() > 1 && !isMultiValue()) {
-      throw new IllegalArgumentException("Cannot index multiple values into single value field");
+      throw new IllegalArgumentException(
+          "Cannot index multiple values into single value field: " + getName());
     }
 
     for (int i = 0; i < fieldValues.size(); i++) {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/VectorFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/VectorFieldDef.java
@@ -85,7 +85,8 @@ public class VectorFieldDef extends IndexableFieldDef {
   public void parseDocumentField(
       Document document, List<String> fieldValues, List<List<String>> facetHierarchyPaths) {
     if (fieldValues.size() > 1 && !isMultiValue()) {
-      throw new IllegalArgumentException("Cannot index multiple values into single value field");
+      throw new IllegalArgumentException(
+          "Cannot index multiple values into single value field: " + getName());
     } else if (fieldValues.size() == 1) {
       if (hasDocValues() && docValuesType == DocValuesType.BINARY) {
         float[] floatArr = parseVectorFieldToFloatArr(fieldValues.get(0));

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/VectorFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/VectorFieldDefTest.java
@@ -140,7 +140,9 @@ public class VectorFieldDefTest extends ServerTestCase {
     Exception exception =
         Assert.assertThrows(RuntimeException.class, () -> addDocuments(documentRequests.stream()));
     assertTrue(
-        exception.getMessage().contains("Cannot index multiple values into single value field"));
+        exception
+            .getMessage()
+            .contains("Cannot index multiple values into single value field: vector_field"));
   }
 
   @Test


### PR DESCRIPTION
This makes it easier to understand why you're getting an error when adding documents which have multi-valued field but the field is defined as a single-valued field.