### PR TITLE
Add config option for max s3 client retries

### DIFF
--- a/docs/server_configuration.rst
+++ b/docs/server_configuration.rst
@@ -76,6 +76,11 @@ Example server configuration
      - Name of bucket to use for external storage
      - DEFAULT_ARCHIVE_BUCKET
 
+   * - maxS3ClientRetries
+     - int
+     - Max retries to configure for the server s3 client. If <= 0, the default retry policy is used.
+     - -1 (default policy)
+
    * - botoCfgPath
      - str
      - Path to AWS credentials (if using S3 for remote storage)

--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -45,6 +45,7 @@ public class LuceneServerConfiguration {
   public static final Path DEFAULT_INDEX_DIR =
       Paths.get(DEFAULT_USER_DIR.toString(), "default_index");
   private static final String DEFAULT_BUCKET_NAME = "DEFAULT_ARCHIVE_BUCKET";
+  static final int DEFAULT_MAX_S3_CLIENT_RETRIES = -1;
   private static final String DEFAULT_HOSTNAME = "localhost";
   private static final int DEFAULT_PORT = 50051;
   private static final int DEFAULT_REPLICATION_PORT = 50052;
@@ -71,6 +72,7 @@ public class LuceneServerConfiguration {
   private final String archiveDirectory;
   private final String botoCfgPath;
   private final String bucketName;
+  private final int maxS3ClientRetries;
   private final double[] metricsBuckets;
   private final boolean publishJvmMetrics;
   private final String[] plugins;
@@ -128,6 +130,8 @@ public class LuceneServerConfiguration {
     archiveDirectory = configReader.getString("archiveDirectory", DEFAULT_ARCHIVER_DIR.toString());
     botoCfgPath = configReader.getString("botoCfgPath", DEFAULT_BOTO_CFG_PATH.toString());
     bucketName = configReader.getString("bucketName", DEFAULT_BUCKET_NAME);
+    maxS3ClientRetries =
+        configReader.getInteger("maxS3ClientRetries", DEFAULT_MAX_S3_CLIENT_RETRIES);
     double[] metricsBuckets;
     try {
       List<Double> bucketList = configReader.getDoubleList("metricsBuckets");
@@ -218,6 +222,11 @@ public class LuceneServerConfiguration {
 
   public String getBucketName() {
     return bucketName;
+  }
+
+  /** Get max number of retries to configure for s3 client. If <= 0, use client default. */
+  public int getMaxS3ClientRetries() {
+    return maxS3ClientRetries;
   }
 
   public String getArchiveDirectory() {

--- a/src/test/java/com/yelp/nrtsearch/server/config/LuceneServerConfigurationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/LuceneServerConfigurationTest.java
@@ -143,4 +143,20 @@ public class LuceneServerConfigurationTest {
     LuceneServerConfiguration luceneConfig = getForConfig(config);
     assertEquals(100L, luceneConfig.getInitialSyncMaxTimeMs());
   }
+
+  @Test
+  public void testMaxS3ClientRetries_default() {
+    String config = "nodeName: \"lucene_server_foo\"";
+    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    assertEquals(
+        LuceneServerConfiguration.DEFAULT_MAX_S3_CLIENT_RETRIES,
+        luceneConfig.getMaxS3ClientRetries());
+  }
+
+  @Test
+  public void testMaxS3ClientRetries_set() {
+    String config = "maxS3ClientRetries: 10";
+    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    assertEquals(10, luceneConfig.getMaxS3ClientRetries());
+  }
 }


### PR DESCRIPTION
Makes the maximum number of retries by the server s3 client configurable with the `maxS3ClientRetries` option. When this option is set to a value > 0, a retry policy is configured using the default retry condition and backoff strategy. If the value is <= 0 (default -1), the default client retry policy is used.