### PR TITLE
Added tests to verify multivalued objects

### DIFF
--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/MultivaluedObjectTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/MultivaluedObjectTest.java
@@ -15,6 +15,9 @@
  */
 package com.yelp.nrtsearch.server.luceneserver.field;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,9 +35,6 @@ import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
 import com.yelp.nrtsearch.server.utils.StructValueTransformer;
 import io.grpc.StatusRuntimeException;
 import io.grpc.testing.GrpcCleanupRule;
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -48,25 +48,24 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.ClassRule;
+import org.junit.Test;
 
 /**
- * Tests for multivalued objects. These tests verify that:
- * 1. Multivalued objects can be indexed, updated, deleted, retrieved and queried
- * 2. The objects order is not defined in the response
- * 3. Objects that don't have fields defined cannot be queried
- * 4. Multivalued objects need to have all child fields multivalued as well
+ * Tests for multivalued objects. These tests verify that: 1. Multivalued objects can be indexed,
+ * updated, deleted, retrieved and queried 2. The objects order is not defined in the response 3.
+ * Objects that don't have fields defined cannot be queried 4. Multivalued objects need to have all
+ * child fields multivalued as well
  *
- * The test documents have all integer type fields defined as doubles to make comparison with the
+ * <p>The test documents have all integer type fields defined as doubles to make comparison with the
  * response easier since the response sets integer values in the double field.
  */
 public class MultivaluedObjectTest extends ServerTestCase {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-  private static final Map<Integer, String> MULTIVALUED_OBJECTS_JSON = Map.of(
+  private static final Map<Integer, String> MULTIVALUED_OBJECTS_JSON =
+      Map.of(
           1, readObjectFromResource("object1.json"),
           2, readObjectFromResource("object2.json"),
           3, readObjectFromResource("object3.json"),
@@ -74,10 +73,10 @@ public class MultivaluedObjectTest extends ServerTestCase {
           5, readObjectFromResource("object5.json"),
           6, readObjectFromResource("object6.json"),
           7, readObjectFromResource("object7.json"),
-          8, readObjectFromResource("object8.json")
-  );
+          8, readObjectFromResource("object8.json"));
 
-  private static final Map<Integer, Map<String, Object>> MULTIVALUED_OBJECTS = Map.of(
+  private static final Map<Integer, Map<String, Object>> MULTIVALUED_OBJECTS =
+      Map.of(
           1, convertJsonToMap(getMultivaluedObject(1)),
           2, convertJsonToMap(getMultivaluedObject(2)),
           3, convertJsonToMap(getMultivaluedObject(3)),
@@ -85,22 +84,21 @@ public class MultivaluedObjectTest extends ServerTestCase {
           5, convertJsonToMap(getMultivaluedObject(5)),
           6, convertJsonToMap(getMultivaluedObject(6)),
           7, convertJsonToMap(getMultivaluedObject(7)),
-          8, convertJsonToMap(getMultivaluedObject(8))
-  );
+          8, convertJsonToMap(getMultivaluedObject(8)));
 
-  private static final Map<Integer, List<Map<String, Object>>> DOC_ID_TO_MULTIVALUED_OBJECTS = Map.of(
+  private static final Map<Integer, List<Map<String, Object>>> DOC_ID_TO_MULTIVALUED_OBJECTS =
+      Map.of(
           1, List.of(MULTIVALUED_OBJECTS.get(1)),
-          2, List.of(
+          2,
+              List.of(
                   MULTIVALUED_OBJECTS.get(2),
                   MULTIVALUED_OBJECTS.get(3),
-                  MULTIVALUED_OBJECTS.get(4)
-          ),
-          3, List.of(
+                  MULTIVALUED_OBJECTS.get(4)),
+          3,
+              List.of(
                   MULTIVALUED_OBJECTS.get(5),
                   MULTIVALUED_OBJECTS.get(6),
-                  MULTIVALUED_OBJECTS.get(7)
-          )
-  );
+                  MULTIVALUED_OBJECTS.get(7)));
 
   @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
@@ -116,12 +114,12 @@ public class MultivaluedObjectTest extends ServerTestCase {
     String resourceFileName = "/field/multivalued_object/" + fileName;
     InputStream fileStream = ServerTestCase.class.getResourceAsStream(resourceFileName);
     return new BufferedReader(new InputStreamReader(fileStream, StandardCharsets.UTF_8))
-                    .lines()
-                    .collect(Collectors.joining(System.lineSeparator()));
+        .lines()
+        .collect(Collectors.joining(System.lineSeparator()));
   }
 
   private static Map<String, Object> convertJsonToMap(String json) {
-    TypeReference<HashMap<String,Object>> typeRef = new TypeReference<>() {};
+    TypeReference<HashMap<String, Object>> typeRef = new TypeReference<>() {};
     try {
       return OBJECT_MAPPER.readValue(json, typeRef);
     } catch (JsonProcessingException e) {
@@ -134,40 +132,54 @@ public class MultivaluedObjectTest extends ServerTestCase {
   }
 
   protected void initIndex(String name) throws Exception {
-    List<AddDocumentRequest> docs = List.of(
+    List<AddDocumentRequest> docs =
+        List.of(
             buildAddDocumentRequest(name, "1", 1),
             buildAddDocumentRequest(name, "2", 2, 3, 4),
-            buildAddDocumentRequest(name, "3", 5, 6, 7)
-    );
+            buildAddDocumentRequest(name, "3", 5, 6, 7));
     addDocuments(docs.stream());
   }
 
-  private AddDocumentRequest buildAddDocumentRequest(String indexName, String docId, int... objectIds) {
-    AddDocumentRequest.MultiValuedField.Builder builder = AddDocumentRequest.MultiValuedField.newBuilder();
+  private AddDocumentRequest buildAddDocumentRequest(
+      String indexName, String docId, int... objectIds) {
+    AddDocumentRequest.MultiValuedField.Builder builder =
+        AddDocumentRequest.MultiValuedField.newBuilder();
     for (int objectId : objectIds) {
       builder.addValue(getMultivaluedObject(objectId));
     }
     return AddDocumentRequest.newBuilder()
-            .setIndexName(indexName)
-            .putFields(
-                    "doc_id", AddDocumentRequest.MultiValuedField.newBuilder().addValue(docId).build())
-            .putFields("multivalued_object", builder.build())
-            .build();
+        .setIndexName(indexName)
+        .putFields(
+            "doc_id", AddDocumentRequest.MultiValuedField.newBuilder().addValue(docId).build())
+        .putFields("multivalued_object", builder.build())
+        .build();
   }
 
   @Test
   public void testQueryObjectFieldsAndRetrieval() {
-    List<List> inputsAndExpectedOutput = List.of(
+    List<List> inputsAndExpectedOutput =
+        List.of(
             List.of("doc_id", "1", 1),
             List.of("multivalued_object.field1", "11", 1),
             List.of("multivalued_object.field1", "22", 2),
             List.of("multivalued_object.field2", "object3_field2", 2),
             List.of("multivalued_object.field2", "object4_field2_c", 2),
-            List.of("multivalued_object.inner_object1.inner_field1", "object5_inner_object1_a_inner_field1", 3),
-            List.of("multivalued_object.inner_object1.inner_field2", "object6_inner_object2_b_inner_field1", 3),
-            List.of("multivalued_object.inner_object1.inner_field1", "object7_inner_object1_c_inner_field1_b", 3),
-            List.of("multivalued_object.inner_object1.inner_field2", "object7_inner_object2_b_inner_field1_c", 3)
-    );
+            List.of(
+                "multivalued_object.inner_object1.inner_field1",
+                "object5_inner_object1_a_inner_field1",
+                3),
+            List.of(
+                "multivalued_object.inner_object1.inner_field2",
+                "object6_inner_object2_b_inner_field1",
+                3),
+            List.of(
+                "multivalued_object.inner_object1.inner_field1",
+                "object7_inner_object1_c_inner_field1_b",
+                3),
+            List.of(
+                "multivalued_object.inner_object1.inner_field2",
+                "object7_inner_object2_b_inner_field1_c",
+                3));
 
     for (List inputAndExpectedOutput : inputsAndExpectedOutput) {
       String field = (String) inputAndExpectedOutput.get(0);
@@ -178,36 +190,54 @@ public class MultivaluedObjectTest extends ServerTestCase {
 
       assertEquals(response.getHitsCount(), 1);
       SearchResponse.Hit hit = response.getHits(0);
-      assertEquals(String.valueOf(docId), hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue());
+      assertEquals(
+          String.valueOf(docId), hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue());
 
-      assertEquals(new HashSet<>(DOC_ID_TO_MULTIVALUED_OBJECTS.get(docId)), new HashSet<>(getMultivaluedObjectsFromHit(hit)));
+      assertEquals(
+          new HashSet<>(DOC_ID_TO_MULTIVALUED_OBJECTS.get(docId)),
+          new HashSet<>(getMultivaluedObjectsFromHit(hit)));
     }
   }
 
   @Test
   public void testQueryMultipleObjectFields() {
-    SearchResponse response = doQuery(Query.newBuilder()
-            .setBooleanQuery(BooleanQuery.newBuilder()
-                    .addClauses(BooleanClause.newBuilder()
-                            .setOccur(BooleanClause.Occur.SHOULD)
-                            .setQuery(buildTermQuery("multivalued_object.field1", "32").toBuilder().setBoost(2))
-                            .build())
-                    .addClauses(BooleanClause.newBuilder()
-                            .setOccur(BooleanClause.Occur.SHOULD)
-                            .setQuery(buildTermQuery("multivalued_object.inner_object1.inner_field2", "object6_inner_object2_b_inner_field1"))
-                            .build())
-                    .build())
-            .build());
+    SearchResponse response =
+        doQuery(
+            Query.newBuilder()
+                .setBooleanQuery(
+                    BooleanQuery.newBuilder()
+                        .addClauses(
+                            BooleanClause.newBuilder()
+                                .setOccur(BooleanClause.Occur.SHOULD)
+                                .setQuery(
+                                    buildTermQuery("multivalued_object.field1", "32")
+                                        .toBuilder()
+                                        .setBoost(2))
+                                .build())
+                        .addClauses(
+                            BooleanClause.newBuilder()
+                                .setOccur(BooleanClause.Occur.SHOULD)
+                                .setQuery(
+                                    buildTermQuery(
+                                        "multivalued_object.inner_object1.inner_field2",
+                                        "object6_inner_object2_b_inner_field1"))
+                                .build())
+                        .build())
+                .build());
 
     assertEquals(response.getHitsCount(), 2);
 
     SearchResponse.Hit hit = response.getHits(0);
     assertEquals("2", hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue());
-    assertEquals(new HashSet<>(DOC_ID_TO_MULTIVALUED_OBJECTS.get(2)), new HashSet<>(getMultivaluedObjectsFromHit(hit)));
+    assertEquals(
+        new HashSet<>(DOC_ID_TO_MULTIVALUED_OBJECTS.get(2)),
+        new HashSet<>(getMultivaluedObjectsFromHit(hit)));
 
     hit = response.getHits(1);
     assertEquals("3", hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue());
-    assertEquals(new HashSet<>(DOC_ID_TO_MULTIVALUED_OBJECTS.get(3)), new HashSet<>(getMultivaluedObjectsFromHit(hit)));
+    assertEquals(
+        new HashSet<>(DOC_ID_TO_MULTIVALUED_OBJECTS.get(3)),
+        new HashSet<>(getMultivaluedObjectsFromHit(hit)));
   }
 
   @Test
@@ -215,19 +245,21 @@ public class MultivaluedObjectTest extends ServerTestCase {
     // Test uses document with doc_id 3
     AddDocumentRequest addDocumentRequest = buildAddDocumentRequest(DEFAULT_TEST_INDEX, "3", 6, 8);
     addDocuments(Stream.of(addDocumentRequest));
-    getGrpcServer().getBlockingStub().refresh(RefreshRequest.newBuilder().setIndexName(DEFAULT_TEST_INDEX).build());
+    getGrpcServer()
+        .getBlockingStub()
+        .refresh(RefreshRequest.newBuilder().setIndexName(DEFAULT_TEST_INDEX).build());
 
-    SearchResponse response = doQuery(
-                    buildTermQuery("multivalued_object.inner_object1.inner_field2", "object8_inner_object2_a_inner_field1_b")
-            );
+    SearchResponse response =
+        doQuery(
+            buildTermQuery(
+                "multivalued_object.inner_object1.inner_field2",
+                "object8_inner_object2_a_inner_field1_b"));
 
     assertEquals(response.getHitsCount(), 1);
     SearchResponse.Hit hit = response.getHits(0);
     assertEquals("3", hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue());
-    HashSet<Map<String, Object>> expectedObjects = new HashSet<>(List.of(
-            MULTIVALUED_OBJECTS.get(6),
-            MULTIVALUED_OBJECTS.get(8)
-    ));
+    HashSet<Map<String, Object>> expectedObjects =
+        new HashSet<>(List.of(MULTIVALUED_OBJECTS.get(6), MULTIVALUED_OBJECTS.get(8)));
     assertEquals(expectedObjects, new HashSet<>(getMultivaluedObjectsFromHit(hit)));
   }
 
@@ -239,14 +271,23 @@ public class MultivaluedObjectTest extends ServerTestCase {
     assertEquals(response.getHitsCount(), 1);
     SearchResponse.Hit hit = response.getHits(0);
     assertEquals("2", hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue());
-    assertEquals(new HashSet<>(DOC_ID_TO_MULTIVALUED_OBJECTS.get(2)), new HashSet<>(getMultivaluedObjectsFromHit(hit)));
+    assertEquals(
+        new HashSet<>(DOC_ID_TO_MULTIVALUED_OBJECTS.get(2)),
+        new HashSet<>(getMultivaluedObjectsFromHit(hit)));
 
-    getGrpcServer().getBlockingStub().deleteByQuery(DeleteByQueryRequest.newBuilder()
-                    .setIndexName(DEFAULT_TEST_INDEX)
-                    .addQuery(buildTermQuery("multivalued_object.inner_object1.inner_field2", "object3_inner_field2"))
-            .build());
+    getGrpcServer()
+        .getBlockingStub()
+        .deleteByQuery(
+            DeleteByQueryRequest.newBuilder()
+                .setIndexName(DEFAULT_TEST_INDEX)
+                .addQuery(
+                    buildTermQuery(
+                        "multivalued_object.inner_object1.inner_field2", "object3_inner_field2"))
+                .build());
 
-    getGrpcServer().getBlockingStub().refresh(RefreshRequest.newBuilder().setIndexName(DEFAULT_TEST_INDEX).build());
+    getGrpcServer()
+        .getBlockingStub()
+        .refresh(RefreshRequest.newBuilder().setIndexName(DEFAULT_TEST_INDEX).build());
 
     response = doQuery(buildTermQuery("doc_id", "2"));
 
@@ -261,7 +302,11 @@ public class MultivaluedObjectTest extends ServerTestCase {
     } catch (StatusRuntimeException e) {
       exception = e;
     }
-    assertTrue(exception.getMessage().contains("field \"multivalued_object.inner_object1.inner_object2.object\" is unknown: it was not registered with registerField"));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "field \"multivalued_object.inner_object1.inner_object2.object\" is unknown: it was not registered with registerField"));
 
     exception = null;
     try {
@@ -269,37 +314,35 @@ public class MultivaluedObjectTest extends ServerTestCase {
     } catch (StatusRuntimeException e) {
       exception = e;
     }
-    assertTrue(exception.getMessage().contains("field type: OBJECT is not supported for TermQuery"));
+    assertTrue(
+        exception.getMessage().contains("field type: OBJECT is not supported for TermQuery"));
   }
 
   private Query buildTermQuery(String doc_id, String s) {
     return Query.newBuilder()
-            .setTermQuery(
-                    TermQuery.newBuilder()
-                            .setField(doc_id)
-                            .setTextValue(s)
-                            .build())
-            .build();
+        .setTermQuery(TermQuery.newBuilder().setField(doc_id).setTextValue(s).build())
+        .build();
   }
 
   private SearchResponse doQuery(Query query) {
     return getGrpcServer()
-            .getBlockingStub()
-            .search(
-                    SearchRequest.newBuilder()
-                            .setIndexName(DEFAULT_TEST_INDEX)
-                            .setStartHit(0)
-                            .setTopHits(10)
-                            .addAllRetrieveFields(List.of("doc_id", "multivalued_object"))
-                            .setQuery(query)
-                            .build());
+        .getBlockingStub()
+        .search(
+            SearchRequest.newBuilder()
+                .setIndexName(DEFAULT_TEST_INDEX)
+                .setStartHit(0)
+                .setTopHits(10)
+                .addAllRetrieveFields(List.of("doc_id", "multivalued_object"))
+                .setQuery(query)
+                .build());
   }
 
   private List<Map<String, Object>> getMultivaluedObjectsFromHit(SearchResponse.Hit hit) {
     return convertMultivaluedObjectsFromResponseToMap(hit.getFieldsMap().get("multivalued_object"));
   }
 
-  private List<Map<String, Object>> convertMultivaluedObjectsFromResponseToMap(SearchResponse.Hit.CompositeFieldValue multivaluedObject) {
+  private List<Map<String, Object>> convertMultivaluedObjectsFromResponseToMap(
+      SearchResponse.Hit.CompositeFieldValue multivaluedObject) {
     List<Map<String, Object>> multivaluedObjects = new ArrayList<>();
     for (SearchResponse.Hit.FieldValue object : multivaluedObject.getFieldValueList()) {
       multivaluedObjects.add(StructValueTransformer.transformStruct(object.getStructValue()));

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/MultivaluedObjectTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/MultivaluedObjectTest.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.field;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.BooleanClause;
+import com.yelp.nrtsearch.server.grpc.BooleanQuery;
+import com.yelp.nrtsearch.server.grpc.DeleteByQueryRequest;
+import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
+import com.yelp.nrtsearch.server.grpc.Query;
+import com.yelp.nrtsearch.server.grpc.RefreshRequest;
+import com.yelp.nrtsearch.server.grpc.SearchRequest;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import com.yelp.nrtsearch.server.grpc.TermQuery;
+import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
+import com.yelp.nrtsearch.server.utils.StructValueTransformer;
+import io.grpc.testing.GrpcCleanupRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for multivalued objects. These tests verify that:
+ * 1. Multivalued objects can be indexed, updated, deleted, retrieved and queried
+ * 2. The objects order is not defined in the response
+ * 3. Objects that don't have fields defined cannot be queried
+ * 4. Multivalued objects need to have all child fields multivalued as well
+ *
+ * The test documents have all integer type fields defined as doubles to make comparison with the
+ * response easier since the response sets integer values in the double field.
+ */
+public class MultivaluedObjectTest extends ServerTestCase {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static final Map<Integer, String> MULTIVALUED_OBJECTS_JSON = Map.of(
+          1, readObjectFromResource("object1.json"),
+          2, readObjectFromResource("object2.json"),
+          3, readObjectFromResource("object3.json"),
+          4, readObjectFromResource("object4.json"),
+          5, readObjectFromResource("object5.json"),
+          6, readObjectFromResource("object6.json"),
+          7, readObjectFromResource("object7.json"),
+          8, readObjectFromResource("object8.json")
+  );
+
+  private static final Map<Integer, Map<String, Object>> MULTIVALUED_OBJECTS = Map.of(
+          1, convertJsonToMap(getMultivaluedObject(1)),
+          2, convertJsonToMap(getMultivaluedObject(2)),
+          3, convertJsonToMap(getMultivaluedObject(3)),
+          4, convertJsonToMap(getMultivaluedObject(4)),
+          5, convertJsonToMap(getMultivaluedObject(5)),
+          6, convertJsonToMap(getMultivaluedObject(6)),
+          7, convertJsonToMap(getMultivaluedObject(7)),
+          8, convertJsonToMap(getMultivaluedObject(8))
+  );
+
+  private static final Map<Integer, List<Map<String, Object>>> DOC_ID_TO_MULTIVALUED_OBJECTS = Map.of(
+          1, List.of(MULTIVALUED_OBJECTS.get(1)),
+          2, List.of(
+                  MULTIVALUED_OBJECTS.get(2),
+                  MULTIVALUED_OBJECTS.get(3),
+                  MULTIVALUED_OBJECTS.get(4)
+          ),
+          3, List.of(
+                  MULTIVALUED_OBJECTS.get(5),
+                  MULTIVALUED_OBJECTS.get(6),
+                  MULTIVALUED_OBJECTS.get(7)
+          )
+  );
+
+  @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  protected List<String> getIndices() {
+    return Collections.singletonList(DEFAULT_TEST_INDEX);
+  }
+
+  protected FieldDefRequest getIndexDef(String name) throws IOException {
+    return getFieldsFromResourceFile("/field/registerFieldsMultivaluedObject.json");
+  }
+
+  private static String readObjectFromResource(String fileName) {
+    String resourceFileName = "/field/multivalued_object/" + fileName;
+    InputStream fileStream = ServerTestCase.class.getResourceAsStream(resourceFileName);
+    return new BufferedReader(new InputStreamReader(fileStream, StandardCharsets.UTF_8))
+                    .lines()
+                    .collect(Collectors.joining(System.lineSeparator()));
+  }
+
+  private static Map<String, Object> convertJsonToMap(String json) {
+    TypeReference<HashMap<String,Object>> typeRef = new TypeReference<>() {};
+    try {
+      return OBJECT_MAPPER.readValue(json, typeRef);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static String getMultivaluedObject(int id) {
+    return MULTIVALUED_OBJECTS_JSON.get(id);
+  }
+
+  protected void initIndex(String name) throws Exception {
+    List<AddDocumentRequest> docs = List.of(
+            buildAddDocumentRequest(name, "1", 1),
+            buildAddDocumentRequest(name, "2", 2, 3, 4),
+            buildAddDocumentRequest(name, "3", 5, 6, 7)
+    );
+    addDocuments(docs.stream());
+  }
+
+  private AddDocumentRequest buildAddDocumentRequest(String indexName, String docId, int... objectIds) {
+    AddDocumentRequest.MultiValuedField.Builder builder = AddDocumentRequest.MultiValuedField.newBuilder();
+    for (int objectId : objectIds) {
+      builder.addValue(getMultivaluedObject(objectId));
+    }
+    return AddDocumentRequest.newBuilder()
+            .setIndexName(indexName)
+            .putFields(
+                    "doc_id", AddDocumentRequest.MultiValuedField.newBuilder().addValue(docId).build())
+            .putFields("multivalued_object", builder.build())
+            .build();
+  }
+
+  @Test
+  public void testQueryObjectFieldsAndRetrieval() {
+    List<List> inputsAndExpectedOutput = List.of(
+            List.of("doc_id", "1", 1),
+            List.of("multivalued_object.field1", "11", 1),
+            List.of("multivalued_object.field1", "22", 2),
+            List.of("multivalued_object.field2", "object3_field2", 2),
+            List.of("multivalued_object.field2", "object4_field2_c", 2),
+            List.of("multivalued_object.inner_object1.inner_field1", "object5_inner_object1_a_inner_field1", 3),
+            List.of("multivalued_object.inner_object1.inner_field2", "object6_inner_object2_b_inner_field1", 3),
+            List.of("multivalued_object.inner_object1.inner_field1", "object7_inner_object1_c_inner_field1_b", 3),
+            List.of("multivalued_object.inner_object1.inner_field2", "object7_inner_object2_b_inner_field1_c", 3)
+    );
+
+    for (List inputAndExpectedOutput : inputsAndExpectedOutput) {
+      String field = (String) inputAndExpectedOutput.get(0);
+      String value = (String) inputAndExpectedOutput.get(1);
+      int docId = (int) inputAndExpectedOutput.get(2);
+
+      SearchResponse response = doQuery(buildTermQuery(field, value));
+
+      assertEquals(response.getHitsCount(), 1);
+      SearchResponse.Hit hit = response.getHits(0);
+      assertEquals(String.valueOf(docId), hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue());
+
+      assertEquals(new HashSet<>(DOC_ID_TO_MULTIVALUED_OBJECTS.get(docId)), new HashSet<>(getMultivaluedObjectsFromHit(hit)));
+    }
+  }
+
+  @Test
+  public void testQueryMultipleObjectFields() {
+    SearchResponse response = doQuery(Query.newBuilder()
+            .setBooleanQuery(BooleanQuery.newBuilder()
+                    .addClauses(BooleanClause.newBuilder()
+                            .setOccur(BooleanClause.Occur.SHOULD)
+                            .setQuery(buildTermQuery("multivalued_object.field1", "32").toBuilder().setBoost(2))
+                            .build())
+                    .addClauses(BooleanClause.newBuilder()
+                            .setOccur(BooleanClause.Occur.SHOULD)
+                            .setQuery(buildTermQuery("multivalued_object.inner_object1.inner_field2", "object6_inner_object2_b_inner_field1"))
+                            .build())
+                    .build())
+            .build());
+
+    assertEquals(response.getHitsCount(), 2);
+
+    SearchResponse.Hit hit = response.getHits(0);
+    assertEquals("2", hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue());
+    assertEquals(new HashSet<>(DOC_ID_TO_MULTIVALUED_OBJECTS.get(2)), new HashSet<>(getMultivaluedObjectsFromHit(hit)));
+
+    hit = response.getHits(1);
+    assertEquals("3", hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue());
+    assertEquals(new HashSet<>(DOC_ID_TO_MULTIVALUED_OBJECTS.get(3)), new HashSet<>(getMultivaluedObjectsFromHit(hit)));
+  }
+
+  @Test
+  public void testMultivaluedObjectUpdate() throws Exception {
+    // Test uses document with doc_id 3
+    AddDocumentRequest addDocumentRequest = buildAddDocumentRequest(DEFAULT_TEST_INDEX, "3", 6, 8);
+    addDocuments(Stream.of(addDocumentRequest));
+    getGrpcServer().getBlockingStub().refresh(RefreshRequest.newBuilder().setIndexName(DEFAULT_TEST_INDEX).build());
+
+    SearchResponse response = doQuery(
+                    buildTermQuery("multivalued_object.inner_object1.inner_field2", "object8_inner_object2_a_inner_field1_b")
+            );
+
+    assertEquals(response.getHitsCount(), 1);
+    SearchResponse.Hit hit = response.getHits(0);
+    assertEquals("3", hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue());
+    HashSet<Map<String, Object>> expectedObjects = new HashSet<>(List.of(
+            MULTIVALUED_OBJECTS.get(6),
+            MULTIVALUED_OBJECTS.get(8)
+    ));
+    assertEquals(expectedObjects, new HashSet<>(getMultivaluedObjectsFromHit(hit)));
+  }
+
+  @Test
+  public void testMultivaluedObjectDelete() {
+    // Test uses document with doc_id 2
+    SearchResponse response = doQuery(buildTermQuery("doc_id", "2"));
+
+    assertEquals(response.getHitsCount(), 1);
+    SearchResponse.Hit hit = response.getHits(0);
+    assertEquals("2", hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue());
+    assertEquals(new HashSet<>(DOC_ID_TO_MULTIVALUED_OBJECTS.get(2)), new HashSet<>(getMultivaluedObjectsFromHit(hit)));
+
+    getGrpcServer().getBlockingStub().deleteByQuery(DeleteByQueryRequest.newBuilder()
+                    .setIndexName(DEFAULT_TEST_INDEX)
+                    .addQuery(buildTermQuery("multivalued_object.inner_object1.inner_field2", "object3_inner_field2"))
+            .build());
+
+    getGrpcServer().getBlockingStub().refresh(RefreshRequest.newBuilder().setIndexName(DEFAULT_TEST_INDEX).build());
+
+    response = doQuery(buildTermQuery("doc_id", "2"));
+
+    assertEquals(response.getHitsCount(), 0);
+  }
+
+  private Query buildTermQuery(String doc_id, String s) {
+    return Query.newBuilder()
+            .setTermQuery(
+                    TermQuery.newBuilder()
+                            .setField(doc_id)
+                            .setTextValue(s)
+                            .build())
+            .build();
+  }
+
+  private SearchResponse doQuery(Query query) {
+    return getGrpcServer()
+            .getBlockingStub()
+            .search(
+                    SearchRequest.newBuilder()
+                            .setIndexName(DEFAULT_TEST_INDEX)
+                            .setStartHit(0)
+                            .setTopHits(10)
+                            .addAllRetrieveFields(List.of("doc_id", "multivalued_object"))
+                            .setQuery(query)
+                            .build());
+  }
+
+  private List<Map<String, Object>> getMultivaluedObjectsFromHit(SearchResponse.Hit hit) {
+    return convertMultivaluedObjectsFromResponseToMap(hit.getFieldsMap().get("multivalued_object"));
+  }
+
+  private List<Map<String, Object>> convertMultivaluedObjectsFromResponseToMap(SearchResponse.Hit.CompositeFieldValue multivaluedObject) {
+    List<Map<String, Object>> multivaluedObjects = new ArrayList<>();
+    for (SearchResponse.Hit.FieldValue object : multivaluedObject.getFieldValueList()) {
+      multivaluedObjects.add(StructValueTransformer.transformStruct(object.getStructValue()));
+    }
+    return multivaluedObjects;
+  }
+}

--- a/src/test/resources/field/multivalued_object/object1.json
+++ b/src/test/resources/field/multivalued_object/object1.json
@@ -1,0 +1,32 @@
+{
+    "field1": [
+        10.0,
+        11.0,
+        1100.0
+    ],
+    "field2": [
+        "object1_field2"
+    ],
+    "inner_object1": [
+        {
+            "inner_field1": [
+                "object1_inner_field_1"
+            ],
+            "inner_field2": [
+                "object1_inner_field2_a",
+                "object1_inner_field2_b",
+                "object1_inner_field2_c"
+            ],
+            "inner_object2": [
+                {
+                    "object": "{\"k1\":\"v1\",\"k2\":\"v2\"}",
+                    "4": 5.0
+                },
+                {
+                    "a": "b",
+                    "100": "d"
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/field/multivalued_object/object10.json
+++ b/src/test/resources/field/multivalued_object/object10.json
@@ -1,0 +1,27 @@
+{
+    "field1": [
+        1000.0
+    ],
+    "field2": [
+        "object10_field2_a",
+        "object10_field2_b",
+        "object10_field2_c",
+        "object10_field2_d"
+    ],
+    "inner_object1": [
+        {
+            "inner_field1": [
+                "object10_inner_field1_a",
+                "object10_inner_field1_b"
+            ],
+            "inner_field2": [
+                "object10_inner_field2"
+            ],
+            "inner_object2": [
+                {
+                    "10": 5.0
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/field/multivalued_object/object11.json
+++ b/src/test/resources/field/multivalued_object/object11.json
@@ -1,19 +1,19 @@
 {
-    "field1": 500.0,
+    "field1": 1100.0,
     "field2": [
-        "object5_a_field2"
+        "object11_a_field2"
     ],
     "inner_object1": [
         {
             "inner_field1": [
-                "object5_inner_object1_a_inner_field1"
+                "object11_inner_object1_a_inner_field1"
             ],
             "inner_field2": [
-                "object5_inner_object1_a_inner_field2"
+                "object11_inner_object2_a_inner_field1"
             ],
             "inner_object2": [
                 {
-                    "5": 55.0
+                    "11": 111.0
                 }
             ]
         }

--- a/src/test/resources/field/multivalued_object/object12.json
+++ b/src/test/resources/field/multivalued_object/object12.json
@@ -1,0 +1,82 @@
+{
+    "field1": [
+        1200.0,
+        1201.0,
+        1202.0
+    ],
+    "field2": [
+        "object12_field2_a",
+        "object12_field2_b",
+        "object12_field2_c",
+        "object12_field2_d"
+    ],
+    "inner_object1": [
+        {
+            "inner_field1": [
+                "object12_inner_object1_a_inner_field1_a",
+                "object12_inner_object1_a_inner_field1_b"
+            ],
+            "inner_field2": [
+                "object12_inner_object2_a_inner_field1_a",
+                "object12_inner_object2_a_inner_field1_b",
+                "object12_inner_object2_a_inner_field1_c"
+            ],
+            "inner_object2": [
+                {
+                    "6": 12.0
+                },
+                {
+                    "ab": "cd",
+                    "ef": "gh"
+                }
+            ]
+        },
+        {
+            "inner_field1": [
+                "object12_inner_object1_b_inner_field1_a",
+                "object12_inner_object1_b_inner_field1_b"
+            ],
+            "inner_field2": [
+                "object12_inner_object2_b_inner_field1_a",
+                "object12_inner_object2_b_inner_field1_b",
+                "object12_inner_object2_b_inner_field1_c"
+            ],
+            "inner_object2": [
+                {
+                    "12": 1212.0
+                },
+                {
+                    "121": 122.0
+                }
+            ]
+        },
+        {
+            "inner_field1": [
+                "object12_inner_object1_c_inner_field1_a",
+                "object12_inner_object1_c_inner_field1_b",
+                "object12_inner_object1_c_inner_field1_c"
+            ],
+            "inner_field2": [
+                "object12_inner_object2_c_inner_field1_a",
+                "object12_inner_object2_c_inner_field1_b"
+            ],
+            "inner_object2": [
+                {
+                    "120": 12012.0,
+                    "1201212": 121201212.0,
+                    "121212": 12120.0
+                },
+                {
+                    "121": 120121.0,
+                    "1211212": 1212012121.0,
+                    "1212121": 121201.0
+                },
+                {
+                    "1201": 1201211.0,
+                    "12012121": 12120121211.0,
+                    "12121211": 12011.0
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/field/multivalued_object/object13.json
+++ b/src/test/resources/field/multivalued_object/object13.json
@@ -1,25 +1,25 @@
 {
     "field1": [
-        22.0
+        1313.0
     ],
     "field2": [
-        "object2_field2_a",
-        "object2_field2_b",
-        "object2_field2_c",
-        "object2_field2_d"
+        "object13_field2_a",
+        "object13_field2_b",
+        "object13_field2_c",
+        "object13_field2_d"
     ],
     "inner_object1": [
         {
             "inner_field1": [
-                "object2_inner_object1_a_inner_field1_a",
-                "object2_inner_object1_a_inner_field1_b"
+                "object13_inner_object1_a_inner_field1_a",
+                "object13_inner_object1_a_inner_field1_b"
             ],
             "inner_field2": [
-                "object2_inner_object1_a_inner_field2"
+                "object13_inner_object1_a_inner_field2"
             ],
             "inner_object2": [
                 {
-                    "2": 22.0
+                    "13": 13131.0
                 },
                 {
                     "ab": "cd",
@@ -29,15 +29,15 @@
         },
         {
             "inner_field1": [
-                "object2_inner_object1_b_inner_field1_a",
-                "object2_inner_object1_b_inner_field1_b"
+                "object13_inner_object1_b_inner_field1_a",
+                "object13_inner_object1_b_inner_field1_b"
             ],
             "inner_field2": [
-                "object2_inner_object1_b_inner_field2"
+                "object13_inner_object1_b_inner_field2"
             ],
             "inner_object2": [
                 {
-                    "222": 2222.0
+                    "131313": 1313131313.0
                 }
             ]
         }

--- a/src/test/resources/field/multivalued_object/object2.json
+++ b/src/test/resources/field/multivalued_object/object2.json
@@ -1,0 +1,45 @@
+{
+    "field1": [
+        22.0
+    ],
+    "field2": [
+        "object2_field2_a",
+        "object2_field2_b",
+        "object2_field2_c",
+        "object2_field2_d"
+    ],
+    "inner_object1": [
+        {
+            "inner_field1": [
+                "object2_inner_object1_a_inner_field1_a",
+                "object2_inner_object1_a_inner_field1_b"
+            ],
+            "inner_field2": [
+                "object2_inner_field2"
+            ],
+            "inner_object2": [
+                {
+                    "2": 22.0
+                },
+                {
+                    "ab": "cd",
+                    "ef": "gh"
+                }
+            ]
+        },
+        {
+            "inner_field1": [
+                "object2_inner_object1_b_inner_field1_a",
+                "object2_inner_object1_b_inner_field1_b"
+            ],
+            "inner_field2": [
+                "inner_value2_2_2"
+            ],
+            "inner_object2": [
+                {
+                    "222": 2222.0
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/field/multivalued_object/object3.json
+++ b/src/test/resources/field/multivalued_object/object3.json
@@ -1,0 +1,29 @@
+{
+    "field1": [
+        31.0,
+        32.0
+    ],
+    "field2": [
+        "object3_field2"
+    ],
+    "inner_object1": [
+        {
+            "inner_field1": [
+                "object3_inner_field1"
+            ],
+            "inner_field2": [
+                "object3_inner_field2"
+            ],
+            "inner_object2": [
+                {
+                    "1": 2.0,
+                    "3": "4"
+                },
+                {
+                    "5": 6.0,
+                    "7": "8"
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/field/multivalued_object/object4.json
+++ b/src/test/resources/field/multivalued_object/object4.json
@@ -1,0 +1,27 @@
+{
+    "field1": [
+        40.0
+    ],
+    "field2": [
+        "object4_field2_a",
+        "object4_field2_b",
+        "object4_field2_c",
+        "object4_field2_d"
+    ],
+    "inner_object1": [
+        {
+            "inner_field1": [
+                "object4_inner_field1_a",
+                "object4_inner_field1_b"
+            ],
+            "inner_field2": [
+                "object4_inner_field2"
+            ],
+            "inner_object2": [
+                {
+                    "4": 5.0
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/field/multivalued_object/object5.json
+++ b/src/test/resources/field/multivalued_object/object5.json
@@ -1,0 +1,21 @@
+{
+    "field1": 500.0,
+    "field2": [
+        "object5_a_field2"
+    ],
+    "inner_object1": [
+        {
+            "inner_field1": [
+                "object5_inner_object1_a_inner_field1"
+            ],
+            "inner_field2": [
+                "object5_inner_object2_a_inner_field1"
+            ],
+            "inner_object2": [
+                {
+                    "5": 55.0
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/field/multivalued_object/object6.json
+++ b/src/test/resources/field/multivalued_object/object6.json
@@ -16,7 +16,7 @@
                 "object6_inner_object1_a_inner_field1"
             ],
             "inner_field2": [
-                "object6_inner_object2_a_inner_field1"
+                "object6_inner_object1_a_inner_field2"
             ],
             "inner_object2": [
                 {
@@ -29,7 +29,7 @@
                 "object6_inner_object1_b_inner_field1"
             ],
             "inner_field2": [
-                "object6_inner_object2_b_inner_field1"
+                "object6_inner_object1_b_inner_field2"
             ],
             "inner_object2": [
                 {
@@ -42,7 +42,7 @@
                 "object6_inner_object1_c_inner_field1"
             ],
             "inner_field2": [
-                "object6_inner_object2_c_inner_field1"
+                "object6_inner_object1_c_inner_field2"
             ],
             "inner_object2": [
                 {

--- a/src/test/resources/field/multivalued_object/object6.json
+++ b/src/test/resources/field/multivalued_object/object6.json
@@ -1,0 +1,54 @@
+{
+    "field1": [
+        600.0,
+        601.0,
+        602.0
+    ],
+    "field2": [
+        "object6_field2_a",
+        "object6_field2_b",
+        "object6_field2_c",
+        "object6_field2_d"
+    ],
+    "inner_object1": [
+        {
+            "inner_field1": [
+                "object6_inner_object1_a_inner_field1"
+            ],
+            "inner_field2": [
+                "object6_inner_object2_a_inner_field1"
+            ],
+            "inner_object2": [
+                {
+                    "600": 66.0
+                }
+            ]
+        },
+        {
+            "inner_field1": [
+                "object6_inner_object1_b_inner_field1"
+            ],
+            "inner_field2": [
+                "object6_inner_object2_b_inner_field1"
+            ],
+            "inner_object2": [
+                {
+                    "6001": 661.0
+                }
+            ]
+        },
+        {
+            "inner_field1": [
+                "object6_inner_object1_c_inner_field1"
+            ],
+            "inner_field2": [
+                "object6_inner_object2_c_inner_field1"
+            ],
+            "inner_object2": [
+                {
+                    "60011": 6611.0
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/field/multivalued_object/object7.json
+++ b/src/test/resources/field/multivalued_object/object7.json
@@ -17,9 +17,9 @@
                 "object7_inner_object1_a_inner_field1_b"
             ],
             "inner_field2": [
-                "object7_inner_object2_a_inner_field1_a",
-                "object7_inner_object2_a_inner_field1_b",
-                "object7_inner_object2_a_inner_field1_c"
+                "object7_inner_object1_a_inner_field2_a",
+                "object7_inner_object1_a_inner_field2_b",
+                "object7_inner_object1_a_inner_field2_c"
             ],
             "inner_object2": [
                 {
@@ -37,9 +37,9 @@
                 "object7_inner_object1_b_inner_field1_b"
             ],
             "inner_field2": [
-                "object7_inner_object2_b_inner_field1_a",
-                "object7_inner_object2_b_inner_field1_b",
-                "object7_inner_object2_b_inner_field1_c"
+                "object7_inner_object1_b_inner_field2_a",
+                "object7_inner_object1_b_inner_field2_b",
+                "object7_inner_object1_b_inner_field2_c"
             ],
             "inner_object2": [
                 {
@@ -57,8 +57,8 @@
                 "object7_inner_object1_c_inner_field1_c"
             ],
             "inner_field2": [
-                "object7_inner_object2_c_inner_field1_a",
-                "object7_inner_object2_c_inner_field1_b"
+                "object7_inner_object1_c_inner_field2_a",
+                "object7_inner_object1_c_inner_field2_b"
             ],
             "inner_object2": [
                 {

--- a/src/test/resources/field/multivalued_object/object7.json
+++ b/src/test/resources/field/multivalued_object/object7.json
@@ -1,0 +1,82 @@
+{
+    "field1": [
+        700.0,
+        701.0,
+        702.0
+    ],
+    "field2": [
+        "object7_field2_a",
+        "object7_field2_b",
+        "object7_field2_c",
+        "object7_field2_d"
+    ],
+    "inner_object1": [
+        {
+            "inner_field1": [
+                "object7_inner_object1_a_inner_field1_a",
+                "object7_inner_object1_a_inner_field1_b"
+            ],
+            "inner_field2": [
+                "object7_inner_object2_a_inner_field1_a",
+                "object7_inner_object2_a_inner_field1_b",
+                "object7_inner_object2_a_inner_field1_c"
+            ],
+            "inner_object2": [
+                {
+                    "6": 7.0
+                },
+                {
+                    "ab": "cd",
+                    "ef": "gh"
+                }
+            ]
+        },
+        {
+            "inner_field1": [
+                "object7_inner_object1_b_inner_field1_a",
+                "object7_inner_object1_b_inner_field1_b"
+            ],
+            "inner_field2": [
+                "object7_inner_object2_b_inner_field1_a",
+                "object7_inner_object2_b_inner_field1_b",
+                "object7_inner_object2_b_inner_field1_c"
+            ],
+            "inner_object2": [
+                {
+                    "7": 77.0
+                },
+                {
+                    "71": 72.0
+                }
+            ]
+        },
+        {
+            "inner_field1": [
+                "object7_inner_object1_c_inner_field1_a",
+                "object7_inner_object1_c_inner_field1_b",
+                "object7_inner_object1_c_inner_field1_c"
+            ],
+            "inner_field2": [
+                "object7_inner_object2_c_inner_field1_a",
+                "object7_inner_object2_c_inner_field1_b"
+            ],
+            "inner_object2": [
+                {
+                    "70": 707.0,
+                    "7077": 77077.0,
+                    "777": 770.0
+                },
+                {
+                    "71": 7071.0,
+                    "7177": 770771.0,
+                    "7771": 7701.0
+                },
+                {
+                    "701": 70711.0,
+                    "70771": 7707711.0,
+                    "77711": 77011.0
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/field/multivalued_object/object8.json
+++ b/src/test/resources/field/multivalued_object/object8.json
@@ -1,0 +1,38 @@
+{
+    "field1": [
+        800.0,
+        801.0,
+        802.0
+    ],
+    "field2": [
+        "object8_field2_a",
+        "object8_field2_b",
+        "object8_field2_c",
+        "object8_field2_d"
+    ],
+    "inner_object1": [
+        {
+            "inner_field1": [
+                "object8_inner_object1_a_inner_field1_a",
+                "object8_inner_object1_a_inner_field1_b",
+                "object8_inner_object1_a_inner_field1_c"
+            ],
+            "inner_field2": [
+                "object8_inner_object2_a_inner_field1_a",
+                "object8_inner_object2_a_inner_field1_b",
+                "object8_inner_object2_a_inner_field1_c",
+                "object8_inner_object2_a_inner_field1_d"
+            ],
+            "inner_object2": [
+                {
+                    "800": 88.0
+                },
+                {
+                    "80": 808.0,
+                    "8088": 88088.0,
+                    "888": 880.0
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/field/multivalued_object/object9.json
+++ b/src/test/resources/field/multivalued_object/object9.json
@@ -1,25 +1,25 @@
 {
     "field1": [
-        22.0
+        99.0
     ],
     "field2": [
-        "object2_field2_a",
-        "object2_field2_b",
-        "object2_field2_c",
-        "object2_field2_d"
+        "object9_field2_a",
+        "object9_field2_b",
+        "object9_field2_c",
+        "object9_field2_d"
     ],
     "inner_object1": [
         {
             "inner_field1": [
-                "object2_inner_object1_a_inner_field1_a",
-                "object2_inner_object1_a_inner_field1_b"
+                "object9_inner_object1_a_inner_field1_a",
+                "object9_inner_object1_a_inner_field1_b"
             ],
             "inner_field2": [
-                "object2_inner_object1_a_inner_field2"
+                "object9_inner_field2"
             ],
             "inner_object2": [
                 {
-                    "2": 22.0
+                    "9": 99.0
                 },
                 {
                     "ab": "cd",
@@ -29,15 +29,15 @@
         },
         {
             "inner_field1": [
-                "object2_inner_object1_b_inner_field1_a",
-                "object2_inner_object1_b_inner_field1_b"
+                "object9_inner_object1_b_inner_field1_a",
+                "object9_inner_object1_b_inner_field1_b"
             ],
             "inner_field2": [
-                "object2_inner_object1_b_inner_field2"
+                "inner_value2_2_2"
             ],
             "inner_object2": [
                 {
-                    "222": 2222.0
+                    "999": 9999.0
                 }
             ]
         }

--- a/src/test/resources/field/registerFieldsMultivaluedObject.json
+++ b/src/test/resources/field/registerFieldsMultivaluedObject.json
@@ -1,0 +1,64 @@
+{
+  "indexName": "test_index",
+  "field": [
+    {
+      "name": "doc_id",
+      "type": "_ID",
+      "search": true,
+      "storeDocValues": true
+    },
+    {
+      "name": "multivalued_object",
+      "type": "OBJECT",
+      "search": true,
+      "store": false,
+      "storeDocValues": true,
+      "multiValued": true,
+      "childFields": [
+        {
+          "name": "field1",
+          "type": "INT",
+          "search": true,
+          "storeDocValues": true,
+          "multiValued": true
+        },
+        {
+          "name": "field2",
+          "type": "ATOM",
+          "search": true,
+          "storeDocValues": true,
+          "multiValued": true
+        },
+        {
+          "name": "inner_object1",
+          "type": "OBJECT",
+          "search": true,
+          "multiValued": true,
+          "childFields": [
+            {
+              "name": "inner_field1",
+              "type": "ATOM",
+              "search": true,
+              "storeDocValues": true,
+              "multiValued": true
+            },
+            {
+              "name": "inner_field2",
+              "type": "ATOM",
+              "search": true,
+              "storeDocValues": true,
+              "multiValued": true
+            },
+            {
+              "name": "inner_object2",
+              "type": "OBJECT",
+              "search": true,
+              "storeDocValues": true,
+              "multiValued": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
 These tests verify that:
 1. Multivalued objects can be indexed, updated, deleted, retrieved and queried
 2. The objects order is not defined in the response
 3. Objects that don't have fields defined cannot be queried
 4. Multivalued objects need to have all child fields multivalued as well

The test documents have all integer type fields defined as doubles to make comparison with the response easier since the response sets integer values in the double field.