### PR TITLE
log more info when fvh failed

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighter.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighter.java
@@ -142,11 +142,10 @@ public class NRTFastVectorHighlighter implements Highlighter {
           DEFAULT_ENCODER);
     } catch (RuntimeException runtimeException) {
       logger.warn(
-          String.format(
-              "FVH failed creating fragments for the luceneDocId %d, the highlight query is %s and the exception is: %s",
+              "FVH failed creating fragments for the luceneDocId: {}, highlight query: {}, exception: {}",
               leafDocId + hitLeaf.docBase,
               settings.getHighlightQuery(),
-              runtimeException.getMessage()));
+              runtimeException.getMessage());
       return new String[0];
     }
   }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighter.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighter.java
@@ -145,6 +145,7 @@ public class NRTFastVectorHighlighter implements Highlighter {
           "FVH failed creating fragments for the luceneDocId: {}, highlight query: {}, exception: {}",
           leafDocId + hitLeaf.docBase,
           settings.getHighlightQuery(),
+          runtimeException.getMessage(),
           runtimeException);
       return new String[0];
     }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighter.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighter.java
@@ -142,7 +142,11 @@ public class NRTFastVectorHighlighter implements Highlighter {
           DEFAULT_ENCODER);
     } catch (RuntimeException runtimeException) {
       logger.warn(
-          "FVH failed creating fragments, and the exception is: ", runtimeException.getMessage());
+          String.format(
+              "FVH failed creating fragments for the luceneDocId %d, the highlight query is %s and the exception is: %s",
+              leafDocId + hitLeaf.docBase,
+              settings.getHighlightQuery(),
+              runtimeException.getMessage()));
       return new String[0];
     }
   }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighter.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighter.java
@@ -145,7 +145,7 @@ public class NRTFastVectorHighlighter implements Highlighter {
           "FVH failed creating fragments for the luceneDocId: {}, highlight query: {}, exception: {}",
           leafDocId + hitLeaf.docBase,
           settings.getHighlightQuery(),
-          runtimeException.getMessage());
+          runtimeException);
       return new String[0];
     }
   }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighter.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/highlights/NRTFastVectorHighlighter.java
@@ -142,10 +142,10 @@ public class NRTFastVectorHighlighter implements Highlighter {
           DEFAULT_ENCODER);
     } catch (RuntimeException runtimeException) {
       logger.warn(
-              "FVH failed creating fragments for the luceneDocId: {}, highlight query: {}, exception: {}",
-              leafDocId + hitLeaf.docBase,
-              settings.getHighlightQuery(),
-              runtimeException.getMessage());
+          "FVH failed creating fragments for the luceneDocId: {}, highlight query: {}, exception: {}",
+          leafDocId + hitLeaf.docBase,
+          settings.getHighlightQuery(),
+          runtimeException.getMessage());
       return new String[0];
     }
   }


### PR DESCRIPTION
The fvh exception is not logged properly. Fix the bug, and add more context on the message.
from 
```
[WARN ] 2024-01-19 15:06:37.546 [GrpcLuceneServerExecutor-6-thread-28] NRTFastVectorHighlighter - FVH failed creating fragments, and the exception is: }
```
to
```
[WARN ] 2024-01-22 16:29:36.059 [GrpcLuceneServerExecutor-5-thread-17] NRTFastVectorHighlighter - FVH failed creating fragments for the luceneDocId: 1, highlight query: #_nested_path:reviews +(((reviews.raw_text:pepper)^5.0 (reviews.raw_text:salt)^3.0)~1), exception: dummy runtime exception
java.lang.RuntimeException: dummy runtime exception
        at com.yelp.nrtsearch.server.luceneserver.highlights.NRTFastVectorHighlighter.getHighlights(NRTFastVectorHighlighter.java:131) ~[nrtsearch-0.30.0.jar:?]
        at com.yelp.nrtsearch.server.luceneserver.highlights.HighlightFetchTask.processHit(HighlightFetchTask.java:80) ~[nrtsearch-0.30.0.jar:?]
        at com.yelp.nrtsearch.server.luceneserver.search.FetchTasks.processHit(FetchTasks.java:161) ~[nrtsearch-0.30.0.jar:?]
        at com.yelp.nrtsearch.server.luceneserver.SearchHandler$FillDocsTask.fetchSlice(SearchHandler.java:922) ~[nrtsearch-0.30.0.jar:?]
        at com.yelp.nrtsearch.server.luceneserver.SearchHandler$FillDocsTask.run(SearchHandler.java:850) ~[nrtsearch-0.30.0.jar:?]
        at com.yelp.nrtsearch.server.luceneserver.SearchHandler.fetchFields(SearchHandler.java:423) ~[nrtsearch-0.30.0.jar:?]
        at com.yelp.nrtsearch.server.luceneserver.SearchHandler.handle(SearchHandler.java:222) ~[nrtsearch-0.30.0.jar:?]
        at com.yelp.nrtsearch.server.grpc.LuceneServer$LuceneServerImpl.search(LuceneServer.java:1069) ~[nrtsearch-0.30.0.jar:?]
        at com.yelp.nrtsearch.server.grpc.LuceneServerGrpc$MethodHandlers.invoke(LuceneServerGrpc.java:3376) ~[clientlib-0.30.0.jar:?]
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182) ~[grpc-stub-1.46.0.jar:1.46.0]
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35) ~[grpc-api-1.46.0.jar:1.46.0]
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23) ~[grpc-api-1.46.0.jar:1.46.0]
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:340) ~[grpc-core-1.46.0.jar:1.46.0]
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:866) ~[grpc-core-1.46.0.jar:1.46.0]
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37) ~[grpc-core-1.46.0.jar:1.46.0]
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133) ~[grpc-core-1.46.0.jar:1.46.0]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]



```

Note that the query would be the "LUCENE" query, but still informative for engineers to debug.