### PR TITLE
enable defaultAwsCredentialChain when botoCfgPath is neglected

### DIFF
--- a/docs/server_configuration.rst
+++ b/docs/server_configuration.rst
@@ -83,8 +83,8 @@ Example server configuration
 
    * - botoCfgPath
      - str
-     - Path to AWS credentials (if using S3 for remote storage)
-     - `<DEFAULT_USER_DIR> <https://github.com/Yelp/nrtsearch/blob/f612f5d3e14e468ab8c9b45dd4be0ab84231b9de/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java#L35>`_/boto.cfg
+     - Path to AWS credentials (if using S3 for remote storage); Will use the DefaultAWSCredentialsProviderChain if omitted.
+     - null
 
    * - archiveDirectory
      - str

--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -44,8 +44,6 @@ public class LuceneServerConfiguration {
       Paths.get(System.getProperty("user.home"), "lucene", "server");
   public static final Path DEFAULT_ARCHIVER_DIR =
       Paths.get(DEFAULT_USER_DIR.toString(), "archiver");
-  public static final Path DEFAULT_BOTO_CFG_PATH =
-      Paths.get(DEFAULT_USER_DIR.toString(), "boto.cfg");
   public static final Path DEFAULT_STATE_DIR =
       Paths.get(DEFAULT_USER_DIR.toString(), "default_state");
   public static final Path DEFAULT_INDEX_DIR =
@@ -137,7 +135,7 @@ public class LuceneServerConfiguration {
     stateDir = configReader.getString("stateDir", DEFAULT_STATE_DIR.toString());
     indexDir = configReader.getString("indexDir", DEFAULT_INDEX_DIR.toString());
     archiveDirectory = configReader.getString("archiveDirectory", DEFAULT_ARCHIVER_DIR.toString());
-    botoCfgPath = configReader.getString("botoCfgPath", DEFAULT_BOTO_CFG_PATH.toString());
+    botoCfgPath = configReader.getString("botoCfgPath", null);
     bucketName = configReader.getString("bucketName", DEFAULT_BUCKET_NAME);
     maxS3ClientRetries =
         configReader.getInteger("maxS3ClientRetries", DEFAULT_MAX_S3_CLIENT_RETRIES);


### PR DESCRIPTION
RP-10149

- Change the default `botoCfgPath` to be null
- Allow default credential chain when this value is null
- Enable global bucket access for loading the bucket region. This is needed for the latest java SDK to getBucketLocation from a different region. (learn from RP-10121)