### PR TITLE
Add metric for total acked copy data transfered

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/NrtMetrics.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/NrtMetrics.java
@@ -112,6 +112,13 @@ public class NrtMetrics {
           .labelNames("index")
           .create();
 
+  public static final Counter nrtAckedCopyMB =
+      Counter.build()
+          .name("nrt_acked_copy_mb")
+          .help("Total acked data copied.")
+          .labelNames("index")
+          .create();
+
   /**
    * Add all nrt metrics to the collector registry.
    *
@@ -129,5 +136,6 @@ public class NrtMetrics {
     registry.register(nrtMergeTime);
     registry.register(nrtMergeCopyStartCount);
     registry.register(nrtMergeCopyEndCount);
+    registry.register(nrtAckedCopyMB);
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/SimpleCopyJobTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/SimpleCopyJobTest.java
@@ -61,7 +61,7 @@ public class SimpleCopyJobTest {
 
     Throwable expectedError = new Throwable();
 
-    FileChunkStreamingIterator fcsi = new FileChunkStreamingIterator();
+    FileChunkStreamingIterator fcsi = new FileChunkStreamingIterator("test_index");
     fcsi.init(mockObserver);
     sendData(fcsi, 10, 5, 1);
     for (int i = 0; i < 5; ++i) {
@@ -94,7 +94,7 @@ public class SimpleCopyJobTest {
     ArgumentCaptor<FileInfo> inputCapture = ArgumentCaptor.forClass(FileInfo.class);
     doNothing().when(mockObserver).onNext(inputCapture.capture());
 
-    FileChunkStreamingIterator fcsi = new FileChunkStreamingIterator();
+    FileChunkStreamingIterator fcsi = new FileChunkStreamingIterator("test_index");
     fcsi.init(mockObserver);
     sendData(fcsi, chunkSize, numChunks, ackEvery);
     verifyData(fcsi, chunkSize, numChunks, ackEvery);
@@ -113,7 +113,7 @@ public class SimpleCopyJobTest {
     ArgumentCaptor<FileInfo> inputCapture = ArgumentCaptor.forClass(FileInfo.class);
     doNothing().when(mockObserver).onNext(inputCapture.capture());
 
-    FileChunkStreamingIterator fcsi = new FileChunkStreamingIterator();
+    FileChunkStreamingIterator fcsi = new FileChunkStreamingIterator("test_index");
     fcsi.init(mockObserver);
     sendData(fcsi, chunkSize, numChunks, ackEvery);
     fcsi.onCompleted();


### PR DESCRIPTION
Add metric to track the total amount of data moved through the acked copy functionality of index data streaming. The intent is to get some visibility into the data transfer speed.