### PR TITLE
Avoid calling query.toString()

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/MyIndexSearcher.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/MyIndexSearcher.java
@@ -15,6 +15,8 @@
  */
 package com.yelp.nrtsearch.server.luceneserver;
 
+import static org.apache.lucene.facet.DrillSidewaysQueryCheck.isDrillSidewaysQuery;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -240,8 +242,7 @@ public class MyIndexSearcher extends IndexSearcher {
   protected void search(List<LeafReaderContext> leaves, Weight weight, Collector collector)
       throws IOException {
     boolean isDrillSidewaysQueryOrCompletionQuery =
-        weight.getQuery() instanceof CompletionQuery
-            || weight.getQuery().toString().contains("DrillSidewaysQuery");
+        weight.getQuery() instanceof CompletionQuery || isDrillSidewaysQuery(weight.getQuery());
     for (LeafReaderContext ctx : leaves) { // search each subreader
       // we force the use of Scorer (not BulkScorer) to make sure
       // that the scorer passed to LeafCollector.setScorer supports

--- a/src/main/java/org/apache/lucene/facet/DrillSidewaysQueryCheck.java
+++ b/src/main/java/org/apache/lucene/facet/DrillSidewaysQueryCheck.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.facet;
+
+import org.apache.lucene.search.Query;
+
+public class DrillSidewaysQueryCheck {
+
+  public static boolean isDrillSidewaysQuery(Query query) {
+    return query instanceof DrillSidewaysQuery;
+  }
+}

--- a/src/test/java/org/apache/lucene/facet/DrillSidewaysQueryCheckTest.java
+++ b/src/test/java/org/apache/lucene/facet/DrillSidewaysQueryCheckTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.facet;
+
+import static org.apache.lucene.facet.DrillSidewaysQueryCheck.isDrillSidewaysQuery;
+import static org.junit.Assert.*;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.TermQuery;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class DrillSidewaysQueryCheckTest {
+
+  @Test
+  public void testIsDrillSidewaysQuery() {
+    assertFalse(isDrillSidewaysQuery(null));
+
+    assertFalse(isDrillSidewaysQuery(new TermQuery(new Term("field", "text"))));
+
+    DrillSidewaysQuery dsq = Mockito.mock(DrillSidewaysQuery.class);
+    assertTrue(isDrillSidewaysQuery(dsq));
+  }
+}


### PR DESCRIPTION
If a query is large and complex, `query.toString()` can be expensive. We had earlier changed it so that it's only executed once per query (#524) but it's better to not call it at all.
Replacing the toString call with instanceof here. Since `DrillSidewaysQuery` is package-private, we need to do the instaceof check in a class in `org.apache.lucene.facet` package.