### PR TITLE
Add live index settings override from config file

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/BackendStateManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/BackendStateManager.java
@@ -48,6 +48,7 @@ public class BackendStateManager implements IndexStateManager {
   private final String indexName;
   private final String indexUniqueName;
   private final String id;
+  private final IndexLiveSettings liveSettingsOverrides;
   private final StateBackend stateBackend;
   private final GlobalState globalState;
 
@@ -59,14 +60,20 @@ public class BackendStateManager implements IndexStateManager {
    *
    * @param indexName index name
    * @param id index instance id
+   * @param liveSettingsOverrides local overrides for index live settings
    * @param stateBackend state backend
    * @param globalState global state
    */
   public BackendStateManager(
-      String indexName, String id, StateBackend stateBackend, GlobalState globalState) {
+      String indexName,
+      String id,
+      IndexLiveSettings liveSettingsOverrides,
+      StateBackend stateBackend,
+      GlobalState globalState) {
     this.indexName = indexName;
     this.id = id;
     this.indexUniqueName = BackendGlobalState.getUniqueIndexName(indexName, id);
+    this.liveSettingsOverrides = liveSettingsOverrides;
     this.stateBackend = stateBackend;
     this.globalState = globalState;
   }
@@ -84,7 +91,8 @@ public class BackendStateManager implements IndexStateManager {
     UpdatedFieldInfo updatedFieldInfo =
         FieldUpdateHandler.updateFields(
             new FieldAndFacetState(), Collections.emptyMap(), stateInfo.getFieldsMap().values());
-    currentState = createIndexState(stateInfo, updatedFieldInfo.fieldAndFacetState);
+    currentState =
+        createIndexState(stateInfo, updatedFieldInfo.fieldAndFacetState, liveSettingsOverrides);
   }
 
   /**
@@ -115,7 +123,8 @@ public class BackendStateManager implements IndexStateManager {
       throw new IllegalStateException("Creating index, but state already exists for: " + indexName);
     }
     stateInfo = getDefaultStateInfo();
-    ImmutableIndexState indexState = createIndexState(stateInfo, new FieldAndFacetState());
+    ImmutableIndexState indexState =
+        createIndexState(stateInfo, new FieldAndFacetState(), liveSettingsOverrides);
     stateBackend.commitIndexState(indexUniqueName, stateInfo);
     currentState = indexState;
   }
@@ -140,19 +149,20 @@ public class BackendStateManager implements IndexStateManager {
     }
     IndexStateInfo updatedStateInfo = mergeSettings(currentState.getCurrentStateInfo(), settings);
     ImmutableIndexState updatedIndexState =
-        createIndexState(updatedStateInfo, currentState.getFieldAndFacetState());
+        createIndexState(
+            updatedStateInfo, currentState.getFieldAndFacetState(), liveSettingsOverrides);
     stateBackend.commitIndexState(indexUniqueName, updatedStateInfo);
     currentState = updatedIndexState;
     return updatedIndexState.getMergedSettings();
   }
 
   @Override
-  public IndexLiveSettings getLiveSettings() {
+  public IndexLiveSettings getLiveSettings(boolean withLocal) {
     ImmutableIndexState indexState = currentState;
     if (indexState == null) {
       throw new IllegalStateException("No state for index: " + indexName);
     }
-    return indexState.getMergedLiveSettings();
+    return indexState.getMergedLiveSettings(withLocal);
   }
 
   @Override
@@ -165,13 +175,14 @@ public class BackendStateManager implements IndexStateManager {
     IndexStateInfo updatedStateInfo =
         mergeLiveSettings(currentState.getCurrentStateInfo(), liveSettings);
     ImmutableIndexState updatedIndexState =
-        createIndexState(updatedStateInfo, currentState.getFieldAndFacetState());
+        createIndexState(
+            updatedStateInfo, currentState.getFieldAndFacetState(), liveSettingsOverrides);
     stateBackend.commitIndexState(indexUniqueName, updatedStateInfo);
     currentState = updatedIndexState;
     for (Map.Entry<Integer, ShardState> entry : currentState.getShards().entrySet()) {
       entry.getValue().updatedLiveSettings(liveSettings);
     }
-    return updatedIndexState.getMergedLiveSettings();
+    return updatedIndexState.getMergedLiveSettings(false);
   }
 
   @Override
@@ -187,7 +198,8 @@ public class BackendStateManager implements IndexStateManager {
     IndexStateInfo updatedStateInfo =
         replaceFields(currentState.getCurrentStateInfo(), updatedFieldInfo.fields);
     ImmutableIndexState updatedIndexState =
-        createIndexState(updatedStateInfo, updatedFieldInfo.fieldAndFacetState);
+        createIndexState(
+            updatedStateInfo, updatedFieldInfo.fieldAndFacetState, liveSettingsOverrides);
     stateBackend.commitIndexState(indexUniqueName, updatedStateInfo);
     currentState = updatedIndexState;
     return updatedIndexState.getAllFieldsJSON();
@@ -215,7 +227,8 @@ public class BackendStateManager implements IndexStateManager {
               .setGen(currentState.getCurrentStateInfo().getGen() + 1)
               .build();
       ImmutableIndexState updatedIndexState =
-          createIndexState(updatedStateInfo, currentState.getFieldAndFacetState());
+          createIndexState(
+              updatedStateInfo, currentState.getFieldAndFacetState(), liveSettingsOverrides);
       stateBackend.commitIndexState(indexUniqueName, updatedStateInfo);
       currentState = updatedIndexState;
     }
@@ -232,7 +245,10 @@ public class BackendStateManager implements IndexStateManager {
 
   // Declared protected for use during testing
   protected ImmutableIndexState createIndexState(
-      IndexStateInfo indexStateInfo, FieldAndFacetState fieldAndFacetState) throws IOException {
+      IndexStateInfo indexStateInfo,
+      FieldAndFacetState fieldAndFacetState,
+      IndexLiveSettings liveSettingsOverrides)
+      throws IOException {
     Map<Integer, ShardState> previousShardState =
         currentState == null ? null : currentState.getShards();
     return new ImmutableIndexState(
@@ -242,6 +258,7 @@ public class BackendStateManager implements IndexStateManager {
         indexUniqueName,
         indexStateInfo,
         fieldAndFacetState,
+        liveSettingsOverrides,
         previousShardState);
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/IndexStateManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/IndexStateManager.java
@@ -63,8 +63,12 @@ public interface IndexStateManager extends Closeable {
    */
   IndexSettings updateSettings(IndexSettings settings) throws IOException;
 
-  /** Get the current index live settings. */
-  IndexLiveSettings getLiveSettings();
+  /**
+   * Get the current index live settings.
+   *
+   * @param withLocal If local overrides should be included in the live settings
+   */
+  IndexLiveSettings getLiveSettings(boolean withLocal);
 
   /**
    * Update the index live setting from the given input settings. Input settings will be merged into

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/handlers/LiveSettingsV2Handler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/handlers/LiveSettingsV2Handler.java
@@ -43,7 +43,7 @@ public class LiveSettingsV2Handler {
       responseSettings =
           indexStateManager.updateLiveSettings(liveSettingsRequest.getLiveSettings());
     } else {
-      responseSettings = indexStateManager.getLiveSettings();
+      responseSettings = indexStateManager.getLiveSettings(false);
     }
     return LiveSettingsV2Response.newBuilder().setLiveSettings(responseSettings).build();
   }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/BackendGlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/state/BackendGlobalState.java
@@ -24,6 +24,7 @@ import com.yelp.nrtsearch.server.grpc.CreateIndexRequest;
 import com.yelp.nrtsearch.server.grpc.DummyResponse;
 import com.yelp.nrtsearch.server.grpc.GlobalStateInfo;
 import com.yelp.nrtsearch.server.grpc.IndexGlobalState;
+import com.yelp.nrtsearch.server.grpc.IndexLiveSettings;
 import com.yelp.nrtsearch.server.grpc.Mode;
 import com.yelp.nrtsearch.server.grpc.RestoreIndex;
 import com.yelp.nrtsearch.server.grpc.StartIndexRequest;
@@ -129,7 +130,11 @@ public class BackendGlobalState extends GlobalState {
     Map<String, IndexStateManager> managerMap = new HashMap<>();
     for (Map.Entry<String, IndexGlobalState> entry : globalStateInfo.getIndicesMap().entrySet()) {
       IndexStateManager stateManager =
-          createIndexStateManager(entry.getKey(), entry.getValue().getId(), stateBackend);
+          createIndexStateManager(
+              entry.getKey(),
+              entry.getValue().getId(),
+              luceneServerConfiguration.getLiveSettingsOverride(entry.getKey()),
+              stateBackend);
       stateManager.load();
       managerMap.put(entry.getKey(), stateManager);
     }
@@ -163,8 +168,11 @@ public class BackendGlobalState extends GlobalState {
    * @return index state manager
    */
   protected IndexStateManager createIndexStateManager(
-      String indexName, String indexId, StateBackend stateBackend) {
-    return new BackendStateManager(indexName, indexId, stateBackend, this);
+      String indexName,
+      String indexId,
+      IndexLiveSettings liveSettingsOverrides,
+      StateBackend stateBackend) {
+    return new BackendStateManager(indexName, indexId, liveSettingsOverrides, stateBackend, this);
   }
 
   /**
@@ -188,7 +196,12 @@ public class BackendGlobalState extends GlobalState {
       String indexName = entry.getKey();
       IndexStateManager stateManager = immutableState.indexStateManagerMap.get(indexName);
       if (stateManager == null || !entry.getValue().getId().equals(stateManager.getIndexId())) {
-        stateManager = createIndexStateManager(indexName, entry.getValue().getId(), stateBackend);
+        stateManager =
+            createIndexStateManager(
+                indexName,
+                entry.getValue().getId(),
+                getConfiguration().getLiveSettingsOverride(indexName),
+                stateBackend);
       }
       stateManager.load();
       newManagerMap.put(indexName, stateManager);
@@ -262,11 +275,21 @@ public class BackendGlobalState extends GlobalState {
     IndexStateManager stateManager;
     if (createIndexRequest.getExistsWithId().isEmpty()) {
       indexId = getIndexId();
-      stateManager = createIndexStateManager(indexName, indexId, stateBackend);
+      stateManager =
+          createIndexStateManager(
+              indexName,
+              indexId,
+              getConfiguration().getLiveSettingsOverride(indexName),
+              stateBackend);
       stateManager.create();
     } else {
       indexId = createIndexRequest.getExistsWithId();
-      stateManager = createIndexStateManager(indexName, indexId, stateBackend);
+      stateManager =
+          createIndexStateManager(
+              indexName,
+              indexId,
+              getConfiguration().getLiveSettingsOverride(indexName),
+              stateBackend);
       stateManager.load();
     }
 

--- a/src/main/java/com/yelp/nrtsearch/server/utils/JsonUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/server/utils/JsonUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+
+/** Class with utility methods for working with json using the jackson library. */
+public class JsonUtils {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private JsonUtils() {}
+
+  /**
+   * Convert the provided object into a json string.
+   *
+   * @param obj object to convert
+   * @return json string representation
+   * @throws IOException
+   */
+  public static String objectToJsonStr(Object obj) throws IOException {
+    return OBJECT_MAPPER.writeValueAsString(obj);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/cli/CreateIndexCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/cli/CreateIndexCommandTest.java
@@ -216,7 +216,7 @@ public class CreateIndexCommandTest {
   }
 
   private IndexLiveSettings getIndexLiveSettings(TestServer server) throws IOException {
-    return server.getGlobalState().getIndexStateManager("test_index").getLiveSettings();
+    return server.getGlobalState().getIndexStateManager("test_index").getLiveSettings(false);
   }
 
   private Map<String, FieldDef> getIndexFields(TestServer server) throws IOException {

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/IndexStartTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/IndexStartTest.java
@@ -830,7 +830,7 @@ public class IndexStartTest {
         server
             .getGlobalState()
             .getIndexStateManager("test_index")
-            .getLiveSettings()
+            .getLiveSettings(false)
             .getAddDocumentsMaxBufferLen()
             .getValue());
     assertEquals(

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/index/BackendStateManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/index/BackendStateManagerTest.java
@@ -60,6 +60,12 @@ import org.junit.Test;
 
 public class BackendStateManagerTest {
 
+  private static final IndexLiveSettings LIVE_SETTINGS_OVERRIDES =
+      IndexLiveSettings.newBuilder()
+          .setSliceMaxDocs(Int32Value.newBuilder().setValue(1).build())
+          .setSliceMaxSegments(Int32Value.newBuilder().setValue(1).build())
+          .build();
+
   @BeforeClass
   public static void setup() {
     String configFile = "nodeName: \"lucene_server_foo\"";
@@ -74,11 +80,13 @@ public class BackendStateManagerTest {
   @Before
   public void setupTest() {
     MockStateManager.verifyFieldsState = Assert::assertNotNull;
+    MockStateManager.expectedLiveSettingsOverrides = IndexLiveSettings.newBuilder().build();
   }
 
   private static class MockStateManager extends BackendStateManager {
     public static ImmutableIndexState nextState;
     public static IndexStateInfo expectedState;
+    public static IndexLiveSettings expectedLiveSettingsOverrides;
     public static Consumer<FieldAndFacetState> verifyFieldsState = Assert::assertNotNull;
     public static FieldAndFacetState lastFieldAndFacetState;
 
@@ -92,13 +100,25 @@ public class BackendStateManagerTest {
      */
     public MockStateManager(
         String indexName, String id, StateBackend stateBackend, GlobalState globalState) {
-      super(indexName, id, stateBackend, globalState);
+      this(indexName, id, IndexLiveSettings.newBuilder().build(), stateBackend, globalState);
+    }
+
+    public MockStateManager(
+        String indexName,
+        String id,
+        IndexLiveSettings liveSettingsOverrides,
+        StateBackend stateBackend,
+        GlobalState globalState) {
+      super(indexName, id, liveSettingsOverrides, stateBackend, globalState);
     }
 
     @Override
     public ImmutableIndexState createIndexState(
-        IndexStateInfo indexStateInfo, FieldAndFacetState fieldAndFacetState) {
+        IndexStateInfo indexStateInfo,
+        FieldAndFacetState fieldAndFacetState,
+        IndexLiveSettings liveSettingsOverrides) {
       assertEquals(expectedState, indexStateInfo);
+      assertEquals(expectedLiveSettingsOverrides, liveSettingsOverrides);
       verifyFieldsState.accept(fieldAndFacetState);
       lastFieldAndFacetState = fieldAndFacetState;
       return nextState;
@@ -120,6 +140,33 @@ public class BackendStateManagerTest {
     ImmutableIndexState mockState = mock(ImmutableIndexState.class);
     MockStateManager.nextState = mockState;
     MockStateManager.expectedState = initialState;
+
+    stateManager.load();
+    assertSame(mockState, stateManager.getCurrent());
+
+    verify(mockBackend, times(1))
+        .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+
+    verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState);
+  }
+
+  @Test
+  public void testLoadsExistingState_liveSettingsOverride() throws IOException {
+    StateBackend mockBackend = mock(StateBackend.class);
+    GlobalState mockGlobalState = mock(GlobalState.class);
+    BackendStateManager stateManager =
+        new MockStateManager(
+            "test_index", "test_id", LIVE_SETTINGS_OVERRIDES, mockBackend, mockGlobalState);
+
+    IndexStateInfo initialState =
+        IndexStateInfo.newBuilder().setIndexName("test_index").setCommitted(false).build();
+    when(mockBackend.loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id")))
+        .thenReturn(initialState);
+
+    ImmutableIndexState mockState = mock(ImmutableIndexState.class);
+    MockStateManager.nextState = mockState;
+    MockStateManager.expectedState = initialState;
+    MockStateManager.expectedLiveSettingsOverrides = LIVE_SETTINGS_OVERRIDES;
 
     stateManager.load();
     assertSame(mockState, stateManager.getCurrent());
@@ -173,6 +220,35 @@ public class BackendStateManagerTest {
     } catch (IllegalStateException e) {
       assertEquals("No committed state for index: test_index", e.getMessage());
     }
+  }
+
+  @Test
+  public void testCreateIndexState_liveSettingsOverride() throws IOException {
+    StateBackend mockBackend = mock(StateBackend.class);
+    GlobalState mockGlobalState = mock(GlobalState.class);
+    BackendStateManager stateManager =
+        new MockStateManager(
+            "test_index", "test_id", LIVE_SETTINGS_OVERRIDES, mockBackend, mockGlobalState);
+
+    when(mockBackend.loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id")))
+        .thenReturn(null);
+
+    ImmutableIndexState mockState = mock(ImmutableIndexState.class);
+    MockStateManager.nextState = mockState;
+    MockStateManager.expectedState = stateManager.getDefaultStateInfo();
+    MockStateManager.expectedLiveSettingsOverrides = LIVE_SETTINGS_OVERRIDES;
+
+    stateManager.create();
+    assertSame(mockState, stateManager.getCurrent());
+
+    verify(mockBackend, times(1))
+        .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+    verify(mockBackend, times(1))
+        .commitIndexState(
+            BackendGlobalState.getUniqueIndexName("test_index", "test_id"),
+            stateManager.getDefaultStateInfo());
+
+    verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState);
   }
 
   @Test
@@ -474,6 +550,90 @@ public class BackendStateManagerTest {
   }
 
   @Test
+  public void testUpdateExistingSettings_liveSettingsOverride() throws IOException {
+    StateBackend mockBackend = mock(StateBackend.class);
+    GlobalState mockGlobalState = mock(GlobalState.class);
+    BackendStateManager stateManager =
+        new MockStateManager(
+            "test_index", "test_id", LIVE_SETTINGS_OVERRIDES, mockBackend, mockGlobalState);
+
+    IndexStateInfo initialState =
+        IndexStateInfo.newBuilder()
+            .setIndexName("test_index")
+            .setCommitted(true)
+            .setSettings(
+                IndexSettings.newBuilder()
+                    .setConcurrentMergeSchedulerMaxThreadCount(
+                        Int32Value.newBuilder().setValue(10).build())
+                    .setConcurrentMergeSchedulerMaxMergeCount(
+                        Int32Value.newBuilder().setValue(5).build())
+                    .setNrtCachingDirectoryMaxSizeMB(
+                        DoubleValue.newBuilder().setValue(100.0).build())
+                    .build())
+            .build();
+    when(mockBackend.loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id")))
+        .thenReturn(initialState);
+
+    ImmutableIndexState mockState = mock(ImmutableIndexState.class);
+    when(mockState.isStarted()).thenReturn(false);
+    when(mockState.getCurrentStateInfo()).thenReturn(initialState);
+    when(mockState.getFieldAndFacetState()).thenReturn(mock(FieldAndFacetState.class));
+    MockStateManager.nextState = mockState;
+    MockStateManager.expectedState = initialState;
+    MockStateManager.expectedLiveSettingsOverrides = LIVE_SETTINGS_OVERRIDES;
+
+    stateManager.load();
+    assertSame(mockState, stateManager.getCurrent());
+
+    IndexSettings settingsUpdate =
+        IndexSettings.newBuilder()
+            .setDirectory(StringValue.newBuilder().setValue("MMapDirectory").build())
+            .setIndexMergeSchedulerAutoThrottle(BoolValue.newBuilder().setValue(true).build())
+            .setNrtCachingDirectoryMaxSizeMB(DoubleValue.newBuilder().setValue(75.0).build())
+            .build();
+    IndexSettings expectedSavedSettings =
+        IndexSettings.newBuilder()
+            .setDirectory(StringValue.newBuilder().setValue("MMapDirectory").build())
+            .setIndexMergeSchedulerAutoThrottle(BoolValue.newBuilder().setValue(true).build())
+            .setNrtCachingDirectoryMaxSizeMB(DoubleValue.newBuilder().setValue(75.0).build())
+            .setConcurrentMergeSchedulerMaxThreadCount(Int32Value.newBuilder().setValue(10).build())
+            .setConcurrentMergeSchedulerMaxMergeCount(Int32Value.newBuilder().setValue(5).build())
+            .build();
+    IndexSettings expectedMergedSettings =
+        ImmutableIndexState.DEFAULT_INDEX_SETTINGS
+            .toBuilder()
+            .setDirectory(StringValue.newBuilder().setValue("MMapDirectory").build())
+            .setIndexMergeSchedulerAutoThrottle(BoolValue.newBuilder().setValue(true).build())
+            .setNrtCachingDirectoryMaxSizeMB(DoubleValue.newBuilder().setValue(75.0).build())
+            .setConcurrentMergeSchedulerMaxThreadCount(Int32Value.newBuilder().setValue(10).build())
+            .setConcurrentMergeSchedulerMaxMergeCount(Int32Value.newBuilder().setValue(5).build())
+            .build();
+
+    ImmutableIndexState mockState2 = mock(ImmutableIndexState.class);
+    when(mockState2.getMergedSettings()).thenReturn(expectedMergedSettings);
+
+    IndexStateInfo expectedStateInfo =
+        initialState.toBuilder().setGen(1).setSettings(expectedSavedSettings).build();
+    MockStateManager.nextState = mockState2;
+    MockStateManager.expectedState = expectedStateInfo;
+    MockStateManager.expectedLiveSettingsOverrides = LIVE_SETTINGS_OVERRIDES;
+
+    assertEquals(expectedMergedSettings, stateManager.updateSettings(settingsUpdate));
+
+    verify(mockBackend, times(1))
+        .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+    verify(mockBackend, times(1))
+        .commitIndexState(
+            BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
+    verify(mockState, times(1)).isStarted();
+    verify(mockState, times(1)).getCurrentStateInfo();
+    verify(mockState, times(1)).getFieldAndFacetState();
+    verify(mockState2, times(1)).getMergedSettings();
+
+    verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState, mockState2);
+  }
+
+  @Test
   public void testUpdateSettingsNoExistingState() throws IOException {
     StateBackend mockBackend = mock(StateBackend.class);
     GlobalState mockGlobalState = mock(GlobalState.class);
@@ -545,18 +705,67 @@ public class BackendStateManagerTest {
         .thenReturn(initialState);
 
     ImmutableIndexState mockState = mock(ImmutableIndexState.class);
-    when(mockState.getMergedLiveSettings()).thenReturn(indexLiveSettings);
+    when(mockState.getMergedLiveSettings(false)).thenReturn(indexLiveSettings);
     MockStateManager.nextState = mockState;
     MockStateManager.expectedState = initialState;
 
     stateManager.load();
     assertSame(mockState, stateManager.getCurrent());
 
-    assertEquals(indexLiveSettings, stateManager.getLiveSettings());
+    assertEquals(indexLiveSettings, stateManager.getLiveSettings(false));
 
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
-    verify(mockState, times(1)).getMergedLiveSettings();
+    verify(mockState, times(1)).getMergedLiveSettings(false);
+
+    verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState);
+  }
+
+  @Test
+  public void testGetLiveSettings_liveSettingsOverride() throws IOException {
+    StateBackend mockBackend = mock(StateBackend.class);
+    GlobalState mockGlobalState = mock(GlobalState.class);
+    BackendStateManager stateManager =
+        new MockStateManager(
+            "test_index", "test_id", LIVE_SETTINGS_OVERRIDES, mockBackend, mockGlobalState);
+
+    IndexLiveSettings indexLiveSettings =
+        IndexLiveSettings.newBuilder()
+            .setMaxRefreshSec(DoubleValue.newBuilder().setValue(10.0).build())
+            .setSegmentsPerTier(Int32Value.newBuilder().setValue(20).build())
+            .build();
+    IndexLiveSettings settingsWithLocal =
+        indexLiveSettings
+            .toBuilder()
+            .setSliceMaxSegments(Int32Value.newBuilder().setValue(1).build())
+            .setSliceMaxDocs(Int32Value.newBuilder().setValue(1).build())
+            .build();
+    IndexStateInfo initialState =
+        IndexStateInfo.newBuilder()
+            .setIndexName("test_index")
+            .setCommitted(true)
+            .setLiveSettings(indexLiveSettings)
+            .build();
+    when(mockBackend.loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id")))
+        .thenReturn(initialState);
+
+    ImmutableIndexState mockState = mock(ImmutableIndexState.class);
+    when(mockState.getMergedLiveSettings(false)).thenReturn(indexLiveSettings);
+    when(mockState.getMergedLiveSettings(true)).thenReturn(settingsWithLocal);
+    MockStateManager.nextState = mockState;
+    MockStateManager.expectedState = initialState;
+    MockStateManager.expectedLiveSettingsOverrides = LIVE_SETTINGS_OVERRIDES;
+
+    stateManager.load();
+    assertSame(mockState, stateManager.getCurrent());
+
+    assertEquals(indexLiveSettings, stateManager.getLiveSettings(false));
+    assertEquals(settingsWithLocal, stateManager.getLiveSettings(true));
+
+    verify(mockBackend, times(1))
+        .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+    verify(mockState, times(1)).getMergedLiveSettings(false);
+    verify(mockState, times(1)).getMergedLiveSettings(true);
 
     verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState);
   }
@@ -572,7 +781,7 @@ public class BackendStateManagerTest {
         .thenReturn(null);
 
     try {
-      stateManager.getLiveSettings();
+      stateManager.getLiveSettings(false);
       fail();
     } catch (IllegalStateException e) {
       assertEquals("No state for index: test_index", e.getMessage());
@@ -605,7 +814,7 @@ public class BackendStateManagerTest {
     assertSame(mockState, stateManager.getCurrent());
 
     ImmutableIndexState mockState2 = mock(ImmutableIndexState.class);
-    when(mockState2.getMergedLiveSettings())
+    when(mockState2.getMergedLiveSettings(false))
         .thenReturn(ImmutableIndexState.DEFAULT_INDEX_LIVE_SETTINGS);
     ShardState mockShard = mock(ShardState.class);
     Map<Integer, ShardState> mockShardMap =
@@ -627,7 +836,7 @@ public class BackendStateManagerTest {
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
     verify(mockState, times(1)).getCurrentStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
-    verify(mockState2, times(1)).getMergedLiveSettings();
+    verify(mockState2, times(1)).getMergedLiveSettings(false);
     verify(mockState2, times(1)).getShards();
     verify(mockShard, times(1)).updatedLiveSettings(IndexLiveSettings.newBuilder().build());
 
@@ -674,7 +883,7 @@ public class BackendStateManagerTest {
             .build();
 
     ImmutableIndexState mockState2 = mock(ImmutableIndexState.class);
-    when(mockState2.getMergedLiveSettings()).thenReturn(expectedMergedSettings);
+    when(mockState2.getMergedLiveSettings(false)).thenReturn(expectedMergedSettings);
     ShardState mockShard = mock(ShardState.class);
     Map<Integer, ShardState> mockShardMap =
         ImmutableMap.<Integer, ShardState>builder().put(0, mockShard).build();
@@ -694,7 +903,7 @@ public class BackendStateManagerTest {
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
     verify(mockState, times(1)).getCurrentStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
-    verify(mockState2, times(1)).getMergedLiveSettings();
+    verify(mockState2, times(1)).getMergedLiveSettings(false);
     verify(mockState2, times(1)).getShards();
     verify(mockShard, times(1)).updatedLiveSettings(settingsUpdate);
 
@@ -756,7 +965,7 @@ public class BackendStateManagerTest {
             .build();
 
     ImmutableIndexState mockState2 = mock(ImmutableIndexState.class);
-    when(mockState2.getMergedLiveSettings()).thenReturn(expectedMergedSettings);
+    when(mockState2.getMergedLiveSettings(false)).thenReturn(expectedMergedSettings);
     ShardState mockShard = mock(ShardState.class);
     Map<Integer, ShardState> mockShardMap =
         ImmutableMap.<Integer, ShardState>builder().put(0, mockShard).build();
@@ -776,7 +985,92 @@ public class BackendStateManagerTest {
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
     verify(mockState, times(1)).getCurrentStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
-    verify(mockState2, times(1)).getMergedLiveSettings();
+    verify(mockState2, times(1)).getMergedLiveSettings(false);
+    verify(mockState2, times(1)).getShards();
+    verify(mockShard, times(1)).updatedLiveSettings(settingsUpdate);
+
+    verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState, mockState2, mockShard);
+  }
+
+  @Test
+  public void testUpdateExistingLiveSettings_liveSettingsOverride() throws IOException {
+    StateBackend mockBackend = mock(StateBackend.class);
+    GlobalState mockGlobalState = mock(GlobalState.class);
+    BackendStateManager stateManager =
+        new MockStateManager(
+            "test_index", "test_id", LIVE_SETTINGS_OVERRIDES, mockBackend, mockGlobalState);
+
+    IndexStateInfo initialState =
+        IndexStateInfo.newBuilder()
+            .setIndexName("test_index")
+            .setCommitted(true)
+            .setLiveSettings(
+                IndexLiveSettings.newBuilder()
+                    .setMaxRefreshSec(DoubleValue.newBuilder().setValue(15.0).build())
+                    .setSliceMaxSegments(Int32Value.newBuilder().setValue(10).build())
+                    .setAddDocumentsMaxBufferLen(Int32Value.newBuilder().setValue(250).build())
+                    .build())
+            .build();
+    when(mockBackend.loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id")))
+        .thenReturn(initialState);
+
+    ImmutableIndexState mockState = mock(ImmutableIndexState.class);
+    when(mockState.getCurrentStateInfo()).thenReturn(initialState);
+    when(mockState.getFieldAndFacetState()).thenReturn(mock(FieldAndFacetState.class));
+    MockStateManager.nextState = mockState;
+    MockStateManager.expectedState = initialState;
+    MockStateManager.expectedLiveSettingsOverrides = LIVE_SETTINGS_OVERRIDES;
+
+    stateManager.load();
+    assertSame(mockState, stateManager.getCurrent());
+
+    IndexLiveSettings settingsUpdate =
+        IndexLiveSettings.newBuilder()
+            .setSliceMaxSegments(Int32Value.newBuilder().setValue(3).build())
+            .setSliceMaxDocs(Int32Value.newBuilder().setValue(10000).build())
+            .setIndexRamBufferSizeMB(DoubleValue.newBuilder().setValue(512.0).build())
+            .build();
+    IndexLiveSettings expectedSavedSettings =
+        IndexLiveSettings.newBuilder()
+            .setMaxRefreshSec(DoubleValue.newBuilder().setValue(15.0).build())
+            .setAddDocumentsMaxBufferLen(Int32Value.newBuilder().setValue(250).build())
+            .setSliceMaxSegments(Int32Value.newBuilder().setValue(3).build())
+            .setSliceMaxDocs(Int32Value.newBuilder().setValue(10000).build())
+            .setIndexRamBufferSizeMB(DoubleValue.newBuilder().setValue(512.0).build())
+            .build();
+    IndexLiveSettings expectedMergedSettings =
+        ImmutableIndexState.DEFAULT_INDEX_LIVE_SETTINGS
+            .toBuilder()
+            .setMaxRefreshSec(DoubleValue.newBuilder().setValue(15.0).build())
+            .setAddDocumentsMaxBufferLen(Int32Value.newBuilder().setValue(250).build())
+            .setSliceMaxSegments(Int32Value.newBuilder().setValue(3).build())
+            .setSliceMaxDocs(Int32Value.newBuilder().setValue(10000).build())
+            .setIndexRamBufferSizeMB(DoubleValue.newBuilder().setValue(512.0).build())
+            .build();
+
+    ImmutableIndexState mockState2 = mock(ImmutableIndexState.class);
+    when(mockState2.getMergedLiveSettings(false)).thenReturn(expectedMergedSettings);
+    ShardState mockShard = mock(ShardState.class);
+    Map<Integer, ShardState> mockShardMap =
+        ImmutableMap.<Integer, ShardState>builder().put(0, mockShard).build();
+    when(mockState2.getShards()).thenReturn(mockShardMap);
+
+    IndexStateInfo expectedStateInfo =
+        initialState.toBuilder().setGen(1).setLiveSettings(expectedSavedSettings).build();
+    MockStateManager.nextState = mockState2;
+    MockStateManager.expectedState = expectedStateInfo;
+    MockStateManager.expectedLiveSettingsOverrides = LIVE_SETTINGS_OVERRIDES;
+
+    assertEquals(expectedMergedSettings, stateManager.updateLiveSettings(settingsUpdate));
+
+    verify(mockBackend, times(1))
+        .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+    verify(mockBackend, times(1))
+        .commitIndexState(
+            BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
+    verify(mockState, times(1)).getCurrentStateInfo();
+    verify(mockState, times(1)).getFieldAndFacetState();
+    verify(mockState2, times(1)).getMergedLiveSettings(false);
     verify(mockState2, times(1)).getShards();
     verify(mockShard, times(1)).updatedLiveSettings(settingsUpdate);
 
@@ -857,6 +1151,81 @@ public class BackendStateManagerTest {
           assertTrue(fieldState.getFields().containsKey("field1"));
           assertTrue(fieldState.getFields().containsKey("field2"));
         };
+
+    stateManager.updateFields(addFields);
+    assertSame(mockState2, stateManager.getCurrent());
+
+    verify(mockBackend, times(1))
+        .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+    verify(mockBackend, times(1))
+        .commitIndexState(
+            BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedState);
+    verify(mockState, times(2)).getCurrentStateInfo();
+    verify(mockState, times(1)).getFieldAndFacetState();
+    verify(mockState2, times(1)).getAllFieldsJSON();
+
+    verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState, mockState2);
+  }
+
+  @Test
+  public void testUpdateFields_liveSettingsOverride() throws IOException {
+    StateBackend mockBackend = mock(StateBackend.class);
+    GlobalState mockGlobalState = mock(GlobalState.class);
+    BackendStateManager stateManager =
+        new MockStateManager(
+            "test_index", "test_id", LIVE_SETTINGS_OVERRIDES, mockBackend, mockGlobalState);
+
+    IndexStateInfo initialState =
+        IndexStateInfo.newBuilder().setIndexName("test_index").setCommitted(true).build();
+    when(mockBackend.loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id")))
+        .thenReturn(initialState);
+
+    ImmutableIndexState mockState = mock(ImmutableIndexState.class);
+    when(mockState.getCurrentStateInfo()).thenReturn(initialState);
+    when(mockState.getFieldAndFacetState()).thenReturn(new FieldAndFacetState());
+    MockStateManager.nextState = mockState;
+    MockStateManager.expectedState = initialState;
+    MockStateManager.verifyFieldsState =
+        (fieldState) -> assertEquals(0, fieldState.getFields().keySet().size());
+    MockStateManager.expectedLiveSettingsOverrides = LIVE_SETTINGS_OVERRIDES;
+
+    stateManager.load();
+    assertSame(mockState, stateManager.getCurrent());
+
+    List<Field> addFields = new ArrayList<>();
+    addFields.add(
+        Field.newBuilder()
+            .setName("field1")
+            .setType(FieldType.FLOAT)
+            .setStoreDocValues(true)
+            .setMultiValued(true)
+            .build());
+    addFields.add(
+        Field.newBuilder()
+            .setName("field2")
+            .setType(FieldType.ATOM)
+            .setStoreDocValues(true)
+            .setMultiValued(false)
+            .build());
+
+    IndexStateInfo expectedState =
+        initialState
+            .toBuilder()
+            .setGen(1)
+            .putFields("field1", addFields.get(0))
+            .putFields("field2", addFields.get(1))
+            .build();
+
+    ImmutableIndexState mockState2 = mock(ImmutableIndexState.class);
+    MockStateManager.nextState = mockState2;
+    MockStateManager.expectedState = expectedState;
+    MockStateManager.verifyFieldsState =
+        (fieldState) -> {
+          assertEquals(2, fieldState.getFields().size());
+          assertTrue(fieldState.getFields().containsKey("field1"));
+          assertTrue(fieldState.getFields().containsKey("field2"));
+        };
+    MockStateManager.expectedLiveSettingsOverrides = LIVE_SETTINGS_OVERRIDES;
 
     stateManager.updateFields(addFields);
     assertSame(mockState2, stateManager.getCurrent());
@@ -1064,6 +1433,41 @@ public class BackendStateManagerTest {
     when(mockState.isStarted()).thenReturn(false);
     MockStateManager.nextState = mockState;
     MockStateManager.expectedState = initialState;
+
+    stateManager.load();
+    assertSame(mockState, stateManager.getCurrent());
+
+    ReplicationServerClient mockReplicationClient = mock(ReplicationServerClient.class);
+    stateManager.start(Mode.PRIMARY, Path.of("/tmp"), 1, mockReplicationClient);
+
+    verify(mockBackend, times(1))
+        .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+    verify(mockState, times(1)).getCurrentStateInfo();
+    verify(mockState, times(1)).isStarted();
+    verify(mockState, times(1)).start(Mode.PRIMARY, Path.of("/tmp"), 1, mockReplicationClient);
+
+    verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState);
+  }
+
+  @Test
+  public void testStartIndex_liveSettingsOverride() throws IOException {
+    StateBackend mockBackend = mock(StateBackend.class);
+    GlobalState mockGlobalState = mock(GlobalState.class);
+    BackendStateManager stateManager =
+        new MockStateManager(
+            "test_index", "test_id", LIVE_SETTINGS_OVERRIDES, mockBackend, mockGlobalState);
+
+    IndexStateInfo initialState =
+        IndexStateInfo.newBuilder().setIndexName("test_index").setCommitted(true).build();
+    when(mockBackend.loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id")))
+        .thenReturn(initialState);
+
+    ImmutableIndexState mockState = mock(ImmutableIndexState.class);
+    when(mockState.getCurrentStateInfo()).thenReturn(initialState);
+    when(mockState.isStarted()).thenReturn(false);
+    MockStateManager.nextState = mockState;
+    MockStateManager.expectedState = initialState;
+    MockStateManager.expectedLiveSettingsOverrides = LIVE_SETTINGS_OVERRIDES;
 
     stateManager.load();
     assertSame(mockState, stateManager.getCurrent());

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/index/ImmutableIndexStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/index/ImmutableIndexStateTest.java
@@ -147,6 +147,7 @@ public class ImmutableIndexStateTest {
         BackendGlobalState.getUniqueIndexName("test_index", "test_id"),
         stateInfo,
         fieldState,
+        IndexLiveSettings.newBuilder().build(),
         shards);
   }
 
@@ -636,6 +637,7 @@ public class ImmutableIndexStateTest {
         BackendGlobalState.getUniqueIndexName("test_index", "test_id"),
         getStateWithLiveSettings(settings),
         new FieldAndFacetState(),
+        IndexLiveSettings.newBuilder().build(),
         new HashMap<>());
   }
 
@@ -851,7 +853,68 @@ public class ImmutableIndexStateTest {
             .setMaxRefreshSec(wrap(10.0))
             .setSegmentsPerTier(wrap(5))
             .build();
-    assertEquals(expectedMergedSettings, indexState.getMergedLiveSettings());
+    assertEquals(expectedMergedSettings, indexState.getMergedLiveSettings(false));
+    assertEquals(expectedMergedSettings, indexState.getMergedLiveSettings(true));
+  }
+
+  private ImmutableIndexState getIndexStateForLiveSettingsOverrides(
+      IndexLiveSettings settings, IndexLiveSettings overrides) throws IOException {
+    IndexStateManager mockManager = mock(IndexStateManager.class);
+    GlobalState mockGlobalState = mock(GlobalState.class);
+
+    String configFile = "nodeName: \"lucene_server_foo\"";
+    LuceneServerConfiguration dummyConfig =
+        new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+
+    when(mockGlobalState.getIndexDirBase()).thenReturn(folder.getRoot().toPath());
+    when(mockGlobalState.getConfiguration()).thenReturn(dummyConfig);
+    return new ImmutableIndexState(
+        mockManager,
+        mockGlobalState,
+        "test_index",
+        BackendGlobalState.getUniqueIndexName("test_index", "test_id"),
+        getStateWithLiveSettings(settings),
+        new FieldAndFacetState(),
+        overrides,
+        new HashMap<>());
+  }
+
+  @Test
+  public void testLiveSettingsOverrides() throws IOException {
+    IndexLiveSettings liveSettings =
+        IndexLiveSettings.newBuilder()
+            .setDefaultTerminateAfter(wrap(100))
+            .setMaxRefreshSec(wrap(10.0))
+            .setSegmentsPerTier(wrap(5))
+            .build();
+    IndexLiveSettings liveSettingsOverrides =
+        IndexLiveSettings.newBuilder()
+            .setSliceMaxDocs(Int32Value.newBuilder().setValue(1).build())
+            .setSliceMaxSegments(Int32Value.newBuilder().setValue(1).build())
+            .setDefaultTerminateAfter(Int32Value.newBuilder().setValue(10).build())
+            .build();
+    ImmutableIndexState indexState =
+        getIndexStateForLiveSettingsOverrides(liveSettings, liveSettingsOverrides);
+    IndexLiveSettings expectedMergedSettings =
+        ImmutableIndexState.DEFAULT_INDEX_LIVE_SETTINGS
+            .toBuilder()
+            .setDefaultTerminateAfter(wrap(100))
+            .setMaxRefreshSec(wrap(10.0))
+            .setSegmentsPerTier(wrap(5))
+            .build();
+    IndexLiveSettings expectedMergedSettingsWithLocal =
+        expectedMergedSettings
+            .toBuilder()
+            .setSliceMaxDocs(Int32Value.newBuilder().setValue(1).build())
+            .setSliceMaxSegments(Int32Value.newBuilder().setValue(1).build())
+            .setDefaultTerminateAfter(Int32Value.newBuilder().setValue(10).build())
+            .build();
+    assertEquals(expectedMergedSettings, indexState.getMergedLiveSettings(false));
+    assertEquals(expectedMergedSettingsWithLocal, indexState.getMergedLiveSettings(true));
+
+    assertEquals(1, indexState.getSliceMaxDocs());
+    assertEquals(1, indexState.getSliceMaxSegments());
+    assertEquals(10, indexState.getDefaultTerminateAfter());
   }
 
   @Test


### PR DESCRIPTION
Adds the ability to override index live settings through the config file. This would be useful for testing changes on a subset of nodes, before applying to the full cluster.

Example:
```
indexLiveSettingsOverrides:
  test_index:
    sliceMaxDocs: 1,
    virtualShards: 100
  test_index_2:
    defaultSearchTimeoutSec: 10.25
    segmentsPerTier: 30
```

These overrides are loaded on startup and merged into the final resolved live settings after any change.

I intend to follow this up with another branch that adds the ability to get/modify these local overrides through the `liveSettingsV2` endpoint.