### PR TITLE
Fix NPE loading vector with no data from index

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/doc/LoadedDocValues.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/doc/LoadedDocValues.java
@@ -612,7 +612,7 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
    */
   public static final class SingleSearchVector extends LoadedDocValues<VectorType> {
     private final FloatVectorValues vectorValues;
-    private VectorType value;
+    private VectorType value = null;
 
     public SingleSearchVector(FloatVectorValues vectorValues) {
       this.vectorValues = vectorValues;
@@ -620,13 +620,15 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
 
     @Override
     public void setDocId(int docID) throws IOException {
-      if (vectorValues.docID() < docID) {
-        vectorValues.advance(docID);
-      }
-      if (vectorValues.docID() == docID) {
-        value = new VectorType(vectorValues.vectorValue());
-      } else {
-        value = null;
+      if (vectorValues != null) {
+        if (vectorValues.docID() < docID) {
+          vectorValues.advance(docID);
+        }
+        if (vectorValues.docID() == docID) {
+          value = new VectorType(vectorValues.vectorValue());
+        } else {
+          value = null;
+        }
       }
     }
 

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/VectorFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/VectorFieldDefTest.java
@@ -424,6 +424,24 @@ public class VectorFieldDefTest extends ServerTestCase {
   }
 
   @Test
+  public void testVectorSearch_index_value_no_data() {
+    String field = "vector_no_data";
+    SearchResponse searchResponse =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(VECTOR_SEARCH_INDEX_NAME)
+                    .addRetrieveFields(field)
+                    .setTopHits(3)
+                    .build());
+    assertEquals(3, searchResponse.getHitsCount());
+    assertEquals(0, searchResponse.getHits(0).getFieldsOrThrow(field).getFieldValueCount());
+    assertEquals(0, searchResponse.getHits(1).getFieldsOrThrow(field).getFieldValueCount());
+    assertEquals(0, searchResponse.getHits(2).getFieldsOrThrow(field).getFieldValueCount());
+  }
+
+  @Test
   public void testVectorSearch_start_hit() {
     List<Float> queryVector = List.of(0.25f, 0.5f, 0.75f);
     String field = "vector_cosine";

--- a/src/test/resources/field/registerFieldsVectorSearch.json
+++ b/src/test/resources/field/registerFieldsVectorSearch.json
@@ -45,6 +45,13 @@
       "type": "VECTOR",
       "storeDocValues": true,
       "vectorDimensions": 3
+    },
+    {
+      "name": "vector_no_data",
+      "type": "VECTOR",
+      "search": true,
+      "vectorDimensions": 3,
+      "vectorSimilarity": "dot_product"
     }
   ]
 }


### PR DESCRIPTION
If no data has been written for a vector field in a segment, the `FloatVectorValues` passed to `SingleSearchVector` will be null. This will result in an NPE when calling `setDocId()`.

This code path is only used when loading vector data indexed for search, instead of separate doc values.