### PR TITLE
Refactor verbose index metrics to search response metrics

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/LuceneServer.java
@@ -235,7 +235,7 @@ public class LuceneServer {
     new DirSizeCollector(globalState).register(collectorRegistry);
     new ProcStatCollector().register(collectorRegistry);
     new MergeSchedulerCollector(globalState).register(collectorRegistry);
-    new VerboseIndexCollector(globalState).register(collectorRegistry);
+    new SearchResponseCollector(globalState).register(collectorRegistry);
   }
 
   /** Main launches the server from the command line. */

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
@@ -45,7 +45,7 @@ import com.yelp.nrtsearch.server.luceneserver.search.SearchContext;
 import com.yelp.nrtsearch.server.luceneserver.search.SearchCutoffWrapper.CollectionTimeoutException;
 import com.yelp.nrtsearch.server.luceneserver.search.SearchRequestProcessor;
 import com.yelp.nrtsearch.server.luceneserver.search.SearcherResult;
-import com.yelp.nrtsearch.server.monitoring.VerboseIndexCollector;
+import com.yelp.nrtsearch.server.monitoring.SearchResponseCollector;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -290,9 +290,11 @@ public class SearchHandler implements Handler<SearchRequest, SearchResponse> {
     // if we are out of time, don't bother with serialization
     DeadlineUtils.checkDeadline("SearchHandler: end", diagnostics, "SEARCH");
     SearchResponse searchResponse = searchContext.getResponseBuilder().build();
-    if (!warming && searchContext.getIndexState().getVerboseMetrics()) {
-      VerboseIndexCollector.updateSearchResponseMetrics(
-          searchResponse, searchContext.getIndexState().getName());
+    if (!warming) {
+      SearchResponseCollector.updateSearchResponseMetrics(
+          searchResponse,
+          searchContext.getIndexState().getName(),
+          searchContext.getIndexState().getVerboseMetrics());
     }
     return searchResponse;
   }


### PR DESCRIPTION
Refactor the `VerboseIndexCollector` into the `SearchResponseCollector`.

This collector now always publishes the count of search timeouts and early terminations by index.

If verbose index metrics are enabled, it also publishes other `Summary` metrics related to the `SearchResponse`.