### PR TITLE
change the max message size in grpc gateway to 100M

### DIFF
--- a/http_wrapper.go
+++ b/http_wrapper.go
@@ -32,7 +32,7 @@ func run() error {
   mux := runtime.NewServeMux()
   runtime.SetHTTPBodyMarshaler(mux)
 
-  opts := []grpc.DialOption{grpc.WithInsecure()}
+  opts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(104_857_600))}
   err := gw.RegisterLuceneServerHandlerFromEndpoint(ctx, mux,  *grpcServerEndpoint, opts)
   if err != nil {
     return err


### PR DESCRIPTION
Increase the maxInboundMessageSize in grpc-gateway to 100MB.

Set up local manual test with the same request before and after the change, as work as expected.