### PR TITLE
Dirchev: Return SuggestScoreDoc's key for CompletionQuery

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/MyTopSuggestDocsCollector.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/MyTopSuggestDocsCollector.java
@@ -36,6 +36,7 @@ import org.apache.lucene.search.suggest.document.TopSuggestDocs;
 import org.apache.lucene.search.suggest.document.TopSuggestDocsCollector;
 
 public class MyTopSuggestDocsCollector extends DocCollector {
+  public static final String SUGGEST_KEY_FIELD_NAME = "__suggest_key";
   private static final Comparator<TopSuggestDocs.SuggestScoreDoc> SUGGEST_SCORE_DOC_COMPARATOR =
       (a, b) -> {
         // sort by higher score
@@ -73,7 +74,7 @@ public class MyTopSuggestDocsCollector extends DocCollector {
     if (scoreDoc instanceof TopSuggestDocs.SuggestScoreDoc) {
       // set the retrieval key from the SuggestScoreDoc to the hit response as "__suggest_key" field
       hitResponse.putFields(
-          "__suggest_key",
+          SUGGEST_KEY_FIELD_NAME,
           SearchResponse.Hit.CompositeFieldValue.newBuilder()
               .addFieldValue(
                   SearchResponse.Hit.FieldValue.newBuilder()

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/MyTopSuggestDocsCollector.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/MyTopSuggestDocsCollector.java
@@ -70,6 +70,17 @@ public class MyTopSuggestDocsCollector extends DocCollector {
     if (!Float.isNaN(scoreDoc.score)) {
       hitResponse.setScore(scoreDoc.score);
     }
+    if (scoreDoc instanceof TopSuggestDocs.SuggestScoreDoc) {
+      // set the retrieval key from the SuggestScoreDoc to the hit response as "__suggest_key" field
+      hitResponse.putFields(
+          "__suggest_key",
+          SearchResponse.Hit.CompositeFieldValue.newBuilder()
+              .addFieldValue(
+                  SearchResponse.Hit.FieldValue.newBuilder()
+                      .setTextValue(((TopSuggestDocs.SuggestScoreDoc) scoreDoc).key.toString())
+                      .build())
+              .build());
+    }
   }
 
   @Override

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/ContextSuggestFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/ContextSuggestFieldDefTest.java
@@ -122,6 +122,15 @@ public class ContextSuggestFieldDefTest extends ServerTestCase {
 
     Set<String> hitsIds = getHitsIds(searchResponse);
     assertTrue(hitsIds.contains("3"));
+    String suggestKeyValueFromHit =
+        searchResponse
+            .getHitsList()
+            .get(0)
+            .getFieldsMap()
+            .get("__suggest_key")
+            .getFieldValue(0)
+            .getTextValue();
+    assertEquals("Tasty Burger", suggestKeyValueFromHit);
   }
 
   @Test
@@ -143,6 +152,15 @@ public class ContextSuggestFieldDefTest extends ServerTestCase {
 
     Set<String> hitsIds = getHitsIds(searchResponse);
     assertTrue(hitsIds.contains("5"));
+    String suggestKeyValueFromHit =
+        searchResponse
+            .getHitsList()
+            .get(0)
+            .getFieldsMap()
+            .get("__suggest_key")
+            .getFieldValue(0)
+            .getTextValue();
+    assertEquals("Fantastic Fries", suggestKeyValueFromHit);
   }
 
   @Test
@@ -182,6 +200,15 @@ public class ContextSuggestFieldDefTest extends ServerTestCase {
         getGrpcServer().getBlockingStub().search(getRequestWithQuery(query));
 
     assertEquals(1, searchResponse.getHitsCount());
+    String suggestKeyValueFromHit =
+        searchResponse
+            .getHitsList()
+            .get(0)
+            .getFieldsMap()
+            .get("__suggest_key")
+            .getFieldValue(0)
+            .getTextValue();
+    assertEquals("Burger Fries", suggestKeyValueFromHit);
 
     Set<String> hitsIds = getHitsIds(searchResponse);
     assertTrue(hitsIds.contains("4"));

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/ContextSuggestFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/ContextSuggestFieldDefTest.java
@@ -15,6 +15,7 @@
  */
 package com.yelp.nrtsearch.server.luceneserver.field;
 
+import static com.yelp.nrtsearch.server.luceneserver.search.collectors.MyTopSuggestDocsCollector.SUGGEST_KEY_FIELD_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -127,7 +128,7 @@ public class ContextSuggestFieldDefTest extends ServerTestCase {
             .getHitsList()
             .get(0)
             .getFieldsMap()
-            .get("__suggest_key")
+            .get(SUGGEST_KEY_FIELD_NAME)
             .getFieldValue(0)
             .getTextValue();
     assertEquals("Tasty Burger", suggestKeyValueFromHit);
@@ -157,7 +158,7 @@ public class ContextSuggestFieldDefTest extends ServerTestCase {
             .getHitsList()
             .get(0)
             .getFieldsMap()
-            .get("__suggest_key")
+            .get(SUGGEST_KEY_FIELD_NAME)
             .getFieldValue(0)
             .getTextValue();
     assertEquals("Fantastic Fries", suggestKeyValueFromHit);
@@ -205,7 +206,7 @@ public class ContextSuggestFieldDefTest extends ServerTestCase {
             .getHitsList()
             .get(0)
             .getFieldsMap()
-            .get("__suggest_key")
+            .get(SUGGEST_KEY_FIELD_NAME)
             .getFieldValue(0)
             .getTextValue();
     assertEquals("Burger Fries", suggestKeyValueFromHit);


### PR DESCRIPTION
# Return `SuggestStoreDoc`'s key for `CompletionQuery`

## Problem

When making searches using the new `CompletionQuery`, we have a use-case in which we want to retrieve the suggest key that was matched with the underlying `PrefixCompletionQuery`. This key is used later for raking.

## Solution

Updated the custom collector `MySuggestScoreDoc` collector to insert a new text field for each hit - `__suggest_key`. The field value is set to the `key` value of the `SuggestScoreDoc` for that hit.

## Example

For example, if we have a document with a `name_suggest` field of type `CONTEXT_SUGGEST`:

```json5
{
    "name_suggest": [
        "{\"value\":\"italian pizza\",\"contexts\":[\"US\"],\"weight\":5}",
        "{\"value\":\"pizza\",\"contexts\":[\"US\"],\"weight\":3}"
    ],
   "name": 
        "value": [
            "Italian Pizza"
        ],
    // ... other fields
}
```

And we make a search request using a `CompletionQuery`

```json5
{
    "indexName": "my_index",
    "startHit": 0,
    "topHits": 5,
    "retrieveFields": ["name"],
    "query": {
        "completionQuery": {
            "field": "name_suggest",
            "queryType": "PREFIX_QUERY",
            "text": "pi",
            "contexts": ["US"]
        }
    }
}
```

We get our matched document in the hit list, along with the new `__suggest_key` which corresponds to the matched key from the `name_suggest` field in addition to all other fields that were requested from `retrieveFields`

```
hits {
  luceneDocId: 26901
  score: 3.0
  fields {
    key: "__suggest_key"
    value {
      fieldValue {
        textValue: "pizza"
      }
    }
  }
  fields {
    key: "name"
    value {
      fieldValue {
        textValue: "{value=[Italian Pizza]}"
      }
    }
  }
}
```