### PR TITLE
For primary and standalone modes check indexWriter is started when ready endpoint is called

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -201,10 +201,10 @@ public class ShardState implements Closeable {
 
   /** True if this index is started. */
   public boolean isStarted() {
-    if (!isReplica()) {
-      return started && writer != null && writer.isOpen();
+    if (started) {
+      return isReplica() || (writer != null && writer.isOpen());
     }
-    return started;
+    return false;
   }
 
   public boolean isRestored() {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -201,6 +201,9 @@ public class ShardState implements Closeable {
 
   /** True if this index is started. */
   public boolean isStarted() {
+    if (!isReplica()) {
+      return started && writer != null && writer.isOpen();
+    }
     return started;
   }
 
@@ -257,7 +260,9 @@ public class ShardState implements Closeable {
   public synchronized void close() throws IOException {
     logger.info(String.format("ShardState.close name= %s", name));
 
-    commit();
+    if (writer != null && writer.isOpen()) {
+      commit();
+    }
 
     List<Closeable> closeables = new ArrayList<>();
     // nocommit catch exc & rollback:


### PR DESCRIPTION
Status quo: readiness passes even if IndexWriter crashes on a primary

With this change: readiness will fail when IndexWriter crashes and the node will be replaced