### PR TITLE
Throw proper error if index does not exist when adding documents

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -1088,7 +1088,6 @@ public class LuceneServer {
                           "error while trying to execute search for index %s. check logs for full searchRequest.",
                           searchRequest.getIndexName()))
                   .augmentDescription(e.getMessage())
-                  .withCause(e)
                   .asRuntimeException());
         }
       }
@@ -1140,7 +1139,6 @@ public class LuceneServer {
                           "error while trying to execute search for index %s. check logs for full searchRequest.",
                           searchRequest.getIndexName()))
                   .augmentDescription(e.getMessage())
-                  .withCause(e)
                   .asRuntimeException());
         }
       }

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -719,26 +719,22 @@ public class LuceneServer {
     public StreamObserver<AddDocumentRequest> addDocuments(
         StreamObserver<AddDocumentResponse> responseObserver) {
 
-      return new StreamObserver<AddDocumentRequest>() {
+      return new StreamObserver<>() {
         Multimap<String, Future<Long>> futures = HashMultimap.create();
         // Map of {indexName: addDocumentRequestQueue}
         Map<String, ArrayBlockingQueue<AddDocumentRequest>> addDocumentRequestQueueMap =
             new ConcurrentHashMap<>();
         // Map of {indexName: count}
         Map<String, Long> countMap = new ConcurrentHashMap<>();
-        private static final int DEFAULT_MAX_BUFFER_LEN = 100;
 
         private int getAddDocumentsMaxBufferLen(String indexName) {
           try {
             return globalState.getIndex(indexName).getAddDocumentsMaxBufferLen();
           } catch (Exception e) {
-            logger.warn(
-                String.format(
-                    "error while trying to get addDocumentsMaxBufferLen from"
-                        + "liveSettings of index %s. Using DEFAULT_MAX_BUFFER_LEN %d.",
-                    indexName, DEFAULT_MAX_BUFFER_LEN),
-                e);
-            return DEFAULT_MAX_BUFFER_LEN;
+            String error =
+                String.format("Index %s does not exist, unable to add documents", indexName);
+            logger.error(error, e);
+            throw Status.INVALID_ARGUMENT.withDescription(error).withCause(e).asRuntimeException();
           }
         }
 
@@ -770,8 +766,13 @@ public class LuceneServer {
         @Override
         public void onNext(AddDocumentRequest addDocumentRequest) {
           String indexName = addDocumentRequest.getIndexName();
-          ArrayBlockingQueue<AddDocumentRequest> addDocumentRequestQueue =
-              getAddDocumentRequestQueue(indexName);
+          ArrayBlockingQueue<AddDocumentRequest> addDocumentRequestQueue;
+          try {
+            addDocumentRequestQueue = getAddDocumentRequestQueue(indexName);
+          } catch (Exception e) {
+            onError(e);
+            return;
+          }
           logger.debug(
               String.format(
                   "onNext, index: %s, addDocumentRequestQueue size: %s",
@@ -1087,6 +1088,7 @@ public class LuceneServer {
                           "error while trying to execute search for index %s. check logs for full searchRequest.",
                           searchRequest.getIndexName()))
                   .augmentDescription(e.getMessage())
+                  .withCause(e)
                   .asRuntimeException());
         }
       }
@@ -1138,6 +1140,7 @@ public class LuceneServer {
                           "error while trying to execute search for index %s. check logs for full searchRequest.",
                           searchRequest.getIndexName()))
                   .augmentDescription(e.getMessage())
+                  .withCause(e)
                   .asRuntimeException());
         }
       }
@@ -1815,7 +1818,12 @@ public class LuceneServer {
         responseObserver.onCompleted();
       } catch (Exception e) {
         logger.error("Error processing custom request {}", request, e);
-        responseObserver.onError(e);
+        responseObserver.onError(
+            Status.INTERNAL
+                .withDescription("Unable to process custom request: " + request)
+                .augmentDescription(e.getMessage())
+                .withCause(e)
+                .asException());
       }
     }
   }

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -1815,13 +1815,10 @@ public class LuceneServer {
         responseObserver.onNext(response);
         responseObserver.onCompleted();
       } catch (Exception e) {
-        logger.error("Error processing custom request {}", request, e);
-        responseObserver.onError(
-            Status.INTERNAL
-                .withDescription("Unable to process custom request: " + request)
-                .augmentDescription(e.getMessage())
-                .withCause(e)
-                .asException());
+        String error =
+            String.format("Error processing custom request %s, error: %s", request, e.getMessage());
+        logger.error(error);
+        responseObserver.onError(Status.INTERNAL.withDescription(error).withCause(e).asException());
       }
     }
   }


### PR DESCRIPTION
If the index does not exist when adding documents we can throw an exception immediately rather than assuming a default queue size. We already take use this default when the settings are applied for the index.

Also throwing a proper exception in case of failure in the custom endpoint.