### PR TITLE
Lucene 9.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ def _artifactId = 'server'
 //This is for https://github.com/gradle/gradle/issues/11308
 System.setProperty("org.gradle.internal.publish.checksums.insecure", "True")
 
-def luceneVersion = '9.7.0'
+def luceneVersion = '9.8.0'
 project.ext.slf4jVersion = '2.0.0-alpha1'
 project.ext.grpcVersion = '1.46.0'
 project.ext.lz4Version = '1.7.0'

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/MyIndexSearcher.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/MyIndexSearcher.java
@@ -282,6 +282,9 @@ public class MyIndexSearcher extends IndexSearcher {
           }
         }
       }
+      // Note: this is called if collection ran successfully, including the above special case of
+      // CollectionTerminatedException, but no other exception.
+      leafCollector.finish();
     }
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
@@ -74,7 +74,7 @@ import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.DoubleValues;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.NrtsearchKnnCollector;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.search.ScoreDoc;
@@ -139,7 +139,7 @@ public class SearchHandler implements Handler<SearchRequest, SearchResponse> {
       // produce the top k documents with their similarity scores.
       if (searchContext.getVectorScoringMode() != VectorScoringMode.NONE) {
         vectorQueries = new ArrayList<>();
-        for (KnnCollector knnCollector : searchContext.getKnnCollectors()) {
+        for (NrtsearchKnnCollector knnCollector : searchContext.getKnnCollectors()) {
           VectorDiagnostics.Builder vectorDiagnosticsBuilder = VectorDiagnostics.newBuilder();
           long vectorSearchStart = System.nanoTime();
           vectorQueries.add(

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/VectorFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/VectorFieldDef.java
@@ -34,7 +34,6 @@ import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesType;
-import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.util.BytesRef;
@@ -135,9 +134,11 @@ public class VectorFieldDef extends IndexableFieldDef {
     }
 
     if (requestField.getSearch()) {
-      if (requestField.getVectorDimensions() > FloatVectorValues.MAX_DIMENSIONS) {
+      if (requestField.getVectorDimensions() > Lucene95HnswVectorsFormat.DEFAULT_MAX_DIMENSIONS) {
         throw new IllegalArgumentException(
-            "Vector dimension must be <= " + FloatVectorValues.MAX_DIMENSIONS + " for search");
+            "Vector dimension must be <= "
+                + Lucene95HnswVectorsFormat.DEFAULT_MAX_DIMENSIONS
+                + " for search");
       }
     }
   }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchContext.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchContext.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager;
 import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager.SearcherAndTaxonomy;
-import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.NrtsearchKnnCollector;
 import org.apache.lucene.search.Query;
 
 /** Search context class to provide all the information to perform a search. */
@@ -49,7 +49,7 @@ public class SearchContext implements FieldFetchContext {
   private final SharedDocContext sharedDocContext;
   private final Map<String, Object> extraContext;
   private final String queryNestedPath;
-  private final List<KnnCollector> knnCollectors;
+  private final List<NrtsearchKnnCollector> knnCollectors;
   private final VectorScoringMode vectorScoringMode;
 
   public enum VectorScoringMode {
@@ -176,7 +176,7 @@ public class SearchContext implements FieldFetchContext {
   }
 
   /** Get collector to perform kNN vector search queries */
-  public List<KnnCollector> getKnnCollectors() {
+  public List<NrtsearchKnnCollector> getKnnCollectors() {
     return knnCollectors;
   }
 
@@ -247,7 +247,7 @@ public class SearchContext implements FieldFetchContext {
     private SharedDocContext sharedDocContext;
     private Map<String, Object> extraContext;
     private String queryNestedPath;
-    private List<KnnCollector> knnCollectors;
+    private List<NrtsearchKnnCollector> knnCollectors;
     private VectorScoringMode vectorScoringMode;
     private boolean explain;
 
@@ -360,7 +360,7 @@ public class SearchContext implements FieldFetchContext {
      *
      * @param knnCollectors vector search collectors
      */
-    public Builder setKnnCollectors(List<KnnCollector> knnCollectors) {
+    public Builder setKnnCollectors(List<NrtsearchKnnCollector> knnCollectors) {
       this.knnCollectors = knnCollectors;
       return this;
     }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
@@ -70,7 +70,7 @@ import org.apache.lucene.queryparser.classic.QueryParserBase;
 import org.apache.lucene.queryparser.simple.SimpleQueryParser;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.NrtsearchKnnCollector;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.QueryBuilder;
 
@@ -194,9 +194,10 @@ public class SearchRequestProcessor {
 
     contextBuilder.setExtraContext(new ConcurrentHashMap<>());
 
-    List<KnnCollector> knnCollectors = new ArrayList<>();
+    List<NrtsearchKnnCollector> knnCollectors = new ArrayList<>();
     for (KnnQuery knnQuery : searchRequest.getKnnList()) {
-      knnCollectors.add(new KnnCollector(knnQuery, indexState, searcherAndTaxonomy.searcher));
+      knnCollectors.add(
+          new NrtsearchKnnCollector(knnQuery, indexState, searcherAndTaxonomy.searcher));
     }
     contextBuilder.setKnnCollectors(knnCollectors);
     // determine how vector search results should combine with standard query

--- a/src/main/java/org/apache/lucene/search/NrtsearchKnnCollector.java
+++ b/src/main/java/org/apache/lucene/search/NrtsearchKnnCollector.java
@@ -44,7 +44,7 @@ import org.apache.lucene.util.Bits;
  * to do parallel collection by index slice. A numCandidates value may be provided that is greater
  * than k. This is the per segment documents considered for approximate vector search.
  */
-public class KnnCollector {
+public class NrtsearchKnnCollector {
   private static final TopDocs NO_RESULTS = TopDocsCollector.EMPTY_TOPDOCS;
   static final int NUM_CANDIDATES_LIMIT = 10000;
   private final String field;
@@ -62,7 +62,7 @@ public class KnnCollector {
    * @param indexState index state
    * @param searcher index searcher
    */
-  public KnnCollector(KnnQuery grpcQuery, IndexState indexState, IndexSearcher searcher) {
+  public NrtsearchKnnCollector(KnnQuery grpcQuery, IndexState indexState, IndexSearcher searcher) {
     this.field = grpcQuery.getField();
     FieldDef fieldDef = indexState.getField(field);
     if (!(fieldDef instanceof VectorFieldDef)) {

--- a/src/test/java/org/apache/lucene/search/NrtsearchKnnCollectorTest.java
+++ b/src/test/java/org/apache/lucene/search/NrtsearchKnnCollectorTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager.SearcherAndTaxonomy;
 import org.junit.Test;
 
-public class KnnCollectorTest extends ServerTestCase {
+public class NrtsearchKnnCollectorTest extends ServerTestCase {
 
   @Override
   protected List<String> getIndices() {
@@ -46,7 +46,8 @@ public class KnnCollectorTest extends ServerTestCase {
     SearcherAndTaxonomy s = null;
     try {
       s = indexState.getShard(0).acquire();
-      new KnnCollector(KnnQuery.newBuilder().setField("unknown").build(), indexState, s.searcher);
+      new NrtsearchKnnCollector(
+          KnnQuery.newBuilder().setField("unknown").build(), indexState, s.searcher);
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals(
@@ -64,7 +65,8 @@ public class KnnCollectorTest extends ServerTestCase {
     SearcherAndTaxonomy s = null;
     try {
       s = indexState.getShard(0).acquire();
-      new KnnCollector(KnnQuery.newBuilder().setField("filter").build(), indexState, s.searcher);
+      new NrtsearchKnnCollector(
+          KnnQuery.newBuilder().setField("filter").build(), indexState, s.searcher);
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("Field is not a vector: filter", e.getMessage());
@@ -81,7 +83,7 @@ public class KnnCollectorTest extends ServerTestCase {
     SearcherAndTaxonomy s = null;
     try {
       s = indexState.getShard(0).acquire();
-      new KnnCollector(
+      new NrtsearchKnnCollector(
           KnnQuery.newBuilder().setField("vector_not_search").build(), indexState, s.searcher);
       fail();
     } catch (IllegalArgumentException e) {
@@ -99,7 +101,7 @@ public class KnnCollectorTest extends ServerTestCase {
     SearcherAndTaxonomy s = null;
     try {
       s = indexState.getShard(0).acquire();
-      new KnnCollector(
+      new NrtsearchKnnCollector(
           KnnQuery.newBuilder()
               .setField("vector_cosine")
               .setK(5)
@@ -124,7 +126,7 @@ public class KnnCollectorTest extends ServerTestCase {
     SearcherAndTaxonomy s = null;
     try {
       s = indexState.getShard(0).acquire();
-      new KnnCollector(
+      new NrtsearchKnnCollector(
           KnnQuery.newBuilder()
               .setField("vector_cosine")
               .setNumCandidates(10)
@@ -148,7 +150,7 @@ public class KnnCollectorTest extends ServerTestCase {
     SearcherAndTaxonomy s = null;
     try {
       s = indexState.getShard(0).acquire();
-      new KnnCollector(
+      new NrtsearchKnnCollector(
           KnnQuery.newBuilder()
               .setField("vector_cosine")
               .setK(15)
@@ -173,7 +175,7 @@ public class KnnCollectorTest extends ServerTestCase {
     SearcherAndTaxonomy s = null;
     try {
       s = indexState.getShard(0).acquire();
-      new KnnCollector(
+      new NrtsearchKnnCollector(
           KnnQuery.newBuilder()
               .setField("vector_cosine")
               .setK(15)


### PR DESCRIPTION
Upgrading to Lucene 9.8. Changes:
1. Calling `leafCollector.finish()` in `MyIndexSearcher` like it's added to `IndexSearcher` in https://github.com/apache/lucene/pull/12380. Without this, facet tests were failing since the data structures for adding matching docs were not getting updated. We should also look into removing the overriden search method in MyIndexSearcher - I'm not sure if it's needed now.
2. Renamed `KnnCollector` to `NrtsearchKnnCollector` because Lucene 9.8 adds an interface called `KnnCollector`: https://github.com/apache/lucene/pull/12434. We should probably look into implementing this.
3. Getting max vector dimensions from the codec since it's configurable in the codec. The value is still fixed to 1024 for now.

Example plugin test fails because the jar is not uploaded yet.