### PR TITLE
Highlighter bug fixing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ sourceCompatibility = 1.14
 targetCompatibility = 1.14
 
 allprojects {
-    version = '0.20.0'
+    version = '0.20.1'
     group = 'com.yelp.nrtsearch'
 }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/HighlightSettings.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/HighlightSettings.java
@@ -66,7 +66,8 @@ public class HighlightSettings {
         .withHighlightQuery(this.highlightQuery)
         .withFieldMatch(this.fieldMatch)
         .withScoreOrdered(this.scoreOrdered)
-        .withFragmenter(this.fragmenter);
+        .withFragmenter(this.fragmenter)
+        .withDiscreteMultivalue(this.discreteMultivalue);
   }
 
   public Highlighter getHighlighter() {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/HighlightUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/HighlightUtils.java
@@ -151,21 +151,15 @@ public class HighlightUtils {
         .withDiscreteMultivalue(
             settings.hasDiscreteMultivalue()
                 ? settings.getDiscreteMultivalue().getValue()
-                : DEFAULT_DISCRETE_MULTIVALUE);
-
-    if (settings.hasMaxNumberOfFragments() && settings.getMaxNumberOfFragments().getValue() == 0) {
-      builder.withMaxNumFragments(Integer.MAX_VALUE).withFragmentSize(Integer.MAX_VALUE);
-    } else {
-      builder
-          .withMaxNumFragments(
-              settings.hasMaxNumberOfFragments()
-                  ? settings.getMaxNumberOfFragments().getValue()
-                  : DEFAULT_MAX_NUM_FRAGMENTS)
-          .withFragmentSize(
-              settings.hasFragmentSize()
-                  ? settings.getFragmentSize().getValue()
-                  : DEFAULT_FRAGMENT_SIZE);
-    }
+                : DEFAULT_DISCRETE_MULTIVALUE)
+        .withMaxNumFragments(
+            settings.hasMaxNumberOfFragments()
+                ? settings.getMaxNumberOfFragments().getValue()
+                : DEFAULT_MAX_NUM_FRAGMENTS)
+        .withFragmentSize(
+            settings.hasFragmentSize()
+                ? settings.getFragmentSize().getValue()
+                : DEFAULT_FRAGMENT_SIZE);
 
     Query query =
         settings.hasHighlightQuery()

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighter.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighter.java
@@ -86,8 +86,7 @@ public class NRTFastVectorHighlighter implements Highlighter {
     int numberOfFragments = settings.getMaxNumFragments();
     int fragmentCharSize = settings.getFragmentSize();
     if (settings.getMaxNumFragments() == 0) {
-      // a HACK to make highlighter do highlighting, even though its using the single frag list
-      // builder
+      // This is required to support the feature to return the entire text as a single fragment.
       fragListBuilder = SINGLE_FRAG_LIST_BUILDER;
       numberOfFragments = Integer.MAX_VALUE;
       fragmentCharSize = Integer.MAX_VALUE;

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighterTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighterTest.java
@@ -354,7 +354,7 @@ public class NRTFastVectorHighlighterTest extends ServerTestCase {
         .containsExactly("the <em>food</em> here is amazing, service was good");
     assertThat(response.getHits(1).getHighlightsMap().get("comment").getFragmentsList())
         .containsExactly(
-            "This is my first time eating at this restaurant. The <em>food</em> here is pretty good, the service could be better. My favorite food was chilly chicken.");
+            "This is my first time eating at this restaurant. The <em>food</em> here is pretty good, the service could be better. My favorite <em>food</em> was chilly chicken.");
     assertThat(response.getDiagnostics().getHighlightTimeMs()).isGreaterThan(0);
   }
 


### PR DESCRIPTION
Fixes two issues:

1. settings toBuilder missed field `discreteMultivalue`
2. highlight utils causes some failures in highlight single fragments when fragmentNumber is 0 (it is handled in NRTFastVectorHighlighter already)