### PR TITLE
Added local rst documentation generation using gradle plugin + some documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,8 @@ plugins {
     id "com.diffplug.gradle.spotless" version "4.3.0"
     id 'java-library'
     id 'jacoco'
+    // Build docs locally by running "site" command
+    id 'kr.motd.sphinx' version '2.10.0'
 }
 
 repositories {
@@ -308,6 +310,13 @@ spotless {
         trimTrailingWhitespace()
         googleJavaFormat()
     }
+}
+
+sphinx {
+    sourceDirectory = "${projectDir}/docs"
+    outputDirectory = "${project.buildDir}/docs"
+    // Remove if not using OS X. This is required on non-Intel macs since aarch-64 build is not available.
+    binaryUrl       = 'https://github.com/trustin/sphinx-binary/releases/download/v0.8.2/sphinx.osx-x86_64'
 }
 
 // Inject properties file containing the project version into resources.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,2 @@
+# This file is required by Sphinx gradle plugin.
+project = "Nrtsearch"

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,0 +1,8 @@
+Development
+===========
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   development/*

--- a/docs/development/add_live_setting.rst
+++ b/docs/development/add_live_setting.rst
@@ -1,7 +1,7 @@
 Adding A New Live Setting
 ==========================
 
-* Add new live setting to ``IndexSettings`` in ``luceneserver.proto`` and regenerate the protobuf files
+* Add new live setting to ``IndexLiveSettings`` in ``luceneserver.proto`` using the appropriate `wrapped primitive <https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/wrappers.proto>`_ and regenerate the protobuf files
 * Add abstract getter method to ``IndexState.java``
 * Implement the getter method in ``LegacyIndexState.java`` and return a sane default
 * In ``ImmutableIndexState.java``:

--- a/docs/development/add_live_setting.rst
+++ b/docs/development/add_live_setting.rst
@@ -1,0 +1,15 @@
+Adding A New Live Setting
+==========================
+
+* Add new live setting to ``IndexSettings`` in ``luceneserver.proto`` and regenerate the protobuf files
+* Add abstract getter method to ``IndexState.java``
+* Implement the getter method in ``LegacyIndexState.java`` and return a sane default
+* In ``ImmutableIndexState.java``:
+   * Create a class field to hold the instance value
+   * Assign instance value in the constructor
+   * Implement the getter method and return the class field
+   * Add default value in ``DEFAULT_INDEX_LIVE_SETTINGS`` which is used when the field is not specified in the committed state
+   * Add validation to ``validateLiveSettings`` method
+* Add to ``LiveSettingsV2Command`` in cli
+* Access the new live setting by calling ``indexStateManager.getCurrent().get<new_live_setting_name>()``
+* Add _set/_default/_invalid tests for the new property to ``ImmutableIndexStateTest.java``

--- a/docs/development/writing_documentation.rst
+++ b/docs/development/writing_documentation.rst
@@ -1,0 +1,9 @@
+Writing Documentation
+=====================
+
+* Create a ``.rst`` file under ``<root>/docs/<subdirectory>``
+* Add the content following `ReStructuredText <https://en.wikipedia.org/wiki/ReStructuredText>`_ format
+* Make sure the new file can be accessed from the index by adding any links if needed
+* Generate the documents to preview by running ``./gradlew site``
+* The previews will be generated under ``<root>/build/docs``
+* Make any changes if needed, once satisfied create a PR and merge to master after approval

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,3 +16,4 @@ A high performance gRPC server, with optional REST APIs on top of `Apache Lucene
    index_live_settings
    docker_compose
    server_configuration
+   development


### PR DESCRIPTION
Using a gradle plugin to generate html for the rst files under docs. I've also added documentation for the same under a new "Development" section in the docs and also added instructions to add a new live setting to nrtsearch.

The generated documentation looks like this:
![Screenshot 2022-12-21 at 7 06 46 PM](https://user-images.githubusercontent.com/12890299/209047166-7497e880-6559-4b08-929c-15a0437845a5.png)
![Screenshot 2022-12-22 at 2 31 07 PM](https://user-images.githubusercontent.com/12890299/209236661-abbdc766-ef82-4007-8391-c19f053ac5a0.png)

