### PR TITLE
Add gradle task dependency to fix publish

### DIFF
--- a/clientlib/build.gradle
+++ b/clientlib/build.gradle
@@ -95,6 +95,7 @@ task javadocsJar(type: Jar) {
 }
 
 task sourcesJar(type: Jar) {
+    dependsOn "generateProto"
     archiveClassifier = 'sources'
     from sourceSets.main.java.srcDirs
 }


### PR DESCRIPTION
Executing the `publish` gradle task fails because of a missing task dependency.