### PR TITLE
Call weight.getQuery().toString() once per query instead of once per leaf

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/MyIndexSearcher.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/MyIndexSearcher.java
@@ -239,6 +239,9 @@ public class MyIndexSearcher extends IndexSearcher {
   @Override
   protected void search(List<LeafReaderContext> leaves, Weight weight, Collector collector)
       throws IOException {
+    boolean isDrillSidewaysQueryOrCompletionQuery =
+        weight.getQuery() instanceof CompletionQuery
+            || weight.getQuery().toString().contains("DrillSidewaysQuery");
     for (LeafReaderContext ctx : leaves) { // search each subreader
       // we force the use of Scorer (not BulkScorer) to make sure
       // that the scorer passed to LeafCollector.setScorer supports
@@ -251,8 +254,7 @@ public class MyIndexSearcher extends IndexSearcher {
         // continue with the following leaf
         continue;
       }
-      if (weight.getQuery().toString().contains("DrillSidewaysQuery")
-          || weight.getQuery() instanceof CompletionQuery) {
+      if (isDrillSidewaysQueryOrCompletionQuery) {
         BulkScorer scorer = weight.bulkScorer(ctx);
         if (scorer != null) {
           try {


### PR DESCRIPTION
`toString` on a query object can be significantly expensive for large queries. Trying to avoid doing it multiple times for a single query. I also changed the order of the calls so the toString would not be called at all for CompletionQuery.

It would be better to avoid calling toString at all....but I couldn't find any test for which `weight.getQuery().toString().contains("DrillSidewaysQuery")` is true.