### PR TITLE
Skip loading index state during ready endpoint

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -1362,7 +1362,8 @@ public class LuceneServer {
       try {
         List<String> indicesNotStarted = new ArrayList<>();
         for (String indexName : indexNames) {
-          IndexState indexState = globalState.getIndex(indexName);
+          // The ready endpoint should skip loading index state
+          IndexState indexState = globalState.getIndex(indexName, true);
           if (!indexState.isStarted()) {
             indicesNotStarted.add(indexName);
           }


### PR DESCRIPTION
### Problem

During the `/v1/ready/<index1,index2...>` endpoint, if an `IndexState` doesn't exist for an index, it will be created and eventually invoke [initSaveLoadState()](https://github.com/Yelp/nrtsearch/blob/0742a1047727572813e0cc7359945f0d703669fb/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/LegacyIndexState.java#L351). If the index's state directory was restored from a backup, NrtSearch will register fields and settings from it. This is unexpected behavior from the `ready` endpoint which is intended as a healthcheck. A consequence is that if a client sends a `startIndex` request afterwards, then then it will result in an `java.lang.IllegalArgumentException: field "<field>" was already registered`.

Passing `hasRestore: false` into the `getIndex` to skip registering fields and settings during the ready endpoint.


### Verification
Tested manually. 