### PR TITLE
Handle multi value vector fields in Nrtsearch

### DIFF
--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/VectorFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/VectorFieldDefTest.java
@@ -67,6 +67,8 @@ public class VectorFieldDefTest extends ServerTestCase {
   private static final List<String> VECTOR_FIELD_VALUES =
       Arrays.asList("[1.0, 2.5, 1000.1000]", "[0.1, -2.0, 5.6]");
 
+  private static final List<String> VECTOR_FIELD_EPIPE_VALUES = Arrays.asList("1.2", "3.4", "5.6");
+
   @Override
   protected List<String> getIndices() {
     return List.of(DEFAULT_TEST_INDEX, VECTOR_SEARCH_INDEX_NAME);
@@ -224,6 +226,22 @@ public class VectorFieldDefTest extends ServerTestCase {
             .getMessage()
             .contains(
                 "The size of the vector data: 2 should match vectorDimensions field property: 3"));
+  }
+
+  @Test
+  public void vectorFieldMultiValueSameSizeAsDimension() throws Exception {
+    List<AddDocumentRequest> documentRequests = new ArrayList<>();
+    documentRequests.add(
+        AddDocumentRequest.newBuilder()
+            .setIndexName(DEFAULT_TEST_INDEX)
+            .putFields(
+                FIELD_NAME,
+                AddDocumentRequest.MultiValuedField.newBuilder()
+                    .addAllValue(VECTOR_FIELD_EPIPE_VALUES)
+                    .build())
+            .build());
+
+    addDocuments(documentRequests.stream());
   }
 
   @Test


### PR DESCRIPTION
It turns out that the indexer is sending vector values in this format:

```
doc_id,embeddings
2,"0.1;0.2;0.3"
```

Which is a list of floats.

Currently we're only expecting the value to be in this format:
```
doc_id,embeddings
0,"[0.1,0.2,0.3]"
```

I think this issue should be handled in the indexer. However, because of long weekend I don't want to make changes to the indexer. That's why I'm making this hacky solution in this experimental branch
