### PR TITLE
Set max num fragments 0 instead of Integer.MAX_VALUE for per field setting

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/HighlightUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/HighlightUtils.java
@@ -109,7 +109,7 @@ public class HighlightUtils {
           builder.withMaxNumFragments(globalSettings.getMaxNumFragments());
         } else {
           if (settings.getMaxNumberOfFragments().getValue() == 0) {
-            builder.withMaxNumFragments(Integer.MAX_VALUE).withFragmentSize(Integer.MAX_VALUE);
+            builder.withMaxNumFragments(0).withFragmentSize(Integer.MAX_VALUE);
           } else {
             builder.withMaxNumFragments(settings.getMaxNumberOfFragments().getValue());
           }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighterTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighterTest.java
@@ -382,7 +382,7 @@ public class NRTFastVectorHighlighterTest extends ServerTestCase {
         .containsExactly("the <em>food</em> here is amazing, service was good");
     assertThat(response.getHits(1).getHighlightsMap().get("comment").getFragmentsList())
         .containsExactly(
-            "This is my first time eating at this restaurant. The <em>food</em> here is pretty good, the service could be better. My favorite food was chilly chicken.");
+            "This is my first time eating at this restaurant. The <em>food</em> here is pretty good, the service could be better. My favorite <em>food</em> was chilly chicken.");
     assertThat(response.getDiagnostics().getHighlightTimeMs()).isGreaterThan(0);
   }
 


### PR DESCRIPTION
#551 fixed an issue with highlighting so that setting max num fragments to 0 would correctly return the entire field as a single fragment and with all possible highlights. However this only worked if the global max num fragments was set to 0 since we were overriding field level setting to Integer.MAX_VALUE.
By setting this to 0 [NRTFastVectorHighlighter](https://github.com/Yelp/nrtsearch/blob/master/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighter.java#L88) will be able to use SingleFragListBuilder and have the desired behavior.