### PR TITLE
Add ProportionalCopyThread

### DIFF
--- a/docs/server_configuration.rst
+++ b/docs/server_configuration.rst
@@ -116,6 +116,11 @@ Example server configuration
      - Enables gRPC deadline based cancellation of requests. A request is cancelled early if it exceeds the deadline. Currently only supported by the search endpoint.
      - false
 
+   * - lowPriorityCopyPercentage
+     - int
+     - Percentage of gRPC data copy cycles to give priority to low priority (merge pre copy) tasks. The remaining cycles give priority to high priority (nrt point) tasks, if present.
+     - 0
+
    * - plugins
      - list
      - List of plugins located in the ``pluginSearchPath`` to load

--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -113,6 +113,7 @@ public class LuceneServerConfiguration {
   private final boolean savePluginBeforeUnzip;
 
   private final boolean enableGlobalBucketAccess;
+  private final int lowPriorityCopyPercentage;
 
   @Inject
   public LuceneServerConfiguration(InputStream yamlStream) {
@@ -186,6 +187,7 @@ public class LuceneServerConfiguration {
         configReader.getBoolean("filterIncompatibleSegmentReaders", false);
     savePluginBeforeUnzip = configReader.getBoolean("savePluginBeforeUnzip", false);
     enableGlobalBucketAccess = configReader.getBoolean("enableGlobalBucketAccess", false);
+    lowPriorityCopyPercentage = configReader.getInteger("lowPriorityCopyPercentage", 0);
 
     List<String> indicesWithOverrides = configReader.getKeysOrEmpty("indexLiveSettingsOverrides");
     Map<String, IndexLiveSettings> liveSettingsMap = new HashMap<>();
@@ -380,6 +382,10 @@ public class LuceneServerConfiguration {
 
   public boolean getEnableGlobalBucketAccess() {
     return enableGlobalBucketAccess;
+  }
+
+  public int getLowPriorityCopyPercentage() {
+    return lowPriorityCopyPercentage;
   }
 
   public IndexLiveSettings getLiveSettingsOverride(String indexName) {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/ShardState.java
@@ -956,7 +956,8 @@ public class ShardState implements Closeable {
               verbose ? System.out : new PrintStream(OutputStream.nullOutputStream()),
               configuration.getFileCopyConfig().getAckedCopy(),
               configuration.getDecInitialCommit(),
-              configuration.getFilterIncompatibleSegmentReaders());
+              configuration.getFilterIncompatibleSegmentReaders(),
+              configuration.getLowPriorityCopyPercentage());
       if (primaryGen != -1) {
         nrtReplicaNode.start(primaryGen);
       } else {

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/nrt/DefaultCopyThread.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/nrt/DefaultCopyThread.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.nrt;
+
+import java.util.PriorityQueue;
+import org.apache.lucene.replicator.nrt.CopyJob;
+import org.apache.lucene.replicator.nrt.Node;
+
+/**
+ * Copy thread that uses a priority queue to manage copy jobs. High priority jobs are processed
+ * before low priority jobs.
+ */
+public class DefaultCopyThread extends NrtCopyThread {
+
+  private final PriorityQueue<CopyJob> queue = new PriorityQueue<>();
+
+  public DefaultCopyThread(Node node) {
+    super(node);
+  }
+
+  @Override
+  boolean hasJob() {
+    return !queue.isEmpty();
+  }
+
+  @Override
+  CopyJob getJob() {
+    return queue.poll();
+  }
+
+  @Override
+  void addJob(CopyJob job) {
+    queue.offer(job);
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/nrt/ProportionalCopyThread.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/nrt/ProportionalCopyThread.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.nrt;
+
+import java.util.PriorityQueue;
+import org.apache.lucene.replicator.nrt.CopyJob;
+import org.apache.lucene.replicator.nrt.Node;
+
+/**
+ * Copy thread that uses separate priority queues for high and low priority jobs. The value of
+ * lowPriorityCopyPercentage determines the proportion of times a low priority job is selected over
+ * a high priority job. For example, if lowPriorityCopyPercentage is 10, then a low priority job
+ * will be selected 10% of the time and a high priority job will be selected 90% of the time. If
+ * there are no high priority jobs, then a low priority job will always be selected.
+ */
+public class ProportionalCopyThread extends NrtCopyThread {
+  private final PriorityQueue<CopyJob> highPriorityQueue = new PriorityQueue<>();
+  private final PriorityQueue<CopyJob> lowPriorityQueue = new PriorityQueue<>();
+  private final int lowPriorityCopyPercentage;
+  private long counter = 0;
+
+  public ProportionalCopyThread(Node node, int lowPriorityCopyPercentage) {
+    super(node);
+    if (lowPriorityCopyPercentage < 0 || lowPriorityCopyPercentage > 100) {
+      throw new IllegalArgumentException(
+          "lowPriorityCopyPercentage must be between 0 and 100, inclusive. Got: "
+              + lowPriorityCopyPercentage);
+    }
+    this.lowPriorityCopyPercentage = lowPriorityCopyPercentage;
+  }
+
+  @Override
+  boolean hasJob() {
+    return !highPriorityQueue.isEmpty() || !lowPriorityQueue.isEmpty();
+  }
+
+  @Override
+  CopyJob getJob() {
+    CopyJob job;
+    if (counter++ % 100 < lowPriorityCopyPercentage) {
+      job = lowPriorityQueue.poll();
+      if (job != null) {
+        return job;
+      }
+    }
+    job = highPriorityQueue.poll();
+    if (job != null) {
+      return job;
+    }
+    return lowPriorityQueue.poll();
+  }
+
+  @Override
+  void addJob(CopyJob job) {
+    if (job.highPriority) {
+      highPriorityQueue.offer(job);
+    } else {
+      lowPriorityQueue.offer(job);
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/config/LuceneServerConfigurationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/LuceneServerConfigurationTest.java
@@ -180,4 +180,18 @@ public class LuceneServerConfigurationTest {
         IndexLiveSettings.newBuilder().build(),
         luceneConfig.getLiveSettingsOverride("test_index_3"));
   }
+
+  @Test
+  public void testLowPriorityCopyPercentage_default() {
+    String config = "nodeName: \"lucene_server_foo\"";
+    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    assertEquals(0, luceneConfig.getLowPriorityCopyPercentage());
+  }
+
+  @Test
+  public void testLowPriorityCopyPercentage_set() {
+    String config = "lowPriorityCopyPercentage: 10";
+    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    assertEquals(10, luceneConfig.getLowPriorityCopyPercentage());
+  }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/NrtReplicaNodeTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/NrtReplicaNodeTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver;
+
+import static org.junit.Assert.assertTrue;
+
+import com.yelp.nrtsearch.server.luceneserver.nrt.DefaultCopyThread;
+import com.yelp.nrtsearch.server.luceneserver.nrt.NrtCopyThread;
+import com.yelp.nrtsearch.server.luceneserver.nrt.ProportionalCopyThread;
+import org.junit.Test;
+
+public class NrtReplicaNodeTest {
+
+  @Test
+  public void testDefaultCopyThread() {
+    NrtCopyThread ct = NRTReplicaNode.getNrtCopyThread(null, 0);
+    assertTrue(ct instanceof DefaultCopyThread);
+  }
+
+  @Test
+  public void testProportionalCopyThread() {
+    NrtCopyThread ct = NRTReplicaNode.getNrtCopyThread(null, 15);
+    assertTrue(ct instanceof ProportionalCopyThread);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/nrt/DefaultCopyThreadTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/nrt/DefaultCopyThreadTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.nrt;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yelp.nrtsearch.server.luceneserver.SimpleCopyJob;
+import java.io.IOException;
+import java.util.Collections;
+import org.apache.lucene.replicator.nrt.CopyJob;
+import org.apache.lucene.replicator.nrt.ReplicaNode;
+import org.junit.Test;
+
+public class DefaultCopyThreadTest {
+  private CopyJob getJob(boolean highPriority) throws IOException {
+    ReplicaNode mockNode = mock(ReplicaNode.class);
+    when(mockNode.getFilesToCopy(null)).thenReturn(Collections.emptyList());
+    return new SimpleCopyJob("", null, null, mockNode, null, highPriority, null, "", true);
+  }
+
+  @Test
+  public void testHasJob_empty() {
+    DefaultCopyThread pct = new DefaultCopyThread(null);
+    assertFalse(pct.hasJob());
+  }
+
+  @Test
+  public void testHasJob() throws IOException {
+    DefaultCopyThread pct = new DefaultCopyThread(null);
+    CopyJob job = getJob(true);
+    pct.addJob(job);
+    assertTrue(pct.hasJob());
+  }
+
+  @Test
+  public void testOnlyHighPriority() throws IOException {
+    DefaultCopyThread pct = new DefaultCopyThread(null);
+    CopyJob job = getJob(true);
+    pct.addJob(job);
+
+    for (int i = 0; i < 100; i++) {
+      CopyJob nextJob = pct.getJob();
+      assertSame(nextJob, job);
+      pct.addJob(nextJob);
+    }
+  }
+
+  @Test
+  public void testOnlyLowPriority() throws IOException {
+    DefaultCopyThread pct = new DefaultCopyThread(null);
+    CopyJob job = getJob(false);
+    pct.addJob(job);
+
+    for (int i = 0; i < 100; i++) {
+      CopyJob nextJob = pct.getJob();
+      assertSame(nextJob, job);
+      pct.addJob(nextJob);
+    }
+  }
+
+  @Test
+  public void testMixedPriority() throws IOException {
+    DefaultCopyThread pct = new DefaultCopyThread(null);
+    CopyJob jobHigh = getJob(true);
+    CopyJob jobLow = getJob(false);
+    pct.addJob(jobHigh);
+    pct.addJob(jobLow);
+
+    for (int i = 0; i < 100; i++) {
+      CopyJob nextJob = pct.getJob();
+      assertSame(nextJob, jobHigh);
+      pct.addJob(nextJob);
+    }
+  }
+
+  @Test
+  public void testGetJob_empty() {
+    DefaultCopyThread pct = new DefaultCopyThread(null);
+    assertNull(pct.getJob());
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/nrt/ProportionalCopyThreadTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/nrt/ProportionalCopyThreadTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.nrt;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yelp.nrtsearch.server.luceneserver.SimpleCopyJob;
+import java.io.IOException;
+import java.util.Collections;
+import org.apache.lucene.replicator.nrt.CopyJob;
+import org.apache.lucene.replicator.nrt.ReplicaNode;
+import org.junit.Test;
+
+public class ProportionalCopyThreadTest {
+
+  private CopyJob getJob(boolean highPriority) throws IOException {
+    ReplicaNode mockNode = mock(ReplicaNode.class);
+    when(mockNode.getFilesToCopy(null)).thenReturn(Collections.emptyList());
+    return new SimpleCopyJob("", null, null, mockNode, null, highPriority, null, "", true);
+  }
+
+  @Test
+  public void testHasJob_empty() {
+    ProportionalCopyThread pct = new ProportionalCopyThread(null, 10);
+    assertFalse(pct.hasJob());
+  }
+
+  @Test
+  public void testHasJob_highPriority() throws IOException {
+    ProportionalCopyThread pct = new ProportionalCopyThread(null, 10);
+    CopyJob job = getJob(true);
+    pct.addJob(job);
+    assertTrue(pct.hasJob());
+  }
+
+  @Test
+  public void testHadJob_lowPriority() throws IOException {
+    ProportionalCopyThread pct = new ProportionalCopyThread(null, 10);
+    CopyJob job = getJob(false);
+    pct.addJob(job);
+    assertTrue(pct.hasJob());
+  }
+
+  @Test
+  public void testHadJob_mixedPriority() throws IOException {
+    ProportionalCopyThread pct = new ProportionalCopyThread(null, 10);
+    CopyJob jobHigh = getJob(true);
+    CopyJob jobLow = getJob(false);
+    pct.addJob(jobHigh);
+    pct.addJob(jobLow);
+    assertTrue(pct.hasJob());
+  }
+
+  @Test
+  public void testOnlyHighPriority() throws IOException {
+    ProportionalCopyThread pct = new ProportionalCopyThread(null, 10);
+    CopyJob job = getJob(true);
+    pct.addJob(job);
+
+    for (int i = 0; i < 1000; i++) {
+      CopyJob nextJob = pct.getJob();
+      assertSame(nextJob, job);
+      pct.addJob(nextJob);
+    }
+  }
+
+  @Test
+  public void testOnlyLowPriority() throws IOException {
+    ProportionalCopyThread pct = new ProportionalCopyThread(null, 10);
+    CopyJob job = getJob(false);
+    pct.addJob(job);
+
+    for (int i = 0; i < 1000; i++) {
+      CopyJob nextJob = pct.getJob();
+      assertSame(nextJob, job);
+      pct.addJob(nextJob);
+    }
+  }
+
+  @Test
+  public void testMixedPriority() throws IOException {
+    ProportionalCopyThread pct = new ProportionalCopyThread(null, 10);
+    CopyJob jobHigh = getJob(true);
+    CopyJob jobLow = getJob(false);
+    pct.addJob(jobHigh);
+    pct.addJob(jobLow);
+
+    int highCount = 0;
+    int lowCount = 0;
+    for (int i = 0; i < 1000; i++) {
+      CopyJob nextJob = pct.getJob();
+      if (nextJob == jobHigh) {
+        highCount++;
+      } else if (nextJob == jobLow) {
+        lowCount++;
+      } else {
+        fail();
+      }
+      pct.addJob(nextJob);
+    }
+    assertEquals(100, lowCount);
+    assertEquals(900, highCount);
+  }
+
+  @Test
+  public void testGetJob_empty() {
+    ProportionalCopyThread pct = new ProportionalCopyThread(null, 10);
+    assertNull(pct.getJob());
+  }
+
+  @Test
+  public void testLowPercentage() {
+    try {
+      new ProportionalCopyThread(null, -1);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals(
+          "lowPriorityCopyPercentage must be between 0 and 100, inclusive. Got: -1",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testHighPercentage() {
+    try {
+      new ProportionalCopyThread(null, 101);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals(
+          "lowPriorityCopyPercentage must be between 0 and 100, inclusive. Got: 101",
+          e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
The status quo copy thread processes chunks of data from queued copy jobs, starting with those of high priority (nrt point data). It seems that under high indexing load, this slows down the processing of merge pre copy data.

I refactored the current copy thread, and added an implementation that gives priority to low priority tasks a given percentage of time. This can let merges make progress more consistently, and may help smooth out the merge rate under indexing load.

The default value is 0%, which uses the status quo single job queue implementation. 