### PR TITLE
Delete Replica unused last commit files

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -82,6 +82,7 @@ public class LuceneServerConfiguration {
   private final boolean downloadAsStream;
   private final boolean fileSendDelay;
   private final boolean virtualSharding;
+  private final boolean replicaCleanUpEnabled;
   private final boolean syncInitialNrtPoint;
   private final boolean indexVerbose;
   private final FileCopyConfig fileCopyConfig;
@@ -142,6 +143,7 @@ public class LuceneServerConfiguration {
     downloadAsStream = configReader.getBoolean("downloadAsStream", true);
     fileSendDelay = configReader.getBoolean("fileSendDelay", false);
     virtualSharding = configReader.getBoolean("virtualSharding", false);
+    replicaCleanUpEnabled = configReader.getBoolean("replicaCleanUpEnabled", false);
     syncInitialNrtPoint = configReader.getBoolean("syncInitialNrtPoint", true);
     indexVerbose = configReader.getBoolean("indexVerbose", false);
     fileCopyConfig = FileCopyConfig.fromConfig(configReader);
@@ -254,6 +256,10 @@ public class LuceneServerConfiguration {
 
   public boolean getVirtualSharding() {
     return virtualSharding;
+  }
+
+  public boolean getReplicaCleanUpEnabled() {
+    return replicaCleanUpEnabled;
   }
 
   public boolean getSyncInitialNrtPoint() {

--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -82,7 +82,7 @@ public class LuceneServerConfiguration {
   private final boolean downloadAsStream;
   private final boolean fileSendDelay;
   private final boolean virtualSharding;
-  private final boolean replicaCleanUpEnabled;
+  private final boolean decInitialCommit;
   private final boolean syncInitialNrtPoint;
   private final boolean indexVerbose;
   private final FileCopyConfig fileCopyConfig;
@@ -143,7 +143,7 @@ public class LuceneServerConfiguration {
     downloadAsStream = configReader.getBoolean("downloadAsStream", true);
     fileSendDelay = configReader.getBoolean("fileSendDelay", false);
     virtualSharding = configReader.getBoolean("virtualSharding", false);
-    replicaCleanUpEnabled = configReader.getBoolean("replicaCleanUpEnabled", false);
+    decInitialCommit = configReader.getBoolean("decInitialCommit", false);
     syncInitialNrtPoint = configReader.getBoolean("syncInitialNrtPoint", true);
     indexVerbose = configReader.getBoolean("indexVerbose", false);
     fileCopyConfig = FileCopyConfig.fromConfig(configReader);
@@ -258,8 +258,8 @@ public class LuceneServerConfiguration {
     return virtualSharding;
   }
 
-  public boolean getReplicaCleanUpEnabled() {
-    return replicaCleanUpEnabled;
+  public boolean getDecInitialCommit() {
+    return decInitialCommit;
   }
 
   public boolean getSyncInitialNrtPoint() {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -947,7 +947,7 @@ public class ShardState implements Closeable {
               new ShardSearcherFactory(true, false),
               verbose ? System.out : new PrintStream(OutputStream.nullOutputStream()),
               indexState.getGlobalState().getConfiguration().getFileCopyConfig().getAckedCopy(),
-              indexState.getGlobalState().getConfiguration().getReplicaCleanUpEnabled());
+              indexState.getGlobalState().getConfiguration().getDecInitialCommit());
       if (primaryGen != -1) {
         nrtReplicaNode.start(primaryGen);
       } else {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -946,7 +946,8 @@ public class ShardState implements Closeable {
               indexDir,
               new ShardSearcherFactory(true, false),
               verbose ? System.out : new PrintStream(OutputStream.nullOutputStream()),
-              indexState.getGlobalState().getConfiguration().getFileCopyConfig().getAckedCopy());
+              indexState.getGlobalState().getConfiguration().getFileCopyConfig().getAckedCopy(),
+              indexState.getGlobalState().getConfiguration().getReplicaCleanUpEnabled());
       if (primaryGen != -1) {
         nrtReplicaNode.start(primaryGen);
       } else {

--- a/src/main/java/org/apache/lucene/replicator/nrt/ReplicaDeleterManager.java
+++ b/src/main/java/org/apache/lucene/replicator/nrt/ReplicaDeleterManager.java
@@ -16,10 +16,9 @@
 package org.apache.lucene.replicator.nrt;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.HashSet;
+import org.apache.lucene.index.SegmentInfos;
 
 public class ReplicaDeleterManager {
 
@@ -33,25 +32,20 @@ public class ReplicaDeleterManager {
    * This method deletes the files in last committed files which are no longer used.
    * Unfortunately we cannot modify the last committed files list in ReplicaNode
    */
-  public void cleanUpReplicaFiles() throws IOException {
+  public void decReplicaInitialCommitFiles() throws IOException {
     synchronized (replicaNode.commitLock) {
-      String[] allFilesInDir;
-      Collection<String> indexFiles;
       synchronized (replicaNode) {
-        allFilesInDir = replicaNode.dir.listAll();
-        indexFiles = ((SegmentInfosSearcherManager) replicaNode.mgr).getCurrentInfos().files(true);
+        Collection<String> removableFiles = new HashSet<>();
+        String segmentsFileName =
+            SegmentInfos.getLastCommitSegmentsFileName(replicaNode.getDirectory());
+        if (segmentsFileName != null) {
+          Collection<String> indexFiles =
+              SegmentInfos.readCommit(replicaNode.getDirectory(), segmentsFileName).files(false);
+          removableFiles.addAll(indexFiles);
+          removableFiles.add(segmentsFileName);
+          replicaNode.deleter.decRef(removableFiles);
+        }
       }
-      List<String> removableFiles =
-          Arrays.stream(allFilesInDir)
-              .filter(f -> isRemovable(f, indexFiles))
-              .collect(Collectors.toList());
-      replicaNode.deleter.decRef(removableFiles);
     }
-  }
-
-  private boolean isRemovable(String fileName, Collection<String> activeFiles) {
-    return (!activeFiles.contains(fileName))
-        && (!replicaNode.lastNRTFiles.contains(fileName))
-        && (!replicaNode.pendingMergeFiles.contains(fileName));
   }
 }

--- a/src/main/java/org/apache/lucene/replicator/nrt/ReplicaDeleterManager.java
+++ b/src/main/java/org/apache/lucene/replicator/nrt/ReplicaDeleterManager.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.replicator.nrt;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ReplicaDeleterManager {
+
+  private final ReplicaNode replicaNode;
+
+  public ReplicaDeleterManager(ReplicaNode replicaNode) {
+    this.replicaNode = replicaNode;
+  }
+
+  /*
+   * This method deletes the files in last committed files which are no longer used.
+   * Unfortunately we cannot modify the last committed files list in ReplicaNode
+   */
+  public void cleanUpReplicaFiles() throws IOException {
+    synchronized (replicaNode.commitLock) {
+      String[] allFilesInDir;
+      Collection<String> indexFiles;
+      synchronized (replicaNode) {
+        allFilesInDir = replicaNode.dir.listAll();
+        indexFiles = ((SegmentInfosSearcherManager) replicaNode.mgr).getCurrentInfos().files(true);
+      }
+      List<String> removableFiles =
+          Arrays.stream(allFilesInDir)
+              .filter(f -> isRemovable(f, indexFiles))
+              .collect(Collectors.toList());
+      replicaNode.deleter.decRef(removableFiles);
+    }
+  }
+
+  private boolean isRemovable(String fileName, Collection<String> activeFiles) {
+    return (!activeFiles.contains(fileName))
+        && (!replicaNode.lastNRTFiles.contains(fileName))
+        && (!replicaNode.pendingMergeFiles.contains(fileName));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/TestServer.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/TestServer.java
@@ -470,6 +470,7 @@ public class TestServer {
                     .setTopHits(expectedCount + 1)
                     .setStartHit(0)
                     .build());
+
     assertEquals(expectedCount, response.getHitsCount());
     for (Hit hit : response.getHitsList()) {
       int id = Integer.parseInt(hit.getFieldsOrThrow("id").getFieldValue(0).getTextValue());
@@ -488,6 +489,10 @@ public class TestServer {
     client.commit(indexName);
   }
 
+  public void deleteAllDocuments(String indexName) {
+    client.deleteAllDocuments(indexName);
+  }
+
   public void deleteIndex(String indexName) {
     client.deleteIndex(indexName);
   }
@@ -502,6 +507,7 @@ public class TestServer {
     private String serviceName = SERVICE_NAME;
 
     private boolean autoStart = false;
+    private boolean decInitialCommit = false;
     private Mode mode = Mode.STANDALONE;
     private int port = 0;
     private IndexDataLocationType locationType = IndexDataLocationType.LOCAL;
@@ -556,6 +562,11 @@ public class TestServer {
 
     public Builder withIncArchiver(boolean enabled) {
       this.incArchiver = enabled;
+      return this;
+    }
+
+    public Builder withDecInitialCommit(boolean enabled) {
+      this.decInitialCommit = enabled;
       return this;
     }
 
@@ -635,6 +646,7 @@ public class TestServer {
           "stateDir: " + Paths.get(folder.getRoot().toString(), "state_dir"),
           "indexDir: " + Paths.get(folder.getRoot().toString(), "index_dir-" + uuid),
           "archiveDirectory: " + Paths.get(folder.getRoot().toString(), "archive_dir-" + uuid),
+          "decInitialCommit: " + decInitialCommit,
           "syncInitialNrtPoint: true");
     }
   }


### PR DESCRIPTION
Tried the idea to decRef of files not used. Need to add some test but might not be straightforward.

Unfortunately replicaNode.lastCommitFiles is not accessible since it is private. I would prefer using that instead of dir.listAll

Let me know if I should change something
