### PR TITLE
reuse the innerQuery weight for the performance improvement

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
@@ -109,6 +109,9 @@ public class QueryNodeMapper {
   }
 
   public Query applyQueryNestedPath(Query query, IndexState indexState, String path) {
+    if (path == null || path.isEmpty()) {
+      return query;
+    }
     BooleanQuery.Builder builder = new BooleanQuery.Builder();
     builder.add(getNestedPathQuery(indexState, path), BooleanClause.Occur.FILTER);
     builder.add(query, BooleanClause.Occur.MUST);


### PR DESCRIPTION
RP-8556
After profile analysis, we know search is the bottleneck of the innerHit (including createWeight) - RP-8545. Reuse the innerQuery weight for each hit.

To do this, we divide the innerQuery into two parts:
`ParentChildrenBlockJoinQuery`:  to identify the children of the matched parent only
`actual innerQuery`: to rank the children

Then, we implement the search ourselves to avoid creating `actual innerQuery`'s weight each time.
