### PR TITLE
Add support for suggest index searcher

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
@@ -222,6 +222,14 @@ service LuceneServer {
     };
 
     }
+    /* Perform an auto-suggest lookup.*/
+    rpc suggestSearch (SuggestSearchRequest) returns (SuggestSearchResponse) {
+        option (google.api.http) = {
+            post: "/v1/suggest_search"
+            body: "*"
+        };
+
+    }
     /* Updates existing suggestions, if the suggester supports near-real-time changes. */
     rpc updateSuggest (BuildSuggestRequest) returns (BuildSuggestResponse) {
         option (google.api.http) = {

--- a/clientlib/src/main/proto/yelp/nrtsearch/suggest.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/suggest.proto
@@ -79,10 +79,11 @@ enum SuggestSearchSuggestQuery {
 message SuggestSearchRequest {
   string indexName = 1; //Index name
   string suggestField = 2; //Which suggest field to query against
-  SuggestSearchSuggestQuery suggestQuery = 3; //What query should be used for search
-  string text = 4; //Text to suggest from
-  repeated string contexts = 5; //Which contexts to filter by
-  int32 count = 6; //How many suggestions to return, default = 5
+  string payloadField = 3; //Which field to return as payload
+  SuggestSearchSuggestQuery suggestQuery = 4; //What query should be used for search
+  string text = 5; //Text to suggest from
+  repeated string contexts = 6; //Which contexts to filter by
+  int32 count = 7; //How many suggestions to return, default = 5
 }
 
 message SuggestSearchResponse {

--- a/clientlib/src/main/proto/yelp/nrtsearch/suggest.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/suggest.proto
@@ -71,6 +71,30 @@ message OneHighlight {
   string text = 2;
 }
 
+enum SuggestSearchSuggestQuery {
+  PREFIX = 0; // PrefixCompletionQuery within ContextCompletionQuery
+  FUZZY = 1; // FuzzyCompletionQuery within ContextCompletionQuery
+}
+
+message SuggestSearchRequest {
+  string indexName = 1; //Index name
+  string suggestField = 2; //Which suggest field to query against
+  SuggestSearchSuggestQuery suggestQuery = 3; //What query should be used for search
+  string text = 4; //Text to suggest from
+  repeated string contexts = 5; //Which contexts to filter by
+  int32 count = 6; //How many suggestions to return, default = 5
+}
+
+message SuggestSearchResponse {
+  repeated OneSuggestSearchResponse results = 1; //SuggestSearch results as an array
+}
+
+message OneSuggestSearchResponse {
+  string key = 1; //matched completion value
+  int64 score = 2; //score of matched doc
+  string payload = 3; //payload for the suggestion - the document matched
+}
+
 message SuggestLocalSource {
   /* Local file (to the server) to read suggestions + weights from; format is weight U+001F suggestion U+001F payload,
   one per line, with suggestion UTF-8 encoded. If this option is used then searcher, suggestField,

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
@@ -151,6 +151,13 @@ public abstract class IndexState implements Closeable {
                   "field \"" + name + "\" did not specify analyzer or searchAnalyzer");
             }
             return maybeAnalyzer.get();
+          } else if (fd instanceof ContextSuggestFieldDef) {
+            Optional<Analyzer> maybeAnalyzer = ((ContextSuggestFieldDef) fd).getSearchAnalyzer();
+            if (maybeAnalyzer.isEmpty()) {
+              throw new IllegalArgumentException(
+                  "field \"" + name + "\" did not specify analyzer or searchAnalyzer");
+            }
+            return maybeAnalyzer.get();
           }
           throw new IllegalArgumentException("field \"" + name + "\" does not support analysis");
         }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/SuggestSearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/SuggestSearchHandler.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.yelp.nrtsearch.server.grpc.OneSuggestSearchResponse;
+import com.yelp.nrtsearch.server.grpc.SuggestSearchRequest;
+import com.yelp.nrtsearch.server.grpc.SuggestSearchResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.suggest.document.CompletionQuery;
+import org.apache.lucene.search.suggest.document.ContextQuery;
+import org.apache.lucene.search.suggest.document.FuzzyCompletionQuery;
+import org.apache.lucene.search.suggest.document.PrefixCompletionQuery;
+import org.apache.lucene.search.suggest.document.SuggestIndexSearcher;
+import org.apache.lucene.search.suggest.document.TopSuggestDocs;
+
+public class SuggestSearchHandler implements Handler<SuggestSearchRequest, SuggestSearchResponse> {
+  @Override
+  public SuggestSearchResponse handle(
+      IndexState indexState, SuggestSearchRequest suggestLookupRequest) throws HandlerException {
+    ShardState shardState = indexState.getShard(0);
+    indexState.verifyStarted();
+    IndexReader indexReader;
+    try {
+      indexReader = shardState.acquire().searcher.getIndexReader();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    SuggestIndexSearcher suggestIndexSearcher = new SuggestIndexSearcher(indexReader);
+
+    CompletionQuery query = this.generateQuery(indexState, suggestLookupRequest);
+    TopSuggestDocs suggest;
+    try {
+      suggest = suggestIndexSearcher.suggest(query, suggestLookupRequest.getCount(), true);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    Set<OneSuggestSearchResponse> results =
+        Arrays.stream(suggest.scoreLookupDocs())
+            .map(mapScoreDocToOneSuggestSearchResponse(indexState, indexReader))
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+    return SuggestSearchResponse.newBuilder().addAllResults(results).build();
+  }
+
+  /**
+   * Method to process {@link TopSuggestDocs.SuggestScoreDoc} to response TODO: add support for
+   * retrieveFields in {@link SuggestSearchRequest}
+   *
+   * @param indexReader index reader used to retrieve documents
+   * @return a map function that takes a {@link TopSuggestDocs.SuggestScoreDoc} and generates {@link
+   *     OneSuggestSearchResponse}
+   */
+  private Function<TopSuggestDocs.SuggestScoreDoc, OneSuggestSearchResponse>
+      mapScoreDocToOneSuggestSearchResponse(IndexState indexState, IndexReader indexReader) {
+    return scoreDoc -> {
+      try {
+        Document document = indexReader.document(scoreDoc.doc);
+        return OneSuggestSearchResponse.newBuilder()
+            .setKey(scoreDoc.key.toString())
+            .setScore(Math.round(scoreDoc.score))
+            .setPayload(getPayloadFromDocument(indexState, document))
+            .build();
+      } catch (IOException e) {
+        return null;
+      }
+    };
+  }
+
+  private String getPayloadFromDocument(IndexState indexState, Document doc) {
+    Map<String, String[]> map =
+        doc.getFields().stream()
+            .collect(
+                Collectors.toMap(
+                    field -> field.stringValue(), field -> doc.getValues(field.stringValue())));
+    Gson gson = new GsonBuilder().serializeNulls().create();
+    return gson.toJson(map);
+  }
+
+  private CompletionQuery generateQuery(
+      IndexState indexState, SuggestSearchRequest suggestLookupRequest) {
+    CompletionQuery completionQuery;
+    switch (suggestLookupRequest.getSuggestQuery()) {
+      case PREFIX:
+        completionQuery =
+            new PrefixCompletionQuery(
+                indexState.searchAnalyzer,
+                new Term(suggestLookupRequest.getSuggestField(), suggestLookupRequest.getText()));
+        break;
+      case FUZZY:
+        completionQuery =
+            new FuzzyCompletionQuery(
+                indexState.searchAnalyzer,
+                new Term(suggestLookupRequest.getSuggestField(), suggestLookupRequest.getText()));
+        break;
+      default:
+        throw new IllegalArgumentException(
+            String.format(
+                "suggestQuery %s is not supported", suggestLookupRequest.getSuggestQuery()));
+    }
+
+    // wrap in context query and add contexts
+    ContextQuery contextQuery = new ContextQuery(completionQuery);
+    suggestLookupRequest.getContextsList().forEach(s -> contextQuery.addContext(s));
+    return contextQuery;
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/analysis/AnalyzerCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/analysis/AnalyzerCreator.java
@@ -31,6 +31,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.custom.CustomAnalyzer;
 import org.apache.lucene.analysis.standard.ClassicAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.search.suggest.document.CompletionAnalyzer;
 import org.apache.lucene.util.Version;
 
 public class AnalyzerCreator {
@@ -38,6 +39,7 @@ public class AnalyzerCreator {
   private static final String LUCENE_ANALYZER_PATH = "org.apache.lucene.analysis.{0}Analyzer";
   private static final String STANDARD = "standard";
   private static final String CLASSIC = "classic";
+  private static final String COMPLETION = "completion";
 
   private static AnalyzerCreator instance;
 
@@ -46,6 +48,7 @@ public class AnalyzerCreator {
   public AnalyzerCreator(LuceneServerConfiguration configuration) {
     register(STANDARD, name -> new StandardAnalyzer());
     register(CLASSIC, name -> new ClassicAnalyzer());
+    register(COMPLETION, name -> new CompletionAnalyzer(new StandardAnalyzer()));
   }
 
   public Analyzer getAnalyzer(com.yelp.nrtsearch.server.grpc.Analyzer analyzer) {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/ContextSuggestFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/ContextSuggestFieldDef.java
@@ -107,4 +107,8 @@ public class ContextSuggestFieldDef extends IndexableFieldDef {
   public Optional<Analyzer> getSearchAnalyzer() {
     return Optional.ofNullable(this.searchAnalyzer);
   }
+
+  public String getPostingsFormat() {
+    return "Completion84";
+  }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/ContextSuggestFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/ContextSuggestFieldDef.java
@@ -29,6 +29,7 @@ import org.apache.lucene.search.suggest.document.ContextSuggestField;
 public class ContextSuggestFieldDef extends IndexableFieldDef {
   private static final Gson GSON = new GsonBuilder().serializeNulls().create();
   private final Analyzer indexAnalyzer;
+  private final Analyzer searchAnalyzer;
 
   /**
    * @param name name of field
@@ -37,6 +38,7 @@ public class ContextSuggestFieldDef extends IndexableFieldDef {
   protected ContextSuggestFieldDef(String name, Field requestField) {
     super(name, requestField);
     this.indexAnalyzer = this.parseIndexAnalyzer(requestField);
+    this.searchAnalyzer = this.parseSearchAnalyzer(requestField);
   }
 
   @Override
@@ -79,8 +81,20 @@ public class ContextSuggestFieldDef extends IndexableFieldDef {
   }
 
   protected Analyzer parseIndexAnalyzer(Field requestField) {
-    if (AnalyzerCreator.isAnalyzerDefined(requestField.getIndexAnalyzer())) {
+    if (AnalyzerCreator.isAnalyzerDefined(requestField.getAnalyzer())) {
+      return AnalyzerCreator.getInstance().getAnalyzer(requestField.getAnalyzer());
+    } else if (AnalyzerCreator.isAnalyzerDefined(requestField.getIndexAnalyzer())) {
       return AnalyzerCreator.getInstance().getAnalyzer(requestField.getIndexAnalyzer());
+    } else {
+      return AnalyzerCreator.getStandardAnalyzer();
+    }
+  }
+
+  protected Analyzer parseSearchAnalyzer(Field requestField) {
+    if (AnalyzerCreator.isAnalyzerDefined(requestField.getAnalyzer())) {
+      return AnalyzerCreator.getInstance().getAnalyzer(requestField.getAnalyzer());
+    } else if (AnalyzerCreator.isAnalyzerDefined(requestField.getSearchAnalyzer())) {
+      return AnalyzerCreator.getInstance().getAnalyzer(requestField.getSearchAnalyzer());
     } else {
       return AnalyzerCreator.getStandardAnalyzer();
     }
@@ -88,5 +102,9 @@ public class ContextSuggestFieldDef extends IndexableFieldDef {
 
   public Optional<Analyzer> getIndexAnalyzer() {
     return Optional.ofNullable(this.indexAnalyzer);
+  }
+
+  public Optional<Analyzer> getSearchAnalyzer() {
+    return Optional.ofNullable(this.searchAnalyzer);
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/analysis/AnalyzerCreatorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/analysis/AnalyzerCreatorTest.java
@@ -59,6 +59,7 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.analysis.th.ThaiAnalyzer;
 import org.apache.lucene.analysis.util.CharFilterFactory;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
+import org.apache.lucene.search.suggest.document.CompletionAnalyzer;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Version;
 import org.junit.Before;
@@ -98,6 +99,14 @@ public class AnalyzerCreatorTest {
     Analyzer analyzer = AnalyzerCreator.getInstance().getAnalyzer(getPredefinedAnalyzer("classic"));
 
     assertSame(ClassicAnalyzer.class, analyzer.getClass());
+  }
+
+  @Test
+  public void testPredefinedCompletionAnalyzer() {
+    Analyzer analyzer =
+        AnalyzerCreator.getInstance().getAnalyzer(getPredefinedAnalyzer("completion"));
+
+    assertSame(CompletionAnalyzer.class, analyzer.getClass());
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/ContextSuggestFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/ContextSuggestFieldDefTest.java
@@ -16,10 +16,13 @@
 package com.yelp.nrtsearch.server.luceneserver.field;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 import com.google.gson.Gson;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest.MultiValuedField;
+import com.yelp.nrtsearch.server.grpc.Analyzer;
+import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
 import com.yelp.nrtsearch.server.grpc.Query;
 import com.yelp.nrtsearch.server.grpc.SearchRequest;
@@ -30,6 +33,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.lucene.analysis.bg.BulgarianAnalyzer;
+import org.apache.lucene.analysis.en.EnglishAnalyzer;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.search.suggest.document.CompletionAnalyzer;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -84,6 +91,46 @@ public class ContextSuggestFieldDefTest extends ServerTestCase {
   public void initIndex(String name) throws Exception {
     List<AddDocumentRequest> documents = buildDocuments(name, CONTEXT_SUGGEST_VALUES);
     addDocuments(documents.stream());
+  }
+
+  @Test
+  public void validSearchAndIndexAnalyzerWhenFieldAnalyzerIsProvided() {
+    Analyzer standardAnalyzer = Analyzer.newBuilder().setPredefined("standard").build();
+    Analyzer analyzer = Analyzer.newBuilder().setPredefined("completion").build();
+    Field field =
+        Field.newBuilder()
+            .setSearchAnalyzer(standardAnalyzer) // should be ignored as analyzer takes precedence
+            .setIndexAnalyzer(standardAnalyzer) // should be ignored as analyzer takes precedence
+            .setAnalyzer(analyzer)
+            .build();
+    ContextSuggestFieldDef contextSuggestFieldDef = new ContextSuggestFieldDef("test_field", field);
+    assertEquals(
+        CompletionAnalyzer.class, contextSuggestFieldDef.getSearchAnalyzer().get().getClass());
+    assertEquals(
+        CompletionAnalyzer.class, contextSuggestFieldDef.getIndexAnalyzer().get().getClass());
+  }
+
+  @Test
+  public void validSearchAndIndexAnalyzerWhenSearchAndIndexAnalyzersAreProvided() {
+    Analyzer searchAnalyzer = Analyzer.newBuilder().setPredefined("bg.Bulgarian").build();
+    Analyzer indexAnalyzer = Analyzer.newBuilder().setPredefined("en.English").build();
+    Field field =
+        Field.newBuilder()
+            .setSearchAnalyzer(searchAnalyzer)
+            .setIndexAnalyzer(indexAnalyzer)
+            .build();
+    ContextSuggestFieldDef contextSuggestFieldDef = new ContextSuggestFieldDef("test_field", field);
+    assertSame(
+        BulgarianAnalyzer.class, contextSuggestFieldDef.getSearchAnalyzer().get().getClass());
+    assertSame(EnglishAnalyzer.class, contextSuggestFieldDef.getIndexAnalyzer().get().getClass());
+  }
+
+  @Test
+  public void validDefaultSearchAndIndexAnalyzerNoAnalyzersAreProvided() {
+    Field field = Field.newBuilder().build();
+    ContextSuggestFieldDef contextSuggestFieldDef = new ContextSuggestFieldDef("test_field", field);
+    assertSame(StandardAnalyzer.class, contextSuggestFieldDef.getSearchAnalyzer().get().getClass());
+    assertSame(StandardAnalyzer.class, contextSuggestFieldDef.getIndexAnalyzer().get().getClass());
   }
 
   @Test


### PR DESCRIPTION
# Add support for `SuggestIndexSearcher` queries

## Overview

This PR adds support for making `PrefixCompletionQuery` and `FuzzyCompletionQuery` using `SuggestIndexSearcher` over an index. This functionality is provided with a new endpoint - `suggestSearch`.

To use this functionality, a field of type `CONTEXT_SUGGEST` must exist in the index. The name of the field, along with a `suggestQuery = PREFIX | FUZZY` and the search `test` is used in the new `suggestSearch` endpoint

## Implementation Details

### `CompletionSuggestFieldDef` changes

Some changes had to be made to the completion suggest field definition to enable `SuggestIndexSearcher` usage:

1. `getPostingsFormat` is specified to return `Completion84`, allowing `SuggestField`s to be stored in the indexed document. The `SuggestField`s are used when making `CompletionQuery`
2. Added support for `indexAnalyzer` and `searchAnalyzer`, similarly to `TextFieldDef` - required when executing `CompletionQuery` over the field.

### Added `completion` prefedined analyzer

When specifying `analyzer`, users can use the `predefined: "completion"` analyzer to set `CompletionAnalyzer` for `index` or `search` or both.

### The new `suggestSearch` endpoint

**Why `suggestSearch` and not `suggestLookupV2`?**
Since the new `suggestSearch` endpoint uses the index directly, and not a pre-built suggester (which `suggestLookup` does), it is conceptually different from `suggestLookup`. Hence a new endpoint was created. Comments and suggestions about the naming are welcome!

#### Request

The request has the following structure:

```json5
{
    "indexName": "business_index2", // name of the index
    "suggestField": "context_suggest", // suggest field, which must exist in the index and must be of type "CONTEXT_SUGGEST"
    "suggestQuery": "PREFIX", // PREFIX or FUZZY
    "text": "ban", // text to search
    "contexts": ["US"], // contexts to filter by
    "count": 5 // num of results to return
}
```

#### High-level operation

Class responsible for handling these requests is the `SuggestSearchHandler`.

On a high level, the new functionality does the following:

1. Get the index identified by `indexName`
2. Create a `SuggestIndexSearcher` instance
3. Build `CompletionQuery`
  - it is always a `ContextQuery` with `context`, which wraps either a `PrefixCompletionQuery` or `FuzzyCompletionQuery` with `text` for the field specified by `suggestField`. The query is selected based on the `suggestQuery` parameter
4. Execute the `SuggestIndexSearcher.search` using the `CompletionQuery` created
5. Get results and return

**NOTE:**
Step `5` (or how results will be returned back) is not finalized yet!

## Usage Info

The new functionality can be tested by:

1. creating a new index
2. registering a `CONTEXT_SUGGEST` field
3. adding documents, and 
4. using the new `suggestSearch` endpoint

### Example `CONTEXT_SUGGEST` field definition:

```json
{
  "name": "my_amazing_suggest_field",
  "type": "CONTEXT_SUGGEST",
  "analyzer": {
    "predefined": "completion"          
  }
},
```

### Example document value (in JSON):

```json
{
  "index": "my_index",
  "fields":{
    "my_amazing_suggest_field": {
      "value":["{\"value\":\"Magical Burgers\",\"contexts\":[\"US\"],\"weight\":8}"]
    }
}
```

### Example invocation for `prefix` and `fuzzy` queries:

```bash
curl -s -H "Content-Type: application/json" -X POST localhost:8071/v1/suggest_search -d '{
  "indexName": "my_index",
  "suggestField": "my_amazing_suggest_field",
  "suggestQuery": "PREFIX",
  "text": "magi",
  "contexts": [],
  "count": 3,
}'
```

```bash
curl -s -H "Content-Type: application/json" -X POST localhost:8071/v1/suggest_search -d '{
  "indexName": "my_index",
  "suggestField": "my_amazing_suggest_field",
  "suggestQuery": "FUZZY",
  "text": "maagi",
  "contexts": [],
  "count": 3,
}'
```
