### PR TITLE
change the logging level of failed request

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -1111,7 +1111,7 @@ public class LuceneServer {
         } catch (InvalidProtocolBufferException ignored) {
           // Ignore as invalid proto would have thrown an exception earlier
         }
-        logger.warn(
+        logger.debug(
             String.format(
                 "error while trying to execute search for index %s: request: %s",
                 searchRequest.getIndexName(), searchRequestJson),


### PR DESCRIPTION
To reduce the PIIs exposure risks on failed request (especially for lat/long info), reduce the logging level into debug.