### PR TITLE
nrt_utils support defaultCredentialsProvider

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/DeleteIncrementalSnapshotsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/DeleteIncrementalSnapshotsCommand.java
@@ -69,12 +69,13 @@ public class DeleteIncrementalSnapshotsCommand implements Callable<Integer> {
 
   @CommandLine.Option(
       names = {"-c", "--credsFile"},
-      description = "File holding AWS credentials, uses default locations if not set")
+      description =
+          "File holding AWS credentials, uses default locations if not set; Will use DefaultCredentialProvider if this is unset.")
   private String credsFile;
 
   @CommandLine.Option(
       names = {"-p", "--credsProfile"},
-      description = "Profile to use from creds file",
+      description = "Profile to use from creds file; Neglected when credsFile is unset.",
       defaultValue = "default")
   private String credsProfile;
 

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/DeleteIncrementalSnapshotsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/DeleteIncrementalSnapshotsCommand.java
@@ -70,7 +70,7 @@ public class DeleteIncrementalSnapshotsCommand implements Callable<Integer> {
   @CommandLine.Option(
       names = {"-c", "--credsFile"},
       description =
-          "File holding AWS credentials, uses default locations if not set; Will use DefaultCredentialProvider if this is unset.")
+          "File holding AWS credentials; Will use DefaultCredentialProvider if this is unset.")
   private String credsFile;
 
   @CommandLine.Option(

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/IncrementalDataCleanupCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/IncrementalDataCleanupCommand.java
@@ -70,12 +70,13 @@ public class IncrementalDataCleanupCommand implements Callable<Integer> {
 
   @CommandLine.Option(
       names = {"-c", "--credsFile"},
-      description = "File holding AWS credentials, uses default locations if not set")
+      description =
+          "File holding AWS credentials, uses default locations if not set; Will use DefaultCredentialProvider if this is unset.")
   private String credsFile;
 
   @CommandLine.Option(
       names = {"-p", "--credsProfile"},
-      description = "Profile to use from creds file",
+      description = "Profile to use from creds file; Neglected when credsFile is unset.",
       defaultValue = "default")
   private String credsProfile;
 

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/IncrementalDataCleanupCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/IncrementalDataCleanupCommand.java
@@ -71,7 +71,7 @@ public class IncrementalDataCleanupCommand implements Callable<Integer> {
   @CommandLine.Option(
       names = {"-c", "--credsFile"},
       description =
-          "File holding AWS credentials, uses default locations if not set; Will use DefaultCredentialProvider if this is unset.")
+          "File holding AWS credentials; Will use DefaultCredentialProvider if this is unset.")
   private String credsFile;
 
   @CommandLine.Option(

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/ListIncrementalSnapshotsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/ListIncrementalSnapshotsCommand.java
@@ -54,12 +54,13 @@ public class ListIncrementalSnapshotsCommand implements Callable<Integer> {
 
   @CommandLine.Option(
       names = {"-c", "--credsFile"},
-      description = "File holding AWS credentials, uses default locations if not set")
+      description =
+          "File holding AWS credentials, uses default locations if not set; Will use DefaultCredentialProvider if this is unset.")
   private String credsFile;
 
   @CommandLine.Option(
       names = {"-p", "--credsProfile"},
-      description = "Profile to use from creds file",
+      description = "Profile to use from creds file; Neglected when credsFile is unset.",
       defaultValue = "default")
   private String credsProfile;
 

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/ListIncrementalSnapshotsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/ListIncrementalSnapshotsCommand.java
@@ -55,7 +55,7 @@ public class ListIncrementalSnapshotsCommand implements Callable<Integer> {
   @CommandLine.Option(
       names = {"-c", "--credsFile"},
       description =
-          "File holding AWS credentials, uses default locations if not set; Will use DefaultCredentialProvider if this is unset.")
+          "File holding AWS credentials; Will use DefaultCredentialProvider if this is unset.")
   private String credsFile;
 
   @CommandLine.Option(

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/RestoreIncrementalCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/RestoreIncrementalCommand.java
@@ -79,7 +79,7 @@ public class RestoreIncrementalCommand implements Callable<Integer> {
   @CommandLine.Option(
       names = {"-c", "--credsFile"},
       description =
-          "File holding AWS credentials, uses default locations if not set; Will use DefaultCredentialProvider if this is unset.")
+          "File holding AWS credentials; Will use DefaultCredentialProvider if this is unset.")
   private String credsFile;
 
   @CommandLine.Option(

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/RestoreIncrementalCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/RestoreIncrementalCommand.java
@@ -78,12 +78,13 @@ public class RestoreIncrementalCommand implements Callable<Integer> {
 
   @CommandLine.Option(
       names = {"-c", "--credsFile"},
-      description = "File holding AWS credentials, uses default locations if not set")
+      description =
+          "File holding AWS credentials, uses default locations if not set; Will use DefaultCredentialProvider if this is unset.")
   private String credsFile;
 
   @CommandLine.Option(
       names = {"-p", "--credsProfile"},
-      description = "Profile to use from creds file",
+      description = "Profile to use from creds file; Neglected when credsFile is unset.",
       defaultValue = "default")
   private String credsProfile;
 

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/SnapshotIncrementalCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/SnapshotIncrementalCommand.java
@@ -74,12 +74,13 @@ public class SnapshotIncrementalCommand implements Callable<Integer> {
 
   @CommandLine.Option(
       names = {"-c", "--credsFile"},
-      description = "File holding AWS credentials, uses default locations if not set")
+      description =
+          "File holding AWS credentials, uses default locations if not set; Will use DefaultCredentialProvider if this is unset.")
   private String credsFile;
 
   @CommandLine.Option(
       names = {"-p", "--credsProfile"},
-      description = "Profile to use from creds file",
+      description = "Profile to use from creds file; Neglected when credsFile is unset.",
       defaultValue = "default")
   private String credsProfile;
 

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/SnapshotIncrementalCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/incremental/SnapshotIncrementalCommand.java
@@ -75,7 +75,7 @@ public class SnapshotIncrementalCommand implements Callable<Integer> {
   @CommandLine.Option(
       names = {"-c", "--credsFile"},
       description =
-          "File holding AWS credentials, uses default locations if not set; Will use DefaultCredentialProvider if this is unset.")
+          "File holding AWS credentials; Will use DefaultCredentialProvider if this is unset.")
   private String credsFile;
 
   @CommandLine.Option(

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetRemoteStateCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetRemoteStateCommand.java
@@ -60,7 +60,7 @@ public class GetRemoteStateCommand implements Callable<Integer> {
   @CommandLine.Option(
       names = {"-c", "--credsFile"},
       description =
-          "File holding AWS credentials, uses default locations if not set; Will use DefaultCredentialProvider if this is unset.")
+          "File holding AWS credentials; Will use DefaultCredentialProvider if this is unset.")
   private String credsFile;
 
   @CommandLine.Option(

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetRemoteStateCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetRemoteStateCommand.java
@@ -59,12 +59,13 @@ public class GetRemoteStateCommand implements Callable<Integer> {
 
   @CommandLine.Option(
       names = {"-c", "--credsFile"},
-      description = "File holding AWS credentials, uses default locations if not set")
+      description =
+          "File holding AWS credentials, uses default locations if not set; Will use DefaultCredentialProvider if this is unset.")
   private String credsFile;
 
   @CommandLine.Option(
       names = {"-p", "--credsProfile"},
-      description = "Profile to use from creds file",
+      description = "Profile to use from creds file; Neglected when credsFile is unset.",
       defaultValue = "default")
   private String credsProfile;
 

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/PutRemoteStateCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/PutRemoteStateCommand.java
@@ -61,7 +61,7 @@ public class PutRemoteStateCommand implements Callable<Integer> {
   @CommandLine.Option(
       names = {"-c", "--credsFile"},
       description =
-          "File holding AWS credentials, uses default locations if not set; Will use DefaultCredentialProvider if this is unset.")
+          "File holding AWS credentials; Will use DefaultCredentialProvider if this is unset.")
   private String credsFile;
 
   @CommandLine.Option(

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/PutRemoteStateCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/PutRemoteStateCommand.java
@@ -60,12 +60,13 @@ public class PutRemoteStateCommand implements Callable<Integer> {
 
   @CommandLine.Option(
       names = {"-c", "--credsFile"},
-      description = "File holding AWS credentials, uses default locations if not set")
+      description =
+          "File holding AWS credentials, uses default locations if not set; Will use DefaultCredentialProvider if this is unset.")
   private String credsFile;
 
   @CommandLine.Option(
       names = {"-p", "--credsProfile"},
-      description = "Profile to use from creds file",
+      description = "Profile to use from creds file; Neglected when credsFile is unset.",
       defaultValue = "default")
   private String credsProfile;
 

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/StateCommandUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/StateCommandUtils.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.tools.nrt_utils.state;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.auth.profile.ProfilesConfigFile;
 import com.amazonaws.client.builder.AwsClientBuilder;
@@ -67,13 +68,14 @@ public class StateCommandUtils {
    */
   public static AmazonS3 createS3Client(
       String bucketName, String region, String credsFile, String credsProfile, int maxRetry) {
-    ProfilesConfigFile profilesConfigFile = null;
+    AWSCredentialsProvider awsCredentialsProvider;
     if (credsFile != null) {
       Path botoCfgPath = Paths.get(credsFile);
-      profilesConfigFile = new ProfilesConfigFile(botoCfgPath.toFile());
+      ProfilesConfigFile profilesConfigFile = new ProfilesConfigFile(botoCfgPath.toFile());
+      awsCredentialsProvider = new ProfileCredentialsProvider(profilesConfigFile, credsProfile);
+    } else {
+      awsCredentialsProvider = new DefaultAWSCredentialsProviderChain();
     }
-    AWSCredentialsProvider awsCredentialsProvider =
-        new ProfileCredentialsProvider(profilesConfigFile, credsProfile);
 
     String clientRegion;
     if (region == null) {

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/UpdateGlobalIndexStateCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/UpdateGlobalIndexStateCommand.java
@@ -59,12 +59,13 @@ public class UpdateGlobalIndexStateCommand implements Callable<Integer> {
 
   @CommandLine.Option(
       names = {"-c", "--credsFile"},
-      description = "File holding AWS credentials, uses default locations if not set")
+      description =
+          "File holding AWS credentials, uses default locations if not set; Will use DefaultCredentialProvider if this is unset.")
   private String credsFile;
 
   @CommandLine.Option(
       names = {"-p", "--credsProfile"},
-      description = "Profile to use from creds file",
+      description = "Profile to use from creds file; Neglected when credsFile is unset.",
       defaultValue = "default")
   private String credsProfile;
 

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/UpdateGlobalIndexStateCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/UpdateGlobalIndexStateCommand.java
@@ -60,7 +60,7 @@ public class UpdateGlobalIndexStateCommand implements Callable<Integer> {
   @CommandLine.Option(
       names = {"-c", "--credsFile"},
       description =
-          "File holding AWS credentials, uses default locations if not set; Will use DefaultCredentialProvider if this is unset.")
+          "File holding AWS credentials; Will use DefaultCredentialProvider if this is unset.")
   private String credsFile;
 
   @CommandLine.Option(


### PR DESCRIPTION
RP-9895

Support default credential providers for nrt_utils.
This allows us to use instance profile for AmazonS3.

manual test from dev: https://fluffy.yelpcorp.com/i/mfBgzt5W6T7s6KTNV1n38SpSDRg0gkcm.html

edge case:
When a user want to use default cred-file-path with a non-default profile name:
1. manually put `-c ~/.aws/credentials -p profile-name`
2. provide profile name as an env: AWS_PROFILE=profile-name