### PR TITLE
Priority queue improvements for suggest search

### DIFF
--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/MyTopSuggestDocsCollectorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/MyTopSuggestDocsCollectorTest.java
@@ -36,18 +36,18 @@ public class MyTopSuggestDocsCollectorTest {
     suggestScoreDocsByCollector =
         new TopSuggestDocs.SuggestScoreDoc[][] {
           new TopSuggestDocs.SuggestScoreDoc[] {
-            new TopSuggestDocs.SuggestScoreDoc(1, "Pizza", "a", 11),
             new TopSuggestDocs.SuggestScoreDoc(1, "Pizza Place", "a", 22),
-            new TopSuggestDocs.SuggestScoreDoc(3, "Pizza", "a", 15),
             new TopSuggestDocs.SuggestScoreDoc(6, "Pizza", "a", 17),
+            new TopSuggestDocs.SuggestScoreDoc(3, "Pizza", "a", 15),
             new TopSuggestDocs.SuggestScoreDoc(1, "Pizza", "b", 12),
+            new TopSuggestDocs.SuggestScoreDoc(1, "Pizza", "a", 11),
           },
           new TopSuggestDocs.SuggestScoreDoc[] {
+            new TopSuggestDocs.SuggestScoreDoc(2, "Pizza Palace", "a", 25),
+            new TopSuggestDocs.SuggestScoreDoc(4, "Pizza", "a", 16),
             new TopSuggestDocs.SuggestScoreDoc(2, "Pizza", "b", 12),
             new TopSuggestDocs.SuggestScoreDoc(5, "Pizza", "a", 5),
             new TopSuggestDocs.SuggestScoreDoc(7, "Pizza", "a", 4),
-            new TopSuggestDocs.SuggestScoreDoc(2, "Pizza Palace", "a", 25),
-            new TopSuggestDocs.SuggestScoreDoc(4, "Pizza", "a", 16),
           }
         };
   }


### PR DESCRIPTION
After doing some testing with completion queries, it appears that suggestions are collected in descending score order regardless of index sorting.

This branch changes the collector based on this property:
- The priority queue is a min heap with a max size
- Inserting an element into the queue returns what was displaced
- Segment collection terminates early when the current suggestion is lower than the minimum in a full queue

This should help lower the time spent processing non-competitive suggestions.