### PR TITLE
Add utility command to update global index state in remote backend

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/NrtUtilsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/NrtUtilsCommand.java
@@ -22,6 +22,7 @@ import com.yelp.nrtsearch.tools.nrt_utils.incremental.RestoreIncrementalCommand;
 import com.yelp.nrtsearch.tools.nrt_utils.incremental.SnapshotIncrementalCommand;
 import com.yelp.nrtsearch.tools.nrt_utils.state.GetRemoteStateCommand;
 import com.yelp.nrtsearch.tools.nrt_utils.state.PutRemoteStateCommand;
+import com.yelp.nrtsearch.tools.nrt_utils.state.UpdateGlobalIndexStateCommand;
 import picocli.CommandLine;
 
 @CommandLine.Command(
@@ -35,6 +36,7 @@ import picocli.CommandLine;
       PutRemoteStateCommand.class,
       RestoreIncrementalCommand.class,
       SnapshotIncrementalCommand.class,
+      UpdateGlobalIndexStateCommand.class,
       CommandLine.HelpCommand.class
     })
 public class NrtUtilsCommand implements Runnable {

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/UpdateGlobalIndexStateCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/UpdateGlobalIndexStateCommand.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.state;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.util.JsonFormat;
+import com.yelp.nrtsearch.server.backup.VersionManager;
+import com.yelp.nrtsearch.server.grpc.GlobalStateInfo;
+import com.yelp.nrtsearch.server.grpc.IndexGlobalState;
+import com.yelp.nrtsearch.server.luceneserver.state.BackendGlobalState;
+import com.yelp.nrtsearch.server.luceneserver.state.StateUtils;
+import com.yelp.nrtsearch.server.luceneserver.state.backend.RemoteStateBackend;
+import com.yelp.nrtsearch.tools.nrt_utils.incremental.IncrementalCommandUtils;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = UpdateGlobalIndexStateCommand.UPDATE_GLOBAL_INDEX_STATE,
+    description = "Update index properties in global state")
+public class UpdateGlobalIndexStateCommand implements Callable<Integer> {
+  public static final String UPDATE_GLOBAL_INDEX_STATE = "updateGlobalIndexState";
+
+  @CommandLine.Option(
+      names = {"-s", "--serviceName"},
+      description = "Name of nrtsearch cluster",
+      required = true)
+  private String serviceName;
+
+  @CommandLine.Option(
+      names = {"-i", "--indexName"},
+      description = "Name of index to update",
+      required = true)
+  private String indexName;
+
+  @CommandLine.Option(
+      names = {"-b", "--bucketName"},
+      description = "Name of bucket containing state files",
+      required = true)
+  private String bucketName;
+
+  @CommandLine.Option(
+      names = {"--region"},
+      description = "AWS region name, such as us-west-1, us-west-2, us-east-1")
+  private String region;
+
+  @CommandLine.Option(
+      names = {"-c", "--credsFile"},
+      description = "File holding AWS credentials, uses default locations if not set")
+  private String credsFile;
+
+  @CommandLine.Option(
+      names = {"-p", "--credsProfile"},
+      description = "Profile to use from creds file",
+      defaultValue = "default")
+  private String credsProfile;
+
+  @CommandLine.Option(
+      names = {"--setUUID"},
+      description = "If specified, update index UUID to this value")
+  private String uuid;
+
+  @CommandLine.Option(
+      names = {"--setStarted"},
+      description =
+          "Optionally update index started flag for index, valid values: 'true' or 'false'")
+  private String started;
+
+  private AmazonS3 s3Client;
+
+  @VisibleForTesting
+  void setS3Client(AmazonS3 s3Client) {
+    this.s3Client = s3Client;
+  }
+
+  @VisibleForTesting
+  static boolean validateParams(String started, String uuid) {
+    if (started != null) {
+      if (!started.equalsIgnoreCase("true") && !started.equalsIgnoreCase("false")) {
+        System.out.println("setStarted must be one of 'true' or 'false'");
+        return false;
+      }
+    }
+    if (uuid != null) {
+      if (!IncrementalCommandUtils.isUUID(uuid)) {
+        System.out.println("Invalid UUID format: " + uuid);
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public Integer call() throws Exception {
+    if (!validateParams(started, uuid)) {
+      return 1;
+    }
+    if (s3Client == null) {
+      s3Client = StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile);
+    }
+    VersionManager versionManager = new VersionManager(s3Client, bucketName);
+
+    String resolvedResourceName =
+        StateCommandUtils.getResourceName(
+            versionManager, serviceName, RemoteStateBackend.GLOBAL_STATE_RESOURCE, false);
+    String stateFileContents =
+        StateCommandUtils.getStateFileContents(
+            versionManager, serviceName, resolvedResourceName, StateUtils.GLOBAL_STATE_FILE);
+    if (stateFileContents == null) {
+      System.out.println("Could not find cluster global state");
+      return 1;
+    }
+
+    GlobalStateInfo.Builder builder = GlobalStateInfo.newBuilder();
+    JsonFormat.parser().merge(stateFileContents, builder);
+    GlobalStateInfo globalStateInfo = builder.build();
+    System.out.println("Current global state: " + JsonFormat.printer().print(globalStateInfo));
+
+    if (!globalStateInfo.containsIndices(indexName)) {
+      System.out.println("Index does not exist in global state: " + indexName);
+      return 1;
+    }
+
+    IndexGlobalState indexGlobalState = globalStateInfo.getIndicesOrThrow(indexName);
+    boolean updated = false;
+
+    if (uuid != null) {
+      String updatedIndexResource = BackendGlobalState.getUniqueIndexName(indexName, uuid);
+      String updatedIndexDataResource =
+          IncrementalCommandUtils.getIndexDataResource(updatedIndexResource);
+      String updatedIndexStateResource =
+          StateCommandUtils.getIndexStateResource(updatedIndexResource);
+      long dataVersion =
+          versionManager.getLatestVersionNumber(serviceName, updatedIndexDataResource);
+      long stateVersion =
+          versionManager.getLatestVersionNumber(serviceName, updatedIndexStateResource);
+      if (dataVersion == -1 || stateVersion == -1) {
+        System.out.println("Missing blessed resources for new uuid: " + uuid);
+        System.out.println(
+            "Data resource: " + updatedIndexDataResource + ", version: " + dataVersion);
+        System.out.println(
+            "State resource: " + updatedIndexStateResource + ", version: " + stateVersion);
+        return 1;
+      }
+
+      indexGlobalState = indexGlobalState.toBuilder().setId(uuid).build();
+      updated = true;
+    }
+
+    if (started != null) {
+      indexGlobalState =
+          indexGlobalState.toBuilder().setStarted(Boolean.parseBoolean(started)).build();
+      updated = true;
+    }
+
+    if (updated) {
+      GlobalStateInfo.Builder newStateBuilder = globalStateInfo.toBuilder();
+      newStateBuilder.setGen(globalStateInfo.getGen() + 1);
+      newStateBuilder.putIndices(indexName, indexGlobalState);
+      GlobalStateInfo updatedGlobalStateInfo = newStateBuilder.build();
+      String stateStr = JsonFormat.printer().print(updatedGlobalStateInfo);
+      byte[] stateBytes = StateUtils.toUTF8(stateStr);
+      StateCommandUtils.writeStateDataToBackend(
+          versionManager,
+          serviceName,
+          resolvedResourceName,
+          StateUtils.GLOBAL_STATE_FILE,
+          stateBytes);
+
+      System.out.println("Updated global state: " + stateStr);
+    } else {
+      System.out.println("No update requested");
+    }
+
+    return 0;
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/UpdateGlobalIndexStateCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/UpdateGlobalIndexStateCommandTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.state;
+
+import static com.yelp.nrtsearch.server.grpc.TestServer.S3_ENDPOINT;
+import static com.yelp.nrtsearch.server.grpc.TestServer.SERVICE_NAME;
+import static com.yelp.nrtsearch.server.grpc.TestServer.TEST_BUCKET;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.yelp.nrtsearch.server.config.IndexStartConfig.IndexDataLocationType;
+import com.yelp.nrtsearch.server.grpc.Mode;
+import com.yelp.nrtsearch.server.grpc.TestServer;
+import java.io.IOException;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import picocli.CommandLine;
+
+public class UpdateGlobalIndexStateCommandTest {
+
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  @After
+  public void cleanup() {
+    TestServer.cleanupAll();
+  }
+
+  private AmazonS3 getS3() {
+    AmazonS3 s3 = new AmazonS3Client(new AnonymousAWSCredentials());
+    s3.setEndpoint(S3_ENDPOINT);
+    s3.createBucket(TEST_BUCKET);
+    return s3;
+  }
+
+  private CommandLine getInjectedCommand() {
+    UpdateGlobalIndexStateCommand command = new UpdateGlobalIndexStateCommand();
+    command.setS3Client(getS3());
+    return new CommandLine(command);
+  }
+
+  private TestServer getTestServer() throws IOException {
+    TestServer server =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.REMOTE)
+            .withRemoteStateBackend(false)
+            .build();
+    server.createSimpleIndex("test_index");
+    return server;
+  }
+
+  @Test
+  public void testUpdateIndexStarted() throws IOException {
+    TestServer server = getTestServer();
+    server.startPrimaryIndex("test_index", -1, null);
+    assertTrue(server.isStarted("test_index"));
+
+    CommandLine cmd = getInjectedCommand();
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--indexName=test_index",
+            "--setStarted=false");
+    assertEquals(0, exitCode);
+    server.restart();
+    assertFalse(server.isStarted("test_index"));
+
+    exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--indexName=test_index",
+            "--setStarted=true");
+    assertEquals(0, exitCode);
+    server.restart();
+    assertTrue(server.isStarted("test_index"));
+  }
+
+  @Test
+  public void testUpdateIndexUUID() throws IOException {
+    TestServer server = getTestServer();
+    server.startPrimaryIndex("test_index", -1, null);
+    server.addSimpleDocs("test_index", 1, 2, 3);
+    server.refresh("test_index");
+    server.commit("test_index");
+    server.verifySimpleDocs("test_index", 3);
+
+    String firstIndexId = server.getGlobalState().getIndexStateManager("test_index").getIndexId();
+    server.deleteIndex("test_index");
+
+    server.createSimpleIndex("test_index");
+    server.startPrimaryIndex("test_index", -1, null);
+    server.addSimpleDocs("test_index", 1, 2, 3, 4, 5);
+    server.refresh("test_index");
+    server.commit("test_index");
+    server.verifySimpleDocs("test_index", 5);
+    String secondIndexId = server.getGlobalState().getIndexStateManager("test_index").getIndexId();
+    assertNotEquals(firstIndexId, secondIndexId);
+
+    CommandLine cmd = getInjectedCommand();
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--indexName=test_index",
+            "--setUUID=" + firstIndexId);
+    assertEquals(0, exitCode);
+    server.restart();
+    assertTrue(server.isStarted("test_index"));
+
+    String thirdIndexId = server.getGlobalState().getIndexStateManager("test_index").getIndexId();
+    assertEquals(firstIndexId, thirdIndexId);
+    server.verifySimpleDocs("test_index", 3);
+  }
+
+  @Test
+  public void testNoopUpdate() throws IOException {
+    TestServer server = getTestServer();
+    server.startPrimaryIndex("test_index", -1, null);
+    server.createSimpleIndex("test_index_2");
+    String indexId = server.getGlobalState().getIndexStateManager("test_index").getIndexId();
+    String index2Id = server.getGlobalState().getIndexStateManager("test_index_2").getIndexId();
+
+    CommandLine cmd = getInjectedCommand();
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--indexName=test_index");
+    assertEquals(0, exitCode);
+
+    exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--indexName=test_index_2");
+    assertEquals(0, exitCode);
+
+    server.restart();
+    assertTrue(server.isStarted("test_index"));
+    assertFalse(server.isStarted("test_index_2"));
+    assertEquals(indexId, server.getGlobalState().getIndexStateManager("test_index").getIndexId());
+    assertEquals(
+        index2Id, server.getGlobalState().getIndexStateManager("test_index_2").getIndexId());
+  }
+
+  @Test
+  public void testNoGlobalState() throws IOException {
+    TestServer.initS3(folder);
+    CommandLine cmd = getInjectedCommand();
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--indexName=test_index");
+    assertEquals(1, exitCode);
+  }
+
+  @Test
+  public void testIndexNotInState() throws IOException {
+    TestServer server = getTestServer();
+    server.startPrimaryIndex("test_index", -1, null);
+
+    CommandLine cmd = getInjectedCommand();
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--indexName=not_index");
+    assertEquals(1, exitCode);
+  }
+
+  @Test
+  public void testIndexUUIDNotInBackend() throws IOException {
+    TestServer server = getTestServer();
+    server.startPrimaryIndex("test_index", -1, null);
+    String indexId = server.getGlobalState().getIndexStateManager("test_index").getIndexId();
+
+    CommandLine cmd = getInjectedCommand();
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--indexName=not_index",
+            "--setUUID=" + UUID.randomUUID());
+    assertEquals(1, exitCode);
+    server.restart();
+
+    assertTrue(server.isStarted("test_index"));
+    assertEquals(indexId, server.getGlobalState().getIndexStateManager("test_index").getIndexId());
+  }
+
+  @Test
+  public void testValidateStarted() {
+    assertTrue(UpdateGlobalIndexStateCommand.validateParams(null, null));
+    assertTrue(UpdateGlobalIndexStateCommand.validateParams("true", null));
+    assertTrue(UpdateGlobalIndexStateCommand.validateParams("True", null));
+    assertTrue(UpdateGlobalIndexStateCommand.validateParams("false", null));
+    assertTrue(UpdateGlobalIndexStateCommand.validateParams("false", null));
+    assertFalse(UpdateGlobalIndexStateCommand.validateParams("", null));
+    assertFalse(UpdateGlobalIndexStateCommand.validateParams("invalid", null));
+  }
+
+  @Test
+  public void testValidateIndexUUID() {
+    assertTrue(UpdateGlobalIndexStateCommand.validateParams(null, null));
+    assertTrue(
+        UpdateGlobalIndexStateCommand.validateParams(null, "d5401128-7aed-427c-8dc3-70a3e24c7c9a"));
+    assertTrue(
+        UpdateGlobalIndexStateCommand.validateParams(null, "d5401128-7AED-427c-8dc3-70a3e24c7c9a"));
+    assertFalse(UpdateGlobalIndexStateCommand.validateParams(null, ""));
+    assertFalse(UpdateGlobalIndexStateCommand.validateParams(null, "invalid"));
+    assertFalse(
+        UpdateGlobalIndexStateCommand.validateParams(null, "d5401128-7AED-427c-70a3e24c7c9a"));
+  }
+}


### PR DESCRIPTION
Adds the `updateGlobalIndexState ` utility command to `nrt_utils`. Allows for direct modification of the index properties in global state stored in s3. This is intended mainly to be used for debug/disaster recovery, as it can be used to make modifications when the primary is unavailable/unstartable.

Persistence of these changes is not guaranteed. If the primary updates the global state before being restarted, the changes will be overridden.

Allows for changing two properties:

1. Started flag: controls if index should be started when the server starts
2. Index UUID: Unique identifier used when storing state/data, generated on index creation. Changing this id changes the state/data that is loaded from the backend when the index starts. The command verifies that there is blessed state/data for the new UUID.