### PR TITLE
RP-6853: Change default s3 max retries to 20

### DIFF
--- a/docs/server_configuration.rst
+++ b/docs/server_configuration.rst
@@ -79,7 +79,7 @@ Example server configuration
    * - maxS3ClientRetries
      - int
      - Max retries to configure for the server s3 client. If <= 0, the default retry policy is used.
-     - -1 (default policy)
+     - 20
 
    * - botoCfgPath
      - str

--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -45,7 +45,7 @@ public class LuceneServerConfiguration {
   public static final Path DEFAULT_INDEX_DIR =
       Paths.get(DEFAULT_USER_DIR.toString(), "default_index");
   private static final String DEFAULT_BUCKET_NAME = "DEFAULT_ARCHIVE_BUCKET";
-  static final int DEFAULT_MAX_S3_CLIENT_RETRIES = -1;
+  static final int DEFAULT_MAX_S3_CLIENT_RETRIES = 20;
   private static final String DEFAULT_HOSTNAME = "localhost";
   private static final int DEFAULT_PORT = 50051;
   private static final int DEFAULT_REPLICATION_PORT = 50052;


### PR DESCRIPTION
Change the default for `maxS3ClientRetries` to 20. Experimentally, this value avoided occasional exceptions during the initial index download for larger indices.