### PR TITLE
Allow unknown properties with primary file discovery

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClient.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClient.java
@@ -15,6 +15,7 @@
  */
 package com.yelp.nrtsearch.server.grpc;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.GeneratedMessageV3;
 import com.yelp.nrtsearch.server.grpc.discovery.PrimaryFileNameResolverProvider;
@@ -35,7 +36,8 @@ public class ReplicationServerClient implements Closeable {
   public static final int BINARY_MAGIC = 0x3414f5c;
   public static final int MAX_MESSAGE_BYTES_SIZE = 1 * 1024 * 1024 * 1024;
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);;
   private static final int FILE_UPDATE_INTERVAL_MS = 10 * 1000; // 10 seconds
   private static final Logger logger = LoggerFactory.getLogger(ReplicationServerClient.class);
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClientTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClientTest.java
@@ -96,6 +96,26 @@ public class ReplicationServerClientTest {
   }
 
   @Test
+  public void testConnectWithDiscoveryFileIgnoreUnknown() throws IOException {
+    Server replicationServer = getBasicReplicationServer();
+    try {
+      String filePathStr = Paths.get(folder.getRoot().toString(), TEST_FILE).toString();
+      String fileStr =
+          "[{\"host\":\"localhost\",\"port\":"
+              + replicationServer.getPort()
+              + ",\"other\":\"property\"}]";
+      try (FileOutputStream outputStream = new FileOutputStream(filePathStr)) {
+        outputStream.write(fileStr.getBytes());
+      }
+      ReplicationServerClient client =
+          new ReplicationServerClient(new DiscoveryFileAndPort(testFileURI().getPath(), 0));
+      verifyConnected(client);
+    } finally {
+      replicationServer.shutdown();
+    }
+  }
+
+  @Test
   public void testDiscoveryFilePrimaryChange() throws IOException {
     Server replicationServer = getBasicReplicationServer();
     ReplicationServerClient client;


### PR DESCRIPTION
The default jackson object mapper does not allow unknown properties to be present when reading json objects. This branch sets the option to ignore unknown properties, so discovery will not fail if the primary node definition contains more than just the host and port.