### PR TITLE
Update some config defaults

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -127,7 +127,7 @@ public class LuceneServerConfiguration {
       metricsBuckets = DEFAULT_METRICS_BUCKETS;
     }
     this.metricsBuckets = metricsBuckets;
-    publishJvmMetrics = configReader.getBoolean("publishJvmMetrics", false);
+    publishJvmMetrics = configReader.getBoolean("publishJvmMetrics", true);
     plugins = configReader.getStringList("plugins", DEFAULT_PLUGINS).toArray(new String[0]);
     pluginSearchPath =
         configReader.getString("pluginSearchPath", DEFAULT_PLUGIN_SEARCH_PATH.toString());
@@ -138,10 +138,10 @@ public class LuceneServerConfiguration {
     preloadConfig = IndexPreloadConfig.fromConfig(configReader);
     queryCacheConfig = QueryCacheConfig.fromConfig(configReader);
     warmerConfig = WarmerConfig.fromConfig(configReader);
-    downloadAsStream = configReader.getBoolean("downloadAsStream", false);
-    fileSendDelay = configReader.getBoolean("fileSendDelay", true);
+    downloadAsStream = configReader.getBoolean("downloadAsStream", true);
+    fileSendDelay = configReader.getBoolean("fileSendDelay", false);
     virtualSharding = configReader.getBoolean("virtualSharding", false);
-    syncInitialNrtPoint = configReader.getBoolean("syncInitialNrtPoint", false);
+    syncInitialNrtPoint = configReader.getBoolean("syncInitialNrtPoint", true);
     indexVerbose = configReader.getBoolean("indexVerbose", false);
     fileCopyConfig = FileCopyConfig.fromConfig(configReader);
     threadPoolConfiguration = new ThreadPoolConfiguration(configReader);

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
@@ -102,7 +102,7 @@ public class ReplicationServerTest {
 
   @Test
   public void copyFiles() throws IOException, InterruptedException {
-    initNonSyncedInitialNrtPointServers();
+    initServerSyncInitialNrtPointFalse();
 
     GrpcServer.TestServer testServerPrimary =
         new GrpcServer.TestServer(luceneServerPrimary, true, Mode.PRIMARY);
@@ -282,7 +282,7 @@ public class ReplicationServerTest {
 
   @Test
   public void testSyncOnIndexStart() throws IOException, InterruptedException {
-    initDefaultLuceneServer();
+    initServerSyncInitialNrtPointFalse();
 
     // index 4 documents to primary
     GrpcServer.TestServer testServerPrimary =
@@ -309,7 +309,7 @@ public class ReplicationServerTest {
                     .setTopHits(10)
                     .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
                     .build());
-    assertEquals(4, searchResponseSecondary.getHitsCount());
+    assertEquals(0, searchResponseSecondary.getHitsCount());
 
     luceneServerSecondary
         .getGlobalState()
@@ -366,7 +366,7 @@ public class ReplicationServerTest {
 
   @Test
   public void testInitialSyncWithCurrentVersion() throws IOException, InterruptedException {
-    initDefaultLuceneServer();
+    initServerSyncInitialNrtPointFalse();
 
     // index 4 documents to primary
     GrpcServer.TestServer testServerPrimary =
@@ -393,7 +393,7 @@ public class ReplicationServerTest {
                     .setTopHits(10)
                     .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
                     .build());
-    assertEquals(4, searchResponseSecondary.getHitsCount());
+    assertEquals(0, searchResponseSecondary.getHitsCount());
 
     luceneServerSecondary
         .getGlobalState()
@@ -459,7 +459,7 @@ public class ReplicationServerTest {
     initLuceneServers("");
   }
 
-  private void initNonSyncedInitialNrtPointServers() throws IOException {
+  private void initServerSyncInitialNrtPointFalse() throws IOException {
     initLuceneServers("syncInitialNrtPoint: false");
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
@@ -37,7 +37,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Iterator;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -62,12 +61,7 @@ public class ReplicationServerTest {
   private GrpcServer luceneServerSecondary;
   private GrpcServer replicationServerSecondary;
 
-  private final String BUCKET_NAME = "archiver-unittest";
-  private Archiver archiver;
   private S3Mock api;
-  private AmazonS3 s3;
-  private Path s3Directory;
-  private Path archiverDirectory;
 
   @After
   public void tearDown() throws IOException {
@@ -78,77 +72,10 @@ public class ReplicationServerTest {
     rmDir(Paths.get(luceneServerSecondary.getIndexDir()).getParent());
   }
 
-  @Before
-  public void setUp() throws IOException {
-    // setup S3 for backup/restore
-    s3Directory = folder.newFolder("s3").toPath();
-    archiverDirectory = folder.newFolder("archiver").toPath();
-    api = S3Mock.create(8011, s3Directory.toAbsolutePath().toString());
-    api.start();
-    s3 = new AmazonS3Client(new AnonymousAWSCredentials());
-    s3.setEndpoint("http://127.0.0.1:8011");
-    s3.createBucket(BUCKET_NAME);
-    archiver =
-        new ArchiverImpl(s3, BUCKET_NAME, archiverDirectory, new TarImpl(Tar.CompressionMode.LZ4));
-
-    // set up primary servers
-    String testIndex = "test_index";
-    LuceneServerConfiguration luceneServerPrimaryConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.PRIMARY, folder.getRoot());
-    GlobalState globalStatePrimary = GlobalState.createState(luceneServerPrimaryConfiguration);
-    luceneServerPrimary =
-        new GrpcServer(
-            grpcCleanup,
-            luceneServerPrimaryConfiguration,
-            folder,
-            false,
-            globalStatePrimary,
-            luceneServerPrimaryConfiguration.getIndexDir(),
-            testIndex,
-            globalStatePrimary.getPort(),
-            archiver);
-    replicationServerPrimary =
-        new GrpcServer(
-            grpcCleanup,
-            luceneServerPrimaryConfiguration,
-            folder,
-            true,
-            globalStatePrimary,
-            luceneServerPrimaryConfiguration.getIndexDir(),
-            testIndex,
-            luceneServerPrimaryConfiguration.getReplicationPort(),
-            archiver);
-    // set up secondary servers
-    LuceneServerConfiguration luceneServerSecondaryConfiguration =
-        LuceneServerTestConfigurationFactory.getConfig(Mode.REPLICA, folder.getRoot());
-    GlobalState globalStateSecondary = GlobalState.createState(luceneServerSecondaryConfiguration);
-
-    luceneServerSecondary =
-        new GrpcServer(
-            grpcCleanup,
-            luceneServerSecondaryConfiguration,
-            folder,
-            false,
-            globalStateSecondary,
-            luceneServerSecondaryConfiguration.getIndexDir(),
-            testIndex,
-            globalStateSecondary.getPort(),
-            archiver);
-    replicationServerSecondary =
-        new GrpcServer(
-            grpcCleanup,
-            luceneServerSecondaryConfiguration,
-            folder,
-            true,
-            globalStateSecondary,
-            luceneServerSecondaryConfiguration.getIndexDir(),
-            testIndex,
-            globalStateSecondary.getReplicationPort(),
-            archiver);
-  }
-
   @Test
   public void recvCopyState() throws IOException, InterruptedException {
+    initDefaultLuceneServer();
+
     GrpcServer.TestServer testServer =
         new GrpcServer.TestServer(luceneServerPrimary, true, Mode.PRIMARY);
     testServer.addDocuments();
@@ -175,6 +102,8 @@ public class ReplicationServerTest {
 
   @Test
   public void copyFiles() throws IOException, InterruptedException {
+    initNonSyncedInitialNrtPointServers();
+
     GrpcServer.TestServer testServerPrimary =
         new GrpcServer.TestServer(luceneServerPrimary, true, Mode.PRIMARY);
     testServerPrimary.addDocuments();
@@ -231,6 +160,8 @@ public class ReplicationServerTest {
 
   @Test
   public void basicReplication() throws IOException, InterruptedException {
+    initDefaultLuceneServer();
+
     // index 2 documents to primary
     GrpcServer.TestServer testServerPrimary =
         new GrpcServer.TestServer(luceneServerPrimary, true, Mode.PRIMARY);
@@ -283,6 +214,8 @@ public class ReplicationServerTest {
 
   @Test
   public void getConnectedNodes() throws IOException, InterruptedException {
+    initDefaultLuceneServer();
+
     // startIndex primary
     GrpcServer.TestServer testServerPrimary =
         new GrpcServer.TestServer(luceneServerPrimary, true, Mode.PRIMARY);
@@ -301,6 +234,8 @@ public class ReplicationServerTest {
 
   @Test
   public void replicaConnectivity() throws IOException, InterruptedException {
+    initDefaultLuceneServer();
+
     // set ping interval to 10 ms
     luceneServerSecondary.getGlobalState().setReplicaReplicationPortPingInterval(10);
     // startIndex replica
@@ -347,6 +282,8 @@ public class ReplicationServerTest {
 
   @Test
   public void testSyncOnIndexStart() throws IOException, InterruptedException {
+    initDefaultLuceneServer();
+
     // index 4 documents to primary
     GrpcServer.TestServer testServerPrimary =
         new GrpcServer.TestServer(luceneServerPrimary, true, Mode.PRIMARY);
@@ -372,7 +309,7 @@ public class ReplicationServerTest {
                     .setTopHits(10)
                     .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
                     .build());
-    assertEquals(0, searchResponseSecondary.getHitsCount());
+    assertEquals(4, searchResponseSecondary.getHitsCount());
 
     luceneServerSecondary
         .getGlobalState()
@@ -398,6 +335,8 @@ public class ReplicationServerTest {
 
   @Test
   public void testInitialSyncTimeout() throws IOException {
+    initDefaultLuceneServer();
+
     // startIndex replica
     GrpcServer.TestServer testServerReplica =
         new GrpcServer.TestServer(luceneServerSecondary, true, Mode.REPLICA);
@@ -427,6 +366,8 @@ public class ReplicationServerTest {
 
   @Test
   public void testInitialSyncWithCurrentVersion() throws IOException, InterruptedException {
+    initDefaultLuceneServer();
+
     // index 4 documents to primary
     GrpcServer.TestServer testServerPrimary =
         new GrpcServer.TestServer(luceneServerPrimary, true, Mode.PRIMARY);
@@ -452,7 +393,7 @@ public class ReplicationServerTest {
                     .setTopHits(10)
                     .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
                     .build());
-    assertEquals(0, searchResponseSecondary.getHitsCount());
+    assertEquals(4, searchResponseSecondary.getHitsCount());
 
     luceneServerSecondary
         .getGlobalState()
@@ -495,6 +436,8 @@ public class ReplicationServerTest {
 
   @Test
   public void testAddDocumentsOnReplicaFailure() throws IOException, InterruptedException {
+    initDefaultLuceneServer();
+
     // startIndex primary
     GrpcServer.TestServer testServerPrimary =
         new GrpcServer.TestServer(luceneServerPrimary, true, Mode.PRIMARY);
@@ -510,5 +453,82 @@ public class ReplicationServerTest {
             .throwable
             .getMessage()
             .contains("Adding documents to an index on a replica node is not supported"));
+  }
+
+  private void initDefaultLuceneServer() throws IOException {
+    initLuceneServers("");
+  }
+
+  private void initNonSyncedInitialNrtPointServers() throws IOException {
+    initLuceneServers("syncInitialNrtPoint: false");
+  }
+
+  private void initLuceneServers(String extraConfig) throws IOException {
+    // setup S3 for backup/restore
+    Path s3Directory = folder.newFolder("s3").toPath();
+    Path archiverDirectory = folder.newFolder("archiver").toPath();
+    api = S3Mock.create(8011, s3Directory.toAbsolutePath().toString());
+    api.start();
+    AmazonS3 s3 = new AmazonS3Client(new AnonymousAWSCredentials());
+    s3.setEndpoint("http://127.0.0.1:8011");
+    String BUCKET_NAME = "archiver-unittest";
+    s3.createBucket(BUCKET_NAME);
+    Archiver archiver =
+        new ArchiverImpl(s3, BUCKET_NAME, archiverDirectory, new TarImpl(Tar.CompressionMode.LZ4));
+
+    // set up primary servers
+    String testIndex = "test_index";
+    LuceneServerConfiguration luceneServerPrimaryConfiguration =
+        LuceneServerTestConfigurationFactory.getConfig(Mode.PRIMARY, folder.getRoot(), extraConfig);
+    GlobalState globalStatePrimary = GlobalState.createState(luceneServerPrimaryConfiguration);
+    luceneServerPrimary =
+        new GrpcServer(
+            grpcCleanup,
+            luceneServerPrimaryConfiguration,
+            folder,
+            false,
+            globalStatePrimary,
+            luceneServerPrimaryConfiguration.getIndexDir(),
+            testIndex,
+            globalStatePrimary.getPort(),
+            archiver);
+    replicationServerPrimary =
+        new GrpcServer(
+            grpcCleanup,
+            luceneServerPrimaryConfiguration,
+            folder,
+            true,
+            globalStatePrimary,
+            luceneServerPrimaryConfiguration.getIndexDir(),
+            testIndex,
+            luceneServerPrimaryConfiguration.getReplicationPort(),
+            archiver);
+    // set up secondary servers
+    LuceneServerConfiguration luceneServerSecondaryConfiguration =
+        LuceneServerTestConfigurationFactory.getConfig(Mode.REPLICA, folder.getRoot(), extraConfig);
+    GlobalState globalStateSecondary = GlobalState.createState(luceneServerSecondaryConfiguration);
+
+    luceneServerSecondary =
+        new GrpcServer(
+            grpcCleanup,
+            luceneServerSecondaryConfiguration,
+            folder,
+            false,
+            globalStateSecondary,
+            luceneServerSecondaryConfiguration.getIndexDir(),
+            testIndex,
+            globalStateSecondary.getPort(),
+            archiver);
+    replicationServerSecondary =
+        new GrpcServer(
+            grpcCleanup,
+            luceneServerSecondaryConfiguration,
+            folder,
+            true,
+            globalStateSecondary,
+            luceneServerSecondaryConfiguration.getIndexDir(),
+            testIndex,
+            globalStateSecondary.getReplicationPort(),
+            archiver);
   }
 }


### PR DESCRIPTION
## Problem or Feature
Some default values for flags were changed due to their common use in config files. As a result, these flags can be deleted from configs to make them clear.
RP-5650

## Solution
Changed the following values in `LuceneServerConfiguration.java`
1. publishJvmMetrics: true
2. downloadAsStream: true
3. syncInitialNrtPoint: true
4. fileSendDelay: false

## Verification
- `./gradlew clean installDist test  ` successfully builds project
- Run nrtsearch locally and debug to make sure the values are being overwritten when a config file different than the default one is given