### PR TITLE
minScore support in MultiFunctionScoreQuery

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -326,6 +326,10 @@ message MultiFunctionScoreQuery {
     FunctionScoreMode score_mode = 3;
     // Method to modify query document scores with final function score
     BoostMode boost_mode = 4;
+    // Optional minimal score to match a document. By default, it's 0.
+    float minScore = 5;
+    // Determine minimal score is excluded or not. By default, it's false;
+    bool minExclusive = 6;
 }
 
 // Query that produces a score of 1.0 (modifiable by query boost value) for documents that match the filter query.


### PR DESCRIPTION
RP-7117
A replication of https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/common/lucene/search/function/MinScoreScorer.java

support a new feature -  filter on score