### PR TITLE
Bump nrtsearch version to 0.14.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ sourceCompatibility = 1.14
 targetCompatibility = 1.14
 
 allprojects {
-    version = '0.13.0'
+    version = '0.14.0'
     group = 'com.yelp.nrtsearch'
 }
 


### PR DESCRIPTION
This is mainly to deploy the clientlib with highlighting-related fields.