### PR TITLE
Add support for multiValued CONTEXT_SUGGEST field

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/ContextSuggestFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/ContextSuggestFieldDef.java
@@ -60,6 +60,10 @@ public class ContextSuggestFieldDef extends IndexableFieldDef {
   @Override
   public void parseDocumentField(
       Document document, List<String> fieldValues, List<List<String>> facetHierarchyPaths) {
+    if (!isMultiValue() && fieldValues.size() > 1) {
+      throw new IllegalArgumentException(
+          "Cannot index multiple values into single value field: " + getName());
+    }
     for (String fieldValue : fieldValues) {
       parseFieldValueToDocumentField(document, fieldValue);
     }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/ContextSuggestFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/ContextSuggestFieldDef.java
@@ -50,10 +50,6 @@ public class ContextSuggestFieldDef extends IndexableFieldDef {
     if (requestField.getSearch()) {
       throw new IllegalArgumentException("Context Suggest fields cannot be searched");
     }
-
-    if (requestField.getMultiValued()) {
-      throw new IllegalArgumentException("Cannot index multiple values into context suggest field");
-    }
   }
 
   @Override
@@ -64,20 +60,24 @@ public class ContextSuggestFieldDef extends IndexableFieldDef {
   @Override
   public void parseDocumentField(
       Document document, List<String> fieldValues, List<List<String>> facetHierarchyPaths) {
-    if (fieldValues.size() == 1) {
-      ContextSuggestFieldData csfData =
-          GSON.fromJson(fieldValues.get(0), ContextSuggestFieldData.class);
-      CharSequence[] contexts =
-          csfData.getContexts().toArray(new CharSequence[csfData.getContexts().size()]);
-      ContextSuggestField csf =
-          new ContextSuggestField(getName(), csfData.getValue(), csfData.getWeight(), contexts);
-      document.add(csf);
-      if (isStored()) {
-        document.add(new FieldWithData(getName(), fieldType, fieldValues.get(0)));
-      }
-    } else {
-      throw new IllegalArgumentException("Context Suggest Field can only index exactly one value");
+    for (String fieldValue : fieldValues) {
+      parseFieldValueToDocumentField(document, fieldValue);
     }
+  }
+
+  /**
+   * Processes a single fieldValue and adds appropriate fields to the document.
+   *
+   * @param document document to add parsed values to
+   * @param fieldValue string representation of the field value
+   */
+  private void parseFieldValueToDocumentField(Document document, String fieldValue) {
+    ContextSuggestFieldData csfData = GSON.fromJson(fieldValue, ContextSuggestFieldData.class);
+    CharSequence[] contexts =
+        csfData.getContexts().toArray(new CharSequence[csfData.getContexts().size()]);
+    ContextSuggestField csf =
+        new ContextSuggestField(getName(), csfData.getValue(), csfData.getWeight(), contexts);
+    document.add(csf);
   }
 
   protected Analyzer parseIndexAnalyzer(Field requestField) {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/MyTopSuggestDocsCollector.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/MyTopSuggestDocsCollector.java
@@ -136,8 +136,6 @@ public class MyTopSuggestDocsCollector extends DocCollector {
     @Override
     protected void doSetNextReader(LeafReaderContext context) {
       docBase = context.docBase;
-      // clears priority queue
-      priorityQueue.getResults();
     }
 
     @Override

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/ContextSuggestFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/ContextSuggestFieldDefTest.java
@@ -16,7 +16,6 @@
 package com.yelp.nrtsearch.server.luceneserver.field;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -41,7 +40,8 @@ import org.junit.Test;
 
 public class ContextSuggestFieldDefTest extends ServerTestCase {
   @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
-  private static final String FIELD_NAME = "context_suggest_name";
+  private static final String SINGLE_VALUED_FIELD_NAME = "context_suggest_name";
+  private static final String MULTI_VALUED_FIELD_NAME = "context_suggest_name_multi_valued";
   private static final String FIELD_TYPE = "CONTEXT_SUGGEST";
 
   public FieldDef getFieldDef(String testIndex, String fieldName) throws IOException {
@@ -99,41 +99,60 @@ public class ContextSuggestFieldDefTest extends ServerTestCase {
 
   @Test
   public void validContextSuggestFieldDefTest() throws IOException {
-    FieldDef contextSuggestFieldDef = getFieldDef(DEFAULT_TEST_INDEX, FIELD_NAME);
+    FieldDef contextSuggestFieldDef = getFieldDef(DEFAULT_TEST_INDEX, SINGLE_VALUED_FIELD_NAME);
     assertEquals(FIELD_TYPE, contextSuggestFieldDef.getType());
-    assertEquals(FIELD_NAME, contextSuggestFieldDef.getName());
+    assertEquals(SINGLE_VALUED_FIELD_NAME, contextSuggestFieldDef.getName());
   }
 
   @Test
-  public void validCompletionQuerySuggestions_FilterByText() {
+  public void validCompletionQuerySuggestionsSingleValued_FilterByText() {
     Query query =
         Query.newBuilder()
             .setCompletionQuery(
-                CompletionQuery.newBuilder().setField(FIELD_NAME).setText("test").build())
+                CompletionQuery.newBuilder()
+                    .setField(SINGLE_VALUED_FIELD_NAME)
+                    .setText("Tasty")
+                    .build())
             .build();
 
     SearchResponse searchResponse =
         getGrpcServer().getBlockingStub().search(getRequestWithQuery(query));
 
-    assertEquals(4, searchResponse.getHitsCount());
+    assertEquals(1, searchResponse.getHitsCount());
 
     Set<String> hitsIds = getHitsIds(searchResponse);
-    assertTrue(hitsIds.contains("1"));
-    assertTrue(hitsIds.contains("2"));
     assertTrue(hitsIds.contains("3"));
-    assertTrue(hitsIds.contains("4"));
-    assertFalse(hitsIds.contains("5"));
   }
 
   @Test
-  public void validCompletionQuerySuggestions_FilterByTextAndContext() {
+  public void validCompletionQuerySuggestionsSingleValued_FilterByTextAndContext() {
     Query query =
         Query.newBuilder()
             .setCompletionQuery(
                 CompletionQuery.newBuilder()
-                    .setField(FIELD_NAME)
-                    .setText("test")
+                    .setField(SINGLE_VALUED_FIELD_NAME)
+                    .setText("Fantastic")
                     .addContexts("a")
+                    .build())
+            .build();
+
+    SearchResponse searchResponse =
+        getGrpcServer().getBlockingStub().search(getRequestWithQuery(query));
+
+    assertEquals(1, searchResponse.getHitsCount());
+
+    Set<String> hitsIds = getHitsIds(searchResponse);
+    assertTrue(hitsIds.contains("5"));
+  }
+
+  @Test
+  public void validCompletionQuerySuggestionsMultiValued_FilterByText() {
+    Query query =
+        Query.newBuilder()
+            .setCompletionQuery(
+                CompletionQuery.newBuilder()
+                    .setField(MULTI_VALUED_FIELD_NAME)
+                    .setText("Fries")
                     .build())
             .build();
 
@@ -143,11 +162,29 @@ public class ContextSuggestFieldDefTest extends ServerTestCase {
     assertEquals(2, searchResponse.getHitsCount());
 
     Set<String> hitsIds = getHitsIds(searchResponse);
-    assertTrue(hitsIds.contains("1"));
-    assertFalse(hitsIds.contains("2"));
-    assertTrue(hitsIds.contains("3"));
-    assertFalse(hitsIds.contains("4"));
-    assertFalse(hitsIds.contains("5"));
+    assertTrue(hitsIds.contains("4"));
+    assertTrue(hitsIds.contains("5"));
+  }
+
+  @Test
+  public void validCompletionQuerySuggestionsMultiValued_FilterByTextAndContext() {
+    Query query =
+        Query.newBuilder()
+            .setCompletionQuery(
+                CompletionQuery.newBuilder()
+                    .setField(MULTI_VALUED_FIELD_NAME)
+                    .setText("Burger")
+                    .addContexts("b")
+                    .build())
+            .build();
+
+    SearchResponse searchResponse =
+        getGrpcServer().getBlockingStub().search(getRequestWithQuery(query));
+
+    assertEquals(1, searchResponse.getHitsCount());
+
+    Set<String> hitsIds = getHitsIds(searchResponse);
+    assertTrue(hitsIds.contains("4"));
   }
 
   private Set<String> getHitsIds(SearchResponse searchResponse) {
@@ -159,7 +196,7 @@ public class ContextSuggestFieldDefTest extends ServerTestCase {
   private SearchRequest getRequestWithQuery(Query query) {
     return SearchRequest.newBuilder()
         .setIndexName(DEFAULT_TEST_INDEX)
-        .addAllRetrieveFields(Set.of("id", "context_suggest_name"))
+        .addAllRetrieveFields(Set.of("id", SINGLE_VALUED_FIELD_NAME, MULTI_VALUED_FIELD_NAME))
         .setStartHit(0)
         .setTopHits(5)
         .setQuery(query)

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/MyTopSuggestDocsCollectorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/MyTopSuggestDocsCollectorTest.java
@@ -37,12 +37,12 @@ public class MyTopSuggestDocsCollectorTest {
         new TopSuggestDocs.SuggestScoreDoc[][] {
           new TopSuggestDocs.SuggestScoreDoc[] {
             new TopSuggestDocs.SuggestScoreDoc(1, "Pizza", "a", 11),
-            new TopSuggestDocs.SuggestScoreDoc(1, "Pizza", "b", 12),
+            new TopSuggestDocs.SuggestScoreDoc(1, "Pizza Place", "a", 22),
             new TopSuggestDocs.SuggestScoreDoc(3, "Pizza", "a", 15),
             new TopSuggestDocs.SuggestScoreDoc(6, "Pizza", "a", 17),
+            new TopSuggestDocs.SuggestScoreDoc(1, "Pizza", "b", 12),
           },
           new TopSuggestDocs.SuggestScoreDoc[] {
-            new TopSuggestDocs.SuggestScoreDoc(1, "Pizza Place", "a", 22),
             new TopSuggestDocs.SuggestScoreDoc(2, "Pizza", "b", 12),
             new TopSuggestDocs.SuggestScoreDoc(5, "Pizza", "a", 5),
             new TopSuggestDocs.SuggestScoreDoc(7, "Pizza", "a", 4),

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/MyTopSuggestDocsCollectorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/MyTopSuggestDocsCollectorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.search.collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.suggest.document.TopSuggestDocs;
+import org.apache.lucene.search.suggest.document.TopSuggestDocsCollector;
+import org.junit.Test;
+
+public class MyTopSuggestDocsCollectorTest {
+  /**
+   * Tests the reduce method. We simulate two collectors, each containing a different array of
+   * SuggestScoreDoc. The test is designed to have docs unsorted, with same docId withing a single
+   * collector and between the two collectors.
+   *
+   * <p>The test asserts that the final list of suggest score docs is properly deduplicated, sorted
+   * and limited using a predefined expected final array of suggest score docs.
+   *
+   * @throws IOException on error collecting results from collector
+   */
+  @Test
+  public void shouldGetTopScoringSuggestScoreDocsUniqueById() throws IOException {
+    TopSuggestDocs.SuggestScoreDoc[] expectedFinalSuggestScoreDocs = {
+      new TopSuggestDocs.SuggestScoreDoc(2, "Pizza Palace", "a", 25),
+      new TopSuggestDocs.SuggestScoreDoc(1, "Pizza Place", "a", 22),
+      new TopSuggestDocs.SuggestScoreDoc(6, "Pizza", "a", 17),
+      new TopSuggestDocs.SuggestScoreDoc(4, "Pizza", "a", 16),
+      new TopSuggestDocs.SuggestScoreDoc(3, "Pizza", "a", 15),
+    };
+
+    TopSuggestDocs.SuggestScoreDoc[] suggestScoreDocsCollector1 = {
+      new TopSuggestDocs.SuggestScoreDoc(1, "Pizza", "a", 11),
+      new TopSuggestDocs.SuggestScoreDoc(1, "Pizza", "b", 11),
+      new TopSuggestDocs.SuggestScoreDoc(3, "Pizza", "a", 15),
+      new TopSuggestDocs.SuggestScoreDoc(6, "Pizza", "a", 17),
+    };
+
+    TopSuggestDocs.SuggestScoreDoc[] suggestScoreDocsCollector2 = {
+      new TopSuggestDocs.SuggestScoreDoc(1, "Pizza Place", "a", 22),
+      new TopSuggestDocs.SuggestScoreDoc(2, "Pizza", "a", 11),
+      new TopSuggestDocs.SuggestScoreDoc(2, "Pizza Palace", "a", 25),
+      new TopSuggestDocs.SuggestScoreDoc(4, "Pizza", "a", 16),
+      new TopSuggestDocs.SuggestScoreDoc(5, "Pizza", "a", 5),
+    };
+
+    TopSuggestDocs topSuggestDocsCollector1 =
+        new TopSuggestDocs(
+            new TotalHits(suggestScoreDocsCollector1.length, TotalHits.Relation.EQUAL_TO),
+            suggestScoreDocsCollector1);
+    TopSuggestDocs topSuggestDocsCollector2 =
+        new TopSuggestDocs(
+            new TotalHits(suggestScoreDocsCollector2.length, TotalHits.Relation.EQUAL_TO),
+            suggestScoreDocsCollector2);
+
+    TopSuggestDocsCollector collector1 = mock(TopSuggestDocsCollector.class);
+    when(collector1.get()).thenReturn(topSuggestDocsCollector1);
+
+    TopSuggestDocsCollector collector2 = mock(TopSuggestDocsCollector.class);
+    when(collector2.get()).thenReturn(topSuggestDocsCollector2);
+
+    MyTopSuggestDocsCollector.MyTopSuggestDocsCollectorManager manager =
+        new MyTopSuggestDocsCollector.MyTopSuggestDocsCollectorManager(5);
+
+    TopSuggestDocs reduced = manager.reduce(List.of(collector1, collector2));
+
+    // check total hits
+    assertEquals(5, reduced.totalHits.value);
+    assertEquals(TotalHits.Relation.EQUAL_TO, reduced.totalHits.relation);
+
+    // check suggest score docs
+    assertEquals(expectedFinalSuggestScoreDocs.length, reduced.scoreDocs.length);
+    for (int i = 0; i < expectedFinalSuggestScoreDocs.length; i++) {
+      TopSuggestDocs.SuggestScoreDoc expected = expectedFinalSuggestScoreDocs[i];
+      TopSuggestDocs.SuggestScoreDoc actual = reduced.scoreLookupDocs()[i];
+      assertEquals(expected.score, actual.score, 0.001);
+      assertEquals(expected.doc, actual.doc);
+      assertEquals(expected.context, actual.context);
+    }
+  }
+}

--- a/src/test/resources/addContextSuggestDocs.jsonl
+++ b/src/test/resources/addContextSuggestDocs.jsonl
@@ -1,5 +1,5 @@
-{"id":1,"context_suggest_name":"{\"value\":\"Test One\",\"contexts\":[\"a\"],\"weight\":59}"}
-{"id":2,"context_suggest_name":"{\"value\":\"Test Two\",\"contexts\":[\"b\"],\"weight\":37}"}
-{"id":3,"context_suggest_name":"{\"value\":\"Test Three\",\"contexts\":[\"a\"],\"weight\":37}"}
-{"id":4,"context_suggest_name":"{\"value\":\"Test Four\",\"contexts\":[\"b\"],\"weight\":59}"}
-{"id":5,"context_suggest_name":"{\"value\":\"Burger and Fries\",\"contexts\":[\"a\",\"b\"],\"weight\":31}"}
+{"id":1,"context_suggest_name":"{\"value\":\"Magical Pizza\",\"contexts\":[\"a\"],\"weight\":59}","context_suggest_name_multi_valued":["{\"value\":\"Magical Pizza\",\"contexts\":[\"a\"],\"weight\":59}","{\"value\":\"Pizza\",\"contexts\":[\"a\"],\"weight\":59}"]}
+{"id":2,"context_suggest_name":"{\"value\":\"Fantastic Pizza\",\"contexts\":[\"b\"],\"weight\":121}","context_suggest_name_multi_valued":["{\"value\":\"Fantastic Pizza\",\"contexts\":[\"b\"],\"weight\":121}","{\"value\":\"Pizza\",\"contexts\":[\"b\"],\"weight\":121}"]}
+{"id":3,"context_suggest_name":"{\"value\":\"Tasty Burger\",\"contexts\":[\"a\"],\"weight\":34}","context_suggest_name_multi_valued":["{\"value\":\"Tasty Burger\",\"contexts\":[\"a\"],\"weight\":34}","{\"value\":\"Burger\",\"contexts\":[\"a\"],\"weight\":34}"]}
+{"id":4,"context_suggest_name":"{\"value\":\"Cheesy Burger Fries\",\"contexts\":[\"b\"],\"weight\":63}","context_suggest_name_multi_valued":["{\"value\":\"Cheesy Burger Fries\",\"contexts\":[\"b\"],\"weight\":63}","{\"value\":\"Burger Fries\",\"contexts\":[\"b\"],\"weight\":63}", "{\"value\":\"Fries\",\"contexts\":[\"b\"],\"weight\":63}"]}
+{"id":5,"context_suggest_name":"{\"value\":\"Fantastic Fries\",\"contexts\":[\"a\",\"b\"],\"weight\":77}","context_suggest_name_multi_valued":["{\"value\":\"Fantastic Fries\",\"contexts\":[\"a\",\"b\"],\"weight\":77}","{\"value\":\"Fries\",\"contexts\":[\"a\",\"b\"],\"weight\":77}"]}

--- a/src/test/resources/field/registerFieldsContextSuggest.json
+++ b/src/test/resources/field/registerFieldsContextSuggest.json
@@ -13,6 +13,14 @@
         "multiValued": false,
         "store": true,
         "search": false
+      },
+      {
+        "name": "context_suggest_name_multi_valued",
+        "type": "CONTEXT_SUGGEST",
+        "storeDocValues": false,
+        "multiValued": true,
+        "store": true,
+        "search": false
       }
     ]
   }


### PR DESCRIPTION
# Add support for multiValued ContextSuggest field

## Overview

This PR adds support for `multiValued = true` option for `CONTEXT_SUGGEST` field and the appropriate parsing of documents containing multiple values for `CONTEXT_SUGGEST` field.

The PR also updates how `MyTopSuggestDocsCollector` collects results and its final `reduce` logic.

## Implementation Details

### `multiValued = true` for `CONTEXT_SUGGEST` fields

The `ContextSuggestFieldDef` class was updated not to throw and error when `multiValued = true` is used when registering fields. Additionally, the `parseDocumentField` was updated to go through the list of values and process each field individually.

The change allows `CONTEXT_SUGGEST` field to be registered with `multiValued = true`:

```json5
[
  // full field def omitted for clarity
  {
    "name": "my_context_suggest_field",
    "type": "CONTEXT_SUGGEST",
    "multiValued": true // allowed
   }
]
```

Therefore, when adding documents, we can set the value of the field using an array:

```json5
{
  "my_context_suggest_field": [
    "{\"value\":\"Magical Pizza Place\",\"contexts\":[\"a\"],\"weight\":6}",
    "{\"value\":\"Pizza Place\",\"contexts\":[\"b\"],\"weight\":6}",
    "{\"value\":\"Place\",\"contexts\":[\"c\"],\"weight\":5}"
  ]
}
```

Which results in multiple context suggest fields being added to the document while parsing:

```java
document.add(new ContextSuggestField("my_context_suggest_field", "Magical Pizza Place", 7, Set.of("a"));
document.add(new ContextSuggestField("my_context_suggest_field", "Pizza Place", 6, Set.of("b"));
document.add(new ContextSuggestField("my_context_suggest_field", "Place", 5, Set.of("c"));
```

This way the document will be retrieved using a `CompletionQuery` for texts like `Magical`, but also `Pizza` and `Place`.

### Updated `reduce` logic in `MyTopSuggestDocsCollector`

Currently `MyTopSuggestDocsCollector` would create collectors `skipDuplicates = true` resulting in `SuggestScoreDocs` with the same `key` being deduplicated, even if they have a different `docId`. Additionally, the `TopSuggestDocs.merge` would not deduplicate, meaning that `SuggestScoreDocs` for the same document would be persisted.

The logic in `MyTopSuggestDocsCollector` was updated to achieve the following:

1. When collecting documents, each collector will retrieve all `SuggestScoreDocs` that match the completion text (`key`).
2. During `reduce`, when results from each collector are consolidated, we will return the top scoring `SuggestScoreDocs` sorted by highest score first, unique by `docId`, and limited by `numHitsToCollect`.

The test added demonstrates the new behaviour:

https://github.com/Yelp/nrtsearch/blob/367324aacc18d8f54492a5b0ca7534d3c3e441fa/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/MyTopSuggestDocsCollectorTest.java#L41-L98

