### PR TITLE
Add nrt_util with remote state get/put commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,10 +138,18 @@ task backupRestoreTool(type: CreateStartScripts) {
     classpath = startScripts.classpath
 }
 
+task nrtUtils(type: CreateStartScripts) {
+    mainClassName = 'com.yelp.nrtsearch.tools.nrt_utils.NrtUtilsCommand'
+    applicationName = 'nrt_utils'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = startScripts.classpath
+}
+
 applicationDistribution.into('bin') {
     from(luceneServer)
     from(luceneServerClient)
     from(backupRestoreTool)
+    from(nrtUtils)
     fileMode = 0755
 }
 
@@ -169,6 +177,7 @@ test {
         events "failed"
         exceptionFormat "full"
         showStackTraces true
+        //showStandardStreams = true
     }
 }
 

--- a/src/main/java/com/yelp/nrtsearch/server/backup/VersionManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/backup/VersionManager.java
@@ -36,6 +36,16 @@ public class VersionManager {
     this.bucketName = bucketName;
   }
 
+  /** Get S3 client. */
+  public AmazonS3 getS3() {
+    return s3;
+  }
+
+  /** Get S3 bucket name. */
+  public String getBucketName() {
+    return bucketName;
+  }
+
   /**
    * @param serviceName
    * @param resourceName

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/StateUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/StateUtils.java
@@ -19,12 +19,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.util.JsonFormat;
 import com.yelp.nrtsearch.server.grpc.GlobalStateInfo;
 import com.yelp.nrtsearch.server.grpc.IndexStateInfo;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -108,9 +112,8 @@ public class StateUtils {
   public static void writeToFile(String stateStr, Path directory, String fileName)
       throws IOException {
     File tmpStateFile = File.createTempFile(fileName, ".tmp", directory.toFile());
-    FileOutputStream fileOutputStream = new FileOutputStream(tmpStateFile);
-    try (DataOutputStream dataOutputStream = new DataOutputStream(fileOutputStream)) {
-      dataOutputStream.writeUTF(stateStr);
+    try (FileOutputStream fileOutputStream = new FileOutputStream(tmpStateFile)) {
+      fileOutputStream.write(toUTF8(stateStr));
     }
 
     Path tmpStatePath = tmpStateFile.toPath();
@@ -131,11 +134,8 @@ public class StateUtils {
    */
   public static GlobalStateInfo readStateFromFile(Path filePath) throws IOException {
     Objects.requireNonNull(filePath);
-    String stateStr;
-    FileInputStream fileInputStream = new FileInputStream(filePath.toFile());
-    try (DataInputStream dataInputStream = new DataInputStream(fileInputStream)) {
-      stateStr = dataInputStream.readUTF();
-    }
+    byte[] fileData = Files.readAllBytes(filePath);
+    String stateStr = fromUTF8(fileData);
     GlobalStateInfo.Builder stateBuilder = GlobalStateInfo.newBuilder();
     JsonFormat.parser().ignoringUnknownFields().merge(stateStr, stateBuilder);
     return stateBuilder.build();
@@ -150,13 +150,50 @@ public class StateUtils {
    */
   public static IndexStateInfo readIndexStateFromFile(Path filePath) throws IOException {
     Objects.requireNonNull(filePath);
-    String stateStr;
-    FileInputStream fileInputStream = new FileInputStream(filePath.toFile());
-    try (DataInputStream dataInputStream = new DataInputStream(fileInputStream)) {
-      stateStr = dataInputStream.readUTF();
-    }
+    byte[] fileData = Files.readAllBytes(filePath);
+    String stateStr = fromUTF8(fileData);
     IndexStateInfo.Builder stateBuilder = IndexStateInfo.newBuilder();
     JsonFormat.parser().ignoringUnknownFields().merge(stateStr, stateBuilder);
     return stateBuilder.build();
+  }
+
+  /**
+   * Convert a String to a UTF8 encoded byte array.
+   *
+   * @param s input string
+   * @throws IllegalArgumentException on malformed input string
+   */
+  public static byte[] toUTF8(String s) {
+    CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
+    // Make sure we catch any invalid UTF16:
+    encoder.onMalformedInput(CodingErrorAction.REPORT);
+    encoder.onUnmappableCharacter(CodingErrorAction.REPORT);
+    try {
+      ByteBuffer bb = encoder.encode(CharBuffer.wrap(s));
+      byte[] bytes = new byte[bb.limit()];
+      bb.position(0);
+      bb.get(bytes, 0, bytes.length);
+      return bytes;
+    } catch (CharacterCodingException cce) {
+      throw new IllegalArgumentException(cce);
+    }
+  }
+
+  /**
+   * Convert a UTF8 encoded byte array to a String.
+   *
+   * @param bytes input bytes
+   * @throws IllegalArgumentException on malformed input bytes
+   */
+  public static String fromUTF8(byte[] bytes) {
+    CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
+    // Make sure we catch any invalid UTF8:
+    decoder.onMalformedInput(CodingErrorAction.REPORT);
+    decoder.onUnmappableCharacter(CodingErrorAction.REPORT);
+    try {
+      return decoder.decode(ByteBuffer.wrap(bytes)).toString();
+    } catch (CharacterCodingException cce) {
+      throw new IllegalArgumentException(cce);
+    }
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/NrtUtilsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/NrtUtilsCommand.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils;
+
+import com.yelp.nrtsearch.tools.nrt_utils.state.GetRemoteStateCommand;
+import com.yelp.nrtsearch.tools.nrt_utils.state.PutRemoteStateCommand;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "nrt_utils",
+    synopsisSubcommandLabel = "COMMAND",
+    subcommands = {
+      GetRemoteStateCommand.class,
+      PutRemoteStateCommand.class,
+      CommandLine.HelpCommand.class
+    })
+public class NrtUtilsCommand implements Runnable {
+
+  public static void main(String[] args) {
+    System.exit(new CommandLine(new NrtUtilsCommand()).execute(args));
+  }
+
+  @Override
+  public void run() {
+    // if only the base command is run, just print the usage
+    new CommandLine(this).execute("help");
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetRemoteStateCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetRemoteStateCommand.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.state;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.google.common.annotations.VisibleForTesting;
+import com.yelp.nrtsearch.server.backup.VersionManager;
+import com.yelp.nrtsearch.server.luceneserver.IndexBackupUtils;
+import com.yelp.nrtsearch.server.luceneserver.state.StateUtils;
+import com.yelp.nrtsearch.server.luceneserver.state.backend.RemoteStateBackend;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = GetRemoteStateCommand.GET_REMOTE_STATE,
+    description = "Fetch index or global state from remote backend")
+public class GetRemoteStateCommand implements Callable<Integer> {
+  public static final String GET_REMOTE_STATE = "getRemoteState";
+
+  @CommandLine.Option(
+      names = {"-s", "--serviceName"},
+      description = "Name of nrtsearch cluster",
+      required = true)
+  private String serviceName;
+
+  @CommandLine.Option(
+      names = {"-r", "--resourceName"},
+      description =
+          "Resource name, should be index name or \""
+              + RemoteStateBackend.GLOBAL_STATE_RESOURCE
+              + "\"",
+      required = true)
+  private String resourceName;
+
+  @CommandLine.Option(
+      names = {"-b", "--bucketName"},
+      description = "Name of bucket containing state files",
+      required = true)
+  private String bucketName;
+
+  @CommandLine.Option(
+      names = {"--region"},
+      description = "AWS region name, such as us-west-1, us-west-2, us-east-1")
+  private String region;
+
+  @CommandLine.Option(
+      names = {"-c", "--credsFile"},
+      description = "File holding AWS credentials, uses default locations if not set")
+  private String credsFile;
+
+  @CommandLine.Option(
+      names = {"-p", "--credsProfile"},
+      description = "Profile to use from creds file",
+      defaultValue = "default")
+  private String credsProfile;
+
+  @CommandLine.Option(
+      names = {"-o", "--outputFile"},
+      description = "File to write state to, or empty for stdout",
+      defaultValue = "")
+  private String outputFile;
+
+  @CommandLine.Option(
+      names = {"--exactResourceName"},
+      description = "If index resource name already has unique identifier")
+  private boolean exactResourceName;
+
+  private AmazonS3 s3Client;
+
+  @VisibleForTesting
+  void setS3Client(AmazonS3 s3Client) {
+    this.s3Client = s3Client;
+  }
+
+  @Override
+  public Integer call() throws Exception {
+    if (s3Client == null) {
+      s3Client = StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile);
+    }
+    VersionManager versionManager = new VersionManager(s3Client, bucketName);
+
+    String resolvedResourceName =
+        StateCommandUtils.getResourceName(
+            versionManager, serviceName, resourceName, exactResourceName);
+    String stateFileName =
+        IndexBackupUtils.isBackendGlobalState(resolvedResourceName)
+            ? StateUtils.GLOBAL_STATE_FILE
+            : StateUtils.INDEX_STATE_FILE;
+    String stateFileContents =
+        StateCommandUtils.getStateFileContents(
+            versionManager, serviceName, resolvedResourceName, stateFileName);
+    if (stateFileContents != null) {
+      if (outputFile.isEmpty()) {
+        System.out.println("Content: " + stateFileContents);
+      } else {
+        StateCommandUtils.writeStringToFile(stateFileContents, Path.of(outputFile).toFile());
+      }
+    } else {
+      System.out.println("No state found in backend");
+    }
+    return 0;
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/PutRemoteStateCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/PutRemoteStateCommand.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.state;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.google.common.annotations.VisibleForTesting;
+import com.yelp.nrtsearch.server.backup.VersionManager;
+import com.yelp.nrtsearch.server.luceneserver.IndexBackupUtils;
+import com.yelp.nrtsearch.server.luceneserver.state.StateUtils;
+import com.yelp.nrtsearch.server.luceneserver.state.backend.RemoteStateBackend;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = PutRemoteStateCommand.PUT_REMOTE_STATE,
+    description = "Force push index or global state to remote backend")
+public class PutRemoteStateCommand implements Callable<Integer> {
+  public static final String PUT_REMOTE_STATE = "putRemoteState";
+
+  @CommandLine.Option(
+      names = {"-s", "--serviceName"},
+      description = "Name of nrtsearch cluster",
+      required = true)
+  private String serviceName;
+
+  @CommandLine.Option(
+      names = {"-r", "--resourceName"},
+      description =
+          "Resource name, should be index name or \""
+              + RemoteStateBackend.GLOBAL_STATE_RESOURCE
+              + "\"",
+      required = true)
+  private String resourceName;
+
+  @CommandLine.Option(
+      names = {"-b", "--bucketName"},
+      description = "Name of bucket containing state files",
+      required = true)
+  private String bucketName;
+
+  @CommandLine.Option(
+      names = {"--region"},
+      description = "AWS region name, such as us-west-1, us-west-2, us-east-1")
+  private String region;
+
+  @CommandLine.Option(
+      names = {"-c", "--credsFile"},
+      description = "File holding AWS credentials, uses default locations if not set")
+  private String credsFile;
+
+  @CommandLine.Option(
+      names = {"-p", "--credsProfile"},
+      description = "Profile to use from creds file",
+      defaultValue = "default")
+  private String credsProfile;
+
+  @CommandLine.Option(
+      names = {"-f", "--stateFile"},
+      description = "File to write to remote state",
+      required = true)
+  private String stateFile;
+
+  @CommandLine.Option(
+      names = {"--skipValidate"},
+      description = "Skip file data validation before uploading")
+  private boolean skipValidate;
+
+  @CommandLine.Option(
+      names = {"--exactResourceName"},
+      description = "If index resource name already has unique identifier")
+  private boolean exactResourceName;
+
+  @CommandLine.Option(
+      names = {"--backupFile"},
+      description = "If present, writes current state to this file before uploading")
+  private String backupFile;
+
+  private AmazonS3 s3Client;
+
+  @VisibleForTesting
+  void setS3Client(AmazonS3 s3Client) {
+    this.s3Client = s3Client;
+  }
+
+  @Override
+  public Integer call() throws Exception {
+    if (s3Client == null) {
+      s3Client = StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile);
+    }
+    VersionManager versionManager = new VersionManager(s3Client, bucketName);
+
+    String resolvedResourceName =
+        StateCommandUtils.getResourceName(
+            versionManager, serviceName, resourceName, exactResourceName);
+    String stateFileName =
+        IndexBackupUtils.isBackendGlobalState(resolvedResourceName)
+            ? StateUtils.GLOBAL_STATE_FILE
+            : StateUtils.INDEX_STATE_FILE;
+    byte[] fileBytes = Files.readAllBytes(Path.of(stateFile));
+    if (!skipValidate) {
+      StateCommandUtils.validateConfigData(
+          fileBytes, IndexBackupUtils.isBackendGlobalState(resolvedResourceName));
+    }
+
+    if (backupFile != null) {
+      String currentFileContents =
+          StateCommandUtils.getStateFileContents(
+              versionManager, serviceName, resolvedResourceName, stateFileName);
+      if (currentFileContents != null) {
+        StateCommandUtils.writeStringToFile(currentFileContents, Path.of(backupFile).toFile());
+      } else {
+        System.out.println("No existing state in backend, skipping backup");
+      }
+    }
+
+    StateCommandUtils.writeStateDataToBackend(
+        versionManager, serviceName, resolvedResourceName, stateFileName, fileBytes);
+    return 0;
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/StateCommandUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/StateCommandUtils.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.state;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.auth.profile.ProfilesConfigFile;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import com.google.protobuf.util.JsonFormat;
+import com.yelp.nrtsearch.server.backup.VersionManager;
+import com.yelp.nrtsearch.server.grpc.GlobalStateInfo;
+import com.yelp.nrtsearch.server.grpc.IndexGlobalState;
+import com.yelp.nrtsearch.server.grpc.IndexStateInfo;
+import com.yelp.nrtsearch.server.luceneserver.IndexBackupUtils;
+import com.yelp.nrtsearch.server.luceneserver.state.BackendGlobalState;
+import com.yelp.nrtsearch.server.luceneserver.state.StateUtils;
+import com.yelp.nrtsearch.server.luceneserver.state.backend.RemoteStateBackend;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+import net.jpountz.lz4.LZ4FrameInputStream;
+import net.jpountz.lz4.LZ4FrameOutputStream;
+import org.apache.commons.compress.archivers.ArchiveOutputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.utils.IOUtils;
+
+public class StateCommandUtils {
+  private StateCommandUtils() {}
+
+  /**
+   * Get an S3 client usable for remote state operations.
+   *
+   * @param bucketName s3 bucket
+   * @param region aws region, such as us-west-2, or null to detect
+   * @param credsFile file containing aws credentials, or null for default
+   * @param credsProfile profile to use from credentials file
+   * @return s3 client
+   */
+  public static AmazonS3 createS3Client(
+      String bucketName, String region, String credsFile, String credsProfile) {
+    ProfilesConfigFile profilesConfigFile = null;
+    if (credsFile != null) {
+      Path botoCfgPath = Paths.get(credsFile);
+      profilesConfigFile = new ProfilesConfigFile(botoCfgPath.toFile());
+    }
+    AWSCredentialsProvider awsCredentialsProvider =
+        new ProfileCredentialsProvider(profilesConfigFile, credsProfile);
+
+    String clientRegion;
+    if (region == null) {
+      AmazonS3 s3ClientInterim =
+          AmazonS3ClientBuilder.standard().withCredentials(awsCredentialsProvider).build();
+      clientRegion = s3ClientInterim.getBucketLocation(bucketName);
+      // In useast-1, the region is returned as "US" which is an equivalent to "us-east-1"
+      // https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/Region.html#US_Standard
+      // However, this causes an UnknownHostException so we override it to the full region name
+      if (clientRegion.equals("US")) {
+        clientRegion = "us-east-1";
+      }
+    } else {
+      clientRegion = region;
+    }
+    String serviceEndpoint = String.format("s3.%s.amazonaws.com", clientRegion);
+    System.out.printf("S3 ServiceEndpoint: %s%n", serviceEndpoint);
+    return AmazonS3ClientBuilder.standard()
+        .withCredentials(awsCredentialsProvider)
+        .withEndpointConfiguration(
+            new AwsClientBuilder.EndpointConfiguration(serviceEndpoint, clientRegion))
+        .build();
+  }
+
+  /**
+   * Get the contents of the state file stored in remote state.
+   *
+   * @param versionManager state version manager
+   * @param serviceName nrtsearch cluster service name
+   * @param resourceName state resource name, for index this must include unique identifier
+   * @param stateFileName name of state file in archive
+   * @return state file contents as string
+   * @throws IOException
+   */
+  public static String getStateFileContents(
+      VersionManager versionManager, String serviceName, String resourceName, String stateFileName)
+      throws IOException {
+    String backendResourceName =
+        IndexBackupUtils.isBackendGlobalState(resourceName)
+            ? resourceName
+            : getIndexStateResource(resourceName);
+    long currentVersion = versionManager.getLatestVersionNumber(serviceName, backendResourceName);
+    if (currentVersion == -1) {
+      System.out.println(
+          "No state exists for service: " + serviceName + ", resource: " + backendResourceName);
+      return null;
+    }
+    System.out.println("Current version: " + currentVersion);
+    String versionStr =
+        versionManager.getVersionString(
+            serviceName, backendResourceName, String.valueOf(currentVersion));
+    System.out.println("Version string: " + versionStr);
+
+    String absoluteResourcePath = getStateKey(serviceName, backendResourceName, versionStr);
+    if (!versionManager
+        .getS3()
+        .doesObjectExist(versionManager.getBucketName(), absoluteResourcePath)) {
+      System.out.println("Resource does not exist: " + absoluteResourcePath);
+      return null;
+    }
+
+    String stateStr =
+        getStateFileContentsFromS3(
+            versionManager.getS3(),
+            versionManager.getBucketName(),
+            absoluteResourcePath,
+            stateFileName);
+    if (stateStr == null) {
+      System.out.println("No state file found in archive");
+    }
+    return stateStr;
+  }
+
+  /**
+   * Get the contents of a state file archive stored in S3.
+   *
+   * @param s3Client s3 client
+   * @param bucketName bucket name
+   * @param key key for state file archive
+   * @param stateFileName name of state file within archive
+   * @return contents of state file as string
+   * @throws IOException
+   */
+  public static String getStateFileContentsFromS3(
+      AmazonS3 s3Client, String bucketName, String key, String stateFileName) throws IOException {
+    S3Object stateObject = s3Client.getObject(bucketName, key);
+    InputStream contents = stateObject.getObjectContent();
+    String stateStr = null;
+    try (TarArchiveInputStream tarArchiveInputStream =
+        new TarArchiveInputStream(new LZ4FrameInputStream(contents))) {
+      for (TarArchiveEntry tarArchiveEntry = tarArchiveInputStream.getNextTarEntry();
+          tarArchiveEntry != null;
+          tarArchiveEntry = tarArchiveInputStream.getNextTarEntry()) {
+        if (tarArchiveEntry.getName().endsWith(stateFileName)) {
+          byte[] fileData = tarArchiveInputStream.readNBytes((int) tarArchiveEntry.getSize());
+          stateStr = StateUtils.fromUTF8(fileData);
+        }
+      }
+    }
+    return stateStr;
+  }
+
+  /**
+   * Write UTF8 encoding of string to given file.
+   *
+   * @param content contents to write
+   * @param file file to write to
+   * @throws IOException
+   */
+  public static void writeStringToFile(String content, File file) throws IOException {
+    try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
+      fileOutputStream.write(StateUtils.toUTF8(content));
+    }
+  }
+
+  /**
+   * Write the given state file data to the remote backend, and bless it.
+   *
+   * @param versionManager state version manager
+   * @param serviceName nrtsearch cluster service name
+   * @param resourceName state resource name, for index this must include unique identifier
+   * @param stateFileName name of state file in archive
+   * @param data utf8 encoded state file data
+   * @throws IOException
+   */
+  public static void writeStateDataToBackend(
+      VersionManager versionManager,
+      String serviceName,
+      String resourceName,
+      String stateFileName,
+      byte[] data)
+      throws IOException {
+    byte[] archiveData = buildStateFileArchive(resourceName, stateFileName, data);
+
+    String versionStr = UUID.randomUUID().toString();
+    String backendResourceName =
+        IndexBackupUtils.isBackendGlobalState(resourceName)
+            ? resourceName
+            : resourceName + IndexBackupUtils.INDEX_STATE_SUFFIX;
+    String absoluteResourcePath = getStateKey(serviceName, backendResourceName, versionStr);
+    System.out.println("Writing to resource: " + absoluteResourcePath);
+    writeDataToS3(
+        versionManager.getS3(), versionManager.getBucketName(), absoluteResourcePath, archiveData);
+    versionManager.blessVersion(serviceName, backendResourceName, versionStr);
+  }
+
+  /**
+   * Write a data buffer to an S3 object.
+   *
+   * @param s3Client s3 client
+   * @param bucketName bucket name
+   * @param key key for object to write
+   * @param data data buffer
+   */
+  public static void writeDataToS3(AmazonS3 s3Client, String bucketName, String key, byte[] data) {
+    ObjectMetadata metadata = new ObjectMetadata();
+    metadata.setContentLength(data.length);
+    s3Client.putObject(
+        new PutObjectRequest(bucketName, key, new ByteArrayInputStream(data), metadata));
+  }
+
+  /**
+   * Given the data of a state file, build an archive of the expected format and return its data.
+   *
+   * @param resourceName name of index resource
+   * @param stateFileName name of state file within archive
+   * @param data UTF-8 representation of state file
+   * @return buffer containing archive data
+   * @throws IOException
+   */
+  public static byte[] buildStateFileArchive(String resourceName, String stateFileName, byte[] data)
+      throws IOException {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    try (ArchiveOutputStream archiveOutputStream =
+        new TarArchiveOutputStream(new LZ4FrameOutputStream(outputStream))) {
+      TarArchiveEntry entry = new TarArchiveEntry(resourceName + "/");
+      archiveOutputStream.putArchiveEntry(entry);
+      archiveOutputStream.closeArchiveEntry();
+
+      entry = new TarArchiveEntry(resourceName + "/" + stateFileName);
+      entry.setSize(data.length);
+      archiveOutputStream.putArchiveEntry(entry);
+      try (InputStream dataInputStream = new ByteArrayInputStream(data)) {
+        IOUtils.copy(dataInputStream, archiveOutputStream);
+      }
+      archiveOutputStream.closeArchiveEntry();
+    }
+    return outputStream.toByteArray();
+  }
+
+  /**
+   * Validate state file data to ensure it is encoded properly and can be loaded into its state
+   * message.
+   *
+   * @param configData utf8 encoded state data
+   * @param isGlobalState if this is global or index state
+   * @throws IOException
+   */
+  public static void validateConfigData(byte[] configData, boolean isGlobalState)
+      throws IOException {
+    String configStr = StateUtils.fromUTF8(configData);
+    if (isGlobalState) {
+      GlobalStateInfo.Builder builder = GlobalStateInfo.newBuilder();
+      JsonFormat.parser().merge(configStr, builder);
+      builder.build();
+    } else {
+      IndexStateInfo.Builder builder = IndexStateInfo.newBuilder();
+      JsonFormat.parser().merge(configStr, builder);
+      builder.build();
+    }
+  }
+
+  /**
+   * Get the resolved resource name for a given input resource. If the given resource is an index
+   * name, the service global state is loaded to look up the index unique id. If the resource is for
+   * global state, or exactResourceName is true, it is considered to already be resolved.
+   *
+   * @param versionManager state version manager
+   * @param serviceName nrtsearch cluster service name
+   * @param resource resource name to resolve
+   * @param exactResourceName if the provided resource name is already resolved
+   * @return resolved resource name
+   * @throws IOException
+   */
+  public static String getResourceName(
+      VersionManager versionManager, String serviceName, String resource, boolean exactResourceName)
+      throws IOException {
+    if (IndexBackupUtils.isBackendGlobalState(resource)) {
+      System.out.println("Global state resource");
+      return resource;
+    }
+    if (exactResourceName) {
+      System.out.println("Index state resource: " + resource);
+      return resource;
+    }
+    String globalStateContents =
+        getStateFileContents(
+            versionManager,
+            serviceName,
+            RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            StateUtils.GLOBAL_STATE_FILE);
+    if (globalStateContents == null) {
+      throw new IllegalArgumentException(
+          "Unable to load global state for cluster: \"" + serviceName + "\"");
+    }
+    GlobalStateInfo.Builder globalStateBuilder = GlobalStateInfo.newBuilder();
+    JsonFormat.parser().ignoringUnknownFields().merge(globalStateContents, globalStateBuilder);
+    GlobalStateInfo globalState = globalStateBuilder.build();
+
+    IndexGlobalState indexGlobalState = globalState.getIndicesMap().get(resource);
+    if (indexGlobalState == null) {
+      throw new IllegalArgumentException(
+          "Unable to find index: \"" + resource + "\" in cluster: \"" + serviceName + "\"");
+    }
+    if (indexGlobalState.getId().isEmpty()) {
+      throw new IllegalArgumentException("Index id is empty for index: \"" + resource + "\"");
+    }
+    String resolvedResource =
+        BackendGlobalState.getUniqueIndexName(resource, indexGlobalState.getId());
+    System.out.println("Index state resource: " + resolvedResource);
+    return resolvedResource;
+  }
+
+  /**
+   * Given an index resource (index-UUID), produce the index state resource.
+   *
+   * @param indexResource index resource
+   * @return index state resource
+   */
+  public static String getIndexStateResource(String indexResource) {
+    return indexResource + IndexBackupUtils.INDEX_STATE_SUFFIX;
+  }
+
+  /**
+   * Get the S3 key for an index state object.
+   *
+   * @param serviceName nrtsearch cluster service name
+   * @param indexStateResource index state resource
+   * @param versionStr version UUID
+   * @return S3 key for state object
+   */
+  public static String getStateKey(
+      String serviceName, String indexStateResource, String versionStr) {
+    return String.format("%s/%s/%s", serviceName, indexStateResource, versionStr);
+  }
+
+  /**
+   * Get the S3 key prefix (with trailing slash) for all index state objects for a given index.
+   *
+   * @param serviceName nrtsearch cluster service name
+   * @param indexStateResource index state resource
+   * @return S3 index state key prefix
+   */
+  public static String getStateKeyPrefix(String serviceName, String indexStateResource) {
+    return String.format("%s/%s/", serviceName, indexStateResource);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/state/StateUtilsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/state/StateUtilsTest.java
@@ -32,8 +32,8 @@ import com.yelp.nrtsearch.server.grpc.IndexSettings;
 import com.yelp.nrtsearch.server.grpc.IndexStateInfo;
 import com.yelp.nrtsearch.server.grpc.SortFields;
 import com.yelp.nrtsearch.server.grpc.SortType;
-import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Rule;
@@ -187,7 +187,7 @@ public class StateUtilsTest {
     }
   }
 
-  @Test(expected = FileNotFoundException.class)
+  @Test(expected = NoSuchFileException.class)
   public void testReadStateFileNotFound() throws IOException {
     Path expectedStateFilePath =
         Paths.get(folder.getRoot().getAbsolutePath(), StateUtils.GLOBAL_STATE_FILE);
@@ -349,7 +349,7 @@ public class StateUtilsTest {
     }
   }
 
-  @Test(expected = FileNotFoundException.class)
+  @Test(expected = NoSuchFileException.class)
   public void testReadIndexStateFileNotFound() throws IOException {
     Path expectedStateFilePath =
         Paths.get(folder.getRoot().getAbsolutePath(), StateUtils.INDEX_STATE_FILE);

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/state/backend/RemoteStateBackendTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/state/backend/RemoteStateBackendTest.java
@@ -57,7 +57,6 @@ import com.yelp.nrtsearch.server.luceneserver.state.BackendGlobalState;
 import com.yelp.nrtsearch.server.luceneserver.state.StateUtils;
 import io.findify.s3mock.S3Mock;
 import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -196,14 +195,11 @@ public class RemoteStateBackendTest {
         tarArchiveEntry != null;
         tarArchiveEntry = tarArchiveInputStream.getNextTarEntry()) {
       if (tarArchiveEntry.getName().endsWith(StateUtils.GLOBAL_STATE_FILE)) {
-        String stateStr;
-        try (DataInputStream dataInputStream = new DataInputStream(tarArchiveInputStream)) {
-          stateStr = dataInputStream.readUTF();
-        }
+        byte[] fileData = tarArchiveInputStream.readNBytes((int) tarArchiveEntry.getSize());
+        String stateStr = StateUtils.fromUTF8(fileData);
         GlobalStateInfo.Builder stateBuilder = GlobalStateInfo.newBuilder();
         JsonFormat.parser().ignoringUnknownFields().merge(stateStr, stateBuilder);
         stateFromTar = stateBuilder.build();
-        break;
       }
     }
     return stateFromTar;
@@ -233,14 +229,11 @@ public class RemoteStateBackendTest {
         tarArchiveEntry != null;
         tarArchiveEntry = tarArchiveInputStream.getNextTarEntry()) {
       if (tarArchiveEntry.getName().endsWith(StateUtils.INDEX_STATE_FILE)) {
-        String stateStr;
-        try (DataInputStream dataInputStream = new DataInputStream(tarArchiveInputStream)) {
-          stateStr = dataInputStream.readUTF();
-        }
+        byte[] fileData = tarArchiveInputStream.readNBytes((int) tarArchiveEntry.getSize());
+        String stateStr = StateUtils.fromUTF8(fileData);
         IndexStateInfo.Builder stateBuilder = IndexStateInfo.newBuilder();
         JsonFormat.parser().ignoringUnknownFields().merge(stateStr, stateBuilder);
         stateFromTar = stateBuilder.build();
-        break;
       }
     }
     return stateFromTar;

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetRemoteStateCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetRemoteStateCommandTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.state;
+
+import static com.yelp.nrtsearch.server.grpc.TestServer.S3_ENDPOINT;
+import static com.yelp.nrtsearch.server.grpc.TestServer.SERVICE_NAME;
+import static com.yelp.nrtsearch.server.grpc.TestServer.TEST_BUCKET;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.google.protobuf.util.JsonFormat;
+import com.yelp.nrtsearch.server.config.IndexStartConfig.IndexDataLocationType;
+import com.yelp.nrtsearch.server.grpc.GlobalStateInfo;
+import com.yelp.nrtsearch.server.grpc.IndexStateInfo;
+import com.yelp.nrtsearch.server.grpc.Mode;
+import com.yelp.nrtsearch.server.grpc.TestServer;
+import com.yelp.nrtsearch.server.luceneserver.index.ImmutableIndexState;
+import com.yelp.nrtsearch.server.luceneserver.state.StateUtils;
+import com.yelp.nrtsearch.server.luceneserver.state.backend.RemoteStateBackend;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import picocli.CommandLine;
+
+public class GetRemoteStateCommandTest {
+
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  @After
+  public void cleanup() {
+    TestServer.cleanupAll();
+  }
+
+  private AmazonS3 getS3() {
+    AmazonS3 s3 = new AmazonS3Client(new AnonymousAWSCredentials());
+    s3.setEndpoint(S3_ENDPOINT);
+    s3.createBucket(TEST_BUCKET);
+    return s3;
+  }
+
+  private CommandLine getInjectedCommand() {
+    GetRemoteStateCommand command = new GetRemoteStateCommand();
+    command.setS3Client(getS3());
+    return new CommandLine(command);
+  }
+
+  private TestServer getTestServer() throws IOException {
+    TestServer server =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.LOCAL)
+            .withRemoteStateBackend(false)
+            .build();
+    server.createSimpleIndex("test_index");
+    return server;
+  }
+
+  @Test
+  public void testGetGlobalStateNotExists() throws IOException {
+    TestServer.initS3(folder);
+    CommandLine cmd = getInjectedCommand();
+    File stateFile = Paths.get(folder.getRoot().getPath(), "state_file.json").toFile();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=" + RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            "--outputFile=" + stateFile.getAbsolutePath());
+    assertEquals(0, exitCode);
+    assertFalse(stateFile.exists());
+  }
+
+  @Test
+  public void testGetIndexStateNotExists() throws IOException {
+    TestServer.initS3(folder);
+    CommandLine cmd = getInjectedCommand();
+    File stateFile = Paths.get(folder.getRoot().getPath(), "state_file.json").toFile();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index",
+            "--outputFile=" + stateFile.getAbsolutePath(),
+            "--exactResourceName");
+    assertEquals(0, exitCode);
+    assertFalse(stateFile.exists());
+  }
+
+  @Test
+  public void testGetGlobalState() throws IOException {
+    getTestServer();
+    CommandLine cmd = getInjectedCommand();
+    File stateFile = Paths.get(folder.getRoot().getPath(), "state_file.json").toFile();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=" + RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            "--outputFile=" + stateFile.getAbsolutePath());
+    assertEquals(0, exitCode);
+    assertTrue(stateFile.exists());
+
+    String contents = StateUtils.fromUTF8(Files.readAllBytes(stateFile.toPath()));
+    GlobalStateInfo.Builder builder = GlobalStateInfo.newBuilder();
+    JsonFormat.parser().merge(contents, builder);
+    GlobalStateInfo stateInfo = builder.build();
+    assertEquals(1, stateInfo.getIndicesMap().size());
+    assertTrue(stateInfo.getIndicesMap().containsKey("test_index"));
+    assertFalse(stateInfo.getIndicesMap().get("test_index").getStarted());
+  }
+
+  @Test
+  public void testGetIndexState() throws IOException {
+    TestServer server = getTestServer();
+    CommandLine cmd = getInjectedCommand();
+    File stateFile = Paths.get(folder.getRoot().getPath(), "state_file.json").toFile();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index",
+            "--outputFile=" + stateFile.getAbsolutePath());
+    assertEquals(0, exitCode);
+    assertTrue(stateFile.exists());
+
+    String contents = StateUtils.fromUTF8(Files.readAllBytes(stateFile.toPath()));
+    IndexStateInfo.Builder builder = IndexStateInfo.newBuilder();
+    JsonFormat.parser().merge(contents, builder);
+    IndexStateInfo stateInfo = builder.build();
+    IndexStateInfo expected =
+        ((ImmutableIndexState) server.getGlobalState().getIndex("test_index"))
+            .getCurrentStateInfo();
+    assertEquals(expected, stateInfo);
+  }
+
+  @Test
+  public void testGetIndexStateExact() throws IOException {
+    TestServer server = getTestServer();
+    CommandLine cmd = getInjectedCommand();
+    File stateFile = Paths.get(folder.getRoot().getPath(), "state_file.json").toFile();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=" + server.getGlobalState().getDataResourceForIndex("test_index"),
+            "--exactResourceName",
+            "--outputFile=" + stateFile.getAbsolutePath());
+    assertEquals(0, exitCode);
+    assertTrue(stateFile.exists());
+
+    String contents = StateUtils.fromUTF8(Files.readAllBytes(stateFile.toPath()));
+    IndexStateInfo.Builder builder = IndexStateInfo.newBuilder();
+    JsonFormat.parser().merge(contents, builder);
+    IndexStateInfo stateInfo = builder.build();
+    IndexStateInfo expected =
+        ((ImmutableIndexState) server.getGlobalState().getIndex("test_index"))
+            .getCurrentStateInfo();
+    assertEquals(expected, stateInfo);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/PutRemoteStateCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/PutRemoteStateCommandTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.state;
+
+import static com.yelp.nrtsearch.server.grpc.TestServer.S3_ENDPOINT;
+import static com.yelp.nrtsearch.server.grpc.TestServer.SERVICE_NAME;
+import static com.yelp.nrtsearch.server.grpc.TestServer.TEST_BUCKET;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.util.JsonFormat;
+import com.yelp.nrtsearch.server.backup.VersionManager;
+import com.yelp.nrtsearch.server.config.IndexStartConfig.IndexDataLocationType;
+import com.yelp.nrtsearch.server.grpc.GlobalStateInfo;
+import com.yelp.nrtsearch.server.grpc.IndexLiveSettings;
+import com.yelp.nrtsearch.server.grpc.IndexStateInfo;
+import com.yelp.nrtsearch.server.grpc.Mode;
+import com.yelp.nrtsearch.server.grpc.TestServer;
+import com.yelp.nrtsearch.server.luceneserver.index.ImmutableIndexState;
+import com.yelp.nrtsearch.server.luceneserver.state.StateUtils;
+import com.yelp.nrtsearch.server.luceneserver.state.backend.RemoteStateBackend;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import picocli.CommandLine;
+
+public class PutRemoteStateCommandTest {
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  @After
+  public void cleanup() {
+    TestServer.cleanupAll();
+  }
+
+  private AmazonS3 getS3() {
+    AmazonS3 s3 = new AmazonS3Client(new AnonymousAWSCredentials());
+    s3.setEndpoint(S3_ENDPOINT);
+    s3.createBucket(TEST_BUCKET);
+    return s3;
+  }
+
+  private CommandLine getInjectedCommand() {
+    PutRemoteStateCommand command = new PutRemoteStateCommand();
+    command.setS3Client(getS3());
+    return new CommandLine(command);
+  }
+
+  private TestServer getTestServer() throws IOException {
+    TestServer server =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.LOCAL)
+            .withRemoteStateBackend(false)
+            .build();
+    server.createSimpleIndex("test_index");
+    return server;
+  }
+
+  private VersionManager getVersionManager() {
+    return new VersionManager(getS3(), TEST_BUCKET);
+  }
+
+  @Test
+  public void testPutGlobalState() throws IOException {
+    TestServer server = getTestServer();
+    VersionManager versionManager = getVersionManager();
+    String contents =
+        StateCommandUtils.getStateFileContents(
+            versionManager,
+            SERVICE_NAME,
+            RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            StateUtils.GLOBAL_STATE_FILE);
+    assertEquals(1, server.indices().size());
+
+    CommandLine cmd = getInjectedCommand();
+
+    GlobalStateInfo.Builder builder = GlobalStateInfo.newBuilder();
+    JsonFormat.parser().merge(contents, builder);
+    builder.removeIndices("test_index");
+    GlobalStateInfo stateInfo = builder.build();
+
+    File stateFile = folder.newFile("new_state.json");
+    StateCommandUtils.writeStringToFile(JsonFormat.printer().print(stateInfo), stateFile);
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=" + RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            "--stateFile=" + stateFile.getAbsolutePath());
+    assertEquals(0, exitCode);
+
+    server.restart();
+    assertEquals(0, server.indices().size());
+  }
+
+  @Test
+  public void testPutIndexState() throws IOException {
+    TestServer server = getTestServer();
+    IndexStateInfo currentState =
+        ((ImmutableIndexState) server.getGlobalState().getIndex("test_index"))
+            .getCurrentStateInfo();
+    IndexStateInfo updatedState =
+        currentState
+            .toBuilder()
+            .setLiveSettings(
+                IndexLiveSettings.newBuilder()
+                    .setSliceMaxSegments(Int32Value.newBuilder().setValue(1).build())
+                    .build())
+            .build();
+
+    CommandLine cmd = getInjectedCommand();
+
+    File stateFile = folder.newFile("new_state.json");
+    StateCommandUtils.writeStringToFile(JsonFormat.printer().print(updatedState), stateFile);
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index",
+            "--stateFile=" + stateFile.getAbsolutePath());
+    assertEquals(0, exitCode);
+
+    server.restart();
+    IndexStateInfo newCurrentState =
+        ((ImmutableIndexState) server.getGlobalState().getIndex("test_index"))
+            .getCurrentStateInfo();
+    assertEquals(updatedState, newCurrentState);
+    assertNotEquals(currentState, newCurrentState);
+  }
+
+  @Test
+  public void testPutIndexStateExact() throws IOException {
+    TestServer server = getTestServer();
+    IndexStateInfo currentState =
+        ((ImmutableIndexState) server.getGlobalState().getIndex("test_index"))
+            .getCurrentStateInfo();
+    IndexStateInfo updatedState =
+        currentState
+            .toBuilder()
+            .setLiveSettings(
+                IndexLiveSettings.newBuilder()
+                    .setSliceMaxSegments(Int32Value.newBuilder().setValue(1).build())
+                    .build())
+            .build();
+
+    CommandLine cmd = getInjectedCommand();
+
+    File stateFile = folder.newFile("new_state.json");
+    StateCommandUtils.writeStringToFile(JsonFormat.printer().print(updatedState), stateFile);
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=" + server.getGlobalState().getDataResourceForIndex("test_index"),
+            "--exactResourceName",
+            "--stateFile=" + stateFile.getAbsolutePath());
+    assertEquals(0, exitCode);
+
+    server.restart();
+    IndexStateInfo newCurrentState =
+        ((ImmutableIndexState) server.getGlobalState().getIndex("test_index"))
+            .getCurrentStateInfo();
+    assertEquals(updatedState, newCurrentState);
+    assertNotEquals(currentState, newCurrentState);
+  }
+
+  @Test
+  public void testInvalidState() throws IOException {
+    TestServer.initS3(folder);
+    String stateStr =
+        "{\"ind\":{\"test_index\":{\"id\":\"09d9c9e4-483e-4a90-9c4f-d342c8da1210\",\"started\":true}}}";
+    CommandLine cmd = getInjectedCommand();
+
+    File stateFile = folder.newFile("new_state.json");
+    StateCommandUtils.writeStringToFile(stateStr, stateFile);
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=" + RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            "--stateFile=" + stateFile.getAbsolutePath());
+    assertEquals(1, exitCode);
+
+    String contents =
+        StateCommandUtils.getStateFileContents(
+            getVersionManager(),
+            SERVICE_NAME,
+            RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            StateUtils.GLOBAL_STATE_FILE);
+    assertNull(contents);
+  }
+
+  @Test
+  public void testSkipValidate() throws IOException {
+    TestServer.initS3(folder);
+    String stateStr =
+        "{\"ind\":{\"test_index\":{\"id\":\"09d9c9e4-483e-4a90-9c4f-d342c8da1210\",\"started\":true}}}";
+    CommandLine cmd = getInjectedCommand();
+
+    File stateFile = folder.newFile("new_state.json");
+    StateCommandUtils.writeStringToFile(stateStr, stateFile);
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=" + RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            "--stateFile=" + stateFile.getAbsolutePath(),
+            "--skipValidate");
+    assertEquals(0, exitCode);
+
+    String contents =
+        StateCommandUtils.getStateFileContents(
+            getVersionManager(),
+            SERVICE_NAME,
+            RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            StateUtils.GLOBAL_STATE_FILE);
+    assertNotNull(contents);
+  }
+
+  @Test
+  public void testBackupStateNotPresent() throws IOException {
+    TestServer.initS3(folder);
+    CommandLine cmd = getInjectedCommand();
+
+    GlobalStateInfo stateInfo = GlobalStateInfo.newBuilder().build();
+
+    File stateFile = folder.newFile("new_state.json");
+    File backupFile = Paths.get(folder.getRoot().getPath(), "backup.json").toFile();
+    StateCommandUtils.writeStringToFile(JsonFormat.printer().print(stateInfo), stateFile);
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=" + RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            "--stateFile=" + stateFile.getAbsolutePath(),
+            "--backupFile=" + backupFile.getAbsolutePath());
+    assertEquals(0, exitCode);
+    assertFalse(backupFile.exists());
+  }
+
+  @Test
+  public void testBackupFile() throws IOException {
+    TestServer server = getTestServer();
+    VersionManager versionManager = getVersionManager();
+    String contents =
+        StateCommandUtils.getStateFileContents(
+            versionManager,
+            SERVICE_NAME,
+            RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            StateUtils.GLOBAL_STATE_FILE);
+    assertEquals(1, server.indices().size());
+
+    CommandLine cmd = getInjectedCommand();
+
+    GlobalStateInfo.Builder builder = GlobalStateInfo.newBuilder();
+    JsonFormat.parser().merge(contents, builder);
+    builder.removeIndices("test_index");
+    GlobalStateInfo stateInfo = builder.build();
+
+    File stateFile = folder.newFile("new_state.json");
+    File backupFile = Paths.get(folder.getRoot().getPath(), "backup.json").toFile();
+    StateCommandUtils.writeStringToFile(JsonFormat.printer().print(stateInfo), stateFile);
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=" + RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            "--stateFile=" + stateFile.getAbsolutePath(),
+            "--backupFile=" + backupFile.getAbsolutePath());
+    assertEquals(0, exitCode);
+
+    GlobalStateInfo.Builder expectedStateBuilder = GlobalStateInfo.newBuilder();
+    JsonFormat.parser().merge(contents, expectedStateBuilder);
+    GlobalStateInfo expectedState = expectedStateBuilder.build();
+
+    assertTrue(backupFile.exists());
+    byte[] backupFileBytes = Files.readAllBytes(backupFile.toPath());
+    GlobalStateInfo.Builder backupStateBuilder = GlobalStateInfo.newBuilder();
+    JsonFormat.parser().merge(StateUtils.fromUTF8(backupFileBytes), backupStateBuilder);
+    GlobalStateInfo backupState = backupStateBuilder.build();
+    assertEquals(expectedState, backupState);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/StateCommandUtilsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/StateCommandUtilsTest.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.state;
+
+import static com.yelp.nrtsearch.server.grpc.TestServer.S3_ENDPOINT;
+import static com.yelp.nrtsearch.server.grpc.TestServer.SERVICE_NAME;
+import static com.yelp.nrtsearch.server.grpc.TestServer.TEST_BUCKET;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import com.yelp.nrtsearch.server.backup.VersionManager;
+import com.yelp.nrtsearch.server.config.IndexStartConfig.IndexDataLocationType;
+import com.yelp.nrtsearch.server.grpc.GlobalStateInfo;
+import com.yelp.nrtsearch.server.grpc.IndexLiveSettings;
+import com.yelp.nrtsearch.server.grpc.IndexStateInfo;
+import com.yelp.nrtsearch.server.grpc.Mode;
+import com.yelp.nrtsearch.server.grpc.TestServer;
+import com.yelp.nrtsearch.server.luceneserver.IndexBackupUtils;
+import com.yelp.nrtsearch.server.luceneserver.index.ImmutableIndexState;
+import com.yelp.nrtsearch.server.luceneserver.state.StateUtils;
+import com.yelp.nrtsearch.server.luceneserver.state.backend.RemoteStateBackend;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.apache.commons.io.IOUtils;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class StateCommandUtilsTest {
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  @After
+  public void cleanup() {
+    TestServer.cleanupAll();
+  }
+
+  private AmazonS3 getS3() {
+    AmazonS3 s3 = new AmazonS3Client(new AnonymousAWSCredentials());
+    s3.setEndpoint(S3_ENDPOINT);
+    s3.createBucket(TEST_BUCKET);
+    return s3;
+  }
+
+  private VersionManager getVersionManager() {
+    return new VersionManager(getS3(), TEST_BUCKET);
+  }
+
+  private TestServer getTestServer() throws IOException {
+    TestServer server =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.LOCAL)
+            .withRemoteStateBackend(false)
+            .build();
+    server.createSimpleIndex("test_index");
+    return server;
+  }
+
+  @Test
+  public void testGetStateFileContents_GlobalNotExist() throws IOException {
+    TestServer.initS3(folder);
+    String contents =
+        StateCommandUtils.getStateFileContents(
+            getVersionManager(),
+            SERVICE_NAME,
+            RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            StateUtils.GLOBAL_STATE_FILE);
+    assertNull(contents);
+  }
+
+  @Test
+  public void testGetStateFileContents_IndexNotExist() throws IOException {
+    TestServer.initS3(folder);
+    String contents =
+        StateCommandUtils.getStateFileContents(
+            getVersionManager(), SERVICE_NAME, "test_index", StateUtils.INDEX_STATE_FILE);
+    assertNull(contents);
+  }
+
+  @Test
+  public void testGetStateFileContents_ResourceNotExist() throws IOException {
+    TestServer.initS3(folder);
+    VersionManager mockVersionManager = mock(VersionManager.class);
+    String version = UUID.randomUUID().toString();
+    String indexResource = "test_index" + IndexBackupUtils.INDEX_STATE_SUFFIX;
+    when(mockVersionManager.getLatestVersionNumber(SERVICE_NAME, indexResource)).thenReturn(5L);
+    when(mockVersionManager.getVersionString(SERVICE_NAME, indexResource, String.valueOf(5L)))
+        .thenReturn(version);
+    when(mockVersionManager.getS3()).thenReturn(getS3());
+    when(mockVersionManager.getBucketName()).thenReturn(TEST_BUCKET);
+
+    String contents =
+        StateCommandUtils.getStateFileContents(
+            mockVersionManager, SERVICE_NAME, "test_index", StateUtils.INDEX_STATE_FILE);
+    assertNull(contents);
+
+    verify(mockVersionManager, times(1)).getLatestVersionNumber(SERVICE_NAME, indexResource);
+    verify(mockVersionManager, times(1))
+        .getVersionString(SERVICE_NAME, indexResource, String.valueOf(5L));
+    verify(mockVersionManager, times(1)).getS3();
+    verify(mockVersionManager, times(1)).getBucketName();
+    verifyNoMoreInteractions(mockVersionManager);
+  }
+
+  @Test
+  public void testGetStateFileContents_GlobalState() throws IOException {
+    getTestServer();
+    String contents =
+        StateCommandUtils.getStateFileContents(
+            getVersionManager(),
+            SERVICE_NAME,
+            RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            StateUtils.GLOBAL_STATE_FILE);
+    GlobalStateInfo.Builder builder = GlobalStateInfo.newBuilder();
+    JsonFormat.parser().merge(contents, builder);
+    GlobalStateInfo stateInfo = builder.build();
+    assertEquals(1, stateInfo.getIndicesMap().size());
+    assertTrue(stateInfo.getIndicesMap().containsKey("test_index"));
+    assertFalse(stateInfo.getIndicesMap().get("test_index").getStarted());
+  }
+
+  @Test
+  public void testGetStateFileContents_IndexState() throws IOException {
+    TestServer server = getTestServer();
+    String contents =
+        StateCommandUtils.getStateFileContents(
+            getVersionManager(),
+            SERVICE_NAME,
+            server.getGlobalState().getDataResourceForIndex("test_index"),
+            StateUtils.INDEX_STATE_FILE);
+    IndexStateInfo.Builder builder = IndexStateInfo.newBuilder();
+    JsonFormat.parser().merge(contents, builder);
+    IndexStateInfo stateInfo = builder.build();
+    IndexStateInfo expected =
+        ((ImmutableIndexState) server.getGlobalState().getIndex("test_index"))
+            .getCurrentStateInfo();
+    assertEquals(expected, stateInfo);
+  }
+
+  @Test
+  public void testGetStateFileContents_FileNotInTar() throws IOException {
+    getTestServer();
+    String contents =
+        StateCommandUtils.getStateFileContents(
+            getVersionManager(),
+            SERVICE_NAME,
+            RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            "not_state_file");
+    assertNull(contents);
+  }
+
+  @Test
+  public void testWriteStringToFile() throws IOException {
+    File file = folder.newFile();
+    String testString = "This is a test string \u0394";
+    StateCommandUtils.writeStringToFile(testString, file);
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    try (FileInputStream fileInputStream = new FileInputStream(file)) {
+      IOUtils.copy(fileInputStream, byteArrayOutputStream);
+    }
+    String fileString = StateUtils.fromUTF8(byteArrayOutputStream.toByteArray());
+    assertEquals(testString, fileString);
+  }
+
+  @Test
+  public void testWriteStateDataToBackend_GlobalState() throws IOException {
+    TestServer server = getTestServer();
+    VersionManager versionManager = getVersionManager();
+    String contents =
+        StateCommandUtils.getStateFileContents(
+            versionManager,
+            SERVICE_NAME,
+            RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            StateUtils.GLOBAL_STATE_FILE);
+    assertEquals(1, server.indices().size());
+
+    GlobalStateInfo.Builder builder = GlobalStateInfo.newBuilder();
+    JsonFormat.parser().merge(contents, builder);
+    builder.removeIndices("test_index");
+    GlobalStateInfo stateInfo = builder.build();
+
+    byte[] stateBytes = StateUtils.toUTF8(JsonFormat.printer().print(stateInfo));
+    StateCommandUtils.writeStateDataToBackend(
+        versionManager,
+        SERVICE_NAME,
+        RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+        StateUtils.GLOBAL_STATE_FILE,
+        stateBytes);
+
+    server.restart();
+    assertEquals(0, server.indices().size());
+  }
+
+  @Test
+  public void testWriteStateDataToBackend_IndexState() throws IOException {
+    TestServer server = getTestServer();
+    IndexStateInfo currentState =
+        ((ImmutableIndexState) server.getGlobalState().getIndex("test_index"))
+            .getCurrentStateInfo();
+    IndexStateInfo updatedState =
+        currentState
+            .toBuilder()
+            .setLiveSettings(
+                IndexLiveSettings.newBuilder()
+                    .setSliceMaxSegments(Int32Value.newBuilder().setValue(1).build())
+                    .build())
+            .build();
+    byte[] stateBytes = StateUtils.toUTF8(JsonFormat.printer().print(updatedState));
+    StateCommandUtils.writeStateDataToBackend(
+        getVersionManager(),
+        SERVICE_NAME,
+        server.getGlobalState().getDataResourceForIndex("test_index"),
+        StateUtils.INDEX_STATE_FILE,
+        stateBytes);
+
+    server.restart();
+    IndexStateInfo newCurrentState =
+        ((ImmutableIndexState) server.getGlobalState().getIndex("test_index"))
+            .getCurrentStateInfo();
+    assertEquals(updatedState, newCurrentState);
+    assertNotEquals(currentState, newCurrentState);
+  }
+
+  @Test
+  public void testValidateConfigData_ValidGlobalState() throws IOException {
+    String stateStr =
+        "{\"indices\":{\"test_index\":{\"id\":\"09d9c9e4-483e-4a90-9c4f-d342c8da1210\",\"started\":true}}}";
+    StateCommandUtils.validateConfigData(stateStr.getBytes(StandardCharsets.UTF_8), true);
+  }
+
+  @Test
+  public void testValidateConfigData_InvalidGlobalState() throws IOException {
+    String stateStr =
+        "{\"ind\":{\"test_index\":{\"id\":\"09d9c9e4-483e-4a90-9c4f-d342c8da1210\",\"started\":true}}}";
+    try {
+      StateCommandUtils.validateConfigData(stateStr.getBytes(StandardCharsets.UTF_8), false);
+      fail();
+    } catch (InvalidProtocolBufferException ignore) {
+    }
+  }
+
+  @Test
+  public void testValidateConfigData_GlobalStateAsIndexState() throws IOException {
+    String stateStr =
+        "{\"indices\":{\"test_index\":{\"id\":\"09d9c9e4-483e-4a90-9c4f-d342c8da1210\",\"started\":true}}}";
+    try {
+      StateCommandUtils.validateConfigData(stateStr.getBytes(StandardCharsets.UTF_8), false);
+      fail();
+    } catch (InvalidProtocolBufferException ignore) {
+    }
+  }
+
+  @Test
+  public void testValidateConfigData_ValidIndexState() throws IOException {
+    String stateStr =
+        "{\"indexName\":\"test_index\",\"gen\":\"10\",\"committed\":true,\"fields\":{\"field1\":{\"name\":\"field1\",\"type\":\"INT\",\"storeDocValues\":true}}}";
+    StateCommandUtils.validateConfigData(stateStr.getBytes(StandardCharsets.UTF_8), false);
+  }
+
+  @Test
+  public void testValidateConfigData_InvalidIndexState() throws IOException {
+    String stateStr =
+        "{\"indexName\":\"test_index\",\"gen\":\"10\",\"committed\":true,\"fields\":{\"field1\":{\"name\":\"field1\",\"type\":\"INT\",\"docValues\":true}}}";
+    try {
+      StateCommandUtils.validateConfigData(stateStr.getBytes(StandardCharsets.UTF_8), false);
+      fail();
+    } catch (InvalidProtocolBufferException ignore) {
+    }
+  }
+
+  @Test
+  public void testValidateConfigData_IndexStateAsGlobalState() throws IOException {
+    String stateStr =
+        "{\"indexName\":\"test_index\",\"gen\":\"10\",\"committed\":true,\"fields\":{\"field1\":{\"name\":\"field1\",\"type\":\"INT\",\"storeDocValues\":true}}}";
+    try {
+      StateCommandUtils.validateConfigData(stateStr.getBytes(StandardCharsets.UTF_8), true);
+      fail();
+    } catch (InvalidProtocolBufferException ignore) {
+    }
+  }
+
+  @Test
+  public void testValidateConfigData_BadEncoding() throws IOException {
+    byte[] invalidUtf8 = new byte[1];
+    invalidUtf8[0] = (byte) 0xFE;
+    try {
+      StateCommandUtils.validateConfigData(invalidUtf8, true);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("java.nio.charset.MalformedInputException: Input length = 1", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testGetResourceName_GlobalState() throws IOException {
+    String resourceName =
+        StateCommandUtils.getResourceName(
+            mock(VersionManager.class),
+            SERVICE_NAME,
+            RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            false);
+    assertEquals(RemoteStateBackend.GLOBAL_STATE_RESOURCE, resourceName);
+  }
+
+  @Test
+  public void testGetResourceName_GlobalStateExact() throws IOException {
+    String resourceName =
+        StateCommandUtils.getResourceName(
+            mock(VersionManager.class),
+            SERVICE_NAME,
+            RemoteStateBackend.GLOBAL_STATE_RESOURCE,
+            true);
+    assertEquals(RemoteStateBackend.GLOBAL_STATE_RESOURCE, resourceName);
+  }
+
+  @Test
+  public void testGetResourceName_IndexStateExact() throws IOException {
+    String resourceName =
+        StateCommandUtils.getResourceName(
+            mock(VersionManager.class), SERVICE_NAME, "exact-resource-name", true);
+    assertEquals("exact-resource-name", resourceName);
+  }
+
+  @Test
+  public void testGetResourceName_NoGlobalState() throws IOException {
+    TestServer.initS3(folder);
+    VersionManager versionManager = getVersionManager();
+    try {
+      StateCommandUtils.getResourceName(versionManager, SERVICE_NAME, "test_index", false);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("Unable to load global state for cluster: \"test_server\"", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testGetResourceName_IndexNotExists() throws IOException {
+    getTestServer();
+    VersionManager versionManager = getVersionManager();
+    try {
+      StateCommandUtils.getResourceName(versionManager, SERVICE_NAME, "invalid_test_index", false);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals(
+          "Unable to find index: \"invalid_test_index\" in cluster: \"test_server\"",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testGetResourceName_IndexResource() throws IOException {
+    TestServer server = getTestServer();
+    VersionManager versionManager = getVersionManager();
+    String resourceName =
+        StateCommandUtils.getResourceName(versionManager, SERVICE_NAME, "test_index", false);
+    assertEquals(server.getGlobalState().getDataResourceForIndex("test_index"), resourceName);
+  }
+
+  @Test
+  public void testGetIndexStateResource() {
+    assertEquals("test_index-state", StateCommandUtils.getIndexStateResource("test_index"));
+  }
+
+  @Test
+  public void testGetStateKey() {
+    assertEquals("a/b/c", StateCommandUtils.getStateKey("a", "b", "c"));
+  }
+
+  @Test
+  public void testGetStateKeyPrefix() {
+    assertEquals("a/b/", StateCommandUtils.getStateKeyPrefix("a", "b"));
+  }
+}


### PR DESCRIPTION
Creates an `nrt_utils` command as a catch all place for utility methods. Adds commands to get and put state directly to the s3 remote backend. These are intended to mainly be used for debug/emergencies, where the servers are unable to start and use of the typical api endpoints is not possible.

`getRemoteState` - Fetch the global/index start from s3 backend. This can be printed to stdout, or optionally written to a file.

`putRemoteState` - Write the state json in a specified file into the remote s3 backend, replacing the current global/index state. Validates state data to ensure it is valid utf8 and can be built into the expected state message type. Optionally, the current state data can be written to a backup file before uploading the new version.

This branch also changes the storage format of state data to be utf8 encoded bytes. This was needed since the previous storage format prepended the content length, which would make manual editing extremely difficult. This change is not backwards compatible, but the provided utility commands should make updating old state straightforward.