### PR TITLE
add explain support in topHitsCollector

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -755,6 +755,8 @@ message TopHitsCollector {
     QuerySortField querySort = 3;
     //Which fields to retrieve.
     repeated string retrieveFields = 4;
+    // If Lucene explanation should be included in the collector response
+    bool explain = 5;
 }
 
 //Definition of filtering collector, there must be at least one nested collector specified in the Collector message.

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/additional/TopHitsCollectorManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/additional/TopHitsCollectorManager.java
@@ -196,6 +196,22 @@ public class TopHitsCollectorManager
     hitBuilders.sort(Comparator.comparing(Hit.Builder::getLuceneDocId));
 
     new SearchHandler.FillDocsTask(retrievalContext, hitBuilders).run();
+
+    if (grpcTopHitsCollector.getExplain()) {
+      hitBuilders.forEach(
+          hitBuilder -> {
+            try {
+              hitBuilder.setExplain(
+                  searchContext
+                      .getSearcherAndTaxonomy()
+                      .searcher
+                      .explain(searchContext.getQuery(), hitBuilder.getLuceneDocId())
+                      .toString());
+            } catch (IOException ioException) {
+              // ignore failed explain
+            }
+          });
+    }
     return CollectorResult.newBuilder().setHitsResult(hitsResultBuilder.build()).build();
   }
 


### PR DESCRIPTION
RP-7866
To pair with https://github.com/Yelp/nrtsearch/pull/558, we would like to support explain in topHitCollector as well.