### PR TITLE
Handle loading index state created with different name

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/BackendStateManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/BackendStateManager.java
@@ -15,6 +15,7 @@
  */
 package com.yelp.nrtsearch.server.luceneserver.index;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.IndexLiveSettings;
 import com.yelp.nrtsearch.server.grpc.IndexSettings;
@@ -33,6 +34,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,10 +76,31 @@ public class BackendStateManager implements IndexStateManager {
     if (stateInfo == null) {
       throw new IllegalStateException("No committed state for index: " + indexName);
     }
+    // If this state was restored from an index snapshot, it may have the previous index
+    // name. Let's fix it here so that it updates on the next commit.
+    stateInfo = fixIndexName(stateInfo, indexName);
     UpdatedFieldInfo updatedFieldInfo =
         FieldUpdateHandler.updateFields(
             new FieldAndFacetState(), Collections.emptyMap(), stateInfo.getFieldsMap().values());
     currentState = createIndexState(stateInfo, updatedFieldInfo.fieldAndFacetState);
+  }
+
+  /**
+   * Update index name in {@link IndexStateInfo} to the given value, if it is different.
+   *
+   * @param indexStateInfo index state info
+   * @param indexName index name
+   * @return index state info with given index name set
+   */
+  @VisibleForTesting
+  static IndexStateInfo fixIndexName(IndexStateInfo indexStateInfo, String indexName) {
+    Objects.requireNonNull(indexStateInfo);
+    Objects.requireNonNull(indexName);
+    if (!indexName.equals(indexStateInfo.getIndexName())) {
+      return indexStateInfo.toBuilder().setIndexName(indexName).build();
+    } else {
+      return indexStateInfo;
+    }
   }
 
   @Override


### PR DESCRIPTION
Relaxes some of the assumptions about the index name used in index state.
- When `IndexStateInfo` is loaded from the `StateBackend`, the index name is updated to the current value
- When the index state file is loaded from remote state through the `Archiver`, it is no longer required that the file be present in a folder matching the index unique name

These changes will help when doing snapshot/restore. Specifically, if the snapshotted index state does not have the same name as the restored index, this will allow the state to be loadable as is. This allows the restore operation to simply be a copy, rather than needing processing to rewrite the index name.
