### PR TITLE
fix a bug from fetching top N fields from fhv

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -819,7 +819,7 @@ message Highlight {
         repeated string pre_tags = 2;
         // Used along with pre_tags to specify how to wrap the highlighted text.
         repeated string post_tags = 3;
-        // Number of characters in highlighted fragment, 100 by default.
+        // Number of characters in highlighted fragment, 100 by default. Set it to be 0/Integer.MAX_VALUE to fetch the entire field.
         google.protobuf.UInt32Value fragment_size = 4;
         // Maximum number of highlight fragments to return, 5 by default. If set to 0 returns entire text as a single fragment ignoring fragment_size.
         google.protobuf.UInt32Value max_number_of_fragments = 5;

--- a/docs/highlighting.rst
+++ b/docs/highlighting.rst
@@ -48,7 +48,7 @@ This is the proto definition for Highlight message which can be specified in Sea
         repeated string pre_tags = 2;
         // Used along with pre_tags to specify how to wrap the highlighted text.
         repeated string post_tags = 3;
-        // Number of characters in highlighted fragment, 100 by default.
+        // Number of characters in highlighted fragment, 100 by default. Set it to be 0/Integer.MAX_VALUE to fetch the entire field.
         google.protobuf.UInt32Value fragment_size = 4;
         // Maximum number of highlight fragments to return, 5 by default. If set to 0 returns entire text as a single fragment ignoring fragment_size.
         google.protobuf.UInt32Value max_number_of_fragments = 5;

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighter.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighter.java
@@ -90,6 +90,9 @@ public class NRTFastVectorHighlighter implements Highlighter {
       fragListBuilder = SINGLE_FRAG_LIST_BUILDER;
       numberOfFragments = Integer.MAX_VALUE;
       fragmentCharSize = Integer.MAX_VALUE;
+    } else if (fragmentCharSize == 0 || fragmentCharSize == Integer.MAX_VALUE) {
+      fragListBuilder = SINGLE_FRAG_LIST_BUILDER;
+      fragmentCharSize = Integer.MAX_VALUE;
     } else {
       fragListBuilder = SIMPLE_FRAG_LIST_BUILDER;
     }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighterTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighterTest.java
@@ -382,7 +382,7 @@ public class NRTFastVectorHighlighterTest extends ServerTestCase {
         .containsExactly("the <em>food</em> here is amazing, service was good");
     assertThat(response.getHits(1).getHighlightsMap().get("comment").getFragmentsList())
         .containsExactly(
-            "This is my first time eating at this restaurant. The <em>food</em> here is pretty good, the service could be better. My favorite food was chilly chicken.");
+            "This is my first time eating at this restaurant. The <em>food</em> here is pretty good, the service could be better. My favorite <em>food</em> was chilly chicken.");
     assertThat(response.getDiagnostics().getHighlightTimeMs()).isGreaterThan(0);
   }
 


### PR DESCRIPTION
RP-7515

During smart snippets PoC. we find that we shall use `SINGLE_FRAG_LIST_BUILDER` in case of fetching the whole field.
Otherwise, it returns the top 1 field only.

Now, when set `fragment_size == Integer.MAX_VALUE` (or 0 which is easier for users), we use SINGLE_FRAG_LIST_BUILDER.
