### PR TITLE
add sts for web identity auth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ dependencies {
     implementation "org.apache.commons:commons-compress:${commonsCompressVersion}"
     implementation "com.amazonaws:aws-java-sdk-core:${awsJavaSdkVersion}"
     implementation "com.amazonaws:aws-java-sdk-s3:${awsJavaSdkVersion}"
+    implementation "com.amazonaws:aws-java-sdk-sts:${awsJavaSdkVersion}"
     implementation "javax.xml.bind:jaxb-api:2.3.1"
     implementation "com.guicedee.services:guice:${guicedeeVersion}"
     implementation "org.lz4:lz4-java:${project.ext.lz4Version}"

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     implementation "org.apache.commons:commons-compress:${commonsCompressVersion}"
     implementation "com.amazonaws:aws-java-sdk-core:${awsJavaSdkVersion}"
     implementation "com.amazonaws:aws-java-sdk-s3:${awsJavaSdkVersion}"
-    implementation "com.amazonaws:aws-java-sdk-sts:${awsJavaSdkVersion}"
+    runtimeOnly "com.amazonaws:aws-java-sdk-sts:${awsJavaSdkVersion}"
     implementation "javax.xml.bind:jaxb-api:2.3.1"
     implementation "com.guicedee.services:guice:${guicedeeVersion}"
     implementation "org.lz4:lz4-java:${project.ext.lz4Version}"


### PR DESCRIPTION
RP-10059
After verification, the python sdk can access the resources from the container through the web identity token. But it seems that java sdk cannot. We tried to add this class to the plugin package, but it seems that the aws-java-sdk-core from the nrtsearch-core does not recognise it as the plugins are hot loaded.
Therefore, we add it to the runtime.
```
[ERROR] 2024-02-01 13:49:54.461 [main] LuceneServer - Uncaught exception
com.amazonaws.SdkClientException: To use assume role profiles the aws-java-sdk-sts module must be on the class path.
```