### PR TITLE
Let plugins register additional token filters

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/analysis/AnalysisComponent.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/analysis/AnalysisComponent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.analysis;
+
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+
+/**
+ * Interface to provide additional nrtsearch related information to components of {@link
+ * org.apache.lucene.analysis.custom.CustomAnalyzer}s. The {@link
+ * #initializeComponent(LuceneServerConfiguration)} method is called after the custom analyzer is
+ * built, but before it is returned to the caller.
+ *
+ * <p>This is intended mainly to be used by custom implementations registered by plugins (currently
+ * only token filters supported). This is needed because the custom analyzer building does not give
+ * us direct control over instance creation of its subcomponents.
+ */
+public interface AnalysisComponent {
+
+  /**
+   * Method invoked after the {@link org.apache.lucene.analysis.custom.CustomAnalyzer} is built, but
+   * before it is returned to the caller. Provides nrtsearch related context information.
+   *
+   * @param configuration nrtsearch config accessor
+   */
+  void initializeComponent(LuceneServerConfiguration configuration);
+}

--- a/src/main/java/com/yelp/nrtsearch/server/plugins/AnalysisPlugin.java
+++ b/src/main/java/com/yelp/nrtsearch/server/plugins/AnalysisPlugin.java
@@ -19,11 +19,16 @@ import com.yelp.nrtsearch.server.luceneserver.analysis.AnalysisProvider;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.util.TokenFilterFactory;
 
 /**
- * Plugin interface for providing custom analysis implementations. Currently allows for the
- * registration of named {@link Analyzer} providers. These analyzers will be used when the name is
- * provides as the predefined AnalyzerType for queries and field registration.
+ * Plugin interface for providing custom analysis implementations.
+ *
+ * <p>Allows for the registration of named {@link Analyzer} providers. These analyzers will be used
+ * when the name is provided as the predefined AnalyzerType for queries and field registration.
+ *
+ * <p>Allows for the registration of additional {@link TokenFilterFactory} classes for use with
+ * {@link com.yelp.nrtsearch.server.grpc.CustomAnalyzer} building.
  */
 public interface AnalysisPlugin {
 
@@ -35,6 +40,22 @@ public interface AnalysisPlugin {
    * @return registration Map for analyzer name to {@link AnalysisProvider}
    */
   default Map<String, AnalysisProvider<? extends Analyzer>> getAnalyzers() {
+    return Collections.emptyMap();
+  }
+
+  /**
+   * Provides a set of custom {@link TokenFilterFactory} classes to register with the {@link
+   * com.yelp.nrtsearch.server.luceneserver.analysis.AnalyzerCreator} for use with {@link
+   * com.yelp.nrtsearch.server.grpc.CustomAnalyzer} building.
+   *
+   * <p>The class must have a constructor that takes only a param Map[String,String]. If nrtsearch
+   * specific context is required, implement the {@link
+   * com.yelp.nrtsearch.server.luceneserver.analysis.AnalysisComponent} interface to receive
+   * additional initialization during building.
+   *
+   * @return registration Map for token filter name to {@link TokenFilterFactory} class
+   */
+  default Map<String, Class<? extends TokenFilterFactory>> getTokenFilters() {
     return Collections.emptyMap();
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/ServerTestCase.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/ServerTestCase.java
@@ -229,7 +229,7 @@ public class ServerTestCase {
         testIndex,
         globalState.getPort(),
         null,
-        getPlugins());
+        getPlugins(luceneServerConfiguration));
   }
 
   protected void initIndices() throws Exception {
@@ -282,7 +282,7 @@ public class ServerTestCase {
 
   protected void initIndex(String name) throws Exception {}
 
-  protected List<Plugin> getPlugins() {
+  protected List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
     return Collections.emptyList();
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/custom/request/CustomRpcTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/custom/request/CustomRpcTest.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.server.luceneserver.custom.request;
 
 import static org.junit.Assert.assertEquals;
 
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.CustomRequest;
 import com.yelp.nrtsearch.server.grpc.CustomResponse;
 import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
@@ -32,7 +33,7 @@ public class CustomRpcTest extends ServerTestCase {
   @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
   @Override
-  protected List<Plugin> getPlugins() {
+  protected List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
     return List.of(new CustomRequestTestPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SharedDocContextTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SharedDocContextTest.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.server.luceneserver.doc;
 
 import static org.junit.Assert.assertEquals;
 
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
 import com.yelp.nrtsearch.server.grpc.Query;
@@ -109,7 +110,7 @@ public class SharedDocContextTest extends ServerTestCase {
   }
 
   @Override
-  public List<Plugin> getPlugins() {
+  public List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
     return Collections.singletonList(new TestSharedContextPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/FacetScriptFacetsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/facet/FacetScriptFacetsTest.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.server.luceneserver.facet;
 
 import static org.junit.Assert.assertEquals;
 
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.Facet;
 import com.yelp.nrtsearch.server.grpc.FacetResult;
@@ -256,7 +257,8 @@ public class FacetScriptFacetsTest extends ServerTestCase {
     }
   }
 
-  protected List<Plugin> getPlugins() {
+  @Override
+  protected List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
     return Collections.singletonList(new TestFacetScriptPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/rescore/RescorerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/rescore/RescorerTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
 import com.yelp.nrtsearch.server.grpc.PluginRescorer;
@@ -170,7 +171,8 @@ public class RescorerTest extends ServerTestCase {
     }
   }
 
-  protected List<Plugin> getPlugins() {
+  @Override
+  protected List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
     return Collections.singletonList(new TestRescorerPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/FetchTasksTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/FetchTasksTest.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.server.luceneserver.search;
 
 import static org.junit.Assert.assertEquals;
 
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.FetchTask;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
@@ -82,7 +83,7 @@ public class FetchTasksTest extends ServerTestCase {
   }
 
   @Override
-  public List<Plugin> getPlugins() {
+  public List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
     return Collections.singletonList(new TestFetchTaskPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/CollectorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/CollectorTest.java
@@ -23,6 +23,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.Collector;
 import com.yelp.nrtsearch.server.grpc.CollectorResult;
@@ -311,7 +312,8 @@ public class CollectorTest extends ServerTestCase {
     }
   }
 
-  protected List<Plugin> getPlugins() {
+  @Override
+  protected List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
     return Collections.singletonList(new TestCollectorPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/additional/CollectorStatsWrapperTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/additional/CollectorStatsWrapperTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.Collector;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
@@ -111,7 +112,7 @@ public class CollectorStatsWrapperTest extends ServerTestCase {
   }
 
   @Override
-  public List<Plugin> getPlugins() {
+  public List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
     return Collections.singletonList(new TestScriptPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/additional/ScriptTermsCollectorManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/additional/ScriptTermsCollectorManagerTest.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.server.luceneserver.search.collectors.additional;
 
 import static org.junit.Assert.assertEquals;
 
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.BucketResult;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
@@ -225,7 +226,8 @@ public class ScriptTermsCollectorManagerTest extends TermsCollectorManagerTestsB
         .build();
   }
 
-  protected List<Plugin> getPlugins() {
+  @Override
+  protected List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
     return Collections.singletonList(new TestTermsScriptPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/similarity/SimilarityTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/similarity/SimilarityTest.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.server.luceneserver.similarity;
 
 import static org.junit.Assert.assertEquals;
 
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest.MultiValuedField;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
@@ -105,7 +106,8 @@ public class SimilarityTest extends ServerTestCase {
     addDocuments(docs.stream());
   }
 
-  protected List<Plugin> getPlugins() {
+  @Override
+  protected List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
     return Collections.singletonList(new TestSimilarityPlugin());
   }
 


### PR DESCRIPTION
Adds the ability for `AnalysisPlugin`s to register custom `TokenFilterFactory`s for use when building `CustomAnalyzer`s.

The plugin provides a mapping of name to `Class` for these implementations. The name cannot conflict with that of a lucene provided filter, or a filter registered by another plugin.

The `TokenFilterFactory` implementation must provide a constructor that takes a single `Map<String,String>` parameter. This is needed because the `CustomAnalyzer` builder does not provide the ability to control creation of filter instances, and uses this constructor from the provided `Class`.

In order to allow access to nrtsearch information (like configuration), the `AnalysisComponent` interface has been created. Any token filter that implements this interface will have the `initializeComponent` method invoked after the `CustomAnalyzer` is built, but before it is returned to the caller.

This strategy should also work if we later want to extend character filters and tokenizers.