### PR TITLE
Fix node resolver for empty/missing files

### DIFF
--- a/clientlib/src/main/java/com/yelp/nrtsearch/clientlib/NodeAddressFileNameResolver.java
+++ b/clientlib/src/main/java/com/yelp/nrtsearch/clientlib/NodeAddressFileNameResolver.java
@@ -27,6 +27,7 @@ import java.net.SocketAddress;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.stream.Collectors;
@@ -76,10 +77,8 @@ public class NodeAddressFileNameResolver extends NameResolver {
 
   private void loadNodes() {
     List<Node> nodes = readNodesFromFile();
-    if (nodes == null || nodes.size() == 0) {
-      return;
-    }
     updateNodes(nodes);
+    currentNodes = nodes;
   }
 
   private void updateNodes(List<Node> nodes) {
@@ -94,7 +93,9 @@ public class NodeAddressFileNameResolver extends NameResolver {
 
   private List<Node> readNodesFromFile() {
     try {
-      return objectMapper.readValue(nodeAddressesFile, new TypeReference<List<Node>>() {});
+      List<Node> nodes =
+          objectMapper.readValue(nodeAddressesFile, new TypeReference<List<Node>>() {});
+      return nodes == null ? Collections.emptyList() : nodes;
     } catch (IOException e) {
       logger.warn("Unable to read file: {}", nodeAddressesFile, e);
       return Collections.emptyList();
@@ -110,7 +111,7 @@ public class NodeAddressFileNameResolver extends NameResolver {
     @Override
     public void run() {
       List<Node> nodes = readNodesFromFile();
-      if (!nodes.isEmpty() && nodes != currentNodes) {
+      if (!nodes.isEmpty() && !Objects.equals(nodes, currentNodes)) {
         updateNodes(nodes);
         currentNodes = nodes;
       }

--- a/src/test/java/com/yelp/nrtsearch/clientlib/NodeNameResolverAndLoadBalancingTests.java
+++ b/src/test/java/com/yelp/nrtsearch/clientlib/NodeNameResolverAndLoadBalancingTests.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.clientlib;
 
 import static com.yelp.nrtsearch.server.grpc.GrpcServer.TEST_INDEX;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,6 +30,7 @@ import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
 import com.yelp.nrtsearch.server.grpc.FieldType;
 import com.yelp.nrtsearch.server.grpc.GrpcServer;
+import com.yelp.nrtsearch.server.grpc.HealthCheckRequest;
 import com.yelp.nrtsearch.server.grpc.LuceneServerGrpc;
 import com.yelp.nrtsearch.server.grpc.LuceneServerStubBuilder;
 import com.yelp.nrtsearch.server.grpc.Mode;
@@ -36,6 +38,8 @@ import com.yelp.nrtsearch.server.grpc.RefreshRequest;
 import com.yelp.nrtsearch.server.grpc.SearchRequest;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import com.yelp.nrtsearch.server.grpc.StartIndexRequest;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.BufferedWriter;
@@ -310,6 +314,40 @@ public class NodeNameResolverAndLoadBalancingTests {
     assertEquals(resultCounts.get(SERVER_1_ID).intValue(), requestsToEachServer);
     assertEquals(resultCounts.get(SERVER_2_ID).intValue(), requestsToEachServer);
     assertEquals(resultCounts.get(SERVER_3_ID).intValue(), requestsToEachServer);
+  }
+
+  @Test(timeout = 10000)
+  public void testUnavailableOnMissingFile() throws IOException {
+    try (LuceneServerStubBuilder stubBuilder =
+        new LuceneServerStubBuilder("/invalid_file", OBJECT_MAPPER)) {
+      try {
+        stubBuilder
+            .createBlockingStub()
+            .withDeadlineAfter(10, TimeUnit.SECONDS)
+            .status(HealthCheckRequest.newBuilder().build());
+        fail();
+      } catch (StatusRuntimeException e) {
+        assertEquals(Status.UNAVAILABLE.getCode(), e.getStatus().getCode());
+      }
+    }
+  }
+
+  @Test(timeout = 10000)
+  public void testUnavailableOnEmptyFile() throws IOException {
+    addressesFile = folder.newFile("empty.json");
+    writeNodeAddressFile();
+    try (LuceneServerStubBuilder stubBuilder =
+        new LuceneServerStubBuilder(addressesFile.getAbsolutePath(), OBJECT_MAPPER)) {
+      try {
+        stubBuilder
+            .createBlockingStub()
+            .withDeadlineAfter(10, TimeUnit.SECONDS)
+            .status(HealthCheckRequest.newBuilder().build());
+        fail();
+      } catch (StatusRuntimeException e) {
+        assertEquals(Status.UNAVAILABLE.getCode(), e.getStatus().getCode());
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes a couple of issues with the client name resolver:

- When the node file is missing or empty, the resolver now registers an empty node list. If a node list is never registered, requests will block until their deadline expires, rather than throw an immediate `UNAVAILABLE` exception.
- The node list comparison now uses Object equality, rather than reference equality. The reference equality would always be false.