### PR TITLE
Make char filters plugin extendable and add mappingV2 filter

### DIFF
--- a/docs/analysis.rst
+++ b/docs/analysis.rst
@@ -158,6 +158,8 @@ Available character filters:
 
   * patternreplace
 
+  * mappingV2 - Similar to the ``mapping`` filter, except rules are specified directly in the parameters. See `MappingV2CharFilterFactory <https://github.com/Yelp/nrtsearch/blob/master/src/main/java/com/yelp/nrtsearch/server/luceneserver/analysis/MappingV2CharFilterFactory.java>`_.
+
 Available tokenizers:
 
   * keyword

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/analysis/MappingV2CharFilterFactory.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/analysis/MappingV2CharFilterFactory.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2023 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.analysis;
+
+import java.io.Reader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.lucene.analysis.charfilter.MappingCharFilter;
+import org.apache.lucene.analysis.charfilter.NormalizeCharMap;
+import org.apache.lucene.analysis.util.CharFilterFactory;
+
+/**
+ * Implementation of a {@link CharFilterFactory} that allows for specification of character mapping
+ * rules. Unlike the lucene provided {@link
+ * org.apache.lucene.analysis.charfilter.MappingCharFilterFactory}, this one lets you specify the
+ * mapping rules inline as a parameter (instead of within a file).
+ *
+ * <p>Rules must be specified in the 'mappings' parameter string. This value is separated into
+ * multiple rules by splitting on a pattern, which defaults to '[|]'. This pattern may be changed by
+ * giving a 'separator_pattern' param.
+ *
+ * <p>Rules must be of the form chars_from=>chars_to for example:
+ *
+ * <p>i=>j
+ *
+ * <p>,=>
+ *
+ * <p>&=>and
+ *
+ * <p>j=>k|a=>e
+ *
+ * <p>For escaping options, see {@link #parseString(String)}.
+ */
+public class MappingV2CharFilterFactory extends CharFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "mappingV2";
+
+  public static final String SEPARATOR_PATTERN = "separator_pattern";
+  public static final String DEFAULT_SEPARATOR_PATTERN = "[|]";
+  public static final String MAPPINGS = "mappings";
+
+  protected NormalizeCharMap normMap;
+
+  /**
+   * Initialize this factory via a set of key-value pairs.
+   *
+   * @param args
+   */
+  public MappingV2CharFilterFactory(Map<String, String> args) {
+    super(args);
+
+    String separator = args.getOrDefault(SEPARATOR_PATTERN, DEFAULT_SEPARATOR_PATTERN);
+    String mappings = args.get(MAPPINGS);
+    if (mappings == null) {
+      throw new IllegalArgumentException("Filter mappings must be specified");
+    }
+    List<String> rules = extractRules(mappings, separator);
+    final NormalizeCharMap.Builder builder = new NormalizeCharMap.Builder();
+    parseRules(rules, builder);
+    normMap = builder.build();
+  }
+
+  @Override
+  public Reader create(Reader input) {
+    return new MappingCharFilter(normMap, input);
+  }
+
+  @Override
+  public Reader normalize(Reader input) {
+    return create(input);
+  }
+
+  private List<String> extractRules(String mappings, String separator) {
+    return Arrays.asList(mappings.split(separator));
+  }
+
+  static Pattern p = Pattern.compile("(.*)\\s*=>\\s*(.*)\\s*$");
+
+  protected void parseRules(List<String> rules, NormalizeCharMap.Builder builder) {
+    for (String rule : rules) {
+      Matcher m = p.matcher(rule);
+      if (!m.find()) throw new IllegalArgumentException("Invalid Mapping Rule : [" + rule + "]");
+      builder.add(parseString(m.group(1)), parseString(m.group(2)));
+    }
+  }
+
+  char[] out = new char[256];
+
+  protected String parseString(String s) {
+    int readPos = 0;
+    int len = s.length();
+    int writePos = 0;
+    while (readPos < len) {
+      char c = s.charAt(readPos++);
+      if (c == '\\') {
+        if (readPos >= len)
+          throw new IllegalArgumentException("Invalid escaped char in [" + s + "]");
+        c = s.charAt(readPos++);
+        switch (c) {
+          case '\\':
+            c = '\\';
+            break;
+          case '"':
+            c = '"';
+            break;
+          case 'n':
+            c = '\n';
+            break;
+          case 't':
+            c = '\t';
+            break;
+          case 'r':
+            c = '\r';
+            break;
+          case 'b':
+            c = '\b';
+            break;
+          case 'f':
+            c = '\f';
+            break;
+          case 'u':
+            if (readPos + 3 >= len)
+              throw new IllegalArgumentException("Invalid escaped char in [" + s + "]");
+            c = (char) Integer.parseInt(s.substring(readPos, readPos + 4), 16);
+            readPos += 4;
+            break;
+        }
+      }
+      out[writePos++] = c;
+    }
+    return new String(out, 0, writePos);
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/plugins/AnalysisPlugin.java
+++ b/src/main/java/com/yelp/nrtsearch/server/plugins/AnalysisPlugin.java
@@ -19,6 +19,7 @@ import com.yelp.nrtsearch.server.luceneserver.analysis.AnalysisProvider;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.util.CharFilterFactory;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
 /**
@@ -56,6 +57,22 @@ public interface AnalysisPlugin {
    * @return registration Map for token filter name to {@link TokenFilterFactory} class
    */
   default Map<String, Class<? extends TokenFilterFactory>> getTokenFilters() {
+    return Collections.emptyMap();
+  }
+
+  /**
+   * Provides a set of custom {@link CharFilterFactory} classes to register with the {@link
+   * com.yelp.nrtsearch.server.luceneserver.analysis.AnalyzerCreator} for use with {@link
+   * com.yelp.nrtsearch.server.grpc.CustomAnalyzer} building.
+   *
+   * <p>The class must have a constructor that takes only a param Map[String,String]. If nrtsearch
+   * specific context is required, implement the {@link
+   * com.yelp.nrtsearch.server.luceneserver.analysis.AnalysisComponent} interface to receive
+   * additional initialization during building.
+   *
+   * @return registration Map for char filter name to {@link CharFilterFactory} class
+   */
+  default Map<String, Class<? extends CharFilterFactory>> getCharFilters() {
     return Collections.emptyMap();
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/analysis/AnalyzerCreatorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/analysis/AnalyzerCreatorTest.java
@@ -47,6 +47,7 @@ import org.apache.lucene.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.bn.BengaliAnalyzer;
 import org.apache.lucene.analysis.charfilter.HTMLStripCharFilterFactory;
+import org.apache.lucene.analysis.charfilter.MappingCharFilterFactory;
 import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
 import org.apache.lucene.analysis.custom.CustomAnalyzer;
 import org.apache.lucene.analysis.en.EnglishAnalyzer;
@@ -615,5 +616,209 @@ public class AnalyzerCreatorTest {
     assertEquals(1, tokenFilters.size());
     assertTrue(tokenFilters.get(0) instanceof TokenFilterAnalysisComponent);
     assertNotNull(((TokenFilterAnalysisComponent) tokenFilters.get(0)).configuration);
+  }
+
+  public static class MyCharFilter extends MappingCharFilterFactory {
+
+    final Map<String, String> params;
+
+    public MyCharFilter(Map<String, String> params) {
+      super(Collections.emptyMap());
+      this.params = params;
+    }
+  }
+
+  public static class TestCharFilterPlugin extends Plugin implements AnalysisPlugin {
+    @Override
+    public Map<String, Class<? extends CharFilterFactory>> getCharFilters() {
+      return Collections.singletonMap("test_char_filter", MyCharFilter.class);
+    }
+  }
+
+  @Test
+  public void testPluginCharFilterNotDefined() {
+    try {
+      AnalyzerCreator.getInstance()
+          .getAnalyzer(
+              com.yelp.nrtsearch.server.grpc.Analyzer.newBuilder()
+                  .setCustom(
+                      com.yelp.nrtsearch.server.grpc.CustomAnalyzer.newBuilder()
+                          .setTokenizer(NameAndParams.newBuilder().setName("keyword").build())
+                          .addCharFilters(
+                              NameAndParams.newBuilder().setName("test_char_filter").build())
+                          .build())
+                  .build());
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertTrue(
+          e.getMessage()
+              .contains("CharFilterFactory with name 'test_char_filter' does not exist."));
+    }
+  }
+
+  @Test
+  public void testPluginProvidesCharFilter() {
+    init(Collections.singletonList(new TestCharFilterPlugin()));
+
+    CustomAnalyzer analyzer =
+        (CustomAnalyzer)
+            AnalyzerCreator.getInstance()
+                .getAnalyzer(
+                    com.yelp.nrtsearch.server.grpc.Analyzer.newBuilder()
+                        .setCustom(
+                            com.yelp.nrtsearch.server.grpc.CustomAnalyzer.newBuilder()
+                                .setTokenizer(NameAndParams.newBuilder().setName("keyword").build())
+                                .addCharFilters(
+                                    NameAndParams.newBuilder().setName("test_char_filter").build())
+                                .build())
+                        .build());
+    List<CharFilterFactory> charFilters = analyzer.getCharFilterFactories();
+    assertEquals(1, charFilters.size());
+    assertTrue(charFilters.get(0) instanceof MyCharFilter);
+    assertTrue(((MyCharFilter) charFilters.get(0)).params.isEmpty());
+  }
+
+  @Test
+  public void testCharFilterParams() {
+    init(Collections.singletonList(new TestCharFilterPlugin()));
+
+    Map<String, String> params = new HashMap<>();
+    params.put("p1", "v1");
+    params.put("p2", "v2");
+
+    CustomAnalyzer analyzer =
+        (CustomAnalyzer)
+            AnalyzerCreator.getInstance()
+                .getAnalyzer(
+                    com.yelp.nrtsearch.server.grpc.Analyzer.newBuilder()
+                        .setCustom(
+                            com.yelp.nrtsearch.server.grpc.CustomAnalyzer.newBuilder()
+                                .setTokenizer(NameAndParams.newBuilder().setName("keyword").build())
+                                .addCharFilters(
+                                    NameAndParams.newBuilder()
+                                        .setName("test_char_filter")
+                                        .putAllParams(params)
+                                        .build())
+                                .build())
+                        .build());
+    List<CharFilterFactory> charFilters = analyzer.getCharFilterFactories();
+    assertEquals(1, charFilters.size());
+    assertTrue(charFilters.get(0) instanceof MyCharFilter);
+    assertEquals(params, ((MyCharFilter) charFilters.get(0)).params);
+  }
+
+  public static class TestCharFilterDuplicatePlugin extends Plugin implements AnalysisPlugin {
+    @Override
+    public Map<String, Class<? extends CharFilterFactory>> getCharFilters() {
+      return Collections.singletonMap("test_char_filter", MappingCharFilterFactory.class);
+    }
+  }
+
+  @Test
+  public void testCharFilterDuplicatePluginRegistration() {
+    try {
+      init(List.of(new TestCharFilterPlugin(), new TestCharFilterDuplicatePlugin()));
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("Char filter test_char_filter already exists", e.getMessage());
+    }
+  }
+
+  public static class TestCharFilterDuplicateLucenePlugin extends Plugin implements AnalysisPlugin {
+    @Override
+    public Map<String, Class<? extends CharFilterFactory>> getCharFilters() {
+      return Collections.singletonMap("mapping", MyCharFilter.class);
+    }
+  }
+
+  @Test
+  public void testCharFilterDuplicateLuceneRegistration() {
+    try {
+      init(Collections.singletonList(new TestCharFilterDuplicateLucenePlugin()));
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("Char filter mapping already provided by lucene", e.getMessage());
+    }
+  }
+
+  public static class MyBadCharFilter extends MappingCharFilterFactory {
+
+    public MyBadCharFilter(Map<String, String> args, int something) {
+      super(args);
+    }
+  }
+
+  public static class BadCharFilterPlugin extends Plugin implements AnalysisPlugin {
+    @Override
+    public Map<String, Class<? extends CharFilterFactory>> getCharFilters() {
+      return Collections.singletonMap("test_char_filter", MyBadCharFilter.class);
+    }
+  }
+
+  @Test
+  public void testInvalidCharFilterConstructor() {
+    init(Collections.singletonList(new BadCharFilterPlugin()));
+
+    try {
+      AnalyzerCreator.getInstance()
+          .getAnalyzer(
+              com.yelp.nrtsearch.server.grpc.Analyzer.newBuilder()
+                  .setCustom(
+                      com.yelp.nrtsearch.server.grpc.CustomAnalyzer.newBuilder()
+                          .setTokenizer(NameAndParams.newBuilder().setName("keyword").build())
+                          .addCharFilters(
+                              NameAndParams.newBuilder().setName("test_char_filter").build())
+                          .build())
+                  .build());
+      fail();
+    } catch (UnsupportedOperationException e) {
+      assertEquals(
+          "Factory com.yelp.nrtsearch.server.luceneserver.analysis.AnalyzerCreatorTest$MyBadCharFilter "
+              + "cannot be instantiated. This is likely due to missing Map<String,String> constructor.",
+          e.getMessage());
+    }
+  }
+
+  public static class CharFilterAnalysisComponent extends MappingCharFilterFactory
+      implements AnalysisComponent {
+    LuceneServerConfiguration configuration;
+
+    public CharFilterAnalysisComponent(Map<String, String> args) {
+      super(args);
+    }
+
+    @Override
+    public void initializeComponent(LuceneServerConfiguration configuration) {
+      this.configuration = configuration;
+    }
+  }
+
+  public static class CharFilterAnalysisComponentPlugin extends Plugin implements AnalysisPlugin {
+    @Override
+    public Map<String, Class<? extends CharFilterFactory>> getCharFilters() {
+      return Collections.singletonMap("test_char_filter", CharFilterAnalysisComponent.class);
+    }
+  }
+
+  @Test
+  public void testCharFilterAnalysisComponent() {
+    init(Collections.singletonList(new CharFilterAnalysisComponentPlugin()));
+
+    CustomAnalyzer analyzer =
+        (CustomAnalyzer)
+            AnalyzerCreator.getInstance()
+                .getAnalyzer(
+                    com.yelp.nrtsearch.server.grpc.Analyzer.newBuilder()
+                        .setCustom(
+                            com.yelp.nrtsearch.server.grpc.CustomAnalyzer.newBuilder()
+                                .setTokenizer(NameAndParams.newBuilder().setName("keyword").build())
+                                .addCharFilters(
+                                    NameAndParams.newBuilder().setName("test_char_filter").build())
+                                .build())
+                        .build());
+    List<CharFilterFactory> charFilters = analyzer.getCharFilterFactories();
+    assertEquals(1, charFilters.size());
+    assertTrue(charFilters.get(0) instanceof CharFilterAnalysisComponent);
+    assertNotNull(((CharFilterAnalysisComponent) charFilters.get(0)).configuration);
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/analysis/MappingV2CharFilterFactoryITest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/analysis/MappingV2CharFilterFactoryITest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.analysis;
+
+import static org.junit.Assert.assertEquals;
+
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest.MultiValuedField;
+import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
+import com.yelp.nrtsearch.server.grpc.Query;
+import com.yelp.nrtsearch.server.grpc.SearchRequest;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import com.yelp.nrtsearch.server.grpc.TermQuery;
+import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class MappingV2CharFilterFactoryITest extends ServerTestCase {
+  @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  protected List<String> getIndices() {
+    return Collections.singletonList(DEFAULT_TEST_INDEX);
+  }
+
+  protected FieldDefRequest getIndexDef(String name) throws IOException {
+    return getFieldsFromResourceFile("/analysis/registerFieldsCharFilter.json");
+  }
+
+  protected void initIndex(String name) throws Exception {
+    List<AddDocumentRequest> docs = new ArrayList<>();
+    AddDocumentRequest request =
+        AddDocumentRequest.newBuilder()
+            .setIndexName(name)
+            .putFields("doc_id", MultiValuedField.newBuilder().addValue("1").build())
+            .putFields("text_field", MultiValuedField.newBuilder().addValue("?tarm's1").build())
+            .build();
+    docs.add(request);
+    request =
+        AddDocumentRequest.newBuilder()
+            .setIndexName(name)
+            .putFields("doc_id", MultiValuedField.newBuilder().addValue("2").build())
+            .putFields("text_field", MultiValuedField.newBuilder().addValue("tar?m&2").build())
+            .build();
+    docs.add(request);
+    addDocuments(docs.stream());
+  }
+
+  @Test
+  public void testMappingV2Filter() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(DEFAULT_TEST_INDEX)
+                    .setTopHits(10)
+                    .addRetrieveFields("doc_id")
+                    .setQuery(
+                        Query.newBuilder()
+                            .setTermQuery(
+                                TermQuery.newBuilder()
+                                    .setField("text_field")
+                                    .setTextValue("term1")
+                                    .build())
+                            .build())
+                    .build());
+    assertEquals(1, response.getHitsCount());
+    assertEquals(
+        "1", response.getHits(0).getFieldsOrThrow("doc_id").getFieldValue(0).getTextValue());
+
+    response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(DEFAULT_TEST_INDEX)
+                    .setTopHits(10)
+                    .addRetrieveFields("doc_id")
+                    .setQuery(
+                        Query.newBuilder()
+                            .setTermQuery(
+                                TermQuery.newBuilder()
+                                    .setField("text_field")
+                                    .setTextValue("term 2")
+                                    .build())
+                            .build())
+                    .build());
+    assertEquals(1, response.getHitsCount());
+    assertEquals(
+        "2", response.getHits(0).getFieldsOrThrow("doc_id").getFieldValue(0).getTextValue());
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/analysis/MappingV2CharFilterFactoryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/analysis/MappingV2CharFilterFactoryTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.analysis;
+
+import static org.apache.lucene.analysis.util.AnalysisSPILoader.newFactoryClassInstance;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.CharArrayReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class MappingV2CharFilterFactoryTest {
+
+  @Test
+  public void testMappingFilterSingleRule() throws IOException {
+    MappingV2CharFilterFactory factory = getFactory(",=>.");
+    String output = getFiltered(factory, "this. is, a test, string");
+    assertEquals("this. is. a test. string", output);
+  }
+
+  @Test
+  public void testMappingFilterMultipleRules() throws IOException {
+    MappingV2CharFilterFactory factory =
+        getFactory(
+            "'s=>|'S=>|&=>\\u0020and\\u0020|'N'=>\\u0020n\\u0020|/=>\\u0020|\"=>\\u0020|!=>");
+    String output = getFiltered(factory, "a'sb'Sc&d'N'e'n'f/g\"h!i");
+    assertEquals("abc and d n e'n'f g hi", output);
+  }
+
+  @Test
+  public void testDifferentSeparator() throws IOException {
+    MappingV2CharFilterFactory factory =
+        getFactory(
+            "'s=>,'S=>,&=>\\u0020and\\u0020,'N'=>\\u0020n\\u0020,/=>\\u0020,\"=>\\u0020,!=>",
+            "[,]");
+    String output = getFiltered(factory, "a'sb'Sc&d'N'e'n'f/g\"h!i");
+    assertEquals("abc and d n e'n'f g hi", output);
+  }
+
+  @Test
+  public void testNoMappings() {
+    try {
+      newFactoryClassInstance(MappingV2CharFilterFactory.class, new HashMap<>());
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("Filter mappings must be specified", e.getMessage());
+    }
+  }
+
+  private MappingV2CharFilterFactory getFactory(String mappings) {
+    Map<String, String> params = new HashMap<>();
+    params.put(MappingV2CharFilterFactory.MAPPINGS, mappings);
+    return newFactoryClassInstance(MappingV2CharFilterFactory.class, params);
+  }
+
+  private MappingV2CharFilterFactory getFactory(String mappings, String pattern) {
+    Map<String, String> params = new HashMap<>();
+    params.put(MappingV2CharFilterFactory.MAPPINGS, mappings);
+    params.put(MappingV2CharFilterFactory.SEPARATOR_PATTERN, pattern);
+    return newFactoryClassInstance(MappingV2CharFilterFactory.class, params);
+  }
+
+  private String getFiltered(MappingV2CharFilterFactory factory, String inputStr)
+      throws IOException {
+    Reader input = new CharArrayReader(inputStr.toCharArray());
+    char[] output = new char[256];
+    try (Reader reader = factory.create(input)) {
+      int size = reader.read(output);
+      return new String(output, 0, size);
+    }
+  }
+}

--- a/src/test/resources/analysis/registerFieldsCharFilter.json
+++ b/src/test/resources/analysis/registerFieldsCharFilter.json
@@ -1,0 +1,34 @@
+{
+  "indexName": "test_index",
+  "field": [
+    {
+      "name": "doc_id",
+      "type": "_ID",
+      "search": true,
+      "storeDocValues": true
+    },
+    {
+      "name": "text_field",
+      "type": "TEXT",
+      "search": true,
+      "tokenize": true,
+      "multiValued": true,
+      "storeDocValues": true,
+      "analyzer": {
+        "custom": {
+          "tokenizer": {
+            "name": "keyword"
+          },
+          "charFilters": [
+            {
+              "name": "mappingV2",
+              "params": {
+                "mappings": "a=>e|'s=>|?=>|&=>\\u0020"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Extendable Character Filters
Character filters can now be registered by an `AnalysisPlugin`. This is done in a similar way to token filters, where the plugin provides a mapping of classes that extend `CharFilterFactory`. This filters may then be referenced by name when building a `CustomAnalyzer`.

## MappingV2CharFilterFactory
A new character filter has been made available, registered as `mappingV2`. This filter has a similar function to the `mapping` filter, but rules are specified in a parameter instead of a file. Params:
- `mappings` (str): specifies the mapping rules. This string is split into individual rules based on `separator_pattern`. Each rule is of the form `<from>=><to>`. Examples: `a=>b`, `+=>and`, `?=>`, `,=>.|a=>b|&=>and`.
- `separator_pattern` (str): Defines the pattern used to split the `mappings` into multiple rules. Default: `[|]`.