### PR TITLE
Enable global bucket access

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -107,6 +107,8 @@ public class LuceneServerConfiguration {
   private final long maxConnectionAgeGraceForReplication;
   private final boolean savePluginBeforeUnzip;
 
+  private final boolean enableGlobalBucketAccess;
+
   @Inject
   public LuceneServerConfiguration(InputStream yamlStream) {
     configReader = new YamlConfigReader(yamlStream);
@@ -177,7 +179,8 @@ public class LuceneServerConfiguration {
         FSTLoadMode.valueOf(configReader.getString("completionCodecLoadMode", "ON_HEAP"));
     filterIncompatibleSegmentReaders =
         configReader.getBoolean("filterIncompatibleSegmentReaders", false);
-    this.savePluginBeforeUnzip = configReader.getBoolean("savePluginBeforeUnzip", false);
+    savePluginBeforeUnzip = configReader.getBoolean("savePluginBeforeUnzip", false);
+    enableGlobalBucketAccess = configReader.getBoolean("enableGlobalBucketAccess", false);
   }
 
   public ThreadPoolConfiguration getThreadPoolConfiguration() {
@@ -347,6 +350,10 @@ public class LuceneServerConfiguration {
 
   public boolean getSavePluginBeforeUnzip() {
     return savePluginBeforeUnzip;
+  }
+
+  public boolean getEnableGlobalBucketAccess() {
+    return enableGlobalBucketAccess;
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/module/S3Module.java
+++ b/src/main/java/com/yelp/nrtsearch/server/module/S3Module.java
@@ -83,15 +83,14 @@ public class S3Module extends AbstractModule {
         clientBuilder.setClientConfiguration(clientConfiguration);
       }
 
-      AmazonS3ClientBuilder amazonS3ClientBuilder = clientBuilder
-          .withCredentials(awsCredentialsProvider)
-          .withEndpointConfiguration(
-              new EndpointConfiguration(serviceEndpoint, region));
+      AmazonS3ClientBuilder amazonS3ClientBuilder =
+          clientBuilder
+              .withCredentials(awsCredentialsProvider)
+              .withEndpointConfiguration(new EndpointConfiguration(serviceEndpoint, region));
       if (luceneServerConfiguration.getEnableGlobalBucketAccess()) {
         amazonS3ClientBuilder.enableForceGlobalBucketAccess();
       }
-      return amazonS3ClientBuilder
-          .build();
+      return amazonS3ClientBuilder.build();
     }
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/module/S3Module.java
+++ b/src/main/java/com/yelp/nrtsearch/server/module/S3Module.java
@@ -22,6 +22,7 @@ import com.amazonaws.auth.AnonymousAWSCredentials;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.auth.profile.ProfilesConfigFile;
 import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.retry.RetryPolicy;
 import com.amazonaws.services.s3.AmazonS3;
@@ -82,10 +83,14 @@ public class S3Module extends AbstractModule {
         clientBuilder.setClientConfiguration(clientConfiguration);
       }
 
-      return clientBuilder
+      AmazonS3ClientBuilder amazonS3ClientBuilder = clientBuilder
           .withCredentials(awsCredentialsProvider)
           .withEndpointConfiguration(
-              new AwsClientBuilder.EndpointConfiguration(serviceEndpoint, region))
+              new EndpointConfiguration(serviceEndpoint, region));
+      if (luceneServerConfiguration.getEnableGlobalBucketAccess()) {
+        amazonS3ClientBuilder.withForceGlobalBucketAccessEnabled(true);
+      }
+      return amazonS3ClientBuilder
           .build();
     }
   }

--- a/src/main/java/com/yelp/nrtsearch/server/module/S3Module.java
+++ b/src/main/java/com/yelp/nrtsearch/server/module/S3Module.java
@@ -88,7 +88,7 @@ public class S3Module extends AbstractModule {
           .withEndpointConfiguration(
               new EndpointConfiguration(serviceEndpoint, region));
       if (luceneServerConfiguration.getEnableGlobalBucketAccess()) {
-        amazonS3ClientBuilder.withForceGlobalBucketAccessEnabled(true);
+        amazonS3ClientBuilder.enableForceGlobalBucketAccess();
       }
       return amazonS3ClientBuilder
           .build();


### PR DESCRIPTION
If `enableGlobalBucketAccess` is set to true in the server config enable forceGlobalBucketAccess on AmazonS3 client.
This can be helpful if plugins are in a bucket in a different region from the index, or if plugins are in several different buckets.