### PR TITLE
Fixed a bug when creating a match query

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
@@ -266,8 +266,7 @@ public class QueryNodeMapper {
     QueryBuilder queryBuilder = new MatchQueryBuilder(analyzer, matchQuery.getFuzzyParams());
 
     // This created query will be TermQuery or FuzzyQuery if only one token is found after analysis,
-    // otherwise BooleanQuery. The
-    // BooleanQuery may include clauses with TermQuery or FuzzyQuery.
+    // otherwise BooleanQuery. The BooleanQuery may include clauses with TermQuery or FuzzyQuery.
     Query query =
         queryBuilder.createBooleanQuery(
             matchQuery.getField(),
@@ -280,7 +279,9 @@ public class QueryNodeMapper {
     }
 
     // TODO: investigate using createMinShouldMatchQuery instead
-    if (matchQuery.getMinimumNumberShouldMatch() == 0 || query instanceof TermQuery) {
+    if (matchQuery.getMinimumNumberShouldMatch() == 0
+        || query instanceof TermQuery
+        || query instanceof FuzzyQuery) {
       return query;
     }
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
@@ -608,6 +608,32 @@ public class QueryTest {
   }
 
   @Test
+  public void testSearchMatchQueryWithFuzzyParamsAndMinShouldMatch1() {
+    Query query =
+        Query.newBuilder()
+            .setMatchQuery(
+                MatchQuery.newBuilder()
+                    .setField("vendor_name")
+                    .setQuery("SECOND")
+                    .setMinimumNumberShouldMatch(1)
+                    .setFuzzyParams(FuzzyParams.newBuilder().setMaxEdits(2).setMaxExpansions(100))
+                    .setOperator(MatchOperator.SHOULD))
+            .build();
+
+    Consumer<SearchResponse> responseTester =
+        searchResponse -> {
+          assertEquals(1, searchResponse.getTotalHits().getValue());
+          assertEquals(1, searchResponse.getHitsList().size());
+          SearchResponse.Hit hit = searchResponse.getHits(0);
+          String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
+          assertEquals("2", docId);
+          LuceneServerTest.checkHits(hit);
+        };
+
+    testQuery(query, responseTester);
+  }
+
+  @Test
   public void testSearchMatchQueryEmptyAfterAnalysis() {
     Query query =
         Query.newBuilder()


### PR DESCRIPTION
Fixed a bug when creating a match query where if a FuzzyQuery is created and minNumberShouldMatch != 0 ClassCastException is thrown. This is similar to how TermQuery is already being handled, but we missed it and it didn't show up in any tests because we didn't change the mininumNumberShouldMatch param to a value more than 1.