### PR TITLE
add explain support to search query

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -414,6 +414,7 @@ message SearchRequest {
     string responseCompression = 23;
     // Specify how to highlight matched text
     Highlight highlight = 24;
+    bool explain = 25;
 }
 
 /* Virtual field used during search */
@@ -562,6 +563,7 @@ message SearchResponse {
         map<string, CompositeFieldValue> sortedFields = 4; // Sorted field name to value
         // Field name to highlighted text fragments
         map<string, Highlights> highlights = 5;
+        string explain = 6;
     }
 
     message SearchState {

--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -414,6 +414,7 @@ message SearchRequest {
     string responseCompression = 23;
     // Specify how to highlight matched text
     Highlight highlight = 24;
+    // If Lucene explanation should be included in the response
     bool explain = 25;
 }
 
@@ -563,6 +564,7 @@ message SearchResponse {
         map<string, CompositeFieldValue> sortedFields = 4; // Sorted field name to value
         // Field name to highlighted text fragments
         map<string, Highlights> highlights = 5;
+        // Lucene explanation of the hit
         string explain = 6;
     }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
@@ -180,8 +180,8 @@ public class SearchHandler implements Handler<SearchRequest, SearchResponse> {
       List<Explanation> explanations = null;
       if (searchRequest.getExplain()) {
         explanations = new ArrayList<>();
-        for (int i = 0; i < hits.scoreDocs.length; i++) {
-          explanations.add(s.searcher.explain(searchContext.getQuery(), i));
+        for (ScoreDoc doc : hits.scoreDocs) {
+          explanations.add(s.searcher.explain(searchContext.getQuery(), doc.doc));
         }
       }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
@@ -66,7 +66,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
 import org.apache.lucene.search.DoubleValues;
-import org.apache.lucene.search.Explanation
+import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.search.ScoreDoc;

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
@@ -834,6 +834,59 @@ public class QueryTest {
     }
   }
 
+  @Test
+  public void testSearchExplain() {
+    Query query =
+        Query.newBuilder()
+            .setMatchPhraseQuery(
+                MatchPhraseQuery.newBuilder()
+                    .setField("vendor_name")
+                    .setQuery("SECOND second")
+                    .setSlop(1))
+            .build();
+
+    Consumer<SearchResponse> responseTester =
+        searchResponse -> {
+          assertEquals(1, searchResponse.getTotalHits().getValue());
+          assertEquals(1, searchResponse.getHitsList().size());
+          SearchResponse.Hit hit = searchResponse.getHits(0);
+          String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
+          assertEquals("2", docId);
+          LuceneServerTest.checkHits(hit);
+        };
+    SearchResponse searchResponse = grpcServer.getBlockingStub().search(buildSearchRequest(query));
+    responseTester.accept(searchResponse);
+    boolean explain = true;
+    SearchResponse searchResponseExplained =
+        grpcServer.getBlockingStub().search(buildSearchRequestWithExplain(query, explain));
+    responseTester.accept(searchResponseExplained);
+    String expectedExplain =
+        "0.40773362 = weight(vendor_name:\"second second\"~1 in 1) [], result of:\n"
+            + "      0.40773362 = score(freq=0.5), computed as boost * idf * tf from:\n"
+            + "        1.3862944 = idf, sum of:\n"
+            + "          0.6931472 = idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:\n"
+            + "            1 = n, number of documents containing term\n"
+            + "            2 = N, total number of documents with field\n"
+            + "          0.6931472 = idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:\n"
+            + "            1 = n, number of documents containing term\n"
+            + "            2 = N, total number of documents with field\n"
+            + "        0.29411763 = tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:\n"
+            + "          0.5 = phraseFreq=0.5\n"
+            + "          1.2 = k1, term saturation parameter\n"
+            + "          0.75 = b, length normalization parameter\n"
+            + "          4.0 = dl, length of field\n"
+            + "          4.0 = avgdl, average length of field";
+    for (int i = 0; i < searchResponse.getHitsCount(); i++) {
+      SearchResponse.Hit hit = searchResponse.getHits(i);
+      SearchResponse.Hit explainedHit = searchResponseExplained.getHits(i);
+      SearchResponse.Hit hitWithoutExplain = hit.toBuilder().setExplain("").build();
+      SearchResponse.Hit explainedHitWithoutExplain =
+          explainedHit.toBuilder().setExplain("").build();
+      assertEquals(hitWithoutExplain, explainedHitWithoutExplain);
+      assertEquals(explainedHit.getExplain(), expectedExplain);
+    }
+  }
+
   /**
    * Search with the query and then test the response. Additional test with boost will also be
    * performed on the query.
@@ -919,22 +972,6 @@ public class QueryTest {
       SearchResponse.Hit boostedHitWithoutScore =
           SearchResponse.Hit.newBuilder(boostedHit).setScore(0).build();
       assertEquals(hitWithoutScore, boostedHitWithoutScore);
-    }
-  }
-
-  private void testWithExplain(Query query, SearchResponse searchResponse) {
-    boolean explain = true;
-    SearchResponse searchResponseExplained =
-        grpcServer.getBlockingStub().search(buildSearchRequestWithExplain(query, explain));
-    for (int i = 0; i < searchResponse.getHitsCount(); i++) {
-      SearchResponse.Hit hit = searchResponse.getHits(i);
-      SearchResponse.Hit explainedHit = searchResponseExplained.getHits(i);
-      SearchResponse.Hit hitWithoutExplain =
-          SearchResponse.Hit.newBuilder(hit).setExplain("").build();
-      SearchResponse.Hit explainedHitWithoutExplain =
-          SearchResponse.Hit.newBuilder(explainedHit).setExplain("").build();
-      assertEquals(hitWithoutExplain, explainedHitWithoutExplain);
-      assertTrue(explainedHit.getExplain().contains(String.valueOf(explainedHit.getScore())));
     }
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
@@ -862,20 +862,20 @@ public class QueryTest {
     responseTester.accept(searchResponseExplained);
     String expectedExplain =
         "0.40773362 = weight(vendor_name:\"second second\"~1 in 1) [], result of:\n"
-            + "      0.40773362 = score(freq=0.5), computed as boost * idf * tf from:\n"
-            + "        1.3862944 = idf, sum of:\n"
-            + "          0.6931472 = idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:\n"
-            + "            1 = n, number of documents containing term\n"
-            + "            2 = N, total number of documents with field\n"
-            + "          0.6931472 = idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:\n"
-            + "            1 = n, number of documents containing term\n"
-            + "            2 = N, total number of documents with field\n"
-            + "        0.29411763 = tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:\n"
-            + "          0.5 = phraseFreq=0.5\n"
-            + "          1.2 = k1, term saturation parameter\n"
-            + "          0.75 = b, length normalization parameter\n"
-            + "          4.0 = dl, length of field\n"
-            + "          4.0 = avgdl, average length of field";
+            + "  0.40773362 = score(freq=0.5), computed as boost * idf * tf from:\n"
+            + "    1.3862944 = idf, sum of:\n"
+            + "      0.6931472 = idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:\n"
+            + "        1 = n, number of documents containing term\n"
+            + "        2 = N, total number of documents with field\n"
+            + "      0.6931472 = idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:\n"
+            + "        1 = n, number of documents containing term\n"
+            + "        2 = N, total number of documents with field\n"
+            + "    0.29411763 = tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:\n"
+            + "      0.5 = phraseFreq=0.5\n"
+            + "      1.2 = k1, term saturation parameter\n"
+            + "      0.75 = b, length normalization parameter\n"
+            + "      4.0 = dl, length of field\n"
+            + "      4.0 = avgdl, average length of field";
     for (int i = 0; i < searchResponse.getHitsCount(); i++) {
       SearchResponse.Hit hit = searchResponse.getHits(i);
       SearchResponse.Hit explainedHit = searchResponseExplained.getHits(i);
@@ -883,7 +883,7 @@ public class QueryTest {
       SearchResponse.Hit explainedHitWithoutExplain =
           explainedHit.toBuilder().setExplain("").build();
       assertEquals(hitWithoutExplain, explainedHitWithoutExplain);
-      assertEquals(explainedHit.getExplain(), expectedExplain);
+      assertEquals(expectedExplain, explainedHit.getExplain().trim());
     }
   }
 


### PR DESCRIPTION
add explain option to search request for score details.

I only support the search with explain here. The ES explain api is not very necessary here.