### PR TITLE
make NRTSearch empty boolean query result constant score 1

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
@@ -239,6 +239,10 @@ public class QueryNodeMapper {
         new BooleanQuery.Builder()
             .setMinimumNumberShouldMatch(booleanQuery.getMinimumNumberShouldMatch());
 
+    if (booleanQuery.getClausesCount() == 0) {
+      return builder.add(new MatchAllDocsQuery(), BooleanClause.Occur.MUST).build();
+    }
+
     AtomicBoolean allMustNot = new AtomicBoolean(true);
     booleanQuery
         .getClausesList()

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
@@ -891,7 +891,7 @@ public class QueryTest {
   public void testEmptyBooleanQuery() {
     Query query = Query.newBuilder().setBooleanQuery(BooleanQuery.newBuilder().build()).build();
     SearchResponse response = grpcServer.getBlockingStub().search(buildSearchRequest(query));
-    assertTrue(response.getHitsCount() > 0);
+    assertEquals(response.getHitsCount(), 2);
     for (SearchResponse.Hit hit : response.getHitsList()) {
       assertEquals(1.0, hit.getScore(), 0.0);
     }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
@@ -887,6 +887,16 @@ public class QueryTest {
     }
   }
 
+  @Test
+  public void testEmptyBooleanQuery() {
+    Query query = Query.newBuilder().setBooleanQuery(BooleanQuery.newBuilder().build()).build();
+    SearchResponse response = grpcServer.getBlockingStub().search(buildSearchRequest(query));
+    assertTrue(response.getHitsCount() > 0);
+    for (SearchResponse.Hit hit : response.getHitsList()) {
+      assertEquals(1.0, hit.getScore(), 0.0);
+    }
+  }
+
   /**
    * Search with the query and then test the response. Additional test with boost will also be
    * performed on the query.


### PR DESCRIPTION
This is to match the ES behavior. https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java#L310C17-L310C17

For ES, empty boolean query will be converted to MatchAll with constant score 1.
In the current NRT, empty boolean query result will only have score 0 since the occur is Filter if there are no positive clauses.
Change it to match ES to unblock migration