### PR TITLE
Always include fields entry in index state json

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/ImmutableIndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/ImmutableIndexState.java
@@ -721,7 +721,12 @@ public class ImmutableIndexState extends IndexState {
   public JsonObject getSaveState() {
     String stateString;
     try {
-      stateString = JsonFormat.printer().print(currentStateInfo);
+      // Ensure the 'fields' map is always present in the output, even when empty
+      stateString =
+          JsonFormat.printer()
+              .includingDefaultValueFields(
+                  Set.of(IndexStateInfo.getDescriptor().findFieldByName("fields")))
+              .print(currentStateInfo);
     } catch (InvalidProtocolBufferException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
Always have a `fields` entry present in index state json retrieved from `getSaveState`, even if empty.

The json writer for the `IndexStateInfo` will omit `fields` if there are none, by default. This is different behavior than the `LegacyIndexState`, where `fields` was always included. This breaks clients that make that assumption.

Sets the writer property to include the default value for `fields`. Tests have been added to verify the output.