### PR TITLE
Fix issue when reducing nested collectors with different value sets

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/additional/NestedCollectorManagers.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/additional/NestedCollectorManagers.java
@@ -110,7 +110,7 @@ public class NestedCollectorManagers {
       Collection<Collector> collectors =
           nestedCollectors.stream()
               .map(m -> m.nestedCollectorsByValue.get(value))
-              .filter(c -> c.containsKey(entry.getKey()))
+              .filter(c -> c != null && c.containsKey(entry.getKey()))
               .map(c -> c.get(entry.getKey()))
               .collect(Collectors.toList());
       @SuppressWarnings("unchecked")

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/additional/NestedCollectionTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/additional/NestedCollectionTest.java
@@ -56,7 +56,7 @@ public class NestedCollectionTest extends ServerTestCase {
   private static final int NUM_DOCS = 100;
   private static final int SEGMENT_CHUNK = 10;
   private static final List<String> ALL_FIELDS =
-      Arrays.asList("doc_id", "int_field", "int_field_2", "value");
+      Arrays.asList("doc_id", "int_field", "int_field_2", "int_field_3", "value");
 
   protected List<String> getIndices() {
     return Collections.singletonList(DEFAULT_TEST_INDEX);
@@ -99,6 +99,11 @@ public class NestedCollectionTest extends ServerTestCase {
                   "int_field_2",
                   AddDocumentRequest.MultiValuedField.newBuilder()
                       .addValue(String.valueOf(id % 2))
+                      .build())
+              .putFields(
+                  "int_field_3",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(id / 50))
                       .build())
               .putFields(
                   "value",
@@ -346,6 +351,118 @@ public class NestedCollectionTest extends ServerTestCase {
   }
 
   @Test
+  public void testMultiLevelNestedCollectorsReduceDifferentValueSets() {
+    SearchRequest request =
+        SearchRequest.newBuilder()
+            .setIndexName(DEFAULT_TEST_INDEX)
+            .setQuery(
+                Query.newBuilder()
+                    .setFunctionScoreQuery(
+                        FunctionScoreQuery.newBuilder()
+                            .setScript(
+                                Script.newBuilder()
+                                    .setLang(JsScriptEngine.LANG)
+                                    .setSource("value*3")
+                                    .build())
+                            .build())
+                    .build())
+            .putCollectors(
+                "test_collector",
+                Collector.newBuilder()
+                    .setTerms(
+                        TermsCollector.newBuilder().setField("int_field_2").setSize(2).build())
+                    .putNestedCollectors(
+                        "nested1",
+                        Collector.newBuilder()
+                            .setTerms(
+                                TermsCollector.newBuilder()
+                                    .setSize(2)
+                                    .setField("int_field_3")
+                                    .build())
+                            .putNestedCollectors(
+                                "nested2",
+                                Collector.newBuilder()
+                                    .setTopHitsCollector(
+                                        TopHitsCollector.newBuilder()
+                                            .setStartHit(0)
+                                            .setTopHits(5)
+                                            .addAllRetrieveFields(ALL_FIELDS)
+                                            .build())
+                                    .build())
+                            .build())
+                    .build())
+            .build();
+    SearchResponse response = getGrpcServer().getBlockingStub().search(request);
+
+    assertEquals(100, response.getTotalHits().getValue());
+    assertEquals(Relation.EQUAL_TO, response.getTotalHits().getRelation());
+    assertEquals(0, response.getHitsCount());
+
+    assertEquals(1, response.getCollectorResultsCount());
+    CollectorResult collectorResult = response.getCollectorResultsOrThrow("test_collector");
+    assertEquals(CollectorResultsCase.BUCKETRESULT, collectorResult.getCollectorResultsCase());
+    BucketResult bucketResult = collectorResult.getBucketResult();
+    assertEquals(2, bucketResult.getBucketsCount());
+    Map<String, Bucket> bucketMap =
+        bucketResult.getBucketsList().stream().collect(Collectors.toMap(Bucket::getKey, b -> b));
+    assertEquals(Set.of("0", "1"), bucketMap.keySet());
+
+    Bucket bucket = bucketMap.get("0");
+    assertEquals(50, bucket.getCount());
+    assertEquals(1, bucket.getNestedCollectorResultsCount());
+    BucketResult nestedBucketResult =
+        bucket.getNestedCollectorResultsOrThrow("nested1").getBucketResult();
+    assertEquals(2, nestedBucketResult.getBucketsCount());
+    Map<String, Bucket> nestedBucketMap =
+        nestedBucketResult.getBucketsList().stream()
+            .collect(Collectors.toMap(Bucket::getKey, b -> b));
+    assertEquals(Set.of("0", "1"), nestedBucketMap.keySet());
+
+    Bucket nestedBucket = nestedBucketMap.get("0");
+    HitsResult hitsResult =
+        nestedBucket.getNestedCollectorResultsOrThrow("nested2").getHitsResult();
+    assertEquals(25, hitsResult.getTotalHits().getValue());
+    assertEquals(Relation.EQUAL_TO, hitsResult.getTotalHits().getRelation());
+    assertEquals(5, hitsResult.getHitsCount());
+    assertHits(hitsResult, 48, 46, 44, 42, 40);
+    assertScores(hitsResult, 150, 144, 138, 132, 126);
+
+    nestedBucket = nestedBucketMap.get("1");
+    hitsResult = nestedBucket.getNestedCollectorResultsOrThrow("nested2").getHitsResult();
+    assertEquals(25, hitsResult.getTotalHits().getValue());
+    assertEquals(Relation.EQUAL_TO, hitsResult.getTotalHits().getRelation());
+    assertEquals(5, hitsResult.getHitsCount());
+    assertHits(hitsResult, 98, 96, 94, 92, 90);
+    assertScores(hitsResult, 300, 294, 288, 282, 276);
+
+    bucket = bucketMap.get("1");
+    assertEquals(50, bucket.getCount());
+    assertEquals(1, bucket.getNestedCollectorResultsCount());
+    nestedBucketResult = bucket.getNestedCollectorResultsOrThrow("nested1").getBucketResult();
+    assertEquals(2, nestedBucketResult.getBucketsCount());
+    nestedBucketMap =
+        nestedBucketResult.getBucketsList().stream()
+            .collect(Collectors.toMap(Bucket::getKey, b -> b));
+    assertEquals(Set.of("0", "1"), nestedBucketMap.keySet());
+
+    nestedBucket = nestedBucketMap.get("0");
+    hitsResult = nestedBucket.getNestedCollectorResultsOrThrow("nested2").getHitsResult();
+    assertEquals(25, hitsResult.getTotalHits().getValue());
+    assertEquals(Relation.EQUAL_TO, hitsResult.getTotalHits().getRelation());
+    assertEquals(5, hitsResult.getHitsCount());
+    assertHits(hitsResult, 49, 47, 45, 43, 41);
+    assertScores(hitsResult, 153, 147, 141, 135, 129);
+
+    nestedBucket = nestedBucketMap.get("1");
+    hitsResult = nestedBucket.getNestedCollectorResultsOrThrow("nested2").getHitsResult();
+    assertEquals(25, hitsResult.getTotalHits().getValue());
+    assertEquals(Relation.EQUAL_TO, hitsResult.getTotalHits().getRelation());
+    assertEquals(5, hitsResult.getHitsCount());
+    assertHits(hitsResult, 99, 97, 95, 93, 91);
+    assertScores(hitsResult, 303, 297, 291, 285, 279);
+  }
+
+  @Test
   public void testNestedMultipleCollectors() {
     SearchRequest request =
         SearchRequest.newBuilder()
@@ -445,6 +562,7 @@ public class NestedCollectionTest extends ServerTestCase {
           String.valueOf(ids[i]), hit.getFieldsOrThrow("doc_id").getFieldValue(0).getTextValue());
       assertEquals(ids[i] % 5, hit.getFieldsOrThrow("int_field").getFieldValue(0).getIntValue());
       assertEquals(ids[i] % 2, hit.getFieldsOrThrow("int_field_2").getFieldValue(0).getIntValue());
+      assertEquals(ids[i] / 50, hit.getFieldsOrThrow("int_field_3").getFieldValue(0).getIntValue());
       assertEquals(ids[i] + 2, hit.getFieldsOrThrow("value").getFieldValue(0).getIntValue());
     }
   }

--- a/src/test/resources/search/collection/nested.json
+++ b/src/test/resources/search/collection/nested.json
@@ -18,6 +18,11 @@
       "storeDocValues": true
     },
     {
+      "name": "int_field_3",
+      "type": "INT",
+      "storeDocValues": true
+    },
+    {
       "name": "value",
       "type": "INT",
       "storeDocValues": true


### PR DESCRIPTION
Fixes case during nested collector reduction when the nested value does not exist in all parallel collection slices. 