### PR TITLE
Cleanup index restore data

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/backup/Archiver.java
+++ b/src/main/java/com/yelp/nrtsearch/server/backup/Archiver.java
@@ -43,6 +43,14 @@ public interface Archiver {
   boolean deleteVersion(final String serviceName, final String resource, String versionHash)
       throws IOException;
 
+  /**
+   * Delete all locally cached file associated with the given resource.
+   *
+   * @param resource resource name
+   * @return if files were successfully deleted
+   */
+  boolean deleteLocalFiles(final String resource);
+
   List<String> getResources(final String serviceName);
 
   List<VersionedResource> getVersionedResource(final String serviceName, final String resource);

--- a/src/main/java/com/yelp/nrtsearch/server/backup/ArchiverImpl.java
+++ b/src/main/java/com/yelp/nrtsearch/server/backup/ArchiverImpl.java
@@ -425,6 +425,11 @@ public class ArchiverImpl implements Archiver {
     return versionManger.deleteVersion(serviceName, resource, versionHash);
   }
 
+  @Override
+  public boolean deleteLocalFiles(String resource) {
+    return IndexArchiver.deleteLocalResourceFiles(resource, archiverDirectory);
+  }
+
   private String getTmpName() {
     return UUID.randomUUID().toString() + TMP_SUFFIX;
   }

--- a/src/main/java/com/yelp/nrtsearch/server/backup/BackupDiffManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/backup/BackupDiffManager.java
@@ -337,6 +337,11 @@ public class BackupDiffManager implements Archiver {
   }
 
   @Override
+  public boolean deleteLocalFiles(String resource) {
+    return true;
+  }
+
+  @Override
   public List<String> getResources(String serviceName) {
     List<String> resources = new ArrayList<>();
     ListObjectsRequest listObjectsRequest =

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/StateBackendServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/StateBackendServerTest.java
@@ -1579,6 +1579,33 @@ public class StateBackendServerTest {
   }
 
   @Test
+  public void testReplicaReDownloadsIndexData() throws Exception {
+    initArchiver();
+    initPrimaryWithArchiver();
+    createIndexWithFields();
+    startIndex(primaryClient, Mode.PRIMARY);
+    addDocs(docs1.stream());
+    commitIndex(primaryClient);
+    refreshIndex(primaryClient);
+    verifyDocs(1, primaryClient);
+
+    restartReplicaWithArchiver();
+    startIndexWithRestore(replicaClient, Mode.REPLICA, true);
+    verifyDocs(1, replicaClient);
+    stopIndex(replicaClient);
+
+    // commit more docs on primary
+    addDocs(docs2.stream());
+    commitIndex(primaryClient);
+    refreshIndex(primaryClient);
+    verifyDocs(2, primaryClient);
+
+    // start index and pull latest restore
+    startIndexWithRestore(replicaClient, Mode.REPLICA, true);
+    verifyDocs(2, replicaClient);
+  }
+
+  @Test
   public void testReplicaRestoreSchemaChange() throws Exception {
     initArchiver();
     initPrimaryWithArchiver();

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/TestServer.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/TestServer.java
@@ -180,6 +180,10 @@ public class TestServer {
     return serverImpl.getGlobalState().getConfiguration().getServiceName();
   }
 
+  public GlobalState getGlobalState() {
+    return serverImpl.getGlobalState();
+  }
+
   public void cleanup() {
     cleanup(false);
   }


### PR DESCRIPTION
Changes some of the restore behaviour when not using legacy state management.

Cleans up the downloaded index data after attempting to start an index, by adding a method to the `Archiver` interface. This is safe since the `ImmutableIndexState` creates a hard link to the index files, instead of symlinking the directory.

Does not update the restore flag on the `ShardState`, allowing index data to be downloaded again if the index is restarted.