### PR TITLE
Make client:sourcesJar depend on generateProto task

### DIFF
--- a/clientlib/build.gradle
+++ b/clientlib/build.gradle
@@ -95,6 +95,7 @@ task javadocsJar(type: Jar) {
 }
 
 task sourcesJar(type: Jar) {
+    dependsOn "generateProto"
     archiveClassifier = 'sources'
     from sourceSets.main.java.srcDirs
 }


### PR DESCRIPTION
./gradlew publish was throwing an error without this.

```
A problem was found with the configuration of task ':clientlib:sourcesJar' (type 'Jar').
  - Gradle detected a problem with the following location: '/Users/sarthakn/IdeaProjects/nrtsearch/clientlib/build/generated/source/proto/main/java'.
    
    Reason: Task ':clientlib:sourcesJar' uses this output of task ':clientlib:generateProto' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':clientlib:generateProto' as an input of ':clientlib:sourcesJar'.
      2. Declare an explicit dependency on ':clientlib:generateProto' from ':clientlib:sourcesJar' using Task#dependsOn.
      3. Declare an explicit dependency on ':clientlib:generateProto' from ':clientlib:sourcesJar' using Task#mustRunAfter.
```