### PR TITLE
Fix adding fields with similarity after index is started

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
@@ -26,9 +26,9 @@ import com.yelp.nrtsearch.server.luceneserver.field.ContextSuggestFieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.FieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.FieldDefCreator;
 import com.yelp.nrtsearch.server.luceneserver.field.IdFieldDef;
-import com.yelp.nrtsearch.server.luceneserver.field.IndexableFieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.TextBaseFieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.properties.GlobalOrdinalable;
+import com.yelp.nrtsearch.server.luceneserver.index.IndexSimilarity;
 import com.yelp.nrtsearch.server.luceneserver.index.LegacyIndexState;
 import com.yelp.nrtsearch.server.luceneserver.warming.Warmer;
 import com.yelp.nrtsearch.server.luceneserver.warming.WarmerConfig;
@@ -53,7 +53,6 @@ import org.apache.lucene.analysis.AnalyzerWrapper;
 import org.apache.lucene.expressions.Bindings;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.search.similarities.BM25Similarity;
 import org.apache.lucene.search.similarities.PerFieldSimilarityWrapper;
 import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.search.suggest.Lookup;
@@ -169,24 +168,12 @@ public abstract class IndexState implements Closeable {
         }
       };
 
-  /** Per-field wrapper that provides the similarity configured in the FieldDef */
-  public final Similarity sim =
+  /** Per-field wrapper that provides the similarity for searcher */
+  public final Similarity searchSimilarity =
       new PerFieldSimilarityWrapper() {
-        final Similarity defaultSim = new BM25Similarity();
-
         @Override
         public Similarity get(String name) {
-          try {
-            FieldDef fd = getField(name);
-            if (fd instanceof IndexableFieldDef) {
-              return ((IndexableFieldDef) fd).getSimilarity();
-            }
-          } catch (IllegalArgumentException ignored) {
-            // ReplicaNode tries to do a Term query for a field called 'marker'
-            // in finishNRTCopy. Since the field is not in the index, we want
-            // to ignore the exception.
-          }
-          return defaultSim;
+          return IndexSimilarity.getFromState(name, IndexState.this);
         }
       };
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -492,7 +492,7 @@ public class ShardState implements Closeable {
                   indexState.getSliceMaxDocs(),
                   indexState.getSliceMaxSegments(),
                   indexState.getVirtualShards()));
-      searcher.setSimilarity(indexState.sim);
+      searcher.setSimilarity(indexState.searchSimilarity);
       if (loadEagerOrdinals) {
         loadEagerGlobalOrdinals(reader, indexState);
       }
@@ -772,7 +772,7 @@ public class ShardState implements Closeable {
                               indexState.getSliceMaxDocs(),
                               indexState.getSliceMaxSegments(),
                               indexState.getVirtualShards()));
-                  searcher.setSimilarity(indexState.sim);
+                  searcher.setSimilarity(indexState.searchSimilarity);
                   return searcher;
                 }
               });

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/ImmutableIndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/ImmutableIndexState.java
@@ -660,7 +660,7 @@ public class ImmutableIndexState extends IndexState {
       iwc.setIndexSort(indexSort);
     }
 
