### PR TITLE
Remove unneeded initial point wait from tests

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -58,6 +58,8 @@ public class LuceneServerConfiguration {
   private static final Path DEFAULT_PLUGIN_SEARCH_PATH =
       Paths.get(DEFAULT_USER_DIR.toString(), "plugins");
   private static final String DEFAULT_SERVICE_NAME = "nrtsearch-generic";
+  static final long DEFAULT_INITIAL_SYNC_PRIMARY_WAIT_MS = 30000;
+  static final long DEFAULT_INITIAL_SYNC_MAX_TIME_MS = 600000; // 10m
   private final int port;
   private final int replicationPort;
   private final int replicaReplicationPortPingInterval;
@@ -86,6 +88,8 @@ public class LuceneServerConfiguration {
   private final boolean virtualSharding;
   private final boolean decInitialCommit;
   private final boolean syncInitialNrtPoint;
+  private final long initialSyncPrimaryWaitMs;
+  private final long initialSyncMaxTimeMs;
   private final boolean indexVerbose;
   private final FileCopyConfig fileCopyConfig;
   private final ScriptCacheConfig scriptCacheConfig;
@@ -150,6 +154,10 @@ public class LuceneServerConfiguration {
     virtualSharding = configReader.getBoolean("virtualSharding", false);
     decInitialCommit = configReader.getBoolean("decInitialCommit", true);
     syncInitialNrtPoint = configReader.getBoolean("syncInitialNrtPoint", true);
+    initialSyncPrimaryWaitMs =
+        configReader.getLong("initialSyncPrimaryWaitMs", DEFAULT_INITIAL_SYNC_PRIMARY_WAIT_MS);
+    initialSyncMaxTimeMs =
+        configReader.getLong("initialSyncMaxTimeMs", DEFAULT_INITIAL_SYNC_MAX_TIME_MS);
     indexVerbose = configReader.getBoolean("indexVerbose", false);
     fileCopyConfig = FileCopyConfig.fromConfig(configReader);
     threadPoolConfiguration = new ThreadPoolConfiguration(configReader);
@@ -276,6 +284,14 @@ public class LuceneServerConfiguration {
 
   public boolean getSyncInitialNrtPoint() {
     return syncInitialNrtPoint;
+  }
+
+  public long getInitialSyncPrimaryWaitMs() {
+    return initialSyncPrimaryWaitMs;
+  }
+
+  public long getInitialSyncMaxTimeMs() {
+    return initialSyncMaxTimeMs;
   }
 
   public boolean getIndexVerbose() {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -82,8 +82,6 @@ import org.slf4j.LoggerFactory;
 
 public class ShardState implements Closeable {
   private static final Logger logger = LoggerFactory.getLogger(ShardState.class);
-  private static final long INITIAL_SYNC_PRIMARY_WAIT_MS = 30000;
-  private static final long INITIAL_SYNC_MAX_TIME_MS = 600000; // 10m
   public static final int REPLICA_ID = 0;
   public static final String INDEX_DATA_DIR_NAME = "index";
   public static final String TAXONOMY_DATA_DIR_NAME = "taxonomy";
@@ -958,7 +956,7 @@ public class ShardState implements Closeable {
 
       if (configuration.getSyncInitialNrtPoint()) {
         nrtReplicaNode.syncFromCurrentPrimary(
-            INITIAL_SYNC_PRIMARY_WAIT_MS, INITIAL_SYNC_MAX_TIME_MS);
+            configuration.getInitialSyncPrimaryWaitMs(), configuration.getInitialSyncMaxTimeMs());
       }
 
       startSearcherPruningThread(indexState.getGlobalState().getShutdownLatch());

--- a/src/test/java/com/yelp/nrtsearch/server/config/LuceneServerConfigurationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/LuceneServerConfigurationTest.java
@@ -98,6 +98,7 @@ public class LuceneServerConfigurationTest {
     assertEquals(100, luceneConfig.getDiscoveryFileUpdateIntervalMs());
   }
 
+  @Test
   public void testDefaultCompletionCodecLoadMode() {
     String config = "nodeName: \"lucene_server_foo\"";
     LuceneServerConfiguration luceneConfig = getForConfig(config);
@@ -109,5 +110,37 @@ public class LuceneServerConfigurationTest {
     String config = "completionCodecLoadMode: OFF_HEAP";
     LuceneServerConfiguration luceneConfig = getForConfig(config);
     assertEquals(FSTLoadMode.OFF_HEAP, luceneConfig.getCompletionCodecLoadMode());
+  }
+
+  @Test
+  public void testInitialSyncPrimaryWaitMs_default() {
+    String config = "nodeName: \"lucene_server_foo\"";
+    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    assertEquals(
+        LuceneServerConfiguration.DEFAULT_INITIAL_SYNC_PRIMARY_WAIT_MS,
+        luceneConfig.getInitialSyncPrimaryWaitMs());
+  }
+
+  @Test
+  public void testInitialSyncPrimaryWaitMs_set() {
+    String config = "initialSyncPrimaryWaitMs: 100";
+    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    assertEquals(100L, luceneConfig.getInitialSyncPrimaryWaitMs());
+  }
+
+  @Test
+  public void testInitialSyncMaxTimeMs_default() {
+    String config = "nodeName: \"lucene_server_foo\"";
+    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    assertEquals(
+        LuceneServerConfiguration.DEFAULT_INITIAL_SYNC_MAX_TIME_MS,
+        luceneConfig.getInitialSyncMaxTimeMs());
+  }
+
+  @Test
+  public void testInitialSyncMaxTimeMs_set() {
+    String config = "initialSyncMaxTimeMs: 100";
+    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    assertEquals(100L, luceneConfig.getInitialSyncMaxTimeMs());
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/IndexStartTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/IndexStartTest.java
@@ -788,6 +788,7 @@ public class IndexStartTest {
             .withAutoStartConfig(
                 true, Mode.REPLICA, server.getReplicationPort(), IndexDataLocationType.LOCAL)
             .withLocalStateBackend()
+            .withSyncInitialNrtPoint(false)
             .build();
 
     assertTrue(replica.indices().contains("test_index"));

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -224,7 +224,8 @@ public class LuceneServerTest {
         "warmer:",
         "  maxWarmingQueries: 10",
         "  warmOnStartup: true",
-        "  warmingParallelism: 1");
+        "  warmingParallelism: 1",
+        "syncInitialNrtPoint: false");
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
@@ -233,7 +233,7 @@ public class ReplicationServerTest {
 
   @Test
   public void replicaConnectivity() throws IOException, InterruptedException {
-    initDefaultLuceneServer();
+    initServerSyncInitialNrtPointFalse();
 
     // set ping interval to 10 ms
     luceneServerSecondary.getGlobalState().setReplicaReplicationPortPingInterval(10);
@@ -386,7 +386,7 @@ public class ReplicationServerTest {
 
   @Test
   public void testInitialSyncTimeout() throws IOException {
-    initDefaultLuceneServer();
+    initLuceneServers("initialSyncPrimaryWaitMs: 1000");
 
     // startIndex replica
     GrpcServer.TestServer testServerReplica =


### PR DESCRIPTION
Some of the tests had replicas start indices without a primary available. This would make them wait 30s for the initial nrt point sync to time out. Disabling the sync for these tests reduced total run time by ~2m.

I have also made the primary wait time and max time configurable, so that the sync timeout is more testable.