### PR TITLE
Update commons-compress to 1.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ sourceCompatibility = 1.14
 targetCompatibility = 1.14
 
 allprojects {
-    version = '0.12.0'
+    version = '0.12.1'
     group = 'com.yelp.nrtsearch'
 }
 
@@ -43,7 +43,7 @@ def snakeYamlVersion = '1.25'
 def jacksonYamlVersion = '2.13.3'
 def spatial4jVersion = '0.7'
 def s3mockVersion = '0.2.5'
-def commonsCompressVersion = '1.19'
+def commonsCompressVersion = '1.21'
 def awsJavaSdkVersion = '1.11.695'
 def guicedeeVersion = '1.1.1.3-jre14'
 def prometheusClientVersion = '0.8.0'

--- a/src/main/java/com/yelp/nrtsearch/server/backup/TarImpl.java
+++ b/src/main/java/com/yelp/nrtsearch/server/backup/TarImpl.java
@@ -131,6 +131,10 @@ public class TarImpl implements Tar {
     if (!Files.exists(sourceDir)) {
       throw new IOException("source path doesn't exist: " + sourceDir);
     }
+    // Since commons-compress version 1.21, user/group ids are added for archive entries.
+    // Without enabling big number support, adding files will fail if these ids exceed
+    // 2097151. https://issues.apache.org/jira/browse/COMPRESS-587
+    tarArchiveOutputStream.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
     addFilestoTarGz(
         sourceDir.toString(),
         "",


### PR DESCRIPTION
Update the commons-compress library to 1.21 for security fixes.

I also needed to enable support for big numbers, since this new version uses the user/group ids. These ids can potentially be large (such as for osx). Upstream ticket https://issues.apache.org/jira/browse/COMPRESS-587