-    iwc.setSimilarity(sim);
+    iwc.setSimilarity(new IndexSimilarity(indexStateManager));
     iwc.setRAMBufferSizeMB(indexRamBufferSizeMB);
 
     iwc.setMergedSegmentWarmer(new SimpleMergedSegmentWarmer(iwc.getInfoStream()));

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/IndexSimilarity.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/IndexSimilarity.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.index;
+
+import com.yelp.nrtsearch.server.luceneserver.IndexState;
+import com.yelp.nrtsearch.server.luceneserver.field.FieldDef;
+import com.yelp.nrtsearch.server.luceneserver.field.IndexableFieldDef;
+import org.apache.lucene.search.similarities.BM25Similarity;
+import org.apache.lucene.search.similarities.PerFieldSimilarityWrapper;
+import org.apache.lucene.search.similarities.Similarity;
+
+/**
+ * Similarity wrapper for use at indexing time, which finds the proper per field similarity. This
+ * similarity is set in the {@link org.apache.lucene.index.IndexWriterConfig} when an index is
+ * started. The {@link IndexStateManager} provides access to the fields in the latest {@link
+ * com.yelp.nrtsearch.server.luceneserver.IndexState}.
+ */
+public class IndexSimilarity extends PerFieldSimilarityWrapper {
+  private static final Similarity DEFAULT_SIMILARITY = new BM25Similarity();
+  private final IndexStateManager stateManager;
+
+  public IndexSimilarity(IndexStateManager stateManager) {
+    this.stateManager = stateManager;
+  }
+
+  @Override
+  public Similarity get(String name) {
+    return getFromState(name, stateManager.getCurrent());
+  }
+
+  /**
+   * Get the similarity implementation for a given field name from the given index state. If the
+   * field is not found, defaults to {@link BM25Similarity}.
+   *
+   * @param name field name
+   * @param indexState index state
+   * @return similarity implementation
+   */
+  public static Similarity getFromState(String name, IndexState indexState) {
+    try {
+      FieldDef fd = indexState.getField(name);
+      if (fd instanceof IndexableFieldDef) {
+        return ((IndexableFieldDef) fd).getSimilarity();
+      }
+    } catch (IllegalArgumentException ignored) {
+      // ReplicaNode tries to do a Term query for a field called 'marker'
+      // in finishNRTCopy. Since the field is not in the index, we want
+      // to ignore the exception.
+    }
+    return DEFAULT_SIMILARITY;
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/LegacyIndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/LegacyIndexState.java
@@ -1122,7 +1122,7 @@ public class LegacyIndexState extends IndexState implements Restorable {
       iwc.setIndexSort(indexSort);
     }
 
-    iwc.setSimilarity(sim);
+    iwc.setSimilarity(searchSimilarity);
     iwc.setRAMBufferSizeMB(indexRamBufferSizeMB);
 
     // nocommit in primary case we can't do this?

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/AddFieldsSimilarityTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/AddFieldsSimilarityTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.grpc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.yelp.nrtsearch.server.config.IndexStartConfig.IndexDataLocationType;
+import java.io.IOException;
+import java.util.List;
+import org.apache.lucene.search.similarities.BM25Similarity;
+import org.apache.lucene.search.similarities.ClassicSimilarity;
+import org.apache.lucene.search.similarities.PerFieldSimilarityWrapper;
+import org.apache.lucene.search.similarities.Similarity;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class AddFieldsSimilarityTest {
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  private static final List<Field> initialFields =
+      List.of(
+          Field.newBuilder()
+              .setName("id")
+              .setType(FieldType._ID)
+              .setStoreDocValues(true)
+              .setSearch(true)
+              .build(),
+          Field.newBuilder()
+              .setName("field1")
+              .setStoreDocValues(true)
+              .setSearch(true)
+              .setTokenize(true)
+              .setType(FieldType.TEXT)
+              .setSimilarity("classic")
+              .build());
+
+  private static final List<Field> additionalFields =
+      List.of(
+          Field.newBuilder()
+              .setName("field2")
+              .setStoreDocValues(true)
+              .setSearch(true)
+              .setTokenize(true)
+              .setType(FieldType.TEXT)
+              .setSimilarity("classic")
+              .build());
+
+  @After
+  public void cleanup() {
+    TestServer.cleanupAll();
+  }
+
+  private Similarity getSimilarity(TestServer server, String field) throws IOException {
+    Similarity writerSim =
+        server
+            .getGlobalState()
+            .getIndex("test_index")
+            .getShard(0)
+            .writer
+            .getConfig()
+            .getSimilarity();
+    assertTrue(writerSim instanceof PerFieldSimilarityWrapper);
+    return ((PerFieldSimilarityWrapper) writerSim).get(field);
+  }
+
+  @Test
+  public void testAddFieldsPreIndexStart() throws IOException {
+    TestServer primaryServer =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.LOCAL)
+            .build();
+    primaryServer.createIndex("test_index");
+    primaryServer.registerFields("test_index", initialFields);
+    primaryServer.registerFields("test_index", additionalFields);
+    primaryServer.startPrimaryIndex("test_index", -1, null);
+    assertEquals(BM25Similarity.class, getSimilarity(primaryServer, "id").getClass());
+    assertEquals(ClassicSimilarity.class, getSimilarity(primaryServer, "field1").getClass());
+    assertEquals(ClassicSimilarity.class, getSimilarity(primaryServer, "field2").getClass());
+  }
+
+  @Test
+  public void testAddFieldsPostIndexStart() throws IOException {
+    TestServer primaryServer =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.LOCAL)
+            .build();
+    primaryServer.createIndex("test_index");
+    primaryServer.startPrimaryIndex("test_index", -1, null);
+    primaryServer.registerFields("test_index", initialFields);
+    primaryServer.registerFields("test_index", additionalFields);
+    assertEquals(BM25Similarity.class, getSimilarity(primaryServer, "id").getClass());
+    assertEquals(ClassicSimilarity.class, getSimilarity(primaryServer, "field1").getClass());
+    assertEquals(ClassicSimilarity.class, getSimilarity(primaryServer, "field2").getClass());
+  }
+
+  @Test
+  public void testAddFieldsSplitIndexStart() throws IOException {
+    TestServer primaryServer =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.LOCAL)
+            .build();
+    primaryServer.createIndex("test_index");
+    primaryServer.registerFields("test_index", initialFields);
+    primaryServer.startPrimaryIndex("test_index", -1, null);
+    primaryServer.registerFields("test_index", additionalFields);
+    assertEquals(BM25Similarity.class, getSimilarity(primaryServer, "id").getClass());
+    assertEquals(ClassicSimilarity.class, getSimilarity(primaryServer, "field1").getClass());
+    assertEquals(ClassicSimilarity.class, getSimilarity(primaryServer, "field2").getClass());
+  }
+}


### PR DESCRIPTION
The `Similarity` implementation gets set once in the `IndexWriterConfig`, when the index starts. The existing `Similarity` from the `IndexState` only has access to the `FieldDefs` present at that time (since the state is immutable).

This branch creates a new `Similarity` that has access to the `IndexStateManger`, so that it can always see the current set of fields when indexing.

The search can still use the `IndexState` `Similarity`, since it always uses the current state when being recreated.