### PR TITLE
Added configuration to example-plugin to create a zipped artifact

### DIFF
--- a/example-plugin/build.gradle
+++ b/example-plugin/build.gradle
@@ -36,6 +36,14 @@ dependencies {
     testImplementation "org.assertj:assertj-core:3.19.0"
 }
 
+configurations {
+    zipDependency {
+        description = 'ZIPped artifacts that need to be extracted first.'
+        transitive = false
+        visible = false
+    }
+}
+
 distributions {
     main {
         contents {


### PR DESCRIPTION
I missed this in #543 . This is required to create a zipped artifact of the plugin with the dependencies which can be loaded in nrtsearch.