### PR TITLE
Add cleanup command for incremental index backups

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,3 +31,5 @@ jobs:
       run: ./gradlew clean installDist :test -PincludePerfTests=* --tests "com.yelp.nrtsearch.server.YelpReviewsTest.runYelpReviews" --info
     - name: Merge behavior tests
       run: ./gradlew clean installDist :test -PincludePerfTests=* --tests "com.yelp.nrtsearch.server.grpc.MergeBehaviorTests" --info
+    - name: Long running tests
+      run: ./gradlew clean installDist :test -PlongRunningTestsOnly=* --info

--- a/build.gradle
+++ b/build.gradle
@@ -164,12 +164,17 @@ task buildGrpcGateway(dependsOn: installDist, type: Exec) {
 //e.g. default is to exclude perfTests: ./gradlew test
 test {
     finalizedBy 'spotlessJavaCheck'
-    if (!project.hasProperty('includePerfTests')) {
-        exclude '**/YelpReviewsTest.class'
-        exclude '**/YelpSuggestTest.class'
-        exclude '**/MergeBehaviorTests.class'
-        filter {
-            excludeTestsMatching '*.NodeNameResolverAndLoadBalancingTests.testSimpleLoadBalancingAsync'
+    if (project.hasProperty('longRunningTestsOnly')) {
+        include '**/IncrementalDataCleanupCommandTest.class'
+    } else {
+        if (!project.hasProperty('includePerfTests')) {
+            exclude '**/YelpReviewsTest.class'
+            exclude '**/YelpSuggestTest.class'
+            exclude '**/MergeBehaviorTests.class'
+            exclude '**/IncrementalDataCleanupCommandTest.class'
+            filter {
+                excludeTestsMatching '*.NodeNameResolverAndLoadBalancingTests.testSimpleLoadBalancingAsync'
+            }
         }
     }
     systemProperties System.properties

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/NrtUtilsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/NrtUtilsCommand.java
@@ -15,6 +15,7 @@
  */
 package com.yelp.nrtsearch.tools.nrt_utils;
 
+import com.yelp.nrtsearch.tools.nrt_utils.incremental.IncrementalDataCleanupCommand;
 import com.yelp.nrtsearch.tools.nrt_utils.state.GetRemoteStateCommand;
 import com.yelp.nrtsearch.tools.nrt_utils.state.PutRemoteStateCommand;
 import picocli.CommandLine;
@@ -24,6 +25,7 @@ import picocli.CommandLine;
     synopsisSubcommandLabel = "COMMAND",
     subcommands = {
       GetRemoteStateCommand.class,
+      IncrementalDataCleanupCommand.class,
       PutRemoteStateCommand.class,
       CommandLine.HelpCommand.class
     })

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/IncrementalCommandUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/IncrementalCommandUtils.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.incremental;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.S3Object;
+import com.yelp.nrtsearch.server.luceneserver.warming.Warmer;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class IncrementalCommandUtils {
+  private static final String INDEX_DATA_SUFFIX = "_data_index_data";
+  public static final String SNAPSHOT_INDEX_STATE_FILE = "index_state";
+  public static final String SNAPSHOT_INDEX_FILES = "index_files";
+  public static final String SNAPSHOT_WARMING_QUERIES = "index_warming_queries";
+  public static final String SNAPSHOT_DIR = "snapshots";
+  public static final String METADATA_DIR = "metadata";
+
+  private IncrementalCommandUtils() {}
+
+  /**
+   * Get the index data identifier given the base resource name.
+   *
+   * @param indexResource base index resource (name-UUID)
+   * @return index data resource name
+   */
+  public static String getIndexDataResource(String indexResource) {
+    return indexResource + INDEX_DATA_SUFFIX;
+  }
+
+  /**
+   * Get the index warming queries identifier given the base resource name.
+   *
+   * @param indexResource base index resource (name-UUID)
+   * @return index warming queries resource
+   */
+  public static String getWarmingQueriesResource(String indexResource) {
+    return indexResource + Warmer.WARMING_QUERIES_RESOURCE;
+  }
+
+  /**
+   * Get the s3 key prefix for index version files.
+   *
+   * @param serviceName nrtsearch cluster service name
+   * @param indexDataResource index data resource name
+   * @return key prefix
+   */
+  public static String getVersionKeyPrefix(String serviceName, String indexDataResource) {
+    return String.format("%s/_version/%s/", serviceName, indexDataResource);
+  }
+
+  /**
+   * Get the s3 key prefix for index data.
+   *
+   * @param serviceName nrtsearch cluster service name
+   * @param indexDataResource index data resource name
+   * @return key prefix
+   */
+  public static String getDataKeyPrefix(String serviceName, String indexDataResource) {
+    return String.format("%s/%s/", serviceName, indexDataResource);
+  }
+
+  /**
+   * Get the s3 key prefix for saved warming queries.
+   *
+   * @param serviceName nrtsearch cluster service name
+   * @param warmingQueriesResource index warming queries resource name
+   * @return key prefix
+   */
+  public static String getWarmingQueriesKeyPrefix(
+      String serviceName, String warmingQueriesResource) {
+    return String.format("%s/%s/", serviceName, warmingQueriesResource);
+  }
+
+  /**
+   * Get the root S3 key for snapshots. If a snapshotRoot is provided, it will be used. Otherwise,
+   * this defaults to serviceName/snapshots/
+   *
+   * @param snapshotRoot snapshot root key, or null
+   * @param serviceName nrtsearch cluster service name
+   * @return snapshot root key, with trailing slash
+   */
+  public static String getSnapshotRoot(String snapshotRoot, String serviceName) {
+    if (snapshotRoot == null && serviceName == null) {
+      throw new IllegalArgumentException("Must specify snapshotRoot or serviceName");
+    }
+    String root = snapshotRoot == null ? serviceName + "/" + SNAPSHOT_DIR + "/" : snapshotRoot;
+    if (!root.endsWith("/")) {
+      root += "/";
+    }
+    return root;
+  }
+
+  /**
+   * Get the root key for index data for a specific snapshot timestamp.
+   *
+   * @param snapshotRoot root key for all snapshots
+   * @param indexResource index resource (name-UUID)
+   * @param timestampMs snapshot timestamp
+   * @return root key for snapshot data
+   */
+  public static String getSnapshotIndexDataRoot(
+      String snapshotRoot, String indexResource, long timestampMs) {
+    return snapshotRoot + indexResource + "/" + timestampMs + "/";
+  }
+
+  /**
+   * Get the S3 key for metadata object for a specific snapshot timestamp.
+   *
+   * @param snapshotRoot root key for all snapshots
+   * @param indexResource index resource (name-UUID)
+   * @param timestampMs snapshot timestamp
+   * @return key for snapshot metadata
+   */
+  public static String getSnapshotIndexMetadataKey(
+      String snapshotRoot, String indexResource, long timestampMs) {
+    return snapshotRoot + METADATA_DIR + "/" + indexResource + "/" + timestampMs;
+  }
+
+  /**
+   * Check if a file is a lucene index file.
+   *
+   * @param fileName name to check
+   */
+  public static boolean isDataFile(String fileName) {
+    return fileName.startsWith("_") || fileName.startsWith("segments");
+  }
+
+  /**
+   * Check if a file name is a valid manifest file (UUID).
+   *
+   * @param fileName name to check
+   */
+  public static boolean isManifestFile(String fileName) {
+    return isUUID(fileName);
+  }
+
+  /**
+   * Check if a string is a UUID.
+   *
+   * @param s string to check
+   * @return if string is a UUID
+   */
+  public static boolean isUUID(String s) {
+    try {
+      UUID.fromString(s);
+      return true;
+    } catch (IllegalArgumentException ignore) {
+      return false;
+    }
+  }
+
+  /**
+   * Get all index files that are part of the given index data version id (UUID).
+   *
+   * @param s3Client s3 client
+   * @param bucketName s3 bucket
+   * @param serviceName nrtsearch cluster service name
+   * @param indexDataResource index data resource name
+   * @param versionId data version UUID string
+   * @return set of all index files for index version
+   * @throws IOException
+   */
+  public static Set<String> getVersionFiles(
+      AmazonS3 s3Client,
+      String bucketName,
+      String serviceName,
+      String indexDataResource,
+      String versionId)
+      throws IOException {
+    String versionPath = String.format("%s/%s/%s", serviceName, indexDataResource, versionId);
+    S3Object s3Object = s3Client.getObject(bucketName, versionPath);
+
+    String indexFileName;
+    Set<String> indexFileNames = new HashSet<>();
+    try (BufferedReader br =
+        new BufferedReader(new InputStreamReader(s3Object.getObjectContent()))) {
+      while ((indexFileName = br.readLine()) != null) {
+        indexFileNames.add(indexFileName);
+      }
+    }
+    return indexFileNames;
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/IncrementalDataCleanupCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/IncrementalDataCleanupCommand.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.incremental;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Sets;
+import com.yelp.nrtsearch.server.backup.VersionManager;
+import com.yelp.nrtsearch.tools.nrt_utils.state.StateCommandUtils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = IncrementalDataCleanupCommand.INC_DATA_CLEANUP,
+    description = "Delete incremental backup index files in S3 based on given criteria")
+public class IncrementalDataCleanupCommand implements Callable<Integer> {
+  private static final int DELETE_BATCH_SIZE = 1000;
+  public static final String LATEST_VERSION_FILE = "_latest_version";
+  public static final String INC_DATA_CLEANUP = "incrementalDataCleanup";
+
+  @CommandLine.Option(
+      names = {"-s", "--serviceName"},
+      description = "Name of nrtsearch cluster",
+      required = true)
+  private String serviceName;
+
+  @CommandLine.Option(
+      names = {"-i", "--indexName"},
+      description = "Name of cluster index",
+      required = true)
+  private String indexName;
+
+  @CommandLine.Option(
+      names = {"--exactResourceName"},
+      description = "If index resource name already has unique identifier")
+  private boolean exactResourceName;
+
+  @CommandLine.Option(
+      names = {"-b", "--bucketName"},
+      description = "Name of bucket containing state files",
+      required = true)
+  private String bucketName;
+
+  @CommandLine.Option(
+      names = {"--region"},
+      description = "AWS region name, such as us-west-1, us-west-2, us-east-1")
+  private String region;
+
+  @CommandLine.Option(
+      names = {"-c", "--credsFile"},
+      description = "File holding AWS credentials, uses default locations if not set")
+  private String credsFile;
+
+  @CommandLine.Option(
+      names = {"-p", "--credsProfile"},
+      description = "Profile to use from creds file",
+      defaultValue = "default")
+  private String credsProfile;
+
+  @CommandLine.Option(
+      names = {"-d", "--deleteAfter"},
+      description =
+          "Delete unneeded files older than this, in the form <#><unit> "
+              + "with valid units (s)econds, (m)inutes, (h)ours, (d)ays. (60m, 7h, 3d, etc.)",
+      required = true)
+  private String deleteAfter;
+
+  @CommandLine.Option(
+      names = {"--minVersions"},
+      description =
+          "Minimum number of index versions to keep, regardless of age. default: ${DEFAULT-VALUE}",
+      defaultValue = "5")
+  private int minVersions;
+
+  @CommandLine.Option(
+      names = {"--gracePeriod"},
+      description =
+          "Keep files within this grace period from the oldest index version creation, in the form <#><unit> "
+              + "with valid units (s)econds, (m)inutes, (h)ours, (d)ays. (60m, 7h, 3d, etc.) default: ${DEFAULT-VALUE}",
+      defaultValue = "6h")
+  private String gracePeriod;
+
+  @CommandLine.Option(
+      names = {"--dryRun"},
+      description = "Print file deletions, instead of applying to S3")
+  private boolean dryRun;
+
+  private AmazonS3 s3Client;
+
+  @VisibleForTesting
+  void setS3Client(AmazonS3 s3Client) {
+    this.s3Client = s3Client;
+  }
+
+  @Override
+  public Integer call() throws Exception {
+    if (minVersions <= 0) {
+      throw new IllegalArgumentException("minVersions must be > 0");
+    }
+
+    long deleteAfterMs = getTimeIntervalMs(deleteAfter);
+    long gracePeriodMs = getTimeIntervalMs(gracePeriod);
+
+    if (s3Client == null) {
+      s3Client = StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile);
+    }
+    VersionManager versionManager = new VersionManager(s3Client, bucketName);
+
+    String resolvedIndexResource =
+        StateCommandUtils.getResourceName(
+            versionManager, serviceName, indexName, exactResourceName);
+    String indexDataResource = IncrementalCommandUtils.getIndexDataResource(resolvedIndexResource);
+    long currentVersion = versionManager.getLatestVersionNumber(serviceName, indexDataResource);
+    System.out.println("Current index version: " + currentVersion);
+    if (currentVersion < 0) {
+      System.out.println("No data found for index: " + indexDataResource);
+      return 1;
+    }
+
+    long minVersion = getMinRetainedVersion(currentVersion, minVersions);
+    long currentTimeMs = System.currentTimeMillis();
+    long minVersionTimestampMs = currentTimeMs - deleteAfterMs;
+    System.out.println(
+        "Cleaning up version files, minVersion: "
+            + minVersion
+            + ", minTimestampMs: "
+            + minVersionTimestampMs);
+
+    // remove all version number files that are older than deleteAfter and are not needed to
+    // maintain the minimum number of versions
+    String versionKeyPrefix =
+        IncrementalCommandUtils.getVersionKeyPrefix(serviceName, indexDataResource);
+    VersionFileDeletionDecider versionFileDeletionDecider =
+        new VersionFileDeletionDecider(minVersion, minVersionTimestampMs);
+    cleanupS3Files(s3Client, bucketName, versionKeyPrefix, versionFileDeletionDecider, dryRun);
+
+    // the actual version file for minVersion may not exist, as it may have been removed
+    // by a previous cleanup. Use the smallest version that was retained during the
+    // cleanup pass
+    long lowestRetainedVersion = versionFileDeletionDecider.getLowestRetainedVersion();
+    System.out.println("Lowest version retained: " + lowestRetainedVersion);
+    if (lowestRetainedVersion == Long.MAX_VALUE) {
+      System.out.println("Could not determine lowest retained version");
+      return 1;
+    }
+
+    // find the min of current time, current version update time, and lowest version update
+    // time. This conservatively determines the lower bounds, in case there is an issue with
+    // one of the timestamps
+    long currentVersionTimestampMs =
+        getVersionTimestampMs(s3Client, bucketName, serviceName, indexDataResource, currentVersion);
+    long lowestVersionTimestampMs =
+        getVersionTimestampMs(
+            s3Client, bucketName, serviceName, indexDataResource, lowestRetainedVersion);
+    long dataMinTimestampMs =
+        Math.min(Math.min(currentVersionTimestampMs, currentTimeMs), lowestVersionTimestampMs)
+            - gracePeriodMs;
+
+    Set<String> currentFiles =
+        IncrementalCommandUtils.getVersionFiles(
+            s3Client,
+            bucketName,
+            serviceName,
+            indexDataResource,
+            versionManager.getVersionString(
+                serviceName, indexDataResource, String.valueOf(currentVersion)));
+    Set<String> lowestVersionFiles =
+        IncrementalCommandUtils.getVersionFiles(
+            s3Client,
+            bucketName,
+            serviceName,
+            indexDataResource,
+            versionManager.getVersionString(
+                serviceName, indexDataResource, String.valueOf(lowestRetainedVersion)));
+
+    String dataKeyPrefix = IncrementalCommandUtils.getDataKeyPrefix(serviceName, indexDataResource);
+    // uses union of current version and lowest version, this is done to conservatively
+    // protect the lowest version index files to ensure it can be restored
+    Set<String> activeIndexFiles = Sets.union(currentFiles, lowestVersionFiles);
+    System.out.println(
+        "Cleaning up index data files, minTimestampMs: "
+            + dataMinTimestampMs
+            + ", activeIndexFiles: "
+            + activeIndexFiles);
+
+    // clean up all data files that are not needed by the retained index versions and all
+    // manifest files that are past the grace period
+    cleanupS3Files(
+        s3Client,
+        bucketName,
+        dataKeyPrefix,
+        new DataFileDeletionDecider(dataMinTimestampMs, activeIndexFiles),
+        dryRun);
+
+    return 0;
+  }
+
+  static class VersionFileDeletionDecider implements FileDeletionDecider {
+    private final long minVersion;
+    private final long minTimestampMs;
+    private long lowestRetainedVersion = Long.MAX_VALUE;
+
+    /**
+     * Constructor.
+     *
+     * @param minVersion minimum index version to keep
+     * @param minTimestampMs minimum modification timestamp to keep
+     */
+    VersionFileDeletionDecider(long minVersion, long minTimestampMs) {
+      this.minVersion = minVersion;
+      this.minTimestampMs = minTimestampMs;
+    }
+
+    /** Get smallest index data version not deleted. */
+    public long getLowestRetainedVersion() {
+      return lowestRetainedVersion;
+    }
+
+    @Override
+    public boolean shouldDelete(String fileBaseName, long timestampMs) {
+      if (LATEST_VERSION_FILE.equals(fileBaseName)) {
+        return false;
+      }
+      long indexVersion = Long.parseLong(fileBaseName);
+      if (indexVersion < minVersion && timestampMs < minTimestampMs) {
+        return true;
+      } else {
+        if (indexVersion < lowestRetainedVersion) {
+          lowestRetainedVersion = indexVersion;
+        }
+        return false;
+      }
+    }
+  }
+
+  static class DataFileDeletionDecider implements FileDeletionDecider {
+    private final long minTimestampMs;
+    private final Set<String> activeIndexFiles;
+
+    /**
+     * Constructor.
+     *
+     * @param minTimestampMs minimum timestamp of files to keep
+     * @param activeIndexFiles index files currently in use
+     */
+    DataFileDeletionDecider(long minTimestampMs, Set<String> activeIndexFiles) {
+      this.minTimestampMs = minTimestampMs;
+      this.activeIndexFiles = activeIndexFiles;
+    }
+
+    @Override
+    public boolean shouldDelete(String fileBaseName, long timestampMs) {
+      if (timestampMs < minTimestampMs) {
+        if (IncrementalCommandUtils.isDataFile(fileBaseName)) {
+          return !activeIndexFiles.contains(fileBaseName);
+        } else if (IncrementalCommandUtils.isManifestFile(fileBaseName)) {
+          return true;
+        } else {
+          throw new IllegalArgumentException("Cannot classify file: " + fileBaseName);
+        }
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Interface for deciding if an object should be deleted from s3 given its base name and
+   * modification time.
+   */
+  @FunctionalInterface
+  interface FileDeletionDecider {
+
+    /**
+     * Determine if an object should be deleted
+     *
+     * @param fileBaseName file name after the key prefix
+     * @param timestampMs modification timestamp
+     * @return if object should be deleted
+     */
+    boolean shouldDelete(String fileBaseName, long timestampMs);
+  }
+
+  /**
+   * Clean up files in s3. Checks all keys matching the given prefix, and uses the given {@link
+   * FileDeletionDecider} to determine if they should be deleted.
+   *
+   * @param s3Client s3 client
+   * @param bucketName s3 bucket name
+   * @param keyPrefix key prefix to clean up
+   * @param deletionDecider deletion decider
+   * @param dryRun skip sending actual deletion requests to s3
+   */
+  static void cleanupS3Files(
+      AmazonS3 s3Client,
+      String bucketName,
+      String keyPrefix,
+      FileDeletionDecider deletionDecider,
+      boolean dryRun) {
+    ListObjectsV2Request req =
+        new ListObjectsV2Request().withBucketName(bucketName).withPrefix(keyPrefix);
+    ListObjectsV2Result result;
+
+    List<String> deleteList = new ArrayList<>(DELETE_BATCH_SIZE);
+
+    do {
+      result = s3Client.listObjectsV2(req);
+
+      for (S3ObjectSummary objectSummary : result.getObjectSummaries()) {
+        String objFileName = objectSummary.getKey().split(keyPrefix)[1];
+        long versionTimestampMs = objectSummary.getLastModified().getTime();
+        if (deletionDecider.shouldDelete(objFileName, versionTimestampMs)) {
+          System.out.println(
+              "Deleting object - key: "
+                  + objectSummary.getKey()
+                  + ", timestampMs: "
+                  + versionTimestampMs);
+          deleteList.add(objectSummary.getKey());
+          if (deleteList.size() == DELETE_BATCH_SIZE) {
+            if (!dryRun) {
+              deleteObjects(s3Client, bucketName, deleteList);
+            }
+            deleteList.clear();
+          }
+        }
+      }
+      String token = result.getNextContinuationToken();
+      req.setContinuationToken(token);
+    } while (result.isTruncated());
+
+    if (!deleteList.isEmpty() && !dryRun) {
+      deleteObjects(s3Client, bucketName, deleteList);
+    }
+  }
+
+  /**
+   * Delete a list of keys from s3, with a bulk delete request.
+   *
+   * @param s3Client s3 client
+   * @param bucketName s3 bucket
+   * @param keys keys to delete
+   */
+  static void deleteObjects(AmazonS3 s3Client, String bucketName, List<String> keys) {
+    System.out.println("Batch deleting objects, size: " + keys.size());
+    DeleteObjectsRequest multiObjectDeleteRequest =
+        new DeleteObjectsRequest(bucketName).withKeys(keys.toArray(new String[0])).withQuiet(true);
+    s3Client.deleteObjects(multiObjectDeleteRequest);
+  }
+
+  /**
+   * Get the modification timestamp for a given index data version object.
+   *
+   * @param s3Client s3 client
+   * @param bucketName s3 bucket
+   * @param serviceName nrtsearch cluster service name
+   * @param indexResource index data resource name
+   * @param version index data version
+   * @return last modified time of version file
+   */
+  static long getVersionTimestampMs(
+      AmazonS3 s3Client,
+      String bucketName,
+      String serviceName,
+      String indexResource,
+      long version) {
+    String versionPath = String.format("%s/_version/%s/%s", serviceName, indexResource, version);
+    ObjectMetadata metadata = s3Client.getObjectMetadata(bucketName, versionPath);
+    return metadata.getLastModified().getTime();
+  }
+
+  /**
+   * Get the minimum index data version to retain during cleanup.
+   *
+   * @param currentVersion current data version
+   * @param minVersions minimum versions to retain
+   * @return minimum retained version
+   */
+  static long getMinRetainedVersion(long currentVersion, int minVersions) {
+    return Math.min(Math.max(0L, currentVersion - minVersions + 1), currentVersion);
+  }
+
+  /**
+   * Parse an interval string into a numeric interval in ms. The string must be in a form 10s, 5h,
+   * etc. Numeric component must be positive. The units component must be one of (s)econds,
+   * (m)inutes, (h)ours, (d)ays.
+   *
+   * @param interval interval string
+   * @return interval in ms
+   */
+  static long getTimeIntervalMs(String interval) {
+    String trimmed = interval.trim();
+    if (trimmed.length() < 2) {
+      throw new IllegalArgumentException("Invalid time interval: " + trimmed);
+    }
+    char endChar = trimmed.charAt(trimmed.length() - 1);
+    long numberVal = Long.parseLong(trimmed.substring(0, trimmed.length() - 1));
+
+    if (numberVal < 0) {
+      throw new IllegalArgumentException("Time interval must be >= 0");
+    }
+
+    switch (endChar) {
+      case 's':
+        return TimeUnit.SECONDS.toMillis(numberVal);
+      case 'm':
+        return TimeUnit.MINUTES.toMillis(numberVal);
+      case 'h':
+        return TimeUnit.HOURS.toMillis(numberVal);
+      case 'd':
+        return TimeUnit.DAYS.toMillis(numberVal);
+      default:
+        throw new IllegalArgumentException("Unknown time unit: " + endChar);
+    }
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/IncrementalDataCleanupCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/IncrementalDataCleanupCommand.java
@@ -416,8 +416,8 @@ public class IncrementalDataCleanupCommand implements Callable<Integer> {
     char endChar = trimmed.charAt(trimmed.length() - 1);
     long numberVal = Long.parseLong(trimmed.substring(0, trimmed.length() - 1));
 
-    if (numberVal < 0) {
-      throw new IllegalArgumentException("Time interval must be >= 0");
+    if (numberVal < 1) {
+      throw new IllegalArgumentException("Time interval must be > 0");
     }
 
     switch (endChar) {

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/IncrementalCommandUtilsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/IncrementalCommandUtilsTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.incremental;
+
+import static com.yelp.nrtsearch.server.grpc.TestServer.S3_ENDPOINT;
+import static com.yelp.nrtsearch.server.grpc.TestServer.SERVICE_NAME;
+import static com.yelp.nrtsearch.server.grpc.TestServer.TEST_BUCKET;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.yelp.nrtsearch.server.backup.VersionManager;
+import com.yelp.nrtsearch.server.config.IndexStartConfig.IndexDataLocationType;
+import com.yelp.nrtsearch.server.grpc.Mode;
+import com.yelp.nrtsearch.server.grpc.TestServer;
+import java.io.IOException;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class IncrementalCommandUtilsTest {
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  @After
+  public void cleanup() {
+    TestServer.cleanupAll();
+  }
+
+  private AmazonS3 getS3() {
+    AmazonS3 s3 = new AmazonS3Client(new AnonymousAWSCredentials());
+    s3.setEndpoint(S3_ENDPOINT);
+    s3.createBucket(TEST_BUCKET);
+    return s3;
+  }
+
+  private TestServer getTestServer() throws IOException {
+    TestServer server =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.REMOTE)
+            .withRemoteStateBackend(false)
+            .build();
+    server.createSimpleIndex("test_index");
+    return server;
+  }
+
+  @Test
+  public void testGetIndexDataResource() {
+    assertEquals(
+        "test_index_data_index_data", IncrementalCommandUtils.getIndexDataResource("test_index"));
+  }
+
+  @Test
+  public void testGetWarmingQueriesResource() {
+    assertEquals(
+        "test_index_warming_queries",
+        IncrementalCommandUtils.getWarmingQueriesResource("test_index"));
+  }
+
+  @Test
+  public void testGetVersionKeyPrefix() {
+    assertEquals("a/_version/b/", IncrementalCommandUtils.getVersionKeyPrefix("a", "b"));
+  }
+
+  @Test
+  public void testGetDataKeyPrefix() {
+    assertEquals("a/b/", IncrementalCommandUtils.getDataKeyPrefix("a", "b"));
+  }
+
+  @Test
+  public void testGetWarmingQueriesKeyPrefix() {
+    assertEquals("a/b/", IncrementalCommandUtils.getWarmingQueriesKeyPrefix("a", "b"));
+  }
+
+  @Test
+  public void testGetSnapshotRoot_rootProvided() {
+    assertEquals("root/", IncrementalCommandUtils.getSnapshotRoot("root/", null));
+    assertEquals("root/", IncrementalCommandUtils.getSnapshotRoot("root/", "service"));
+    assertEquals("root/", IncrementalCommandUtils.getSnapshotRoot("root", "service"));
+  }
+
+  @Test
+  public void testGetSnapshotRoot_serviceProvided() {
+    assertEquals(
+        "service_name/snapshots/", IncrementalCommandUtils.getSnapshotRoot(null, "service_name"));
+  }
+
+  @Test
+  public void testGetSnapshotRoot_neitherProvided() {
+    try {
+      IncrementalCommandUtils.getSnapshotRoot(null, null);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("Must specify snapshotRoot or serviceName", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testGetSnapshotIndexDataRoot() {
+    assertEquals(
+        "root/test_index/1010/",
+        IncrementalCommandUtils.getSnapshotIndexDataRoot("root/", "test_index", 1010));
+  }
+
+  @Test
+  public void testGetSnapshotIndexMetadataKey() {
+    assertEquals(
+        "root/metadata/test_index/2002",
+        IncrementalCommandUtils.getSnapshotIndexMetadataKey("root/", "test_index", 2002));
+  }
+
+  @Test
+  public void testIsDataFile() {
+    assertTrue(IncrementalCommandUtils.isDataFile("_3.cfs"));
+    assertTrue(IncrementalCommandUtils.isDataFile("_3abcde.cfs"));
+    assertTrue(IncrementalCommandUtils.isDataFile("segments"));
+    assertTrue(IncrementalCommandUtils.isDataFile("segments_15"));
+
+    assertFalse(IncrementalCommandUtils.isDataFile("other_file"));
+    assertFalse(IncrementalCommandUtils.isDataFile("09d9c9e4-483e-4a90-9c4f-d342c8da1210"));
+  }
+
+  @Test
+  public void testIsManifestFile() {
+    assertTrue(IncrementalCommandUtils.isManifestFile("09d9c9e4-483e-4a90-9c4f-d342c8da1210"));
+    assertTrue(IncrementalCommandUtils.isManifestFile("09d9c9e4-483e-4a90-9c4F-D342c8da1210"));
+
+    assertFalse(IncrementalCommandUtils.isManifestFile("09d9c9e4-483e-4a90-D342c8da1210"));
+    assertFalse(IncrementalCommandUtils.isManifestFile("other_file"));
+    assertFalse(IncrementalCommandUtils.isManifestFile("_3.cfs"));
+    assertFalse(IncrementalCommandUtils.isManifestFile("segments"));
+  }
+
+  @Test
+  public void testIsUUID() {
+    assertTrue(IncrementalCommandUtils.isUUID("09d9c9e4-483e-4a90-9c4f-d342c8da1210"));
+    assertTrue(IncrementalCommandUtils.isUUID("09d9c9e4-483e-4a90-9c4F-D342c8da1210"));
+
+    assertFalse(IncrementalCommandUtils.isUUID("09d9c9e4-483e-4a90-D342c8da1210"));
+    assertFalse(IncrementalCommandUtils.isUUID("other_file"));
+    assertFalse(IncrementalCommandUtils.isUUID("_3.cfs"));
+    assertFalse(IncrementalCommandUtils.isUUID("segments"));
+  }
+
+  @Test
+  public void testGetVersionFiles() throws IOException {
+    TestServer server = getTestServer();
+    server.startPrimaryIndex("test_index", -1, null);
+    server.addSimpleDocs("test_index", 1, 2);
+    server.refresh("test_index");
+    server.commit("test_index");
+
+    String indexDataResource =
+        IncrementalCommandUtils.getIndexDataResource(
+            server.getGlobalState().getDataResourceForIndex("test_index"));
+    AmazonS3 s3Client = getS3();
+    VersionManager versionManager = new VersionManager(s3Client, TEST_BUCKET);
+    long indexVersion = versionManager.getLatestVersionNumber(SERVICE_NAME, indexDataResource);
+    String versionId =
+        versionManager.getVersionString(
+            SERVICE_NAME, indexDataResource, String.valueOf(indexVersion));
+    Set<String> indexFiles =
+        IncrementalCommandUtils.getVersionFiles(
+            s3Client, TEST_BUCKET, SERVICE_NAME, indexDataResource, versionId);
+    assertEquals(Set.of("_0.cfe", "_0.si", "_0.cfs", "segments_2"), indexFiles);
+  }
+
+  @Test
+  public void testGetVersionFiles_notExist() throws IOException {
+    TestServer.initS3(folder);
+    try {
+      IncrementalCommandUtils.getVersionFiles(
+          getS3(), TEST_BUCKET, SERVICE_NAME, "test_index", "not_exist");
+      fail();
+    } catch (AmazonS3Exception e) {
+      assertTrue(e.getMessage().startsWith("The resource you requested does not exist"));
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/IncrementalDataCleanupCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/IncrementalDataCleanupCommandTest.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.incremental;
+
+import static com.yelp.nrtsearch.server.grpc.TestServer.S3_ENDPOINT;
+import static com.yelp.nrtsearch.server.grpc.TestServer.SERVICE_NAME;
+import static com.yelp.nrtsearch.server.grpc.TestServer.TEST_BUCKET;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.yelp.nrtsearch.server.backup.VersionManager;
+import com.yelp.nrtsearch.server.config.IndexStartConfig.IndexDataLocationType;
+import com.yelp.nrtsearch.server.grpc.Mode;
+import com.yelp.nrtsearch.server.grpc.TestServer;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.commons.io.IOUtils;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import picocli.CommandLine;
+
+public class IncrementalDataCleanupCommandTest {
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  @After
+  public void cleanup() {
+    TestServer.cleanupAll();
+  }
+
+  private AmazonS3 getS3() {
+    AmazonS3 s3 = new AmazonS3Client(new AnonymousAWSCredentials());
+    s3.setEndpoint(S3_ENDPOINT);
+    s3.createBucket(TEST_BUCKET);
+    return s3;
+  }
+
+  private CommandLine getInjectedCommand() {
+    IncrementalDataCleanupCommand command = new IncrementalDataCleanupCommand();
+    command.setS3Client(getS3());
+    return new CommandLine(command);
+  }
+
+  private TestServer getTestServer() throws IOException {
+    TestServer server =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.REMOTE)
+            .withRemoteStateBackend(false)
+            .build();
+    server.createSimpleIndex("test_index");
+    server.startPrimaryIndex("test_index", -1, null);
+    for (int i = 0; i < 5; ++i) {
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException ignore) {
+      }
+      server.addSimpleDocs("test_index", i * 2, i * 2 + 1);
+      server.refresh("test_index");
+      server.commit("test_index");
+    }
+    return server;
+  }
+
+  private void setCurrentVersion(AmazonS3 s3Client, TestServer server, int currentVersion) {
+    String indexResource = server.getGlobalState().getDataResourceForIndex("test_index");
+    String versionPrefix =
+        IncrementalCommandUtils.getVersionKeyPrefix(
+            SERVICE_NAME, IncrementalCommandUtils.getIndexDataResource(indexResource));
+    String currentVersionKey = versionPrefix + IncrementalDataCleanupCommand.LATEST_VERSION_FILE;
+    s3Client.putObject(TEST_BUCKET, currentVersionKey, String.valueOf(currentVersion));
+  }
+
+  private String getAndDeleteVersion(AmazonS3 s3Client, TestServer server, int currentVersion)
+      throws IOException {
+    String indexResource = server.getGlobalState().getDataResourceForIndex("test_index");
+    String versionPrefix =
+        IncrementalCommandUtils.getVersionKeyPrefix(
+            SERVICE_NAME, IncrementalCommandUtils.getIndexDataResource(indexResource));
+    String currentId =
+        IOUtils.toString(
+            s3Client.getObject(TEST_BUCKET, versionPrefix + currentVersion).getObjectContent());
+    s3Client.deleteObject(TEST_BUCKET, versionPrefix + currentVersion);
+    return currentId;
+  }
+
+  private void putVersion(AmazonS3 s3Client, TestServer server, int version, String id) {
+    String indexResource = server.getGlobalState().getDataResourceForIndex("test_index");
+    String versionPrefix =
+        IncrementalCommandUtils.getVersionKeyPrefix(
+            SERVICE_NAME, IncrementalCommandUtils.getIndexDataResource(indexResource));
+    s3Client.putObject(TEST_BUCKET, versionPrefix + version, id);
+  }
+
+  @Test
+  public void testKeepsRecentVersions() throws IOException {
+    TestServer server = getTestServer();
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=test_index",
+            "--bucketName=" + TEST_BUCKET,
+            "--deleteAfter=1h",
+            "--gracePeriod=0s",
+            "--minVersions=1");
+    assertEquals(0, exitCode);
+
+    assertVersions(server.getGlobalState().getDataResourceForIndex("test_index"), 0, 1, 2, 3, 4, 5);
+  }
+
+  @Test
+  public void testDeletesUnneededVersions() throws IOException {
+    TestServer server = getTestServer();
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=test_index",
+            "--bucketName=" + TEST_BUCKET,
+            "--deleteAfter=0s",
+            "--gracePeriod=0s",
+            "--minVersions=1");
+    assertEquals(0, exitCode);
+
+    assertVersions(server.getGlobalState().getDataResourceForIndex("test_index"), 5);
+  }
+
+  @Test
+  public void testKeepsFutureVersions() throws IOException {
+    TestServer server = getTestServer();
+    CommandLine cmd = getInjectedCommand();
+    AmazonS3 s3Client = getS3();
+
+    // VersionManager will automatically advance back to the latest, so delete the next
+    // version and replace after cleanup
+    setCurrentVersion(s3Client, server, 3);
+    String versionId = getAndDeleteVersion(s3Client, server, 4);
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=test_index",
+            "--bucketName=" + TEST_BUCKET,
+            "--deleteAfter=0s",
+            "--gracePeriod=0s",
+            "--minVersions=1");
+    assertEquals(0, exitCode);
+
+    putVersion(s3Client, server, 4, versionId);
+
+    assertVersions(server.getGlobalState().getDataResourceForIndex("test_index"), 3, 4, 5);
+  }
+
+  @Test
+  public void testKeepsMinVersions() throws IOException {
+    TestServer server = getTestServer();
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=test_index",
+            "--bucketName=" + TEST_BUCKET,
+            "--deleteAfter=0s",
+            "--gracePeriod=0s",
+            "--minVersions=3");
+    assertEquals(0, exitCode);
+
+    assertVersions(server.getGlobalState().getDataResourceForIndex("test_index"), 3, 4, 5);
+  }
+
+  @Test
+  public void testGracePeriod() throws IOException {
+    TestServer server = getTestServer();
+    CommandLine cmd = getInjectedCommand();
+    AmazonS3 s3Client = getS3();
+    String indexDataResource =
+        IncrementalCommandUtils.getIndexDataResource(
+            server.getGlobalState().getDataResourceForIndex("test_index"));
+
+    Set<String> initialIndexFiles = getExistingDataFiles(s3Client, indexDataResource);
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=test_index",
+            "--bucketName=" + TEST_BUCKET,
+            "--deleteAfter=0s",
+            "--gracePeriod=1h",
+            "--minVersions=1");
+    assertEquals(0, exitCode);
+
+    Set<String> cleanedUpFiles = getExistingDataFiles(s3Client, indexDataResource);
+    assertEquals(initialIndexFiles, cleanedUpFiles);
+    assertEquals(Set.of(5), getExistingVersions(s3Client, indexDataResource));
+
+    exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=test_index",
+            "--bucketName=" + TEST_BUCKET,
+            "--deleteAfter=0s",
+            "--gracePeriod=0s",
+            "--minVersions=1");
+    assertEquals(0, exitCode);
+    assertVersions(server.getGlobalState().getDataResourceForIndex("test_index"), 5);
+  }
+
+  private void assertVersions(String indexResource, int... versions) throws IOException {
+    String indexDataResource = IncrementalCommandUtils.getIndexDataResource(indexResource);
+    AmazonS3 s3Client = getS3();
+    Set<Integer> expectedVersions = new HashSet<>();
+    for (int i : versions) {
+      expectedVersions.add(i);
+    }
+    Set<Integer> presentVersions = new HashSet<>();
+    boolean latestVersionFileSeen = false;
+    String versionPrefix =
+        IncrementalCommandUtils.getVersionKeyPrefix(SERVICE_NAME, indexDataResource);
+    ListObjectsV2Result result = s3Client.listObjectsV2(TEST_BUCKET, versionPrefix);
+    for (S3ObjectSummary summary : result.getObjectSummaries()) {
+      String baseName = summary.getKey().split(versionPrefix)[1];
+      if (IncrementalDataCleanupCommand.LATEST_VERSION_FILE.equals(baseName)) {
+        latestVersionFileSeen = true;
+      } else {
+        presentVersions.add(Integer.parseInt(baseName));
+      }
+    }
+    assertTrue(latestVersionFileSeen);
+    assertEquals(expectedVersions, presentVersions);
+
+    Set<String> requiredIndexFiles = new HashSet<>();
+    VersionManager versionManager = new VersionManager(s3Client, TEST_BUCKET);
+    for (int version : versions) {
+      String versionId =
+          versionManager.getVersionString(SERVICE_NAME, indexDataResource, String.valueOf(version));
+      Set<String> versionFiles =
+          IncrementalCommandUtils.getVersionFiles(
+              s3Client, TEST_BUCKET, SERVICE_NAME, indexDataResource, versionId);
+      requiredIndexFiles.addAll(versionFiles);
+    }
+
+    Set<String> presentIndexFiles = getExistingDataFiles(s3Client, indexDataResource);
+    assertEquals(requiredIndexFiles, presentIndexFiles);
+  }
+
+  private Set<Integer> getExistingVersions(AmazonS3 s3Client, String indexDataResource) {
+    Set<Integer> versions = new HashSet<>();
+    boolean latestVersionFileSeen = false;
+    String versionPrefix =
+        IncrementalCommandUtils.getVersionKeyPrefix(SERVICE_NAME, indexDataResource);
+    ListObjectsV2Result result = s3Client.listObjectsV2(TEST_BUCKET, versionPrefix);
+    for (S3ObjectSummary summary : result.getObjectSummaries()) {
+      String baseName = summary.getKey().split(versionPrefix)[1];
+      if (IncrementalDataCleanupCommand.LATEST_VERSION_FILE.equals(baseName)) {
+        latestVersionFileSeen = true;
+      } else {
+        versions.add(Integer.parseInt(baseName));
+      }
+    }
+    assertTrue(latestVersionFileSeen);
+    return versions;
+  }
+
+  private Set<String> getExistingDataFiles(AmazonS3 s3Client, String indexDataResource) {
+    Set<String> indexFiles = new HashSet<>();
+    String indexDataPrefix =
+        IncrementalCommandUtils.getDataKeyPrefix(SERVICE_NAME, indexDataResource);
+    ListObjectsV2Result result = s3Client.listObjectsV2(TEST_BUCKET, indexDataPrefix);
+    for (S3ObjectSummary summary : result.getObjectSummaries()) {
+      String baseName = summary.getKey().split(indexDataPrefix)[1];
+      if (!IncrementalCommandUtils.isManifestFile(baseName)) {
+        indexFiles.add(baseName);
+      }
+    }
+    return indexFiles;
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/IncrementalDataCleanupCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/IncrementalDataCleanupCommandTest.java
@@ -70,13 +70,13 @@ public class IncrementalDataCleanupCommandTest {
     server.createSimpleIndex("test_index");
     server.startPrimaryIndex("test_index", -1, null);
     for (int i = 0; i < 5; ++i) {
+      server.addSimpleDocs("test_index", i * 2, i * 2 + 1);
+      server.refresh("test_index");
+      server.commit("test_index");
       try {
         Thread.sleep(5000);
       } catch (InterruptedException ignore) {
       }
-      server.addSimpleDocs("test_index", i * 2, i * 2 + 1);
-      server.refresh("test_index");
-      server.commit("test_index");
     }
     return server;
   }
@@ -122,7 +122,7 @@ public class IncrementalDataCleanupCommandTest {
             "--indexName=test_index",
             "--bucketName=" + TEST_BUCKET,
             "--deleteAfter=1h",
-            "--gracePeriod=0s",
+            "--gracePeriod=1s",
             "--minVersions=1");
     assertEquals(0, exitCode);
 
@@ -139,8 +139,8 @@ public class IncrementalDataCleanupCommandTest {
             "--serviceName=" + SERVICE_NAME,
             "--indexName=test_index",
             "--bucketName=" + TEST_BUCKET,
-            "--deleteAfter=0s",
-            "--gracePeriod=0s",
+            "--deleteAfter=1s",
+            "--gracePeriod=1s",
             "--minVersions=1");
     assertEquals(0, exitCode);
 
@@ -163,8 +163,8 @@ public class IncrementalDataCleanupCommandTest {
             "--serviceName=" + SERVICE_NAME,
             "--indexName=test_index",
             "--bucketName=" + TEST_BUCKET,
-            "--deleteAfter=0s",
-            "--gracePeriod=0s",
+            "--deleteAfter=1s",
+            "--gracePeriod=1s",
             "--minVersions=1");
     assertEquals(0, exitCode);
 
@@ -183,8 +183,8 @@ public class IncrementalDataCleanupCommandTest {
             "--serviceName=" + SERVICE_NAME,
             "--indexName=test_index",
             "--bucketName=" + TEST_BUCKET,
-            "--deleteAfter=0s",
-            "--gracePeriod=2s",
+            "--deleteAfter=1s",
+            "--gracePeriod=1s",
             "--minVersions=3");
     assertEquals(0, exitCode);
 
@@ -206,7 +206,7 @@ public class IncrementalDataCleanupCommandTest {
             "--serviceName=" + SERVICE_NAME,
             "--indexName=test_index",
             "--bucketName=" + TEST_BUCKET,
-            "--deleteAfter=0s",
+            "--deleteAfter=1s",
             "--gracePeriod=1h",
             "--minVersions=1");
     assertEquals(0, exitCode);
@@ -220,8 +220,8 @@ public class IncrementalDataCleanupCommandTest {
             "--serviceName=" + SERVICE_NAME,
             "--indexName=test_index",
             "--bucketName=" + TEST_BUCKET,
-            "--deleteAfter=0s",
-            "--gracePeriod=0s",
+            "--deleteAfter=1s",
+            "--gracePeriod=1s",
             "--minVersions=1");
     assertEquals(0, exitCode);
     assertVersions(server.getGlobalState().getDataResourceForIndex("test_index"), 5);

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/IncrementalDataCleanupCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/IncrementalDataCleanupCommandTest.java
@@ -71,7 +71,7 @@ public class IncrementalDataCleanupCommandTest {
     server.startPrimaryIndex("test_index", -1, null);
     for (int i = 0; i < 5; ++i) {
       try {
-        Thread.sleep(1000);
+        Thread.sleep(5000);
       } catch (InterruptedException ignore) {
       }
       server.addSimpleDocs("test_index", i * 2, i * 2 + 1);
@@ -184,7 +184,7 @@ public class IncrementalDataCleanupCommandTest {
             "--indexName=test_index",
             "--bucketName=" + TEST_BUCKET,
             "--deleteAfter=0s",
-            "--gracePeriod=0s",
+            "--gracePeriod=2s",
             "--minVersions=3");
     assertEquals(0, exitCode);
 


### PR DESCRIPTION
Adds a utility command to clean up unneeded index files produced by using incremental backups. Otherwise, this data accumulates indefinitely.

## Index data structure
`latest_version file` - file containing a number corresponding to the latest index version, updated on each commit
`version files` - files named with a monotonically increasing version number, contains UUID referencing an index manifest file
`manifest file` - located in main index data directory, named by UUID, contains list of all lucene index files needed for an index version
`index files` - located in the main index data directory, individual lucene segment files

## Cleanup params
`deleteAfter` - remove all versions older than this value
`minVersions` - attempt to keep this many version prior to the current version. This is mainly an attempt for safety, having some previous version to roll back to.
`gracePeriod` - do not delete index files until they are at least this interval older than the oldest retained index version. Provides some safety from timestamp skew. Also, if we start publishing merge pre-copy, this will be needed to ensure we don't end up deleting pending merge files.
`dryRun` - do not execute the deletions against s3

## Process
- Delete all `version files` that are older than `deleteAfter` and are not needed to maintain `minVersions`
- Scan through index data files
- Delete manifest files if: they are older than the min version, minus `gracePeriod`
- Delete index files if: they are older than the min version, minus `gracePeriod` AND they are not needed by union(current version index files, min retained version index files). This should protect against corrupting the retained index versions.

S3 file deletions are batched in groups of 1000 to lower total api calls.

## Tests
Some of these tests are slow, to allow for staggered timestamps of the created index files. I have created a long running test grouping so that this test class is only run when the parameter is specified.