### PR TITLE
Add ngram and simplepattern tokenizers to docs

### DIFF
--- a/docs/analysis.rst
+++ b/docs/analysis.rst
@@ -176,6 +176,8 @@ Available tokenizers:
 
   * simplepatternsplit
 
+  * simplepattern
+
   * classic
 
   * standard

--- a/docs/analysis.rst
+++ b/docs/analysis.rst
@@ -168,6 +168,8 @@ Available tokenizers:
 
   * edgengram
 
+  * ngram
+
   * pathhierarchy
 
   * pattern


### PR DESCRIPTION
I missed adding these tokenizers originally. This is the complete output of `TokenizerFactory.availableTokenizers()`

```
result = {Collections$UnmodifiableSet@3784}  size = 14
 0 = "keyword"
 1 = "letter"
 2 = "whitespace"
 3 = "edgeNGram"
 4 = "nGram"
 5 = "pathHierarchy"
 6 = "pattern"
 7 = "simplePatternSplit"
 8 = "simplePattern"
 9 = "classic"
 10 = "standard"
 11 = "uax29UrlEmail"
 12 = "thai"
 13 = "wikipedia"
```