### PR TITLE
Fix incremental backups when archiver dir does not exist

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/backup/BackupDiffManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/backup/BackupDiffManager.java
@@ -228,7 +228,7 @@ public class BackupDiffManager implements Archiver {
 
   private Path getTempDiffFile(Path tmpPath) throws IOException {
     if (!Files.exists(tmpPath)) {
-      Files.createDirectory(tmpPath);
+      Files.createDirectories(tmpPath);
     }
     return Paths.get(tmpPath.toString(), randomUUID().toString());
   }

--- a/src/test/java/com/yelp/nrtsearch/server/backup/BackupDiffManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/backup/BackupDiffManagerTest.java
@@ -213,6 +213,26 @@ public class BackupDiffManagerTest {
   }
 
   @Test
+  public void uploadDiffArchiveDirNotExist() throws IOException {
+    backupTestHelper.shutdown();
+    folder.delete();
+    backupTestHelper = new BackupTestHelper(BUCKET_NAME, folder, false);
+
+    ImmutableSet<String> toBeAdded = ImmutableSet.of("1", "2");
+    BackupDiffManager.BackupDiffInfo backupDiffInfo =
+        new BackupDiffManager.BackupDiffInfo(ImmutableSet.of(), toBeAdded, ImmutableSet.of());
+    BackupDiffManager backupDiffManager =
+        new BackupDiffManager(
+            backupTestHelper.getContentDownloaderTar(),
+            backupTestHelper.getFileCompressAndUploaderWithTar(),
+            backupTestHelper.getVersionManager(),
+            backupTestHelper.getArchiverDirectory());
+    String diffName = backupDiffManager.uploadDiff("testservice", "testresource", backupDiffInfo);
+    backupTestHelper.testUpload(
+        "testservice", "testresource", diffName, Map.of(diffName, "1\n2\n"), backupDiffManager);
+  }
+
+  @Test
   public void uploadDiffNoTar() throws IOException {
     ImmutableSet<String> toBeAdded = ImmutableSet.of("1", "2");
     BackupDiffManager.BackupDiffInfo backupDiffInfo =

--- a/src/test/java/com/yelp/nrtsearch/server/backup/BackupTestHelper.java
+++ b/src/test/java/com/yelp/nrtsearch/server/backup/BackupTestHelper.java
@@ -61,9 +61,18 @@ public class BackupTestHelper {
   private final Path s3Directory;
 
   public BackupTestHelper(String bucketName, TemporaryFolder folder) throws IOException {
+    this(bucketName, folder, true);
+  }
+
+  public BackupTestHelper(String bucketName, TemporaryFolder folder, boolean createArchiverDir)
+      throws IOException {
     this.bucketName = bucketName;
     s3Directory = folder.newFolder("s3").toPath();
-    archiverDirectory = folder.newFolder("archiver").toPath();
+    if (createArchiverDir) {
+      archiverDirectory = folder.newFolder("archiver").toPath();
+    } else {
+      archiverDirectory = folder.getRoot().toPath().resolve("archiver");
+    }
 
     api = S3Mock.create(8011, s3Directory.toAbsolutePath().toString());
     api.start();


### PR DESCRIPTION
Have the incremental backup uploading create all directories in the path for its temp folder. Otherwise, this will fail if the archiver directory does not exist.

Though this condition is not common, it does happen the first time a cluster primary starts up, since there will be no global state to pull.