### PR TITLE
Fix wildcard retrieval

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
@@ -54,6 +54,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.facet.DrillDownQuery;
@@ -208,7 +209,12 @@ public class SearchRequestProcessor {
       SearchRequest request, Map<String, FieldDef> queryFields) {
     Map<String, FieldDef> retrieveFields = new HashMap<>();
     if (request.getRetrieveFieldsCount() == 1 && request.getRetrieveFields(0).equals(WILDCARD)) {
-      return queryFields;
+      for (Entry<String, FieldDef> entry : queryFields.entrySet()) {
+        if (isRetrievable(entry.getValue())) {
+          retrieveFields.put(entry.getKey(), entry.getValue());
+        }
+      }
+      return retrieveFields;
     }
     for (String field : request.getRetrieveFieldsList()) {
       FieldDef fieldDef = queryFields.get(field);

--- a/src/test/resources/addDocsWildcardRetrieval.csv
+++ b/src/test/resources/addDocsWildcardRetrieval.csv
@@ -1,0 +1,3 @@
+doc_id,vendor_name,vendor_name_atom,license_no,count,long_field_multi,long_field,double_field_multi,double_field,float_field_multi,float_field,boolean_field_multi,boolean_field,description,date,date_multi,text_not_stored
+1,first vendor;first again,first atom vendor;first atom again,300;3100,3,1;2,12,1.1;1.11,1.01,100.1;100.11,100.01,true;false,false,FIRST food,2019-10-12 15:30:41,2019-11-13 10:20:15;2019-12-14 08:40:45,this won't be retrieved
+2,second vendor;second again,second atom vendor;second atom again,411;4222,7,3;4,16,2.2;2.22,2.01,200.2;200.22,200.02,true;false,false,SECOND gas,2020-03-05 01:03:05,2018-01-20 00:31:00;2018-02-21 09:43:30,this also won't be retrieved

--- a/src/test/resources/registerFieldsWildcardRetrieval.json
+++ b/src/test/resources/registerFieldsWildcardRetrieval.json
@@ -1,0 +1,142 @@
+{
+  "indexName": "test_index",
+  "field": [
+    {
+      "name": "doc_id",
+      "type": "ATOM",
+      "storeDocValues": true
+    },
+    {
+      "name": "vendor_name",
+      "type": "TEXT",
+      "search": true,
+      "store": true,
+      "tokenize": true,
+      "multiValued": true,
+      "storeDocValues": true,
+      "analyzer": {
+        "custom": {
+          "tokenizer": {
+            "name": "standard"
+          },
+          "tokenFilters": [
+            {
+              "name": "lowercase"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "vendor_name_atom",
+      "type": "ATOM",
+      "search": true,
+      "store": true,
+      "multiValued": true,
+      "storeDocValues": true
+    },
+    {
+      "name": "license_no",
+      "type": "INT",
+      "multiValued": true,
+      "storeDocValues": true
+    },
+    {
+      "name": "count",
+      "type": "INT",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "long_field",
+      "type": "LONG",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "long_field_multi",
+      "type": "LONG",
+      "search": true,
+      "storeDocValues": true,
+      "multiValued": true,
+      "sort": true
+    },
+    {
+      "name": "double_field_multi",
+      "type": "DOUBLE",
+      "storeDocValues": true,
+      "multiValued": true,
+      "sort": true
+    },
+    {
+      "name": "double_field",
+      "type": "DOUBLE",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "float_field_multi",
+      "type": "FLOAT",
+      "storeDocValues": true,
+      "multiValued": true,
+      "sort": true
+    },
+    {
+      "name": "float_field",
+      "type": "FLOAT",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "boolean_field_multi",
+      "type": "BOOLEAN",
+      "storeDocValues": true,
+      "multiValued": true,
+      "sort": true
+    },
+    {
+      "name": "boolean_field",
+      "type": "BOOLEAN",
+      "search": true,
+      "storeDocValues": true,
+      "sort": true
+    },
+    {
+      "name": "description",
+      "type": "TEXT",
+      "search": true,
+      "store": true,
+      "tokenize": true,
+      "multiValued": true,
+      "storeDocValues": true
+    },
+    {
+      "name": "date",
+      "type": "DATE_TIME",
+      "search": true,
+      "storeDocValues": true,
+      "dateTimeFormat": "yyyy-MM-dd HH:mm:ss"
+    },
+    {
+      "name": "date_multi",
+      "type": "DATE_TIME",
+      "search": true,
+      "storeDocValues": true,
+      "multiValued": true,
+      "dateTimeFormat": "yyyy-MM-dd HH:mm:ss"
+    },
+    {
+      "name": "text_not_stored",
+      "type": "TEXT",
+      "search": true,
+      "store": false,
+      "tokenize": true,
+      "multiValued": true,
+      "storeDocValues": false
+    }
+  ]
+}


### PR DESCRIPTION
Ticket: RP-7346

Wildcard field retrieval currently includes fields that are not stored, i.e. have both `store = false` and `storeDocValues = false`. This results in the following error when wildcard is used:
```
[WARN ] 2023-01-20 19:26:13.227 [grpc-default-executor-0] LuceneServer - error while trying to execute search for index test_index: request: {"indexName":"test_index","topHits":10,"retrieveFields":["*"]}
java.lang.IllegalStateException: No valid method to retrieve indexable field: text_not_stored
	at com.yelp.nrtsearch.server.luceneserver.SearchHandler$FillDocsTask.fetchSlice(SearchHandler.java:882) ~[main/:?]
	at com.yelp.nrtsearch.server.luceneserver.SearchHandler$FillDocsTask.run(SearchHandler.java:828) ~[main/:?]
	at com.yelp.nrtsearch.server.luceneserver.SearchHandler.fetchFields(SearchHandler.java:401) ~[main/:?]
	at com.yelp.nrtsearch.server.luceneserver.SearchHandler.handle(SearchHandler.java:219) ~[main/:?]
	at com.yelp.nrtsearch.server.grpc.LuceneServer$LuceneServerImpl.search(LuceneServer.java:1053) [main/:?]
	at com.yelp.nrtsearch.server.grpc.LuceneServerGrpc$MethodHandlers.invoke(LuceneServerGrpc.java:3376) [clientlib-0.18.0.jar:?]
	at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182) [grpc-stub-1.46.0.jar:1.46.0]
	at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35) [grpc-api-1.46.0.jar:1.46.0]
	at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23) [grpc-api-1.46.0.jar:1.46.0]
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:340) [grpc-core-1.46.0.jar:1.46.0]
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:866) [grpc-core-1.46.0.jar:1.46.0]
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37) [grpc-core-1.46.0.jar:1.46.0]
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133) [grpc-core-1.46.0.jar:1.46.0]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]
```

I have added a check so that only the retrievable fields get added to the list of fields to be retrieved when wildcard is used. I have updated the test to use a different schema which has an additional field "text_not_stored". I have removed the duplication in the test as well - all that was different was how the wildcard was being added in the request using the protobuf java api. The test failed before my changes and now passes.