### PR TITLE
Added a cli command to get all index names in nrtsearch

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/cli/IndicesCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/server/cli/IndicesCommand.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.cli;
+
+import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import java.util.List;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = IndicesCommand.INDICES, description = "Get all indices on the cluster")
+public class IndicesCommand implements Callable<Integer> {
+
+  public static final String INDICES = "indices";
+
+  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+
+  @Override
+  public Integer call() throws Exception {
+    LuceneServerClient client = baseCmd.getClient();
+    try {
+      List<String> indicesList = client.getIndices();
+      System.out.println();
+      if (indicesList.isEmpty()) {
+        System.out.println("No index found");
+      } else {
+        indicesList.forEach(System.out::println);
+      }
+    } finally {
+      client.shutdown();
+    }
+    return 0;
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/cli/LuceneClientCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/server/cli/LuceneClientCommand.java
@@ -38,6 +38,7 @@ import picocli.CommandLine;
       DeleteIndexCommand.class,
       ForceMergeCommand.class,
       ForceMergeDeletesCommand.class,
+      IndicesCommand.class,
       LiveSettingsCommand.class,
       LiveSettingsV2Command.class,
       ReadyCommand.class,

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServerClient.java
@@ -79,6 +79,11 @@ public class LuceneServerClient implements Closeable {
     channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
   }
 
+  @Override
+  public void close() {
+    this.channel.shutdownNow();
+  }
+
   public void createIndex(
       String indexName,
       String existsWithId,
@@ -530,10 +535,5 @@ public class LuceneServerClient implements Closeable {
     logger.info(
         String.format("jsonStr converted to proto SettingsRequest %s", settingsRequest.toString()));
     return settingsRequest;
-  }
-
-  @Override
-  public void close() {
-    this.channel.shutdownNow();
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/cli/IndicesCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/cli/IndicesCommandTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.cli;
+
+import static org.junit.Assert.*;
+
+import com.yelp.nrtsearch.server.grpc.CreateIndexRequest;
+import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import picocli.CommandLine;
+
+public class IndicesCommandTest extends ServerTestCase {
+
+  private ByteArrayOutputStream testOutput;
+  private PrintStream originalSystemOut;
+
+  @Before
+  public void setup() {
+    testOutput = new ByteArrayOutputStream();
+    originalSystemOut = System.out;
+    System.setOut(new PrintStream(testOutput));
+  }
+
+  @After
+  public void cleanUp() {
+    System.setOut(originalSystemOut);
+  }
+
+  @Override
+  protected List<String> getIndices() {
+    // Don't create an index by default
+    return List.of();
+  }
+
+  @Test
+  public void testNoIndices() {
+    int exitCode = runIndicesCommand();
+    assertEquals(0, exitCode);
+    String expected =
+        String.format("%sNo index found%s", System.lineSeparator(), System.lineSeparator());
+    assertEquals(expected, testOutput.toString());
+  }
+
+  @Test
+  public void testIndices() {
+    List<String> indices = new ArrayList<>(List.of("index1", "index2", "index3"));
+    indices.forEach(
+        index -> {
+          CreateIndexRequest request = CreateIndexRequest.newBuilder().setIndexName(index).build();
+          getGrpcServer().getBlockingStub().createIndex(request);
+        });
+    int exitCode = runIndicesCommand();
+    assertEquals(0, exitCode);
+    String expected =
+        String.format(
+            "%s%s%s",
+            System.lineSeparator(),
+            String.join(System.lineSeparator(), indices),
+            System.lineSeparator());
+    assertEquals(expected, testOutput.toString());
+  }
+
+  private int runIndicesCommand() {
+    CommandLine cmd = new CommandLine(new LuceneClientCommand());
+    return cmd.execute(
+        "--hostname=localhost", "--port=" + getGrpcServer().getGlobalState().getPort(), "indices");
+  }
+}


### PR DESCRIPTION
Added a cli command to get the names of all indices in an nrtsearch cluster. I've also made the `LuceneServerClient` closeable and shutting down the client without waiting in that (will be used for other tests).