### PR TITLE
Add readthedocs documentation link and badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Coverage](.github/badges/jacoco.svg)](jacoco.svg)
+[![Coverage](.github/badges/jacoco.svg)](jacoco.svg) ![Docs](https://readthedocs.org/projects/nrtsearch/badge/?version=latest)
 # nrtSearch
 A high performance gRPC server, with optional REST APIs on top of [Apache Lucene](http://lucene.apache.org/) version 8.x source, exposing Lucene's
 core functionality over a simple gRPC based API.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A high performance gRPC server, with optional REST APIs on top of [Apache Lucene](http://lucene.apache.org/) version 8.x source, exposing Lucene's
 core functionality over a simple gRPC based API.
 
+Documentation is available at [readthedocs](https://nrtsearch.readthedocs.io/en/latest/).
+
 # Features
 * Relies on Lucene's [near-real-time segment replication](http://blog.mikemccandless.com/2017/09/lucenes-near-real-time-segment-index.html) for data replication. This means, a dedicated primary/writer node takes care of indexing operations and expensive operations like [segment merges](http://blog.mikemccandless.com/2011/02/visualizing-lucenes-segment-merges.html). This allows the replicas' system resources to be dedicated entirely for search queries. This behavior is in contrast to the document replication approach taken by some other popular search engines based on lucene like elasticsearch where every node is a writer and a reader.
 * [Supports concurrent query execution](http://blog.mikemccandless.com/2019/10/concurrent-query-execution-in-apache.html). This is another feature missing from popular search engines based on lucene like elasticsearch.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Coverage](.github/badges/jacoco.svg)](jacoco.svg) ![Docs](https://readthedocs.org/projects/nrtsearch/badge/?version=latest)
+[![Coverage](.github/badges/jacoco.svg)](jacoco.svg) [![Docs](https://readthedocs.org/projects/nrtsearch/badge/?version=latest)](https://nrtsearch.readthedocs.io/en/latest/)
 # nrtSearch
 A high performance gRPC server, with optional REST APIs on top of [Apache Lucene](http://lucene.apache.org/) version 8.x source, exposing Lucene's
 core functionality over a simple gRPC based API.


### PR DESCRIPTION
The link to documentation is missing from the readme file - I realized this when looking for docs about tokenizers.

Here is just a suggestion how can we link it. 

Also looked at https://docs.readthedocs.io/en/stable/badges.html to include the docs build status badge for visibility. It seems that readthedocs generates it for us via: https://readthedocs.org/projects/nrtsearch/badge/?version=latest. 

## Verification

Preview readme rendering in my branch on github: https://github.com/Yelp/nrtsearch/tree/add-readthedocs-link