### PR TITLE
Add max time to initial nrtsearch point sync

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/NRTReplicaNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/NRTReplicaNode.java
@@ -236,13 +236,14 @@ public class NRTReplicaNode extends ReplicaNode {
   /**
    * Sync the next nrt point from the current primary. Attempts to get the current index version
    * from the primary, giving up after the specified amount of time. Sync is considered completed
-   * when either the index version has updated to at least the initial primary version, or there is
-   * a failure to start a new copy job.
+   * when either the index version has updated to at least the initial primary version, there is a
+   * failure to start a new copy job, or the specified max time elapses.
    *
    * @param primaryWaitMs how long to wait for primary to be available
+   * @param maxTimeMs max time to attempt initial point sync
    * @throws IOException on issue getting searcher version
    */
-  public void syncFromCurrentPrimary(long primaryWaitMs) throws IOException {
+  public void syncFromCurrentPrimary(long primaryWaitMs, long maxTimeMs) throws IOException {
     logger.info("Starting sync of next nrt point from current primary");
     long startMS = System.currentTimeMillis();
     long primaryIndexVersion = -1;
@@ -270,10 +271,10 @@ public class NRTReplicaNode extends ReplicaNode {
     }
     long curVersion = getCurrentSearchingVersion();
     logger.info("Nrt sync: primary version: {}, my version: {}", primaryIndexVersion, curVersion);
-    // Keep trying to sync a new nrt point until either our searcher version updates, or
-    // we are unable to start a new copy job. This is needed since long running nrt points
-    // may fail if the primary cleans up old commit files.
-    while (curVersion < primaryIndexVersion) {
+    // Keep trying to sync a new nrt point until either we run out of time, our searcher version
+    // updates, or we are unable to start a new copy job. This is needed since long running nrt
+    // points may fail if the primary cleans up old commit files.
+    while (curVersion < primaryIndexVersion && (System.currentTimeMillis() - startMS < maxTimeMs)) {
       CopyJob job = newNRTPoint(lastPrimaryGen, Long.MAX_VALUE);
       if (job == null) {
         logger.info("Nrt sync: failed to start copy job, aborting");

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -78,6 +78,7 @@ import org.slf4j.LoggerFactory;
 public class ShardState implements Closeable {
   private static final Logger logger = LoggerFactory.getLogger(ShardState.class);
   private static final long INITIAL_SYNC_PRIMARY_WAIT_MS = 30000;
+  private static final long INITIAL_SYNC_MAX_TIME_MS = 600000; // 10m
   public static final int REPLICA_ID = 0;
   public static final String INDEX_DATA_DIR_NAME = "index";
   final ThreadPoolExecutor searchExecutor;
@@ -921,7 +922,8 @@ public class ShardState implements Closeable {
               indexState.getGlobalState().getConfiguration().getFileCopyConfig().getAckedCopy());
 
       if (indexState.getGlobalState().getConfiguration().getSyncInitialNrtPoint()) {
-        nrtReplicaNode.syncFromCurrentPrimary(INITIAL_SYNC_PRIMARY_WAIT_MS);
+        nrtReplicaNode.syncFromCurrentPrimary(
+            INITIAL_SYNC_PRIMARY_WAIT_MS, INITIAL_SYNC_MAX_TIME_MS);
       }
 
       startSearcherPruningThread(indexState.getGlobalState().getShutdownLatch());


### PR DESCRIPTION
Add an upper bound time of 10m to the initial nrtpoint sync operation. Otherwise, a replica may end up syncing indefinitely if it is far enough behind and there is high indexing traffic.