### PR TITLE
support wildcard query

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
@@ -50,7 +50,6 @@ import com.yelp.nrtsearch.server.luceneserver.search.collectors.SortFieldCollect
 import com.yelp.nrtsearch.server.utils.ScriptParamsUtils;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -206,7 +205,8 @@ public class SearchRequestProcessor {
   private static Map<String, FieldDef> getRetrieveFields(
       SearchRequest request, Map<String, FieldDef> queryFields) {
     Map<String, FieldDef> retrieveFields = new HashMap<>();
-    if (request.getRetrieveFieldsList().equals(Arrays.asList("*"))) {
+    final String WILDCARD = "*";
+    if (request.getRetrieveFieldsCount() == 1 && request.getRetrieveFields(0).equals(WILDCARD)) {
       return queryFields;
     }
     for (String field : request.getRetrieveFieldsList()) {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
@@ -206,7 +206,7 @@ public class SearchRequestProcessor {
   private static Map<String, FieldDef> getRetrieveFields(
       SearchRequest request, Map<String, FieldDef> queryFields) {
     Map<String, FieldDef> retrieveFields = new HashMap<>();
-    if (request.getRetrieveFieldsList().equals(Arrays.asList("*")) || request.getRetrieveF) {
+    if (request.getRetrieveFieldsList().equals(Arrays.asList("*"))) {
       return queryFields;
     }
     for (String field : request.getRetrieveFieldsList()) {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
@@ -50,6 +50,7 @@ import com.yelp.nrtsearch.server.luceneserver.search.collectors.SortFieldCollect
 import com.yelp.nrtsearch.server.utils.ScriptParamsUtils;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -205,6 +206,9 @@ public class SearchRequestProcessor {
   private static Map<String, FieldDef> getRetrieveFields(
       SearchRequest request, Map<String, FieldDef> queryFields) {
     Map<String, FieldDef> retrieveFields = new HashMap<>();
+    if (request.getRetrieveFieldsList().equals(Arrays.asList("*")) || request.getRetrieveF) {
+      return queryFields;
+    }
     for (String field : request.getRetrieveFieldsList()) {
       FieldDef fieldDef = queryFields.get(field);
       if (fieldDef == null) {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
@@ -77,6 +77,8 @@ public class SearchRequestProcessor {
    */
   public static final int TOTAL_HITS_THRESHOLD = 1000;
 
+  public static final String WILDCARD = "*";
+
   private static final QueryNodeMapper QUERY_NODE_MAPPER = QueryNodeMapper.getInstance();
 
   private SearchRequestProcessor() {}
@@ -205,7 +207,6 @@ public class SearchRequestProcessor {
   private static Map<String, FieldDef> getRetrieveFields(
       SearchRequest request, Map<String, FieldDef> queryFields) {
     Map<String, FieldDef> retrieveFields = new HashMap<>();
-    final String WILDCARD = "*";
     if (request.getRetrieveFieldsCount() == 1 && request.getRetrieveFields(0).equals(WILDCARD)) {
       return queryFields;
     }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -867,6 +867,7 @@ public class LuceneServerTest {
         .getBlockingStub()
         .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
 
+    // support format of ["*"]
     SearchResponse searchResponse =
         grpcServer
             .getBlockingStub()
@@ -885,6 +886,7 @@ public class LuceneServerTest {
     SearchResponse.Hit secondHit = searchResponse.getHits(1);
     checkHits(secondHit);
 
+    // support format of "*"
     SearchResponse searchResponsePlainStar =
         grpcServer
             .getBlockingStub()

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -887,7 +887,7 @@ public class LuceneServerTest {
     checkHits(secondHit);
 
     // support format of "*"
-    SearchResponse searchResponsePlainStar =
+    SearchResponse searchResponseWithWildcard =
         grpcServer
             .getBlockingStub()
             .search(
@@ -898,11 +898,11 @@ public class LuceneServerTest {
                     .addRetrieveFields("*")
                     .build());
 
-    assertEquals(2, searchResponsePlainStar.getTotalHits().getValue());
-    assertEquals(2, searchResponsePlainStar.getHitsList().size());
-    SearchResponse.Hit firstHitPlainStar = searchResponsePlainStar.getHits(0);
+    assertEquals(2, searchResponseWithWildcard.getTotalHits().getValue());
+    assertEquals(2, searchResponseWithWildcard.getHitsList().size());
+    SearchResponse.Hit firstHitPlainStar = searchResponseWithWildcard.getHits(0);
     checkHits(firstHitPlainStar);
-    SearchResponse.Hit secondHitPlainStar = searchResponsePlainStar.getHits(1);
+    SearchResponse.Hit secondHitPlainStar = searchResponseWithWildcard.getHits(1);
     checkHits(secondHitPlainStar);
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -79,6 +79,7 @@ public class LuceneServerTest {
           "vendor_name_atom",
           "count",
           "long_field",
+          "long_field_multi",
           "double_field_multi",
           "double_field",
           "float_field_multi",
@@ -86,7 +87,8 @@ public class LuceneServerTest {
           "boolean_field_multi",
           "boolean_field",
           "description",
-          "date");
+          "date",
+          "date_multi");
   public static final List<String> INDEX_VIRTUAL_FIELDS =
       Arrays.asList("virtual_field", "virtual_field_w_score");
   public static final List<String> QUERY_VIRTUAL_FIELDS =
@@ -844,6 +846,36 @@ public class LuceneServerTest {
                     .setStartHit(0)
                     .setTopHits(10)
                     .addAllRetrieveFields(RETRIEVED_VALUES)
+                    .build());
+
+    assertEquals(2, searchResponse.getTotalHits().getValue());
+    assertEquals(2, searchResponse.getHitsList().size());
+    SearchResponse.Hit firstHit = searchResponse.getHits(0);
+    checkHits(firstHit);
+    SearchResponse.Hit secondHit = searchResponse.getHits(1);
+    checkHits(secondHit);
+  }
+
+  @Test
+  public void testSearchFetchingAllFieldsWithWildcard() throws IOException, InterruptedException {
+    GrpcServer.TestServer testAddDocs =
+        new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
+    // 2 docs addDocuments
+    testAddDocs.addDocuments();
+    // manual refresh
+    grpcServer
+        .getBlockingStub()
+        .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+
+    SearchResponse searchResponse =
+        grpcServer
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(grpcServer.getTestIndex())
+                    .setStartHit(0)
+                    .setTopHits(10)
+                    .addAllRetrieveFields(Arrays.asList("*"))
                     .build());
 
     assertEquals(2, searchResponse.getTotalHits().getValue());

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -884,6 +884,24 @@ public class LuceneServerTest {
     checkHits(firstHit);
     SearchResponse.Hit secondHit = searchResponse.getHits(1);
     checkHits(secondHit);
+
+    SearchResponse searchResponsePlainStar =
+        grpcServer
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(grpcServer.getTestIndex())
+                    .setStartHit(0)
+                    .setTopHits(10)
+                    .addRetrieveFields("*")
+                    .build());
+
+    assertEquals(2, searchResponsePlainStar.getTotalHits().getValue());
+    assertEquals(2, searchResponsePlainStar.getHitsList().size());
+    SearchResponse.Hit firstHitPlainStar = searchResponsePlainStar.getHits(0);
+    checkHits(firstHitPlainStar);
+    SearchResponse.Hit secondHitPlainStar = searchResponsePlainStar.getHits(1);
+    checkHits(secondHitPlainStar);
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -881,10 +881,10 @@ public class LuceneServerTest {
 
     assertEquals(2, searchResponse.getTotalHits().getValue());
     assertEquals(2, searchResponse.getHitsList().size());
-    SearchResponse.Hit firstHit = searchResponse.getHits(0);
-    checkHits(firstHit);
-    SearchResponse.Hit secondHit = searchResponse.getHits(1);
-    checkHits(secondHit);
+    SearchResponse.Hit firstHitWithArrOfWildcard = searchResponse.getHits(0);
+    checkHits(firstHitWithArrOfWildcard);
+    SearchResponse.Hit secondHitWithArrOfWildcard = searchResponse.getHits(1);
+    checkHits(secondHitWithArrOfWildcard);
 
     // support format of "*"
     SearchResponse searchResponseWithWildcard =
@@ -900,10 +900,10 @@ public class LuceneServerTest {
 
     assertEquals(2, searchResponseWithWildcard.getTotalHits().getValue());
     assertEquals(2, searchResponseWithWildcard.getHitsList().size());
-    SearchResponse.Hit firstHitPlainStar = searchResponseWithWildcard.getHits(0);
-    checkHits(firstHitPlainStar);
-    SearchResponse.Hit secondHitPlainStar = searchResponseWithWildcard.getHits(1);
-    checkHits(secondHitPlainStar);
+    SearchResponse.Hit firstHitWithStrOfWildcard = searchResponseWithWildcard.getHits(0);
+    checkHits(firstHitWithStrOfWildcard);
+    SearchResponse.Hit secondHitWithStrOfWildcard = searchResponseWithWildcard.getHits(1);
+    checkHits(secondHitWithStrOfWildcard);
   }
 
   @Test


### PR DESCRIPTION
Currently, you need to specify all fields names if you want to retrieve in the nrtsearch search request. This PR enables you to retrieve all index fields with `wild card` option.