### PR TITLE
Start indices after replication server

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -159,30 +159,6 @@ public class LuceneServer {
 
     registerMetrics(globalState);
 
-    LuceneServerMonitoringServerInterceptor monitoringInterceptor =
-        LuceneServerMonitoringServerInterceptor.create(
-            Configuration.allMetrics()
-                .withLatencyBuckets(luceneServerConfiguration.getMetricsBuckets())
-                .withCollectorRegistry(collectorRegistry),
-            serviceName,
-            nodeName);
-    /* The port on which the server should run */
-    server =
-        ServerBuilder.forPort(luceneServerConfiguration.getPort())
-            .addService(ServerInterceptors.intercept(serverImpl, monitoringInterceptor))
-            .addService(ProtoReflectionService.newInstance())
-            .executor(
-                ThreadPoolExecutorFactory.getThreadPoolExecutor(
-                    ThreadPoolExecutorFactory.ExecutorType.LUCENESERVER,
-                    luceneServerConfiguration.getThreadPoolConfiguration()))
-            .maxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
-            .compressorRegistry(LuceneServerStubBuilder.COMPRESSOR_REGISTRY)
-            .decompressorRegistry(LuceneServerStubBuilder.DECOMPRESSOR_REGISTRY)
-            .build()
-            .start();
-    logger.info(
-        "Server started, listening on " + luceneServerConfiguration.getPort() + " for messages");
-
     if (luceneServerConfiguration.getMaxConcurrentCallsPerConnectionForReplication() != -1) {
       replicationServer =
           NettyServerBuilder.forPort(luceneServerConfiguration.getReplicationPort())
@@ -213,11 +189,37 @@ public class LuceneServer {
               .build()
               .start();
     }
-
     logger.info(
         "Server started, listening on "
             + luceneServerConfiguration.getReplicationPort()
             + " for replication messages");
+
+    // Inform global state that the replication server is started, and it is safe to start indices
+    globalState.replicationStarted();
+
+    LuceneServerMonitoringServerInterceptor monitoringInterceptor =
+        LuceneServerMonitoringServerInterceptor.create(
+            Configuration.allMetrics()
+                .withLatencyBuckets(luceneServerConfiguration.getMetricsBuckets())
+                .withCollectorRegistry(collectorRegistry),
+            serviceName,
+            nodeName);
+    /* The port on which the server should run */
+    server =
+        ServerBuilder.forPort(luceneServerConfiguration.getPort())
+            .addService(ServerInterceptors.intercept(serverImpl, monitoringInterceptor))
+            .addService(ProtoReflectionService.newInstance())
+            .executor(
+                ThreadPoolExecutorFactory.getThreadPoolExecutor(
+                    ThreadPoolExecutorFactory.ExecutorType.LUCENESERVER,
+                    luceneServerConfiguration.getThreadPoolConfiguration()))
+            .maxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
+            .compressorRegistry(LuceneServerStubBuilder.COMPRESSOR_REGISTRY)
+            .decompressorRegistry(LuceneServerStubBuilder.DECOMPRESSOR_REGISTRY)
+            .build()
+            .start();
+    logger.info(
+        "Server started, listening on " + luceneServerConfiguration.getPort() + " for messages");
 
     Runtime.getRuntime()
         .addShutdownHook(

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/GlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/GlobalState.java
@@ -183,6 +183,14 @@ public abstract class GlobalState implements Closeable {
     return Paths.get(indexDirBase.toString(), indexName);
   }
 
+  /**
+   * Hook that is invoked during startup after the replication grpc server starts, but before the
+   * client grpc server. Operations such as starting indices can be done here.
+   *
+   * @throws IOException
+   */
+  public abstract void replicationStarted() throws IOException;
+
   /** Get the data resource name for a given index. Used with incremental archiver functionality. */
   public abstract String getDataResourceForIndex(String indexName);
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/BackendGlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/BackendGlobalState.java
@@ -132,9 +132,7 @@ public class BackendGlobalState extends GlobalState {
       managerMap.put(entry.getKey(), stateManager);
     }
     immutableState = new ImmutableState(globalStateInfo, managerMap);
-    if (luceneServerConfiguration.getIndexStartConfig().getAutoStart()) {
-      updateStartedIndices(immutableState);
-    }
+    // If any indices should be started, it will be done in the replicationStarted hook
   }
 
   /**
@@ -206,6 +204,13 @@ public class BackendGlobalState extends GlobalState {
       return getIndex(indexName).getRootDir();
     } catch (IOException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void replicationStarted() throws IOException {
+    if (getConfiguration().getIndexStartConfig().getAutoStart()) {
+      updateStartedIndices(immutableState);
     }
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/LegacyGlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/LegacyGlobalState.java
@@ -139,6 +139,9 @@ public class LegacyGlobalState extends GlobalState implements Restorable {
   }
 
   @Override
+  public void replicationStarted() throws IOException {}
+
+  @Override
   public String getDataResourceForIndex(String indexName) {
     return indexName;
   }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/TestServer.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/TestServer.java
@@ -194,6 +194,8 @@ public class TestServer {
             .addService(new ReplicationServerImpl(serverImpl.getGlobalState()))
             .build()
             .start();
+    serverImpl.getGlobalState().replicationStarted();
+
     server = ServerBuilder.forPort(0).addService(serverImpl).build().start();
     client = new LuceneServerClient("localhost", server.getPort());
   }


### PR DESCRIPTION
Currently, auto starting indices at server startup happens during global state creation. This means that indices are started before the replication grpc server. Which means that replica nodes will not receive nrtpoint notifications or merge warming until afterwards.

The issue is that the initial nrtpoint sync that happens during index start will not get these notifications, resulting in failures as the primary index changes.

This branch changes the order of grpc server initialization, with the replication server now started first. Index starting has been moved from the global state constructor to a separate callback hook, which is invoked after the replication server starts but before the external client server.