### PR TITLE
Merge precopy improvements

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/NRTPrimaryNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/NRTPrimaryNode.java
@@ -375,14 +375,12 @@ public class NRTPrimaryNode extends PrimaryNode {
       for (MergePreCopy preCopy : warmingSegments) {
         logger.debug("warming segment {}", preCopy.files.keySet());
         message("warming segment " + preCopy.files.keySet());
-        synchronized (preCopy.connections) {
-          if (preCopy.connections.contains(replicationServerClient)) {
-            logMessage("this replica is already warming this segment; skipping");
-            // It's possible (maybe) that the replica started up, then a merge kicked off, and it
-            // warmed to this new replica, all before the
-            // replica sent us this command:
-            continue;
-          }
+        if (preCopy.connections.contains(replicationServerClient)) {
+          logMessage("this replica is already warming this segment; skipping");
+          // It's possible (maybe) that the replica started up, then a merge kicked off, and it
+          // warmed to this new replica, all before the
+          // replica sent us this command:
+          continue;
         }
 
         // OK, this new replica is not already warming this segment, so attempt (could fail) to

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/NRTPrimaryNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/NRTPrimaryNode.java
@@ -258,7 +258,7 @@ public class NRTPrimaryNode extends PrimaryNode {
     synchronized (warmingSegments) {
       logMessage(
           String.format(
-              "top: warm merge %s to %d replicas; localAddress=%s: files=%s",
+              "Start merge precopy %s to %d replicas; localAddress=%s: files=%s",
               info, replicasInfos.size(), hostPort, files.keySet()));
 
       Map<ReplicationServerClient, Iterator<TransferStatus>> allCopyStatus =
@@ -282,7 +282,7 @@ public class NRTPrimaryNode extends PrimaryNode {
         }
 
         if (isClosed()) {
-          logMessage("top: primary is closing: now cancel segment warming");
+          logMessage("Primary is closing: cancel merge precopy");
           // Connections are closed in close() method
           return;
         }
@@ -292,7 +292,7 @@ public class NRTPrimaryNode extends PrimaryNode {
           logMessage(
               String.format(
                   Locale.ROOT,
-                  "top: warning: still warming merge %s to %d replicas for %.1f sec...",
+                  "Warning: still warming merge %s to %d replicas for %.1f sec...",
                   info,
                   preCopy.connections.size(),
                   (ns - startNS) / 1000000000.0));
@@ -317,7 +317,7 @@ public class NRTPrimaryNode extends PrimaryNode {
           } catch (Throwable t) {
             String msg =
                 String.format(
-                    "top: ignore exception trying to read byte during warm for segment=%s to replica=%s: %s files=%s",
+                    "Ignore exception trying to read byte during merge precopy for segment=%s to replica=%s: %s files=%s",
                     info, currentReplicationServerClient, t, files.keySet());
             logger.warn(msg, t);
             super.message(msg);
@@ -325,7 +325,7 @@ public class NRTPrimaryNode extends PrimaryNode {
         }
         currentConnections.forEach(preCopy.connections::remove);
       }
-      logMessage("top: done warming merge " + info);
+      logMessage("Done merge precopy " + info);
     } finally {
       warmingSegments.remove(preCopy);
 
@@ -352,13 +352,13 @@ public class NRTPrimaryNode extends PrimaryNode {
         allCopyStatus.put(replicaDetails.replicationServerClient, copyStatus);
         logMessage(
             String.format(
-                "Start warming merged segments for replica %s:%d",
+                "Start precopying merged segments for replica %s:%d",
                 replicaDetails.replicationServerClient.getHost(),
                 replicaDetails.replicationServerClient.getPort()));
       } catch (Throwable t) {
         logMessage(
             String.format(
-                "top: ignore exception trying to warm to replica for host:%s port: %d: %s",
+                "Ignore merge precopy exception for replica host:%s port: %d: %s",
                 replicaDetails.replicationServerClient.getHost(),
                 replicaDetails.replicationServerClient.getPort(),
                 t));
@@ -407,7 +407,7 @@ public class NRTPrimaryNode extends PrimaryNode {
             replicationServerClient.copyFiles(indexName, primaryGen, filesMetadata);
         logMessage(
             String.format(
-                "Start copying merged segments for new replica %s:%d",
+                "Start precopying merged segments for new replica %s:%d",
                 replicaDetails.replicationServerClient.getHost(),
                 replicaDetails.replicationServerClient.getPort()));
 
@@ -418,7 +418,7 @@ public class NRTPrimaryNode extends PrimaryNode {
           // nrt point sent to this replica
           logMessage(
               String.format(
-                  "Warming already completed, unable to add new replica %s:%d",
+                  "Merge precopy already completed, unable to add new replica %s:%d",
                   replicaDetails.replicationServerClient.getHost(),
                   replicaDetails.replicationServerClient.getPort()));
         }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/NRTPrimaryNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/NRTPrimaryNode.java
@@ -124,13 +124,16 @@ public class NRTPrimaryNode extends PrimaryNode {
     final Map<String, FileMetaData> files;
     private boolean finished;
 
-    public MergePreCopy(Map<String, FileMetaData> files, Map<ReplicationServerClient, Iterator<TransferStatus>> clientToTransferStatusIterator) {
+    public MergePreCopy(
+        Map<String, FileMetaData> files,
+        Map<ReplicationServerClient, Iterator<TransferStatus>> clientToTransferStatusIterator) {
       this.files = files;
       this.clientToTransferStatusIterator = new ConcurrentHashMap<>(clientToTransferStatusIterator);
       this.connections.addAll(clientToTransferStatusIterator.keySet());
     }
 
-    public synchronized boolean tryAddConnection(ReplicationServerClient c, Iterator<TransferStatus> transferStatusIterator) {
+    public synchronized boolean tryAddConnection(
+        ReplicationServerClient c, Iterator<TransferStatus> transferStatusIterator) {
       if (finished == false) {
         clientToTransferStatusIterator.put(c, transferStatusIterator);
         connections.add(c);
@@ -258,7 +261,8 @@ public class NRTPrimaryNode extends PrimaryNode {
               "top: warm merge %s to %d replicas; localAddress=%s: files=%s",
               info, replicasInfos.size(), hostPort, files.keySet()));
 
-      Map<ReplicationServerClient, Iterator<TransferStatus>> allCopyStatus = callCopyFilesForPreCopy(files);
+      Map<ReplicationServerClient, Iterator<TransferStatus>> allCopyStatus =
+          callCopyFilesForPreCopy(files);
       preCopy = new MergePreCopy(files, allCopyStatus);
       warmingSegments.add(preCopy);
     }
@@ -332,12 +336,14 @@ public class NRTPrimaryNode extends PrimaryNode {
     }
   }
 
-  private Map<ReplicationServerClient, Iterator<TransferStatus>> callCopyFilesForPreCopy(Map<String, FileMetaData> files) {
+  private Map<ReplicationServerClient, Iterator<TransferStatus>> callCopyFilesForPreCopy(
+      Map<String, FileMetaData> files) {
     // Ask all currently known replicas to pre-copy this newly merged segment's files:
     Iterator<ReplicaDetails> replicaInfos = replicasInfos.iterator();
     ReplicaDetails replicaDetails = null;
     FilesMetadata filesMetadata = RecvCopyStateHandler.writeFilesMetaData(files);
-    Map<ReplicationServerClient, Iterator<TransferStatus>> allCopyStatus = new ConcurrentHashMap<>();
+    Map<ReplicationServerClient, Iterator<TransferStatus>> allCopyStatus =
+        new ConcurrentHashMap<>();
     while (replicaInfos.hasNext()) {
       try {
         replicaDetails = replicaInfos.next();
@@ -384,9 +390,11 @@ public class NRTPrimaryNode extends PrimaryNode {
         logger.debug("warming segment {}", preCopy.files.keySet());
         message("warming segment " + preCopy.files.keySet());
         if (preCopy.connections.contains(replicationServerClient)) {
-          logMessage(String.format("Replica %s:%d is already warming this segment",
-              replicaDetails.replicationServerClient.getHost(),
-              replicaDetails.replicationServerClient.getPort()));
+          logMessage(
+              String.format(
+                  "Replica %s:%d is already warming this segment",
+                  replicaDetails.replicationServerClient.getHost(),
+                  replicaDetails.replicationServerClient.getPort()));
           // It's possible (maybe) that the replica started up, then a merge kicked off, and it
           // warmed to this new replica, all before the
           // replica sent us this command:
@@ -395,10 +403,11 @@ public class NRTPrimaryNode extends PrimaryNode {
 
         // Start copying the segments to the replica
         FilesMetadata filesMetadata = RecvCopyStateHandler.writeFilesMetaData(preCopy.files);
-        Iterator<TransferStatus> transferStatusIterator = replicationServerClient.copyFiles(
-            indexName, primaryGen, filesMetadata);
+        Iterator<TransferStatus> transferStatusIterator =
+            replicationServerClient.copyFiles(indexName, primaryGen, filesMetadata);
         logMessage(
-            String.format("Start copying merged segments for new replica %s:%d",
+            String.format(
+                "Start copying merged segments for new replica %s:%d",
                 replicaDetails.replicationServerClient.getHost(),
                 replicaDetails.replicationServerClient.getPort()));
 
@@ -407,11 +416,12 @@ public class NRTPrimaryNode extends PrimaryNode {
           // This can happen, if all other replicas just now finished warming this segment, and so
           // we were just a bit too late.  In this case the segment must be copied over in the next
           // nrt point sent to this replica
-          logMessage(String.format("Warming already completed, unable to add new replica %s:%d",
-              replicaDetails.replicationServerClient.getHost(),
-              replicaDetails.replicationServerClient.getPort()));
+          logMessage(
+              String.format(
+                  "Warming already completed, unable to add new replica %s:%d",
+                  replicaDetails.replicationServerClient.getHost(),
+                  replicaDetails.replicationServerClient.getPort()));
         }
-
       }
     }
   }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/NRTPrimaryNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/NRTPrimaryNode.java
@@ -242,13 +242,15 @@ public class NRTPrimaryNode extends PrimaryNode {
       return;
     }
 
-    logMessage(
-        String.format(
-            "top: warm merge %s to %d replicas; localAddress=%s: files=%s",
-            info, replicasInfos.size(), hostPort, files.keySet()));
-
     MergePreCopy preCopy = new MergePreCopy(files);
-    warmingSegments.add(preCopy);
+    synchronized (warmingSegments) {
+      logMessage(
+          String.format(
+              "top: warm merge %s to %d replicas; localAddress=%s: files=%s",
+              info, replicasInfos.size(), hostPort, files.keySet()));
+
+      warmingSegments.add(preCopy);
+    }
 
     try {
       // Ask all currently known replicas to pre-copy this newly merged segment's files:


### PR DESCRIPTION
1. Fix possible race condition where a new replica might not be added to merge pre-copy
2. Avoid iterating over all clients when adding a new replica to merge precopy
3. Remove unused synchronization on preCopy.connections
4. Track transferStatus of merge precopy for new replicas. This will avoid errors like
```
top: ignore exception trying to read byte during warm for segment=<segment details> to replica=ReplicationServerClient(host=..., port=..., discoveryFile=): java.lang.NullPointerException: Cannot invoke "java.util.Iterator.hasNext()" because "transferStatusIterator" is null files=[_ihsw2.cfs, _ihsw2.cfe, _ihsw2.si] java.lang.NullPointerException: Cannot invoke "java.util.Iterator.hasNext()" because "transferStatusIterator" is null
	at com.yelp.nrtsearch.server.luceneserver.NRTPrimaryNode.preCopyMergedSegmentFiles(NRTPrimaryNode.java:368)
	at org.apache.lucene.replicator.nrt.PreCopyMergedSegmentWarmer.warm(PreCopyMergedSegmentWarmer.java:58)
	at org.apache.lucene.index.IndexWriter.mergeMiddle(IndexWriter.java:4610)
	at org.apache.lucene.index.IndexWriter.merge(IndexWriter.java:4057)
	at org.apache.lucene.index.ConcurrentMergeScheduler.doMerge(ConcurrentMergeScheduler.java:625)
	at org.apache.lucene.index.ConcurrentMergeScheduler$MergeThread.run(ConcurrentMergeScheduler.java:662)}
```
5. Make logs more understandable
6. Add a deadline to copyFiles. This is a temporary solution, going to follow up with a configurable deadline

I wasn't sure of a good way to write tests for these changes, but I confirmed that setting the deadline does cancel the transferStatusIterator.hasNext() call if deadline is exceeded.