### PR TITLE
Completion more efficient ContextQuery building, off heap FST option

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.lucene.search.suggest.document.CompletionPostingsFormat.FSTLoadMode;
 
 public class LuceneServerConfiguration {
   private static final Pattern ENV_VAR_PATTERN = Pattern.compile("\\$\\{([A-Za-z0-9_]+)}");
@@ -90,6 +91,7 @@ public class LuceneServerConfiguration {
   private final boolean deadlineCancellation;
   private final StateConfig stateConfig;
   private final IndexStartConfig indexStartConfig;
+  private final FSTLoadMode completionCodecLoadMode;
 
   private final YamlConfigReader configReader;
   private final long maxConnectionAgeForReplication;
@@ -152,6 +154,8 @@ public class LuceneServerConfiguration {
     deadlineCancellation = configReader.getBoolean("deadlineCancellation", false);
     stateConfig = StateConfig.fromConfig(configReader);
     indexStartConfig = IndexStartConfig.fromConfig(configReader);
+    completionCodecLoadMode =
+        FSTLoadMode.valueOf(configReader.getString("completionCodecLoadMode", "ON_HEAP"));
   }
 
   public ThreadPoolConfiguration getThreadPoolConfiguration() {
@@ -292,6 +296,10 @@ public class LuceneServerConfiguration {
 
   public IndexStartConfig getIndexStartConfig() {
     return indexStartConfig;
+  }
+
+  public FSTLoadMode getCompletionCodecLoadMode() {
+    return completionCodecLoadMode;
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -80,6 +80,7 @@ import java.util.concurrent.*;
 import java.util.stream.Collectors;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.QueryCache;
+import org.apache.lucene.search.suggest.document.CompletionPostingsFormatUtil;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.slf4j.Logger;
@@ -373,6 +374,8 @@ public class LuceneServer {
       this.restoreFromIncArchiver = configuration.getRestoreFromIncArchiver();
 
       DeadlineUtils.setCancellationEnabled(configuration.getDeadlineCancellation());
+      CompletionPostingsFormatUtil.setCompletionCodecLoadMode(
+          configuration.getCompletionCodecLoadMode());
 
       initQueryCache(configuration);
       initExtendableComponents(configuration, plugins);

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
@@ -63,8 +63,8 @@ import org.apache.lucene.search.join.QueryBitSetProducer;
 import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.search.join.ToParentBlockJoinQuery;
 import org.apache.lucene.search.suggest.document.CompletionQuery;
-import org.apache.lucene.search.suggest.document.ContextQuery;
 import org.apache.lucene.search.suggest.document.FuzzyCompletionQuery;
+import org.apache.lucene.search.suggest.document.MyContextQuery;
 import org.apache.lucene.search.suggest.document.PrefixCompletionQuery;
 import org.apache.lucene.util.QueryBuilder;
 
@@ -172,7 +172,7 @@ public class QueryNodeMapper {
         throw new UnsupportedOperationException(
             "Unsupported suggest query type received: " + completionQueryDef.getQueryType());
     }
-    ContextQuery contextQuery = new ContextQuery(completionQuery);
+    MyContextQuery contextQuery = new MyContextQuery(completionQuery);
     completionQueryDef.getContextsList().forEach(contextQuery::addContext);
     return contextQuery;
   }

--- a/src/main/java/org/apache/lucene/search/suggest/document/Completion84PostingsFormat.java
+++ b/src/main/java/org/apache/lucene/search/suggest/document/Completion84PostingsFormat.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search.suggest.document;
+
+import org.apache.lucene.codecs.PostingsFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Copy of the lucene Completion84PostingsFormat, but allows the FST load mode to be configured.
+ * Since this codec is loaded by class name, it must have the same name as the original and be
+ * present earlier in the class path.
+ */
+public class Completion84PostingsFormat extends CompletionPostingsFormat {
+  private static final Logger logger = LoggerFactory.getLogger(Completion84PostingsFormat.class);
+  /**
+   * Creates a {@link Completion84PostingsFormat} that will load the completion FST based on the
+   * value present in {@link CompletionPostingsFormatUtil}.
+   */
+  public Completion84PostingsFormat() {
+    this(CompletionPostingsFormatUtil.getCompletionCodecLoadMode());
+  }
+
+  /**
+   * Creates a {@link Completion84PostingsFormat} that will use the provided <code>fstLoadMode
+   * </code> to determine if the completion FST should be loaded on or off heap.
+   */
+  public Completion84PostingsFormat(FSTLoadMode fstLoadMode) {
+    super("Completion84", fstLoadMode);
+    logger.info("Created Completion84PostingsFormat with fstLoadMode: " + fstLoadMode);
+  }
+
+  @Override
+  protected PostingsFormat delegatePostingsFormat() {
+    return PostingsFormat.forName("Lucene84");
+  }
+}

--- a/src/main/java/org/apache/lucene/search/suggest/document/CompletionPostingsFormatUtil.java
+++ b/src/main/java/org/apache/lucene/search/suggest/document/CompletionPostingsFormatUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search.suggest.document;
+
+import org.apache.lucene.search.suggest.document.CompletionPostingsFormat.FSTLoadMode;
+
+/** Utility class for setting properties of the suggest completion codec. */
+public class CompletionPostingsFormatUtil {
+  private static FSTLoadMode completionCodecLoadMode = FSTLoadMode.ON_HEAP;
+
+  private CompletionPostingsFormatUtil() {}
+
+  /**
+   * Set the FST load mode used by the modified {@link Completion84PostingsFormat}. Must be set
+   * before any index data is loaded.
+   *
+   * @param loadMode new FST load mode
+   */
+  public static void setCompletionCodecLoadMode(FSTLoadMode loadMode) {
+    completionCodecLoadMode = loadMode;
+  }
+
+  /** Get the current FST load mode for completion codecs. */
+  public static FSTLoadMode getCompletionCodecLoadMode() {
+    return completionCodecLoadMode;
+  }
+}

--- a/src/main/java/org/apache/lucene/search/suggest/document/MyContextQuery.java
+++ b/src/main/java/org/apache/lucene/search/suggest/document/MyContextQuery.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search.suggest.document;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import org.apache.lucene.analysis.miscellaneous.ConcatenateGraphFilter;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.IntsRef;
+import org.apache.lucene.util.IntsRefBuilder;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.apache.lucene.util.automaton.Automata;
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.fst.Util;
+
+/**
+ * Modified version of lucene {@link ContextQuery}. In toContextAutomaton(), the context FST is
+ * built by creating the {@link Automaton} for each context, then creating the union. The original
+ * query unions each context together individually, which is not efficient. Unfortunately, because
+ * of the use of private members/methods, most of the original class needed to be copied.
+ */
+public class MyContextQuery extends ContextQuery {
+  private static final long BASE_RAM_BYTES =
+      RamUsageEstimator.shallowSizeOfInstance(MyContextQuery.class);
+
+  private IntsRefBuilder scratch = new IntsRefBuilder();
+  private Map<IntsRef, ContextMetaData> contexts;
+  private boolean matchAllContexts = false;
+  /** Inner completion query */
+  protected CompletionQuery innerQuery;
+
+  private long ramBytesUsed;
+
+  /**
+   * Constructs a context completion query that matches documents specified by <code>query</code>.
+   *
+   * <p>Use {@link #addContext(CharSequence, float, boolean)} to add context(s) with boost
+   */
+  public MyContextQuery(CompletionQuery query) {
+    super(query);
+    if (query instanceof ContextQuery) {
+      throw new IllegalArgumentException(
+          "'query' parameter must not be of type " + this.getClass().getSimpleName());
+    }
+    this.innerQuery = query;
+    contexts = new HashMap<>();
+    updateRamBytesUsed();
+  }
+
+  private void updateRamBytesUsed() {
+    ramBytesUsed =
+        BASE_RAM_BYTES
+            + RamUsageEstimator.sizeOfObject(contexts)
+            + RamUsageEstimator.sizeOfObject(
+                innerQuery, RamUsageEstimator.QUERY_DEFAULT_RAM_BYTES_USED);
+  }
+
+  /** Adds an exact context with default boost of 1 */
+  public void addContext(CharSequence context) {
+    addContext(context, 1f, true);
+  }
+
+  /** Adds an exact context with boost */
+  public void addContext(CharSequence context, float boost) {
+    addContext(context, boost, true);
+  }
+
+  /**
+   * Adds a context with boost, set <code>exact</code> to false if the context is a prefix of any
+   * indexed contexts
+   */
+  public void addContext(CharSequence context, float boost, boolean exact) {
+    if (boost < 0f) {
+      throw new IllegalArgumentException("'boost' must be >= 0");
+    }
+    for (int i = 0; i < context.length(); i++) {
+      if (ContextSuggestField.CONTEXT_SEPARATOR == context.charAt(i)) {
+        throw new IllegalArgumentException(
+            "Illegal value ["
+                + context
+                + "] UTF-16 codepoint [0x"
+                + Integer.toHexString((int) context.charAt(i))
+                + "] at position "
+                + i
+                + " is a reserved character");
+      }
+    }
+    contexts.put(
+        IntsRef.deepCopyOf(Util.toIntsRef(new BytesRef(context), scratch)),
+        new ContextMetaData(boost, exact));
+    updateRamBytesUsed();
+  }
+
+  /** Add all contexts with a boost of 1f */
+  public void addAllContexts() {
+    matchAllContexts = true;
+  }
+
+  @Override
+  public String toString(String field) {
+    StringBuilder buffer = new StringBuilder();
+    BytesRefBuilder scratch = new BytesRefBuilder();
+    for (Map.Entry<IntsRef, ContextMetaData> entry : contexts.entrySet()) {
+      if (buffer.length() != 0) {
+        buffer.append(",");
+      } else {
+        buffer.append("contexts");
+        buffer.append(":[");
+      }
+      buffer.append(Util.toBytesRef(entry.getKey(), scratch).utf8ToString());
+      ContextMetaData metaData = entry.getValue();
+      if (metaData.exact == false) {
+        buffer.append("*");
+      }
+      if (metaData.boost != 0) {
+        buffer.append("^");
+        buffer.append(Float.toString(metaData.boost));
+      }
+    }
+    if (buffer.length() != 0) {
+      buffer.append("]");
+      buffer.append(",");
+    }
+    return buffer.toString() + innerQuery.toString(field);
+  }
+
+  @Override
+  public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
+      throws IOException {
+    final CompletionWeight innerWeight =
+        ((CompletionWeight) innerQuery.createWeight(searcher, scoreMode, boost));
+    final Automaton innerAutomaton = innerWeight.getAutomaton();
+
+    // If the inner automaton matches nothing, then we return an empty weight to avoid
+    // traversing all contexts during scoring.
+    if (innerAutomaton.getNumStates() == 0) {
+      return new CompletionWeight(this, innerAutomaton);
+    }
+
+    // if separators are preserved the fst contains a SEP_LABEL
+    // behind each gap. To have a matching automaton, we need to
+    // include the SEP_LABEL in the query as well
+    Automaton optionalSepLabel =
+        Operations.optional(Automata.makeChar(ConcatenateGraphFilter.SEP_LABEL));
+    Automaton prefixAutomaton = Operations.concatenate(optionalSepLabel, innerAutomaton);
+    Automaton contextsAutomaton =
+        Operations.concatenate(toContextAutomaton(contexts, matchAllContexts), prefixAutomaton);
+    contextsAutomaton =
+        Operations.determinize(contextsAutomaton, Operations.DEFAULT_MAX_DETERMINIZED_STATES);
+
+    final Map<IntsRef, Float> contextMap = new HashMap<>(contexts.size());
+    final TreeSet<Integer> contextLengths = new TreeSet<>();
+    for (Map.Entry<IntsRef, ContextMetaData> entry : contexts.entrySet()) {
+      ContextMetaData contextMetaData = entry.getValue();
+      contextMap.put(entry.getKey(), contextMetaData.boost);
+      contextLengths.add(entry.getKey().length);
+    }
+    int[] contextLengthArray = new int[contextLengths.size()];
+    final Iterator<Integer> iterator = contextLengths.descendingIterator();
+    for (int i = 0; iterator.hasNext(); i++) {
+      contextLengthArray[i] = iterator.next();
+    }
+    return new ContextCompletionWeight(
+        this, contextsAutomaton, innerWeight, contextMap, contextLengthArray);
+  }
+
+  private static Automaton toContextAutomaton(
+      final Map<IntsRef, ContextMetaData> contexts, final boolean matchAllContexts) {
+    final Automaton matchAllAutomaton = Operations.repeat(Automata.makeAnyString());
+    final Automaton sep = Automata.makeChar(ContextSuggestField.CONTEXT_SEPARATOR);
+    if (matchAllContexts || contexts.size() == 0) {
+      return Operations.concatenate(matchAllAutomaton, sep);
+    } else {
+      List<Automaton> contextAutos = new ArrayList<>(contexts.size());
+      for (Map.Entry<IntsRef, ContextMetaData> entry : contexts.entrySet()) {
+        final ContextMetaData contextMetaData = entry.getValue();
+        final IntsRef ref = entry.getKey();
+        Automaton contextAutomaton = Automata.makeString(ref.ints, ref.offset, ref.length);
+        if (contextMetaData.exact == false) {
+          contextAutomaton = Operations.concatenate(contextAutomaton, matchAllAutomaton);
+        }
+        contextAutos.add(Operations.concatenate(contextAutomaton, sep));
+      }
+      return Operations.union(contextAutos);
+    }
+  }
+
+  /** Holder for context value meta data */
+  private static class ContextMetaData {
+
+    /** Boost associated with a context value */
+    private final float boost;
+
+    /**
+     * flag to indicate whether the context value should be treated as an exact value or a context
+     * prefix
+     */
+    private final boolean exact;
+
+    private ContextMetaData(float boost, boolean exact) {
+      this.boost = boost;
+      this.exact = exact;
+    }
+  }
+
+  private static class ContextCompletionWeight extends CompletionWeight {
+
+    private final Map<IntsRef, Float> contextMap;
+    private final int[] contextLengths;
+    private final CompletionWeight innerWeight;
+    private final BytesRefBuilder scratch = new BytesRefBuilder();
+
+    private float currentBoost;
+    private CharSequence currentContext;
+
+    public ContextCompletionWeight(
+        CompletionQuery query,
+        Automaton automaton,
+        CompletionWeight innerWeight,
+        Map<IntsRef, Float> contextMap,
+        int[] contextLengths)
+        throws IOException {
+      super(query, automaton);
+      this.contextMap = contextMap;
+      this.contextLengths = contextLengths;
+      this.innerWeight = innerWeight;
+    }
+
+    @Override
+    protected void setNextMatch(final IntsRef pathPrefix) {
+      IntsRef ref = pathPrefix.clone();
+
+      // check if the pathPrefix matches any
+      // defined context, longer context first
+      for (int contextLength : contextLengths) {
+        if (contextLength > pathPrefix.length) {
+          continue;
+        }
+        ref.length = contextLength;
+        if (contextMap.containsKey(ref)) {
+          currentBoost = contextMap.get(ref);
+          ref.length = pathPrefix.length;
+          setInnerWeight(ref, contextLength);
+          return;
+        }
+      }
+      // unknown context
+      ref.length = pathPrefix.length;
+      currentBoost = 0f;
+      setInnerWeight(ref, 0);
+    }
+
+    private void setInnerWeight(IntsRef ref, int offset) {
+      IntsRefBuilder refBuilder = new IntsRefBuilder();
+      for (int i = offset; i < ref.length; i++) {
+        if (ref.ints[ref.offset + i] == ContextSuggestField.CONTEXT_SEPARATOR) {
+          if (i > 0) {
+            refBuilder.copyInts(ref.ints, ref.offset, i);
+            currentContext = Util.toBytesRef(refBuilder.get(), scratch).utf8ToString();
+          } else {
+            currentContext = null;
+          }
+          ref.offset = ++i;
+          assert ref.offset < ref.length : "input should not end with the context separator";
+          if (ref.ints[i] == ConcatenateGraphFilter.SEP_LABEL) {
+            ref.offset++;
+            assert ref.offset < ref.length
+                : "input should not end with a context separator followed by SEP_LABEL";
+          }
+          ref.length = ref.length - ref.offset;
+          refBuilder.copyInts(ref.ints, ref.offset, ref.length);
+          innerWeight.setNextMatch(refBuilder.get());
+          return;
+        }
+      }
+    }
+
+    @Override
+    protected CharSequence context() {
+      return currentContext;
+    }
+
+    @Override
+    protected float boost() {
+      return currentBoost + innerWeight.boost();
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int hashCode() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void visit(QueryVisitor visitor) {
+    visitor.visitLeaf(this);
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return ramBytesUsed;
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/config/LuceneServerConfigurationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/LuceneServerConfigurationTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.ByteArrayInputStream;
 import java.lang.reflect.Field;
 import java.util.Map;
+import org.apache.lucene.search.suggest.document.CompletionPostingsFormat.FSTLoadMode;
 import org.junit.Test;
 
 public class LuceneServerConfigurationTest {
@@ -77,5 +78,19 @@ public class LuceneServerConfigurationTest {
             "\n", "nodeName: \"lucene_server_foo\"", "hostName: my_${VAR4}_${VAR3}_${VAR4}_host");
     LuceneServerConfiguration luceneConfig = getForConfig(config);
     assertEquals("my__v3__host", luceneConfig.getHostName());
+  }
+
+  @Test
+  public void testDefaultCompletionCodecLoadMode() {
+    String config = "nodeName: \"lucene_server_foo\"";
+    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    assertEquals(FSTLoadMode.ON_HEAP, luceneConfig.getCompletionCodecLoadMode());
+  }
+
+  @Test
+  public void testSetCompletionCodecLoadMode() {
+    String config = "completionCodecLoadMode: OFF_HEAP";
+    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    assertEquals(FSTLoadMode.OFF_HEAP, luceneConfig.getCompletionCodecLoadMode());
   }
 }

--- a/src/test/java/org/apache/lucene/search/suggest/document/CompletionPostingsFormatUtilTest.java
+++ b/src/test/java/org/apache/lucene/search/suggest/document/CompletionPostingsFormatUtilTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search.suggest.document;
+
+import static org.junit.Assert.assertEquals;
+
+import com.yelp.nrtsearch.server.config.IndexStartConfig.IndexDataLocationType;
+import com.yelp.nrtsearch.server.grpc.Mode;
+import com.yelp.nrtsearch.server.grpc.TestServer;
+import java.io.IOException;
+import org.apache.lucene.search.suggest.document.CompletionPostingsFormat.FSTLoadMode;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class CompletionPostingsFormatUtilTest {
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  @After
+  public void cleanup() {
+    TestServer.cleanupAll();
+  }
+
+  @Test
+  public void testDefaultFSTLoadMode() throws IOException {
+    TestServer.builder(folder)
+        .withAutoStartConfig(true, Mode.REPLICA, 0, IndexDataLocationType.LOCAL)
+        .build();
+    assertEquals(FSTLoadMode.ON_HEAP, CompletionPostingsFormatUtil.getCompletionCodecLoadMode());
+  }
+
+  @Test
+  public void testSetFSTLoadMode() throws IOException {
+    TestServer.builder(folder)
+        .withAutoStartConfig(true, Mode.REPLICA, 0, IndexDataLocationType.LOCAL)
+        .withAdditionalConfig("completionCodecLoadMode: OFF_HEAP")
+        .build();
+    assertEquals(FSTLoadMode.OFF_HEAP, CompletionPostingsFormatUtil.getCompletionCodecLoadMode());
+  }
+}


### PR DESCRIPTION
This branch makes some potential improvement to the completion suggest use case based on some profiling I did.

1. The completion codec defaults to loading the segment field FSTs on heap, which takes up a lot of space for large indices. I added the ability to specify the load mode, to allow for off heap loading. This was not very straightforward to do, since lucene uses Service Provider instantiation to load the class, which does not allow for parameters. I ended up re-defining the class to shadow the lucene version.
2. The `ContextQuery` does not build its weight efficiently for large number of contexts (O(seconds) for O(1k) contexts). The query builds the `Automaton` for each context value, and iteratively unions them together. I created a new version of this query that builds all the context `Automaton`s, then does a single union operation.