### PR TITLE
Update Dockerfiles to use corretto 17 java

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,16 @@
-FROM azul/zulu-openjdk-debian:14
+FROM debian:12
 
 ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+    apt-get install -y wget gnupg2 software-properties-common
+
+RUN wget -O- https://apt.corretto.aws/corretto.key | apt-key add -
+RUN add-apt-repository -y 'deb https://apt.corretto.aws stable main'
+# For some reason, needs to be run again for the repo to be usable
+RUN add-apt-repository -y 'deb https://apt.corretto.aws stable main'
+RUN apt-get update && \
+    apt-get install -y java-17-amazon-corretto-jdk
 
 RUN mkdir /usr/app/
 COPY . /user/app/ 

--- a/grpc-gateway/Dockerfile
+++ b/grpc-gateway/Dockerfile
@@ -1,9 +1,17 @@
-FROM azul/zulu-openjdk-debian:14
+FROM debian:12
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y wget unzip htop \
     golang-go \
-    git
+    git \
+    gnupg2 software-properties-common
+
+RUN wget -O- https://apt.corretto.aws/corretto.key | apt-key add -
+RUN add-apt-repository -y 'deb https://apt.corretto.aws stable main'
+# For some reason, needs to be run again for the repo to be usable
+RUN add-apt-repository -y 'deb https://apt.corretto.aws stable main'
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y java-17-amazon-corretto-jdk
 
 # Install protoc
 ENV PROTOC_VERSION=3.11.4
@@ -44,6 +52,11 @@ RUN go get \
     github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v${GRPC_GATEWAY_VERSION} \
     github.com/golang/protobuf/protoc-gen-go@v${PROTOC_GEN_GO_VERSION} \
     google.golang.org/grpc@v${GRPC_VERSION}
+
+RUN go install \
+    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v${GRPC_GATEWAY_VERSION} \
+    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v${GRPC_GATEWAY_VERSION}
+RUN go install github.com/golang/protobuf/protoc-gen-go@v${PROTOC_GEN_GO_VERSION}
 
 ENV PROTO_PATH=/code/clientlib/src/main/proto
 ENV PROTO_BUILD_PATH=/code/clientlib/build


### PR DESCRIPTION
Backport change from `1.0.0-SNAPSHOT` branch. Use java corretto 17 in docker images.