### PR TITLE
RP-6869: Add option to filter incompatible segment readers during refresh

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -94,6 +94,7 @@ public class LuceneServerConfiguration {
   private final IndexStartConfig indexStartConfig;
   private final int discoveryFileUpdateIntervalMs;
   private final FSTLoadMode completionCodecLoadMode;
+  private final boolean filterIncompatibleSegmentReaders;
 
   private final YamlConfigReader configReader;
   private final long maxConnectionAgeForReplication;
@@ -161,6 +162,8 @@ public class LuceneServerConfiguration {
             "discoveryFileUpdateIntervalMs", ReplicationServerClient.FILE_UPDATE_INTERVAL_MS);
     completionCodecLoadMode =
         FSTLoadMode.valueOf(configReader.getString("completionCodecLoadMode", "ON_HEAP"));
+    filterIncompatibleSegmentReaders =
+        configReader.getBoolean("filterIncompatibleSegmentReaders", false);
   }
 
   public ThreadPoolConfiguration getThreadPoolConfiguration() {
@@ -309,6 +312,10 @@ public class LuceneServerConfiguration {
 
   public FSTLoadMode getCompletionCodecLoadMode() {
     return completionCodecLoadMode;
+  }
+
+  public boolean getFilterIncompatibleSegmentReaders() {
+    return filterIncompatibleSegmentReaders;
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ReplicaCurrentSearchingVersionHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ReplicaCurrentSearchingVersionHandler.java
@@ -25,7 +25,7 @@ public class ReplicaCurrentSearchingVersionHandler implements Handler<IndexName,
   public SearcherVersion handle(IndexState indexState, IndexName indexNameRequest)
       throws HandlerException {
     ShardState shardState = indexState.getShard(0);
-    if (shardState.isReplica() == false) {
+    if (!shardState.isReplica() || !shardState.isStarted()) {
       throw new IllegalArgumentException(
           "index \""
               + indexNameRequest.getIndexName()

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -15,6 +15,7 @@
  */
 package com.yelp.nrtsearch.server.luceneserver;
 
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.DeadlineUtils;
 import com.yelp.nrtsearch.server.grpc.IndexLiveSettings;
 import com.yelp.nrtsearch.server.grpc.ReplicationServerClient;
@@ -939,6 +940,7 @@ public class ShardState implements Closeable {
           new HostPort(
               indexState.getGlobalState().getHostName(),
               indexState.getGlobalState().getReplicationPort());
+      LuceneServerConfiguration configuration = indexState.getGlobalState().getConfiguration();
       nrtReplicaNode =
           new NRTReplicaNode(
               indexState.getName(),
@@ -948,9 +950,9 @@ public class ShardState implements Closeable {
               indexDir,
               new ShardSearcherFactory(true, false),
               verbose ? System.out : new PrintStream(OutputStream.nullOutputStream()),
-              indexState.getGlobalState().getConfiguration().getFileCopyConfig().getAckedCopy(),
-              indexState.getGlobalState().getConfiguration().getDecInitialCommit(),
-              indexState.getGlobalState().getConfiguration().getFilterIncompatibleSegmentReaders());
+              configuration.getFileCopyConfig().getAckedCopy(),
+              configuration.getDecInitialCommit(),
+              configuration.getFilterIncompatibleSegmentReaders());
       if (primaryGen != -1) {
         nrtReplicaNode.start(primaryGen);
       } else {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -949,7 +949,8 @@ public class ShardState implements Closeable {
               new ShardSearcherFactory(true, false),
               verbose ? System.out : new PrintStream(OutputStream.nullOutputStream()),
               indexState.getGlobalState().getConfiguration().getFileCopyConfig().getAckedCopy(),
-              indexState.getGlobalState().getConfiguration().getDecInitialCommit());
+              indexState.getGlobalState().getConfiguration().getDecInitialCommit(),
+              indexState.getGlobalState().getConfiguration().getFilterIncompatibleSegmentReaders());
       if (primaryGen != -1) {
         nrtReplicaNode.start(primaryGen);
       } else {

--- a/src/main/java/org/apache/lucene/replicator/nrt/FilteringSegmentInfosSearcherManager.java
+++ b/src/main/java/org/apache/lucene/replicator/nrt/FilteringSegmentInfosSearcherManager.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.SegmentReader;
@@ -80,12 +81,12 @@ public class FilteringSegmentInfosSearcherManager extends SegmentInfosSearcherMa
         final SegmentReader sr = (SegmentReader) old.getIndexReader().leaves().get(i).reader();
         oldReadersMap.put(sr.getSegmentName(), i);
       }
+      List<LeafReaderContext> leaves = old.getIndexReader().leaves();
       subs = new ArrayList<>();
       for (SegmentCommitInfo commitInfo : newInfos) {
         Integer oldReaderIndex = oldReadersMap.get(commitInfo.info.name);
         if (oldReaderIndex != null) {
-          SegmentReader oldReader =
-              (SegmentReader) old.getIndexReader().leaves().get(oldReaderIndex).reader();
+          SegmentReader oldReader = (SegmentReader) leaves.get(oldReaderIndex).reader();
           // check if old reader is compatible with new segment data
           if (Arrays.equals(commitInfo.info.getId(), oldReader.getSegmentInfo().info.getId())) {
             subs.add(oldReader);

--- a/src/main/java/org/apache/lucene/replicator/nrt/FilteringSegmentInfosSearcherManager.java
+++ b/src/main/java/org/apache/lucene/replicator/nrt/FilteringSegmentInfosSearcherManager.java
@@ -75,13 +75,13 @@ public class FilteringSegmentInfosSearcherManager extends SegmentInfosSearcherMa
     if (old == null) {
       subs = null;
     } else {
+      List<LeafReaderContext> leaves = old.getIndexReader().leaves();
       // create map of segment name to reader ordinal
       final Map<String, Integer> oldReadersMap = new HashMap<>();
-      for (int i = 0; i < old.getIndexReader().leaves().size(); ++i) {
-        final SegmentReader sr = (SegmentReader) old.getIndexReader().leaves().get(i).reader();
+      for (int i = 0; i < leaves.size(); ++i) {
+        final SegmentReader sr = (SegmentReader) leaves.get(i).reader();
         oldReadersMap.put(sr.getSegmentName(), i);
       }
-      List<LeafReaderContext> leaves = old.getIndexReader().leaves();
       subs = new ArrayList<>();
       for (SegmentCommitInfo commitInfo : newInfos) {
         Integer oldReaderIndex = oldReadersMap.get(commitInfo.info.name);

--- a/src/main/java/org/apache/lucene/replicator/nrt/FilteringSegmentInfosSearcherManager.java
+++ b/src/main/java/org/apache/lucene/replicator/nrt/FilteringSegmentInfosSearcherManager.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.replicator.nrt;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.StandardDirectoryReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ReferenceManager;
+import org.apache.lucene.search.SearcherFactory;
+import org.apache.lucene.search.SearcherManager;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.StringHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Extension of {@link SegmentInfosSearcherManager} which filters previous readers that are
+ * incompatible during a refresh. Useful for replicas, when a primary restart may lead to segment
+ * name reuse for un-committed data synced through nrt points.
+ */
+public class FilteringSegmentInfosSearcherManager extends SegmentInfosSearcherManager {
+  private static final Logger logger =
+      LoggerFactory.getLogger(FilteringSegmentInfosSearcherManager.class);
+  private final Directory dir;
+  private final Node node;
+  private final AtomicInteger openReaderCount = new AtomicInteger();
+  private final SearcherFactory searcherFactory;
+
+  public FilteringSegmentInfosSearcherManager(
+      Directory dir,
+      Node node,
+      ReferenceManager<IndexSearcher> mgr,
+      SearcherFactory searcherFactory)
+      throws IOException {
+    super(dir, node, ((SegmentInfosSearcherManager) mgr).getCurrentInfos(), searcherFactory);
+    this.dir = dir;
+    this.node = node;
+    if (searcherFactory == null) {
+      searcherFactory = new SearcherFactory();
+    }
+    this.searcherFactory = searcherFactory;
+  }
+
+  @Override
+  protected IndexSearcher refreshIfNeeded(IndexSearcher old) throws IOException {
+    final SegmentInfos newInfos = getCurrentInfos();
+    List<LeafReader> subs;
+    if (old == null) {
+      subs = null;
+    } else {
+      // create map of segment name to reader ordinal
+      final Map<String, Integer> oldReadersMap = new HashMap<>();
+      for (int i = 0; i < old.getIndexReader().leaves().size(); ++i) {
+        final SegmentReader sr = (SegmentReader) old.getIndexReader().leaves().get(i).reader();
+        oldReadersMap.put(sr.getSegmentName(), i);
+      }
+      subs = new ArrayList<>();
+      for (SegmentCommitInfo commitInfo : newInfos) {
+        Integer oldReaderIndex = oldReadersMap.get(commitInfo.info.name);
+        if (oldReaderIndex != null) {
+          SegmentReader oldReader =
+              (SegmentReader) old.getIndexReader().leaves().get(oldReaderIndex).reader();
+          // check if old reader is compatible with new segment data
+          if (Arrays.equals(commitInfo.info.getId(), oldReader.getSegmentInfo().info.getId())) {
+            subs.add(oldReader);
+          } else {
+            logger.info(
+                "Skipping incompatible old reader, name: "
+                    + commitInfo.info.name
+                    + ", old id: "
+                    + StringHelper.idToString(oldReader.getSegmentInfo().info.getId())
+                    + ", new id: "
+                    + StringHelper.idToString(commitInfo.info.getId()));
+          }
+        }
+      }
+    }
+
+    // Open a new reader, sharing any common segment readers with the old one:
+    DirectoryReader r = StandardDirectoryReader.open(dir, newInfos, subs, Collections.emptyMap());
+    addReaderClosedListenerFilter(r);
+    node.message("refreshed to version=" + newInfos.getVersion() + " r=" + r);
+    IndexReader oldReader = old != null ? old.getIndexReader() : null;
+    return SearcherManager.getSearcher(searcherFactory, r, oldReader);
+  }
+
+  private void addReaderClosedListenerFilter(IndexReader r) {
+    IndexReader.CacheHelper cacheHelper = r.getReaderCacheHelper();
+    if (cacheHelper == null) {
+      throw new IllegalStateException("StandardDirectoryReader must support caching");
+    }
+    openReaderCount.incrementAndGet();
+    cacheHelper.addClosedListener(cacheKey -> onReaderClosedFilter());
+  }
+
+  /**
+   * Tracks how many readers are still open, so that when we are closed, we can additionally wait
+   * until all in-flight searchers are closed. This method must have a different name than the one
+   * in the parent class, since the reference counts are maintained separately.
+   */
+  synchronized void onReaderClosedFilter() {
+    if (openReaderCount.decrementAndGet() == 0) {
+      notifyAll();
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/PrimaryRestartTests.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/PrimaryRestartTests.java
@@ -15,8 +15,19 @@
  */
 package com.yelp.nrtsearch.server.grpc;
 
+import static org.junit.Assert.assertEquals;
+
 import com.yelp.nrtsearch.server.config.IndexStartConfig.IndexDataLocationType;
+import com.yelp.nrtsearch.server.grpc.SearchResponse.Hit;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.SearcherLifetimeManager.PruneByAge;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -64,8 +75,6 @@ public class PrimaryRestartTests {
     replicaServer.verifySimpleDocs("test_index", 5);
   }
 
-  // This test models the current behavior when the primary restarts. This behavior is not
-  // desired, and the test should be updated/extended once it is fixed.
   @Test
   public void testPrimaryRestartReplication() throws IOException {
     TestServer primaryServer =
@@ -102,6 +111,7 @@ public class PrimaryRestartTests {
 
     replicaServer.waitForReplication("test_index");
 
+    // primary index version not greater than local version on replica
     primaryServer.verifySimpleDocIds("test_index", 1, 2, 3, 6, 7, 8);
     replicaServer.verifySimpleDocIds("test_index", 1, 2, 3, 4, 5);
 
@@ -110,7 +120,377 @@ public class PrimaryRestartTests {
 
     replicaServer.waitForReplication("test_index");
 
+    // primary version is greater, but conflicting segment files prevent replica from updating
     primaryServer.verifySimpleDocIds("test_index", 1, 2, 3, 6, 7, 8, 9);
     replicaServer.verifySimpleDocIds("test_index", 1, 2, 3, 4, 5);
+  }
+
+  @Test
+  public void testPrimaryRestartReplicationFilterIncompatible() throws IOException {
+    TestServer primaryServer =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.REMOTE)
+            .withWriteDiscoveryFile(true)
+            .build();
+    primaryServer.createSimpleIndex("test_index");
+    primaryServer.startPrimaryIndex("test_index", -1, null);
+
+    primaryServer.addSimpleDocs("test_index", 1, 2, 3);
+    primaryServer.commit("test_index");
+    primaryServer.refresh("test_index");
+
+    TestServer replicaServer =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.REPLICA, -1, IndexDataLocationType.REMOTE)
+            .withAdditionalConfig(
+                String.join(
+                    "\n",
+                    "discoveryFileUpdateIntervalMs: 1000",
+                    "filterIncompatibleSegmentReaders: true"))
+            .build();
+
+    primaryServer.addSimpleDocs("test_index", 4, 5);
+    primaryServer.refresh("test_index");
+
+    replicaServer.waitForReplication("test_index");
+
+    primaryServer.restart();
+    primaryServer.verifySimpleDocIds("test_index", 1, 2, 3);
+    replicaServer.verifySimpleDocIds("test_index", 1, 2, 3, 4, 5);
+
+    replicaServer.registerWithPrimary("test_index");
+
+    primaryServer.addSimpleDocs("test_index", 6, 7, 8);
+    primaryServer.refresh("test_index");
+
+    replicaServer.waitForReplication("test_index");
+
+    // primary index version not greater than local version on replica
+    primaryServer.verifySimpleDocIds("test_index", 1, 2, 3, 6, 7, 8);
+    replicaServer.verifySimpleDocIds("test_index", 1, 2, 3, 4, 5);
+
+    primaryServer.addSimpleDocs("test_index", 9);
+    primaryServer.refresh("test_index");
+
+    replicaServer.waitForReplication("test_index");
+
+    // primary version is greater and conflicting segments are filtered
+    primaryServer.verifySimpleDocIds("test_index", 1, 2, 3, 6, 7, 8, 9);
+    replicaServer.verifySimpleDocIds("test_index", 1, 2, 3, 6, 7, 8, 9);
+  }
+
+  @Test
+  public void testPreviousReplicaSearcher() throws IOException {
+    TestServer primaryServer =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.REMOTE)
+            .withWriteDiscoveryFile(true)
+            .build();
+    primaryServer.createSimpleIndex("test_index");
+    primaryServer.startPrimaryIndex("test_index", -1, null);
+
+    primaryServer.addSimpleDocs("test_index", 1, 2, 3);
+    primaryServer.commit("test_index");
+    primaryServer.refresh("test_index");
+
+    TestServer replicaServer =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.REPLICA, -1, IndexDataLocationType.REMOTE)
+            .withAdditionalConfig(
+                String.join(
+                    "\n",
+                    "discoveryFileUpdateIntervalMs: 1000",
+                    "filterIncompatibleSegmentReaders: true"))
+            .build();
+
+    primaryServer.addSimpleDocs("test_index", 4, 5);
+    primaryServer.refresh("test_index");
+
+    replicaServer.waitForReplication("test_index");
+    replicaServer.verifySimpleDocIds("test_index", 1, 2, 3, 4, 5);
+    long previousSearcherVersion1 =
+        replicaServer
+            .getClient()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName("test_index")
+                    .setQuery(Query.newBuilder().build())
+                    .build())
+            .getSearchState()
+            .getSearcherVersion();
+
+    primaryServer.addSimpleDocs("test_index", 6, 7, 8);
+    primaryServer.refresh("test_index");
+
+    replicaServer.waitForReplication("test_index");
+    replicaServer.verifySimpleDocIds("test_index", 1, 2, 3, 4, 5, 6, 7, 8);
+    long previousSearcherVersion2 =
+        replicaServer
+            .getClient()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName("test_index")
+                    .setQuery(Query.newBuilder().build())
+                    .build())
+            .getSearchState()
+            .getSearcherVersion();
+
+    primaryServer.restart();
+    primaryServer.verifySimpleDocIds("test_index", 1, 2, 3);
+    replicaServer.verifySimpleDocIds("test_index", 1, 2, 3, 4, 5, 6, 7, 8);
+
+    replicaServer.registerWithPrimary("test_index");
+
+    // advance primary index version past replica
+    primaryServer.addSimpleDocs("test_index", 9);
+    primaryServer.refresh("test_index");
+    primaryServer.addSimpleDocs("test_index", 10);
+    primaryServer.refresh("test_index");
+    primaryServer.addSimpleDocs("test_index", 11);
+    primaryServer.refresh("test_index");
+
+    replicaServer.waitForReplication("test_index");
+
+    primaryServer.verifySimpleDocIds("test_index", 1, 2, 3, 9, 10, 11);
+    replicaServer.verifySimpleDocIds("test_index", 1, 2, 3, 9, 10, 11);
+
+    verifySimpleDocIdsForVersion(
+        replicaServer, previousSearcherVersion1, "test_index", 1, 2, 3, 4, 5);
+    verifySimpleDocIdsForVersion(
+        replicaServer, previousSearcherVersion2, "test_index", 1, 2, 3, 4, 5, 6, 7, 8);
+
+    primaryServer.addSimpleDocs("test_index", 12);
+    primaryServer.refresh("test_index");
+
+    replicaServer.waitForReplication("test_index");
+
+    primaryServer.verifySimpleDocIds("test_index", 1, 2, 3, 9, 10, 11, 12);
+    replicaServer.verifySimpleDocIds("test_index", 1, 2, 3, 9, 10, 11, 12);
+
+    verifySimpleDocIdsForVersion(
+        replicaServer, previousSearcherVersion1, "test_index", 1, 2, 3, 4, 5);
+    verifySimpleDocIdsForVersion(
+        replicaServer, previousSearcherVersion2, "test_index", 1, 2, 3, 4, 5, 6, 7, 8);
+  }
+
+  @Test
+  public void testCleanupPreviousSearcher() throws IOException, InterruptedException {
+    TestServer primaryServer =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.REMOTE)
+            .withWriteDiscoveryFile(true)
+            .build();
+    primaryServer.createSimpleIndex("test_index");
+    primaryServer.startPrimaryIndex("test_index", -1, null);
+
+    primaryServer.addSimpleDocs("test_index", 1, 2, 3);
+    primaryServer.commit("test_index");
+    primaryServer.refresh("test_index");
+
+    TestServer replicaServer =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.REPLICA, -1, IndexDataLocationType.REMOTE)
+            .withAdditionalConfig(
+                String.join(
+                    "\n",
+                    "discoveryFileUpdateIntervalMs: 1000",
+                    "filterIncompatibleSegmentReaders: true"))
+            .build();
+
+    primaryServer.addSimpleDocs("test_index", 4, 5);
+    primaryServer.refresh("test_index");
+
+    replicaServer.waitForReplication("test_index");
+    replicaServer.verifySimpleDocIds("test_index", 1, 2, 3, 4, 5);
+    long previousSearcherVersion1 =
+        replicaServer
+            .getClient()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName("test_index")
+                    .setQuery(Query.newBuilder().build())
+                    .build())
+            .getSearchState()
+            .getSearcherVersion();
+    IndexSearcher previousSearcher1 =
+        replicaServer
+            .getGlobalState()
+            .getIndex("test_index")
+            .getShard(0)
+            .slm
+            .acquire(previousSearcherVersion1);
+    List<LeafReaderContext> previousLeaves1 = previousSearcher1.getIndexReader().leaves();
+    replicaServer
+        .getGlobalState()
+        .getIndex("test_index")
+        .getShard(0)
+        .slm
+        .release(previousSearcher1);
+
+    primaryServer.addSimpleDocs("test_index", 6, 7, 8);
+    primaryServer.refresh("test_index");
+
+    replicaServer.waitForReplication("test_index");
+    replicaServer.verifySimpleDocIds("test_index", 1, 2, 3, 4, 5, 6, 7, 8);
+    long previousSearcherVersion2 =
+        replicaServer
+            .getClient()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName("test_index")
+                    .setQuery(Query.newBuilder().build())
+                    .build())
+            .getSearchState()
+            .getSearcherVersion();
+    IndexSearcher previousSearcher2 =
+        replicaServer
+            .getGlobalState()
+            .getIndex("test_index")
+            .getShard(0)
+            .slm
+            .acquire(previousSearcherVersion2);
+    List<LeafReaderContext> previousLeaves2 = previousSearcher2.getIndexReader().leaves();
+    replicaServer
+        .getGlobalState()
+        .getIndex("test_index")
+        .getShard(0)
+        .slm
+        .release(previousSearcher2);
+
+    primaryServer.restart();
+    primaryServer.verifySimpleDocIds("test_index", 1, 2, 3);
+    replicaServer.verifySimpleDocIds("test_index", 1, 2, 3, 4, 5, 6, 7, 8);
+
+    replicaServer.registerWithPrimary("test_index");
+
+    // advance primary index version past replica
+    primaryServer.addSimpleDocs("test_index", 9);
+    primaryServer.refresh("test_index");
+    primaryServer.addSimpleDocs("test_index", 10);
+    primaryServer.refresh("test_index");
+    primaryServer.addSimpleDocs("test_index", 11);
+    primaryServer.refresh("test_index");
+
+    replicaServer.waitForReplication("test_index");
+    long currentSearcherVersion1 =
+        replicaServer
+            .getClient()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName("test_index")
+                    .setQuery(Query.newBuilder().build())
+                    .build())
+            .getSearchState()
+            .getSearcherVersion();
+    IndexSearcher currentSearcher1 =
+        replicaServer
+            .getGlobalState()
+            .getIndex("test_index")
+            .getShard(0)
+            .slm
+            .acquire(currentSearcherVersion1);
+    List<LeafReaderContext> currentLeaves1 = currentSearcher1.getIndexReader().leaves();
+    replicaServer.getGlobalState().getIndex("test_index").getShard(0).slm.release(currentSearcher1);
+
+    primaryServer.verifySimpleDocIds("test_index", 1, 2, 3, 9, 10, 11);
+    replicaServer.verifySimpleDocIds("test_index", 1, 2, 3, 9, 10, 11);
+
+    verifySimpleDocIdsForVersion(
+        replicaServer, previousSearcherVersion1, "test_index", 1, 2, 3, 4, 5);
+    verifySimpleDocIdsForVersion(
+        replicaServer, previousSearcherVersion2, "test_index", 1, 2, 3, 4, 5, 6, 7, 8);
+
+    primaryServer.addSimpleDocs("test_index", 12);
+    primaryServer.refresh("test_index");
+
+    replicaServer.waitForReplication("test_index");
+    long currentSearcherVersion2 =
+        replicaServer
+            .getClient()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName("test_index")
+                    .setQuery(Query.newBuilder().build())
+                    .build())
+            .getSearchState()
+            .getSearcherVersion();
+    IndexSearcher currentSearcher2 =
+        replicaServer
+            .getGlobalState()
+            .getIndex("test_index")
+            .getShard(0)
+            .slm
+            .acquire(currentSearcherVersion2);
+    List<LeafReaderContext> currentLeaves2 = currentSearcher2.getIndexReader().leaves();
+    replicaServer.getGlobalState().getIndex("test_index").getShard(0).slm.release(currentSearcher2);
+
+    primaryServer.verifySimpleDocIds("test_index", 1, 2, 3, 9, 10, 11, 12);
+    replicaServer.verifySimpleDocIds("test_index", 1, 2, 3, 9, 10, 11, 12);
+
+    verifySimpleDocIdsForVersion(
+        replicaServer, previousSearcherVersion1, "test_index", 1, 2, 3, 4, 5);
+    verifySimpleDocIdsForVersion(
+        replicaServer, previousSearcherVersion2, "test_index", 1, 2, 3, 4, 5, 6, 7, 8);
+
+    verifySegmentsClosed(previousLeaves1);
+    verifySegmentsClosed(previousLeaves2);
+    verifySegmentsClosed(currentLeaves1);
+    verifySegmentsClosed(currentLeaves2);
+
+    Thread.sleep(3000);
+    replicaServer.getGlobalState().getIndex("test_index").getShard(0).slm.prune(new PruneByAge(1));
+
+    verifySegmentsClosed(previousLeaves1, "_1");
+    verifySegmentsClosed(previousLeaves2, "_1", "_2");
+    verifySegmentsClosed(currentLeaves1);
+    verifySegmentsClosed(currentLeaves2);
+  }
+
+  private void verifySimpleDocIdsForVersion(
+      TestServer server, long version, String indexName, int... ids) {
+    Set<Integer> uniqueIds = new HashSet<>();
+    for (int id : ids) {
+      uniqueIds.add(id);
+    }
+    SearchResponse response =
+        server
+            .getClient()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(indexName)
+                    .addAllRetrieveFields(TestServer.simpleFieldNames)
+                    .setTopHits(uniqueIds.size() + 1)
+                    .setStartHit(0)
+                    .setVersion(version)
+                    .build());
+    assertEquals(uniqueIds.size(), response.getHitsCount());
+    Set<Integer> uniqueHitIds = new HashSet<>();
+    for (Hit hit : response.getHitsList()) {
+      int id = Integer.parseInt(hit.getFieldsOrThrow("id").getFieldValue(0).getTextValue());
+      int f1 = hit.getFieldsOrThrow("field1").getFieldValue(0).getIntValue();
+      int f2 = Integer.parseInt(hit.getFieldsOrThrow("field2").getFieldValue(0).getTextValue());
+      assertEquals(id * 3, f1);
+      assertEquals(id * 5, f2);
+      uniqueHitIds.add(id);
+    }
+    assertEquals(uniqueIds, uniqueHitIds);
+  }
+
+  private void verifySegmentsClosed(List<LeafReaderContext> leaves, String... segmentNames) {
+    Set<String> expectedSegments = new HashSet<>(Arrays.asList(segmentNames));
+    Set<String> closedSegments = new HashSet<>();
+    for (LeafReaderContext context : leaves) {
+      if (context.reader().getRefCount() == 0) {
+        closedSegments.add(((SegmentReader) context.reader()).getSegmentName());
+      }
+    }
+    assertEquals(expectedSegments, closedSegments);
   }
 }


### PR DESCRIPTION
This change is intended to address an issue when using incremental backups to remote storage. The remote storage is the source of truth for index data, but replicas may have uncommitted data distributed directly through gRPC nrt points. When the primary restarts, it pulls the last commit from remote storage. As the new primary does not know about uncommitted segments from the old primary, segment names may be reused. The segment id conflict keeps the replicas from opening new searcher versions until all conflicting files one the new primary are merged away.

## Solution
Add option to filter incompatible segment readers during searcher refresh. Typically, all previous segment readers are passed to the reopen operation, so that they can be reused as needed. Instead, create a new implementation of `SegmentInfosSearcherManager` that preemptively checks for segment reader conflicts and filters them. The reopen operation will create a new reader from the new data on disk.

## Limitations
Even with this option, replicas may not immediately sync from a new primary. The replica index version may be higher, which will make them ignore nrt points from the new primary until the index version eclipses that of the old primary.

## Testing
Tests have been added:
- Replica can sync from restarted primary, even when there are segment conflicts
- Older searcher versions are still usable after the conflict is resolved
- Old version of conflicting segments have their reader closed during searcher cleanup