### PR TITLE
Add protobuf dep to example-plugin test

### DIFF
--- a/example-plugin/build.gradle
+++ b/example-plugin/build.gradle
@@ -27,16 +27,21 @@ repositories {
 }
 
 ext {
+    assertjVersion = '3.19.0'
+    grpcVersion = "1.46.0"
+    junitVersion = "4.13.2"
     nrtsearchVersion = "0.+"
+    protobufVersion = "3.24.3"
 }
 
 dependencies {
     compileOnly "com.yelp.nrtsearch:server:${nrtsearchVersion}"
     testImplementation "com.yelp.nrtsearch:server:${nrtsearchVersion}"
     testImplementation("com.yelp.nrtsearch:server:${nrtsearchVersion}:tests")
-    testImplementation "junit:junit:4.13.2"
-    testImplementation "org.assertj:assertj-core:3.19.0"
-    testImplementation "io.grpc:grpc-testing:1.46.0"
+    testImplementation "junit:junit:${junitVersion}"
+    testImplementation "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation "io.grpc:grpc-testing:${grpcVersion}"
+    testImplementation "com.google.protobuf:protobuf-java:${protobufVersion}"
 }
 
 distributions {


### PR DESCRIPTION
Specify the protobuf library as an explicit test dependency for example-plugin to fix the failing test. I think the version resolution may have changed with the newer version of gradle.