### PR TITLE
Improve adding multiple contexts to MyContextQuery

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
@@ -179,7 +179,7 @@ public class QueryNodeMapper {
             "Unsupported suggest query type received: " + completionQueryDef.getQueryType());
     }
     MyContextQuery contextQuery = new MyContextQuery(completionQuery);
-    completionQueryDef.getContextsList().forEach(contextQuery::addContext);
+    contextQuery.addContexts(completionQueryDef.getContextsList());
     return contextQuery;
   }
 

--- a/src/main/java/org/apache/lucene/search/suggest/document/MyContextQuery.java
+++ b/src/main/java/org/apache/lucene/search/suggest/document/MyContextQuery.java
@@ -94,6 +94,25 @@ public class MyContextQuery extends ContextQuery {
    * indexed contexts
    */
   public void addContext(CharSequence context, float boost, boolean exact) {
+    addContextInternal(context, boost, exact);
+    updateRamBytesUsed();
+  }
+
+  /**
+   * Add a List of exact contexts with default boost of 1.
+   *
+   * @param contextsList contexts
+   * @param <T> context type
+   */
+  public <T extends CharSequence> void addContexts(List<T> contextsList) {
+    for (CharSequence context : contextsList) {
+      addContextInternal(context, 1.0f, true);
+    }
+    // updating memory usage scales with number of contexts, so only do it once
+    updateRamBytesUsed();
+  }
+
+  private void addContextInternal(CharSequence context, float boost, boolean exact) {
     if (boost < 0f) {
       throw new IllegalArgumentException("'boost' must be >= 0");
     }
@@ -112,7 +131,6 @@ public class MyContextQuery extends ContextQuery {
     contexts.put(
         IntsRef.deepCopyOf(Util.toIntsRef(new BytesRef(context), scratch)),
         new ContextMetaData(boost, exact));
-    updateRamBytesUsed();
   }
 
   /** Add all contexts with a boost of 1f */


### PR DESCRIPTION
Adds a bulk `addContexts` method to `MyContextQuery`.

I found that adding contexts iteratively scaled poorly because it resulted in N invocations of `updateRamBytesUsed`. Adding O(1k) contexts took O(100ms). Switching to a single invocation noticeably reduced query building time.