### PR TITLE
Add deadline cancellation for indexing

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -794,10 +794,13 @@ public class LuceneServer {
                     "indexing addDocumentRequestQueue size: %s, total: %s",
                     addDocumentRequestQueue.size(), getCount(indexName)));
             try {
+              DeadlineUtils.checkDeadline("addDocuments: onNext", "INDEXING");
+
               List<AddDocumentRequest> addDocRequestList = new ArrayList<>(addDocumentRequestQueue);
               Future<Long> future =
                   globalState.submitIndexingTask(
-                      new DocumentIndexer(globalState, addDocRequestList, indexName));
+                      Context.current()
+                          .wrap(new DocumentIndexer(globalState, addDocRequestList, indexName)));
               futures.put(indexName, future);
             } catch (Exception e) {
               responseObserver.onError(e);
@@ -821,6 +824,8 @@ public class LuceneServer {
                   "onCompleted, addDocumentRequestQueue: %s", addDocumentRequestQueue.size()));
           long highestGen = -1;
           try {
+            DeadlineUtils.checkDeadline("addDocuments: onCompletedForIndex", "INDEXING");
+
             // index the left over docs
             if (!addDocumentRequestQueue.isEmpty()) {
               logger.debug(
@@ -874,24 +879,26 @@ public class LuceneServer {
         public void onCompleted() {
           try {
             globalState.submitIndexingTask(
-                () -> {
-                  try {
-                    // TODO: this should return a map on index to genId in the response
-                    String genId = "-1";
-                    for (String indexName : addDocumentRequestQueueMap.keySet()) {
-                      genId = onCompletedForIndex(indexName);
-                    }
-                    responseObserver.onNext(
-                        AddDocumentResponse.newBuilder()
-                            .setGenId(genId)
-                            .setPrimaryId(globalState.getEphemeralId())
-                            .build());
-                    responseObserver.onCompleted();
-                  } catch (Throwable t) {
-                    responseObserver.onError(t);
-                  }
-                  return null;
-                });
+                Context.current()
+                    .wrap(
+                        () -> {
+                          try {
+                            // TODO: this should return a map on index to genId in the response
+                            String genId = "-1";
+                            for (String indexName : addDocumentRequestQueueMap.keySet()) {
+                              genId = onCompletedForIndex(indexName);
+                            }
+                            responseObserver.onNext(
+                                AddDocumentResponse.newBuilder()
+                                    .setGenId(genId)
+                                    .setPrimaryId(globalState.getEphemeralId())
+                                    .build());
+                            responseObserver.onCompleted();
+                          } catch (Throwable t) {
+                            responseObserver.onError(t);
+                          }
+                          return null;
+                        }));
           } catch (RejectedExecutionException e) {
             logger.error("Threadpool is full, unable to submit indexing completion job");
             responseObserver.onError(

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/AddDocumentHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/AddDocumentHandler.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.server.luceneserver;
 
 import com.google.protobuf.ProtocolStringList;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.DeadlineUtils;
 import com.yelp.nrtsearch.server.grpc.FacetHierarchyPath;
 import com.yelp.nrtsearch.server.luceneserver.field.FieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.IdFieldDef;
@@ -181,6 +182,8 @@ public class AddDocumentHandler {
     }
 
     public long runIndexingJob() throws Exception {
+      DeadlineUtils.checkDeadline("DocumentIndexer: runIndexingJob", "INDEXING");
+
       logger.debug(
           String.format(
               "running indexing job on threadId: %s",


### PR DESCRIPTION
Add grpc deadline cancellation support to the indexing api.

Indexing sub tasks are now wrapped by the current grpc context.

Deadline is checked:
- Before enquing a new batch of documents to index
- Before starting to process a batch of documents
- Before completing indexing for an index