### PR TITLE
Check grpc deadline before shard commit

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -58,6 +58,7 @@ import com.yelp.nrtsearch.server.monitoring.ThreadPoolCollector.RejectionCounter
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.plugins.PluginsService;
 import com.yelp.nrtsearch.server.utils.ThreadPoolExecutorFactory;
+import io.grpc.Context;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptors;
@@ -989,47 +990,55 @@ public class LuceneServer {
         CommitRequest commitRequest, StreamObserver<CommitResponse> commitResponseStreamObserver) {
       try {
         globalState.submitIndexingTask(
-            () -> {
-              try {
-                IndexState indexState = globalState.getIndex(commitRequest.getIndexName());
-                long gen = indexState.commit(backupFromIncArchiver);
-                CommitResponse reply =
-                    CommitResponse.newBuilder()
-                        .setGen(gen)
-                        .setPrimaryId(globalState.getEphemeralId())
-                        .build();
-                logger.debug(
-                    String.format(
-                        "CommitHandler committed to index: %s for sequenceId: %s",
-                        commitRequest.getIndexName(), gen));
-                commitResponseStreamObserver.onNext(reply);
-                commitResponseStreamObserver.onCompleted();
-              } catch (IOException e) {
-                logger.warn(
-                    "error while trying to read index state dir for indexName: "
-                        + commitRequest.getIndexName(),
-                    e);
-                commitResponseStreamObserver.onError(
-                    Status.INTERNAL
-                        .withDescription(
+            Context.current()
+                .wrap(
+                    () -> {
+                      try {
+                        IndexState indexState = globalState.getIndex(commitRequest.getIndexName());
+                        long gen = indexState.commit(backupFromIncArchiver);
+                        CommitResponse reply =
+                            CommitResponse.newBuilder()
+                                .setGen(gen)
+                                .setPrimaryId(globalState.getEphemeralId())
+                                .build();
+                        logger.debug(
+                            String.format(
+                                "CommitHandler committed to index: %s for sequenceId: %s",
+                                commitRequest.getIndexName(), gen));
+                        commitResponseStreamObserver.onNext(reply);
+                        commitResponseStreamObserver.onCompleted();
+                      } catch (IOException e) {
+                        logger.warn(
                             "error while trying to read index state dir for indexName: "
-                                + commitRequest.getIndexName())
-                        .augmentDescription(e.getMessage())
-                        .withCause(e)
-                        .asRuntimeException());
-              } catch (Exception e) {
-                logger.warn(
-                    "error while trying to commit to  index " + commitRequest.getIndexName(), e);
-                commitResponseStreamObserver.onError(
-                    Status.UNKNOWN
-                        .withDescription(
-                            "error while trying to commit to index: "
-                                + commitRequest.getIndexName())
-                        .augmentDescription(e.getMessage())
-                        .asRuntimeException());
-              }
-              return null;
-            });
+                                + commitRequest.getIndexName(),
+                            e);
+                        commitResponseStreamObserver.onError(
+                            Status.INTERNAL
+                                .withDescription(
+                                    "error while trying to read index state dir for indexName: "
+                                        + commitRequest.getIndexName())
+                                .augmentDescription(e.getMessage())
+                                .withCause(e)
+                                .asRuntimeException());
+                      } catch (Exception e) {
+                        logger.warn(
+                            "error while trying to commit to  index "
+                                + commitRequest.getIndexName(),
+                            e);
+                        if (e instanceof StatusRuntimeException) {
+                          commitResponseStreamObserver.onError(e);
+                        } else {
+                          commitResponseStreamObserver.onError(
+                              Status.UNKNOWN
+                                  .withDescription(
+                                      "error while trying to commit to index: "
+                                          + commitRequest.getIndexName())
+                                  .augmentDescription(e.getMessage())
+                                  .asRuntimeException());
+                        }
+                      }
+                      return null;
+                    }));
       } catch (RejectedExecutionException e) {
         logger.error(
             "Threadpool is full, unable to submit commit to index {}",

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -15,6 +15,7 @@
  */
 package com.yelp.nrtsearch.server.luceneserver;
 
+import com.yelp.nrtsearch.server.grpc.DeadlineUtils;
 import com.yelp.nrtsearch.server.grpc.IndexLiveSettings;
 import com.yelp.nrtsearch.server.grpc.ReplicationServerClient;
 import com.yelp.nrtsearch.server.luceneserver.SearchHandler.SearchHandlerException;
@@ -360,6 +361,9 @@ public class ShardState implements Closeable {
 
   /** Commit all state. */
   public synchronized long commit() throws IOException {
+    // This request may already have timed out on the client while waiting for the lock.
+    // If so, there is no reason to continue this heavyweight operation.
+    DeadlineUtils.checkDeadline("ShardState: commit " + this.name, "COMMIT");
 
     long gen;
 


### PR DESCRIPTION
Add deadline cancellation for commit operation. Check the request deadline after acquiring the `ShardState` lock, but before performing the commit.

Since the commit request runs in the indexing thread pool, the `Callable` is wrapped to propagate the current grpc `Context` (which includes the deadline). In the future we may want to do this at the `Executor` level using https://grpc.github.io/grpc-java/javadoc/io/grpc/Context.html#currentContextExecutor-java.util.concurrent.Executor- but would need to make sure nothing assumes it is a `ThreadPoolExector`.

We have seen some commit request backups during indexing with incremental backups, hopefully this will help by skipping work from timed out requests.