### PR TITLE
Fix adding analyzed fields after index is started

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
@@ -108,36 +108,6 @@ public abstract class IndexState implements Closeable {
    */
   public final DocLookup docLookup = new DocLookup(this);
 
-  /** Index-time analyzer. */
-  public final Analyzer indexAnalyzer =
-      new AnalyzerWrapper(Analyzer.PER_FIELD_REUSE_STRATEGY) {
-        @Override
-        public Analyzer getWrappedAnalyzer(String name) {
-          FieldDef fd = getField(name);
-          if (fd instanceof TextBaseFieldDef || fd instanceof ContextSuggestFieldDef) {
-            Optional<Analyzer> maybeAnalyzer = Optional.empty();
-            if (fd instanceof TextBaseFieldDef) {
-              maybeAnalyzer = ((TextBaseFieldDef) fd).getIndexAnalyzer();
-            } else {
-              maybeAnalyzer = ((ContextSuggestFieldDef) fd).getIndexAnalyzer();
-            }
-
-            if (maybeAnalyzer.isEmpty()) {
-              throw new IllegalArgumentException(
-                  "field \"" + name + "\" did not specify analyzer or indexAnalyzer");
-            }
-            return maybeAnalyzer.get();
-          }
-          throw new IllegalArgumentException("field \"" + name + "\" does not support analysis");
-        }
-
-        @Override
-        protected TokenStreamComponents wrapComponents(
-            String fieldName, TokenStreamComponents components) {
-          return components;
-        }
-      };
-
   /** Search-time analyzer. */
   public final Analyzer searchAnalyzer =
       new AnalyzerWrapper(Analyzer.PER_FIELD_REUSE_STRATEGY) {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/ImmutableIndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/ImmutableIndexState.java
@@ -649,7 +649,7 @@ public class ImmutableIndexState extends IndexState {
   @Override
   public IndexWriterConfig getIndexWriterConfig(
       OpenMode openMode, Directory origIndexDir, int shardOrd) throws IOException {
-    IndexWriterConfig iwc = new IndexWriterConfig(indexAnalyzer);
+    IndexWriterConfig iwc = new IndexWriterConfig(new IndexAnalyzer(indexStateManager));
     iwc.setOpenMode(openMode);
     if (getGlobalState().getConfiguration().getIndexVerbose()) {
       logger.info("Enabling verbose logging for Lucene NRT");

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/IndexAnalyzer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/IndexAnalyzer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.index;
+
+import com.yelp.nrtsearch.server.luceneserver.field.ContextSuggestFieldDef;
+import com.yelp.nrtsearch.server.luceneserver.field.FieldDef;
+import com.yelp.nrtsearch.server.luceneserver.field.TextBaseFieldDef;
+import java.util.Optional;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.AnalyzerWrapper;
+
+/**
+ * Analyzer wrapper for use at indexing time, which finds the proper per field analyzer. This
+ * analyzer is set in the {@link org.apache.lucene.index.IndexWriterConfig} when an index is
+ * started. The {@link IndexStateManager} provides access to the fields in the latest {@link
+ * com.yelp.nrtsearch.server.luceneserver.IndexState}.
+ */
+public class IndexAnalyzer extends AnalyzerWrapper {
+  private final IndexStateManager stateManager;
+
+  protected IndexAnalyzer(IndexStateManager stateManager) {
+    super(Analyzer.PER_FIELD_REUSE_STRATEGY);
+    this.stateManager = stateManager;
+  }
+
+  @Override
+  protected Analyzer getWrappedAnalyzer(String name) {
+    FieldDef fd = stateManager.getCurrent().getField(name);
+    if (fd instanceof TextBaseFieldDef || fd instanceof ContextSuggestFieldDef) {
+      Optional<Analyzer> maybeAnalyzer;
+      if (fd instanceof TextBaseFieldDef) {
+        maybeAnalyzer = ((TextBaseFieldDef) fd).getIndexAnalyzer();
+      } else {
+        maybeAnalyzer = ((ContextSuggestFieldDef) fd).getIndexAnalyzer();
+      }
+
+      if (maybeAnalyzer.isEmpty()) {
+        throw new IllegalArgumentException(
+            "field \"" + name + "\" did not specify analyzer or indexAnalyzer");
+      }
+      return maybeAnalyzer.get();
+    }
+    throw new IllegalArgumentException("field \"" + name + "\" does not support analysis");
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/LegacyIndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/LegacyIndexState.java
@@ -50,6 +50,7 @@ import com.yelp.nrtsearch.server.luceneserver.SaveState;
 import com.yelp.nrtsearch.server.luceneserver.ServerCodec;
 import com.yelp.nrtsearch.server.luceneserver.SettingsHandler;
 import com.yelp.nrtsearch.server.luceneserver.ShardState;
+import com.yelp.nrtsearch.server.luceneserver.field.ContextSuggestFieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.FieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.FieldDefBindings;
 import com.yelp.nrtsearch.server.luceneserver.field.IdFieldDef;
@@ -71,6 +72,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.AnalyzerWrapper;
 import org.apache.lucene.expressions.Bindings;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.index.ConcurrentMergeScheduler;
@@ -112,6 +115,37 @@ import org.slf4j.LoggerFactory;
  */
 public class LegacyIndexState extends IndexState implements Restorable {
   private static final Logger logger = LoggerFactory.getLogger(LegacyIndexState.class);
+
+  /** Index-time analyzer. */
+  public final Analyzer indexAnalyzer =
+      new AnalyzerWrapper(Analyzer.PER_FIELD_REUSE_STRATEGY) {
+        @Override
+        public Analyzer getWrappedAnalyzer(String name) {
+          FieldDef fd = getField(name);
+          if (fd instanceof TextBaseFieldDef || fd instanceof ContextSuggestFieldDef) {
+            Optional<Analyzer> maybeAnalyzer = Optional.empty();
+            if (fd instanceof TextBaseFieldDef) {
+              maybeAnalyzer = ((TextBaseFieldDef) fd).getIndexAnalyzer();
+            } else {
+              maybeAnalyzer = ((ContextSuggestFieldDef) fd).getIndexAnalyzer();
+            }
+
+            if (maybeAnalyzer.isEmpty()) {
+              throw new IllegalArgumentException(
+                  "field \"" + name + "\" did not specify analyzer or indexAnalyzer");
+            }
+            return maybeAnalyzer.get();
+          }
+          throw new IllegalArgumentException("field \"" + name + "\" does not support analysis");
+        }
+
+        @Override
+        protected TokenStreamComponents wrapComponents(
+            String fieldName, TokenStreamComponents components) {
+          return components;
+        }
+      };
+
   /** Which norms format to use for all indexed fields. */
   private String normsFormat = "Lucene80";
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/AddFieldsIndexingTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/AddFieldsIndexingTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.grpc;
+
+import static org.junit.Assert.assertEquals;
+
+import com.yelp.nrtsearch.server.config.IndexStartConfig.IndexDataLocationType;
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest.MultiValuedField;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class AddFieldsIndexingTest {
+
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  private static final List<Field> initialFields =
+      List.of(
+          Field.newBuilder()
+              .setName("id")
+              .setType(FieldType._ID)
+              .setStoreDocValues(true)
+              .setSearch(true)
+              .build(),
+          Field.newBuilder()
+              .setName("field1")
+              .setStoreDocValues(true)
+              .setType(FieldType.INT)
+              .build(),
+          Field.newBuilder()
+              .setName("field2")
+              .setStoreDocValues(true)
+              .setSearch(true)
+              .setTokenize(true)
+              .setType(FieldType.TEXT)
+              .build());
+
+  private static final List<Field> additionalFields =
+      List.of(
+          Field.newBuilder()
+              .setName("field3")
+              .setStoreDocValues(true)
+              .setType(FieldType.INT)
+              .build(),
+          Field.newBuilder()
+              .setName("field4")
+              .setStoreDocValues(true)
+              .setSearch(true)
+              .setTokenize(true)
+              .setType(FieldType.TEXT)
+              .build());
+
+  @After
+  public void cleanup() {
+    TestServer.cleanupAll();
+  }
+
+  private void addInitialDoc(TestServer testServer) {
+    AddDocumentRequest addDocumentRequest =
+        AddDocumentRequest.newBuilder()
+            .setIndexName("test_index")
+            .putFields("id", MultiValuedField.newBuilder().addValue("1").build())
+            .putFields("field1", MultiValuedField.newBuilder().addValue("10").build())
+            .putFields("field2", MultiValuedField.newBuilder().addValue("first Vendor").build())
+            .build();
+    testServer.addDocs(Stream.of(addDocumentRequest));
+  }
+
+  private void addAdditionalDoc(TestServer testServer) {
+    AddDocumentRequest addDocumentRequest =
+        AddDocumentRequest.newBuilder()
+            .setIndexName("test_index")
+            .putFields("id", MultiValuedField.newBuilder().addValue("2").build())
+            .putFields("field1", MultiValuedField.newBuilder().addValue("20").build())
+            .putFields("field2", MultiValuedField.newBuilder().addValue("second Vendor").build())
+            .putFields("field3", MultiValuedField.newBuilder().addValue("22").build())
+            .putFields("field4", MultiValuedField.newBuilder().addValue("Test Caption").build())
+            .build();
+    testServer.addDocs(Stream.of(addDocumentRequest));
+  }
+
+  private void verifyDocs(TestServer testServer) {
+    SearchRequest request =
+        SearchRequest.newBuilder()
+            .setIndexName("test_index")
+            .addRetrieveFields("id")
+            .setStartHit(0)
+            .setTopHits(10)
+            .setQuery(
+                Query.newBuilder()
+                    .setMatchQuery(
+                        MatchQuery.newBuilder().setField("field2").setQuery("vendor").build())
+                    .build())
+            .build();
+    SearchResponse response = testServer.getClient().getBlockingStub().search(request);
+    assertEquals(2, response.getHitsCount());
+
+    Set<String> responseIds =
+        Set.of(
+            response.getHits(0).getFieldsOrThrow("id").getFieldValue(0).getTextValue(),
+            response.getHits(1).getFieldsOrThrow("id").getFieldValue(0).getTextValue());
+    assertEquals(Set.of("1", "2"), responseIds);
+
+    request =
+        SearchRequest.newBuilder()
+            .setIndexName("test_index")
+            .addRetrieveFields("id")
+            .setStartHit(0)
+            .setTopHits(10)
+            .setQuery(
+                Query.newBuilder()
+                    .setMatchQuery(
+                        MatchQuery.newBuilder().setField("field4").setQuery("caption").build())
+                    .build())
+            .build();
+    response = testServer.getClient().getBlockingStub().search(request);
+    assertEquals(1, response.getHitsCount());
+
+    responseIds =
+        Set.of(response.getHits(0).getFieldsOrThrow("id").getFieldValue(0).getTextValue());
+    assertEquals(Set.of("2"), responseIds);
+  }
+
+  @Test
+  public void testAddFieldsPreIndexStart() throws IOException {
+    TestServer primaryServer =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.LOCAL)
+            .build();
+    primaryServer.createIndex("test_index");
+    primaryServer.registerFields("test_index", initialFields);
+    primaryServer.registerFields("test_index", additionalFields);
+    primaryServer.startPrimaryIndex("test_index", -1, null);
+    addInitialDoc(primaryServer);
+    addAdditionalDoc(primaryServer);
+    primaryServer.refresh("test_index");
+    verifyDocs(primaryServer);
+  }
+
+  @Test
+  public void testAddFieldsPostIndexStart() throws IOException {
+    TestServer primaryServer =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.LOCAL)
+            .build();
+    primaryServer.createIndex("test_index");
+    primaryServer.startPrimaryIndex("test_index", -1, null);
+    primaryServer.registerFields("test_index", initialFields);
+    primaryServer.registerFields("test_index", additionalFields);
+    addInitialDoc(primaryServer);
+    addAdditionalDoc(primaryServer);
+    primaryServer.refresh("test_index");
+    verifyDocs(primaryServer);
+  }
+
+  @Test
+  public void testAddFieldsSplitIndexStart() throws IOException {
+    TestServer primaryServer =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.LOCAL)
+            .build();
+    primaryServer.createIndex("test_index");
+    primaryServer.registerFields("test_index", initialFields);
+    primaryServer.startPrimaryIndex("test_index", -1, null);
+    addInitialDoc(primaryServer);
+    primaryServer.registerFields("test_index", additionalFields);
+    addAdditionalDoc(primaryServer);
+    primaryServer.refresh("test_index");
+    verifyDocs(primaryServer);
+  }
+}


### PR DESCRIPTION
The `Analyzer` used at index time is set in the `IndexWriterConfig` once, when the index is started. Currently, this means that the `IndexWriter` can only lookup field analyzers for the fields that existed at start time (when using `ImmutableIndexState`).

This branch creates a new `IndexAnalyzer` which gets the current `IndexState` from the `IndexStateManager`, providing access to the latest registered fields.