### PR TITLE
Added a JUnit rule for testing with S3 and replaced most direct usages of S3Mock

### DIFF
--- a/src/test/java/com/yelp/nrtsearch/server/backup/VersionManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/backup/VersionManagerTest.java
@@ -17,18 +17,15 @@ package com.yelp.nrtsearch.server.backup;
 
 import static org.junit.Assert.*;
 
-import com.amazonaws.auth.AnonymousAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.util.IOUtils;
-import io.findify.s3mock.S3Mock;
+import com.yelp.nrtsearch.test_utils.AmazonS3Provider;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,29 +34,18 @@ import org.junit.rules.TemporaryFolder;
 public class VersionManagerTest {
   private final String BUCKET_NAME = "version-manager-unittest";
   private VersionManager versionManager;
-  private S3Mock api;
   private AmazonS3 s3;
-  private Path s3Directory;
   private Path archiverDirectory;
 
   @Rule public final TemporaryFolder folder = new TemporaryFolder();
+  @Rule public final AmazonS3Provider s3Provider = new AmazonS3Provider(BUCKET_NAME);
 
   @Before
   public void setup() throws IOException {
-    s3Directory = folder.newFolder("s3").toPath();
     archiverDirectory = folder.newFolder("version-manager").toPath();
 
-    api = S3Mock.create(8011, s3Directory.toAbsolutePath().toString());
-    api.start();
-    s3 = new AmazonS3Client(new AnonymousAWSCredentials());
-    s3.setEndpoint("http://127.0.0.1:8011");
-    s3.createBucket(BUCKET_NAME);
+    s3 = s3Provider.getAmazonS3();
     versionManager = new VersionManager(s3, BUCKET_NAME);
-  }
-
-  @After
-  public void teardown() {
-    api.shutdown();
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/AckedCopyTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/AckedCopyTest.java
@@ -18,16 +18,14 @@ package com.yelp.nrtsearch.server.grpc;
 import static com.yelp.nrtsearch.server.grpc.GrpcServer.rmDir;
 import static com.yelp.nrtsearch.server.grpc.ReplicationServerTest.validateSearchResults;
 
-import com.amazonaws.auth.AnonymousAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
 import com.yelp.nrtsearch.server.LuceneServerTestConfigurationFactory;
 import com.yelp.nrtsearch.server.backup.Archiver;
 import com.yelp.nrtsearch.server.backup.ArchiverImpl;
 import com.yelp.nrtsearch.server.backup.Tar;
 import com.yelp.nrtsearch.server.backup.TarImpl;
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
-import io.findify.s3mock.S3Mock;
+import com.yelp.nrtsearch.test_utils.AmazonS3Provider;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -48,22 +46,21 @@ public class AckedCopyTest {
    */
   @Rule public final TemporaryFolder folder = new TemporaryFolder();
 
+  @Rule public final AmazonS3Provider s3Provider = new AmazonS3Provider(BUCKET_NAME);
+
   private GrpcServer luceneServerPrimary;
   private GrpcServer replicationServerPrimary;
 
   private GrpcServer luceneServerSecondary;
   private GrpcServer replicationServerSecondary;
 
-  private final String BUCKET_NAME = "archiver-unittest";
+  private static final String BUCKET_NAME = "archiver-unittest";
   private Archiver archiver;
-  private S3Mock api;
   private AmazonS3 s3;
-  private Path s3Directory;
   private Path archiverDirectory;
 
   @After
   public void tearDown() throws IOException {
-    api.shutdown();
     luceneServerPrimary.getGlobalState().close();
     luceneServerSecondary.getGlobalState().close();
     rmDir(Paths.get(luceneServerPrimary.getIndexDir()).getParent());
@@ -71,14 +68,8 @@ public class AckedCopyTest {
   }
 
   public void setUp(int chunkSize, int ackEvery, int maxInFlight) throws IOException {
-    // setup S3 for backup/restore
-    s3Directory = folder.newFolder("s3").toPath();
     archiverDirectory = folder.newFolder("archiver").toPath();
-    api = S3Mock.create(8011, s3Directory.toAbsolutePath().toString());
-    api.start();
-    s3 = new AmazonS3Client(new AnonymousAWSCredentials());
-    s3.setEndpoint("http://127.0.0.1:8011");
-    s3.createBucket(BUCKET_NAME);
+    s3 = s3Provider.getAmazonS3();
     archiver =
         new ArchiverImpl(s3, BUCKET_NAME, archiverDirectory, new TarImpl(Tar.CompressionMode.LZ4));
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/BackupRestoreIndexRequestHandlerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/BackupRestoreIndexRequestHandlerTest.java
@@ -21,9 +21,7 @@ import static com.yelp.nrtsearch.server.grpc.LuceneServerTest.checkHits;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.amazonaws.auth.AnonymousAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
 import com.google.common.collect.ImmutableList;
 import com.yelp.nrtsearch.server.LuceneServerTestConfigurationFactory;
 import com.yelp.nrtsearch.server.backup.Archiver;
@@ -31,7 +29,7 @@ import com.yelp.nrtsearch.server.backup.ArchiverImpl;
 import com.yelp.nrtsearch.server.backup.Tar;
 import com.yelp.nrtsearch.server.backup.TarImpl;
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
-import io.findify.s3mock.S3Mock;
+import com.yelp.nrtsearch.test_utils.AmazonS3Provider;
 import io.grpc.StatusRuntimeException;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.File;
@@ -53,9 +51,7 @@ import org.junit.rules.TemporaryFolder;
 public class BackupRestoreIndexRequestHandlerTest {
   private final String BUCKET_NAME = "archiver-unittest";
   private Archiver archiver;
-  private S3Mock api;
   private AmazonS3 s3;
-  private Path s3Directory;
   private Path archiverDirectory;
 
   @Rule public final TemporaryFolder folder = new TemporaryFolder();
@@ -66,17 +62,14 @@ public class BackupRestoreIndexRequestHandlerTest {
    */
   @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
+  @Rule public final AmazonS3Provider s3Provider = new AmazonS3Provider(BUCKET_NAME);
+
   private GrpcServer grpcServer;
 
   @Before
   public void setup() throws IOException {
-    s3Directory = folder.newFolder("s3").toPath();
     archiverDirectory = folder.newFolder("archiver").toPath();
-    api = S3Mock.create(8011, s3Directory.toAbsolutePath().toString());
-    api.start();
-    s3 = new AmazonS3Client(new AnonymousAWSCredentials());
-    s3.setEndpoint("http://127.0.0.1:8011");
-    s3.createBucket(BUCKET_NAME);
+    s3 = s3Provider.getAmazonS3();
     archiver =
         new ArchiverImpl(s3, BUCKET_NAME, archiverDirectory, new TarImpl(Tar.CompressionMode.LZ4));
     grpcServer = setUpGrpcServer();
@@ -98,7 +91,6 @@ public class BackupRestoreIndexRequestHandlerTest {
 
   @After
   public void teardown() throws IOException {
-    api.shutdown();
     tearDownGrpcServer();
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/utils/S3DownloaderTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/utils/S3DownloaderTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import org.apache.commons.io.IOUtils;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -42,6 +43,11 @@ public class S3DownloaderTest {
     AmazonS3 s3 = S3_PROVIDER.getAmazonS3();
     s3Downloader = new S3Downloader(s3);
     s3.putObject(BUCKET_NAME, KEY, CONTENT);
+  }
+
+  @AfterClass
+  public static void cleanUp() {
+    s3Downloader.close();
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/utils/S3DownloaderTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/utils/S3DownloaderTest.java
@@ -18,52 +18,30 @@ package com.yelp.nrtsearch.server.utils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.AnonymousAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import io.findify.s3mock.S3Mock;
+import com.yelp.nrtsearch.test_utils.AmazonS3Provider;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.nio.file.Path;
 import org.apache.commons.io.IOUtils;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 public class S3DownloaderTest {
   private static final String BUCKET_NAME = "s3-downloader-test";
   private static final String KEY = "test_key";
   private static final String CONTENT = "test_content";
 
-  @ClassRule public static final TemporaryFolder FOLDER = new TemporaryFolder();
+  @ClassRule public static final AmazonS3Provider S3_PROVIDER = new AmazonS3Provider(BUCKET_NAME);
 
-  private static S3Mock api;
   private static S3Downloader s3Downloader;
 
   @BeforeClass
   public static void setup() throws IOException {
-    Path s3Directory = FOLDER.newFolder("s3").toPath();
-    api = S3Mock.create(8011, s3Directory.toAbsolutePath().toString());
-    api.start();
-    AmazonS3 s3 =
-        AmazonS3ClientBuilder.standard()
-            .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
-            .withEndpointConfiguration(new EndpointConfiguration("http://127.0.0.1:8011", ""))
-            .build();
-    s3.createBucket(BUCKET_NAME);
+    AmazonS3 s3 = S3_PROVIDER.getAmazonS3();
     s3Downloader = new S3Downloader(s3);
     s3.putObject(BUCKET_NAME, KEY, CONTENT);
-  }
-
-  @AfterClass
-  public static void shutdown() {
-    api.shutdown();
-    s3Downloader.close();
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/test_utils/AmazonS3Provider.java
+++ b/src/test/java/com/yelp/nrtsearch/test_utils/AmazonS3Provider.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.test_utils;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import io.findify.s3mock.S3Mock;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * A JUnit {@link org.junit.Rule} for mock S3 tests. It provides a mock S3 client which stores any
+ * files in and retrieves from a {@link TemporaryFolder} so that all data added to S3 is deleted
+ * after the test.
+ *
+ * <p>Example of usage:
+ *
+ * <pre>
+ * public static class S3Test {
+ *  &#064;Rule
+ *  public AmazonS3Provider s3Provider = new AmazonS3Provider("test-bucket");
+ *
+ *  &#064;Test
+ *  public void testUsingS3() throws IOException {
+ *      AmazonS3 s3Client = s3Provider.getAmazonS3();
+ *      s3Client.putObject("test_bucket", "key", file);
+ *      // ...
+ *     }
+ * }
+ * </pre>
+ */
+public class AmazonS3Provider extends ExternalResource {
+
+  private final String bucketName;
+  private final TemporaryFolder temporaryFolder;
+  private S3Mock api;
+  private AmazonS3 s3;
+  private String s3Path;
+
+  public AmazonS3Provider(String bucketName) {
+    this.bucketName = bucketName;
+    this.temporaryFolder = new TemporaryFolder();
+    this.s3Path = null;
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    temporaryFolder.create();
+    s3Path = temporaryFolder.newFolder("s3").toString();
+    api = S3Mock.create(8011, s3Path);
+    api.start();
+    s3 =
+        AmazonS3ClientBuilder.standard()
+            .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
+            .withEndpointConfiguration(new EndpointConfiguration("http://127.0.0.1:8011", ""))
+            .build();
+    s3.createBucket(bucketName);
+  }
+
+  @Override
+  protected void after() {
+    s3.shutdown();
+    if (api != null) {
+      api.shutdown();
+    }
+    temporaryFolder.delete();
+  }
+
+  public AmazonS3 getAmazonS3() {
+    return s3;
+  }
+
+  public String getS3DirectoryPath() {
+    if (s3Path == null) {
+      throw new IllegalStateException("S3 not initialized yet");
+    }
+    return s3Path;
+  }
+}


### PR DESCRIPTION
Created a JUnit test rule `AmazonS3Provider` to help with tests requiring a mock AmazonS3 client. This will make it easier to write these tests and also reduce the boilerplate code. 
Usage of the rule from the javadoc for it:
```
/**
 * A JUnit {@link org.junit.Rule} for mock S3 tests. It provides a mock S3 client which stores any
 * files in and retrieves from a {@link TemporaryFolder} so that all data added to S3 is deleted
 * after the test.
 *
 * <p>Example of usage:
 *
 * <pre>
 * public static class S3Test {
 *  &#064;Rule
 *  public AmazonS3Provider s3Provider = new AmazonS3Provider("test-bucket");
 *
 *  &#064;Test
 *  public void testUsingS3() throws IOException {
 *      AmazonS3 s3Client = s3Provider.getAmazonS3();
 *      s3Client.putObject("test_bucket", "key", file);
 *      // ...
 *     }
 * }
 * </pre>
 */
```

I've replaced most direct usages of S3Mock with this rule. As a bonus this also helped reduce the usage of a deprecated constructor for AmazonS3.