### PR TITLE
Use same jackson version in server and clientlib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,11 +36,11 @@ project.ext.slf4jVersion = '2.0.0-alpha1'
 project.ext.grpcVersion = '1.46.0'
 project.ext.lz4Version = '1.7.0'
 project.ext.mockitoVersion = '2.25.1'
+project.ext.jacksonYamlVersion = '2.13.3'
 def log4jVersion = '2.17.0'
 def disruptorVersion = '3.2.1'
 def gsonVersion = '2.9.0'
 def snakeYamlVersion = '1.25'
-def jacksonYamlVersion = '2.13.3'
 def spatial4jVersion = '0.7'
 def s3mockVersion = '0.2.5'
 def commonsCompressVersion = '1.19'
@@ -73,8 +73,8 @@ dependencies {
     implementation "javax.xml.bind:jaxb-api:2.3.1"
     implementation "com.guicedee.services:guice:${guicedeeVersion}"
     implementation "org.lz4:lz4-java:${project.ext.lz4Version}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonYamlVersion}"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonYamlVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${project.ext.jacksonYamlVersion}"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${project.ext.jacksonYamlVersion}"
 
     //lucene deps
     implementation "org.apache.lucene:lucene-core:${luceneVersion}"

--- a/clientlib/build.gradle
+++ b/clientlib/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation "io.grpc:grpc-okhttp:${rootProject.grpcVersion}"
     implementation "javax.annotation:javax.annotation-api:1.2"
     implementation "org.slf4j:slf4j-api:${rootProject.slf4jVersion}"
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
+    implementation "com.fasterxml.jackson.core:jackson-databind:${rootProject.jacksonYamlVersion}"
 
     // for lz4 message compression
     implementation "org.lz4:lz4-java:${rootProject.lz4Version}"


### PR DESCRIPTION
I noticed that we were using an older jackson version in the clientlib. Extracted to a project level variable and used in both server and clientlib.