### PR TITLE
invalidate empty index name and add unit test

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -721,9 +721,7 @@ public class LuceneServer {
         responseObserver.onError(
             Status.INVALID_ARGUMENT
                 .withDescription(
-                    String.format(
-                        "error while trying to start index since indexName was empty: "
-                            + startIndexRequest.getIndexName()))
+                    String.format("error while trying to start index since indexName was empty."))
                 .asRuntimeException());
         return;
       }

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -717,7 +717,7 @@ public class LuceneServer {
         StartIndexRequest startIndexRequest, StreamObserver<StartIndexResponse> responseObserver) {
       logger.info("Received start index request: {}", startIndexRequest);
       if (startIndexRequest.getIndexName().isEmpty()) {
-        logger.warn("error while trying to start index " + startIndexRequest.getIndexName());
+        logger.warn("error while trying to start index with empty index name.");
         responseObserver.onError(
             Status.INVALID_ARGUMENT
                 .withDescription(

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -717,9 +717,13 @@ public class LuceneServer {
         StartIndexRequest startIndexRequest, StreamObserver<StartIndexResponse> responseObserver) {
       logger.info("Received start index request: {}", startIndexRequest);
       if (startIndexRequest.getIndexName().isEmpty()) {
+        logger.warn("error while trying to start index " + startIndexRequest.getIndexName());
         responseObserver.onError(
             Status.INVALID_ARGUMENT
-                .withDescription(String.format("Index name is empty - must not be empty"))
+                .withDescription(
+                    String.format(
+                        "error while trying to start index since indexName was empty: "
+                            + startIndexRequest.getIndexName()))
                 .asRuntimeException());
         return;
       }

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -716,6 +716,13 @@ public class LuceneServer {
     public void startIndex(
         StartIndexRequest startIndexRequest, StreamObserver<StartIndexResponse> responseObserver) {
       logger.info("Received start index request: {}", startIndexRequest);
+      if (startIndexRequest.getIndexName().isEmpty()) {
+        responseObserver.onError(
+            Status.INVALID_ARGUMENT
+                .withDescription(String.format("Index name is empty - must not be empty"))
+                .asRuntimeException());
+        return;
+      }
       try {
         StartIndexResponse reply;
         if (globalState.getConfiguration().getStateConfig().useLegacyStateManagement()) {

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -278,7 +278,7 @@ public class LuceneServerTest {
   }
 
   @Test
-  public void testStartIndex() throws IOException {
+  public void testStartIndex() {
     String testIndex = grpcServer.getTestIndex();
     LuceneServerGrpc.LuceneServerBlockingStub blockingStub = grpcServer.getBlockingStub();
     // create the index
@@ -286,9 +286,7 @@ public class LuceneServerTest {
     try {
       // start the index
       String emptyTestIndex = "";
-      StartIndexResponse reply =
-          blockingStub.startIndex(
-              StartIndexRequest.newBuilder().setIndexName(emptyTestIndex).build());
+      blockingStub.startIndex(StartIndexRequest.newBuilder().setIndexName(emptyTestIndex).build());
       fail("The above line must throw an exception");
     } catch (StatusRuntimeException e) {
       assertEquals(

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -278,6 +278,26 @@ public class LuceneServerTest {
   }
 
   @Test
+  public void testStartIndex() throws IOException {
+    String testIndex = grpcServer.getTestIndex();
+    LuceneServerGrpc.LuceneServerBlockingStub blockingStub = grpcServer.getBlockingStub();
+    // create the index
+    blockingStub.createIndex(CreateIndexRequest.newBuilder().setIndexName(testIndex).build());
+    try {
+      // start the index
+      String emptyTestIndex = "";
+      StartIndexResponse reply =
+          blockingStub.startIndex(
+              StartIndexRequest.newBuilder().setIndexName(emptyTestIndex).build());
+      fail("The above line must throw an exception");
+    } catch (StatusRuntimeException e) {
+      assertEquals(
+          String.format("INVALID_ARGUMENT: Index name is empty - must not be empty"),
+          e.getMessage());
+    }
+  }
+
+  @Test
   public void testRegisterFieldsBasic() throws Exception {
     FieldDefResponse reply =
         new GrpcServer.IndexAndRoleManager(grpcServer)

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -281,33 +281,24 @@ public class LuceneServerTest {
   public void testStartIndexWithEmptyString() {
     LuceneServerGrpc.LuceneServerBlockingStub blockingStub = grpcServer.getBlockingStub();
     try {
-      // start the index without creating any index
+      // start the index
       String emptyTestIndex = "";
       blockingStub.startIndex(StartIndexRequest.newBuilder().setIndexName(emptyTestIndex).build());
       fail("The above line must throw an exception");
     } catch (StatusRuntimeException e) {
       assertEquals(
           String.format(
-              "INVALID_ARGUMENT: error while trying to start index since indexName was empty: "),
+              "INVALID_ARGUMENT: error while trying to start index since indexName was empty."),
           e.getMessage());
     }
-  }
-
-  @Test
-  public void testCreateAndStartIndexWithEmptyString() {
-    LuceneServerGrpc.LuceneServerBlockingStub blockingStub = grpcServer.getBlockingStub();
-    String testIndex = grpcServer.getTestIndex();
-    // create the index
-    blockingStub.createIndex(CreateIndexRequest.newBuilder().setIndexName(testIndex).build());
     try {
-      // start the index after creating an index
-      String emptyTestIndex = "";
-      blockingStub.startIndex(StartIndexRequest.newBuilder().setIndexName(emptyTestIndex).build());
+      // start the index
+      blockingStub.startIndex(StartIndexRequest.newBuilder().build());
       fail("The above line must throw an exception");
     } catch (StatusRuntimeException e) {
       assertEquals(
           String.format(
-              "INVALID_ARGUMENT: error while trying to start index since indexName was empty: "),
+              "INVALID_ARGUMENT: error while trying to start index since indexName was empty."),
           e.getMessage());
     }
   }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -278,19 +278,31 @@ public class LuceneServerTest {
   }
 
   @Test
-  public void testStartIndex() {
-    String testIndex = grpcServer.getTestIndex();
+  public void testStartIndexWithEmptyString() {
     LuceneServerGrpc.LuceneServerBlockingStub blockingStub = grpcServer.getBlockingStub();
-    // create the index
-    blockingStub.createIndex(CreateIndexRequest.newBuilder().setIndexName(testIndex).build());
     try {
-      // start the index
+      // start the index without creating any index
       String emptyTestIndex = "";
       blockingStub.startIndex(StartIndexRequest.newBuilder().setIndexName(emptyTestIndex).build());
       fail("The above line must throw an exception");
     } catch (StatusRuntimeException e) {
       assertEquals(
-          String.format("INVALID_ARGUMENT: Index name is empty - must not be empty"),
+          String.format(
+              "INVALID_ARGUMENT: error while trying to start index since indexName was empty: "),
+          e.getMessage());
+    }
+    String testIndex = grpcServer.getTestIndex();
+    // create the index
+    blockingStub.createIndex(CreateIndexRequest.newBuilder().setIndexName(testIndex).build());
+    try {
+      // start the index after creating an index
+      String emptyTestIndex = "";
+      blockingStub.startIndex(StartIndexRequest.newBuilder().setIndexName(emptyTestIndex).build());
+      fail("The above line must throw an exception");
+    } catch (StatusRuntimeException e) {
+      assertEquals(
+          String.format(
+              "INVALID_ARGUMENT: error while trying to start index since indexName was empty: "),
           e.getMessage());
     }
   }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -291,6 +291,11 @@ public class LuceneServerTest {
               "INVALID_ARGUMENT: error while trying to start index since indexName was empty: "),
           e.getMessage());
     }
+  }
+
+  @Test
+  public void testCreateAndStartIndexWithEmptyString() {
+    LuceneServerGrpc.LuceneServerBlockingStub blockingStub = grpcServer.getBlockingStub();
     String testIndex = grpcServer.getTestIndex();
     // create the index
     blockingStub.createIndex(CreateIndexRequest.newBuilder().setIndexName(testIndex).build());


### PR DESCRIPTION
The server still tries to launch an index when its name is empty, which was never created before. 

The work here is to invalidate empty index name before everything starts.