### PR TITLE
Add span near query support to Nrtsearch

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -404,10 +404,9 @@ message ConstantScoreQuery {
 
 // Wrapper message for different types of SpanQuery
 message SpanQuery {
-  string field = 1;
   oneof query {
-    TermQuery spanTermQuery = 3;
-    SpanNearQuery spanNearQuery = 4;
+    TermQuery spanTermQuery = 1;
+    SpanNearQuery spanNearQuery = 2;
     // Add other SpanQuery types as needed
   }
 }
@@ -446,7 +445,7 @@ enum QueryType {
     PREFIX = 19;
     CONSTANT_SCORE_QUERY = 20;
     GEO_POLYGON = 21;
-    SPAN_NEAR_QUERY = 22;
+    SPAN_QUERY = 22;
 }
 
 // Defines a full query consisting of a QueryNode which may be one of several types.
@@ -477,7 +476,7 @@ message Query {
         PrefixQuery prefixQuery = 22;
         ConstantScoreQuery constantScoreQuery = 23;
         GeoPolygonQuery geoPolygonQuery = 24;
-        SpanNearQuery spanNearQuery = 25;
+        SpanQuery spanQuery = 25;
     }
 }
 

--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -402,6 +402,26 @@ message ConstantScoreQuery {
     Query filter = 1;
 }
 
+// Wrapper message for different types of SpanQuery
+message SpanQuery {
+  string field = 1;
+  oneof query {
+    TermQuery spanTermQuery = 3;
+    SpanNearQuery spanNearQuery = 4;
+    // Add other SpanQuery types as needed
+  }
+}
+
+// A query that matches documents containing terms within a specified range.
+message SpanNearQuery {
+    // Clauses for a span near query.
+    repeated SpanQuery clauses = 1;
+    // Maximum number of positions between matching terms.
+    int32 slop = 2;
+    // True if the matching terms must be in the same order as the query.
+    bool inOrder = 3;
+}
+
 // Defines different types of QueryNodes.
 enum QueryType {
     NONE = 0;
@@ -426,6 +446,7 @@ enum QueryType {
     PREFIX = 19;
     CONSTANT_SCORE_QUERY = 20;
     GEO_POLYGON = 21;
+    SPAN_NEAR_QUERY = 22;
 }
 
 // Defines a full query consisting of a QueryNode which may be one of several types.
@@ -456,6 +477,7 @@ message Query {
         PrefixQuery prefixQuery = 22;
         ConstantScoreQuery constantScoreQuery = 23;
         GeoPolygonQuery geoPolygonQuery = 24;
+        SpanNearQuery spanNearQuery = 25;
     }
 }
 

--- a/grpc-gateway/luceneserver.swagger.json
+++ b/grpc-gateway/luceneserver.swagger.json
@@ -2702,6 +2702,16 @@
       },
       "description": "Query that produces a score of 1.0 (modifiable by query boost value) for documents that match the filter query."
     },
+    "luceneserverSpanNearQuery": {
+      "type": "object",
+      "properties": {
+        "filter": {
+          "$ref": "#/definitions/luceneserverQuery",
+          "title": "Query to determine matching documents within the span"
+        }
+      },
+      "description": "search for documents where the specified terms are within a certain distance from each other"
+    },
     "luceneserverCopyState": {
       "type": "object",
       "properties": {
@@ -4490,6 +4500,9 @@
         },
         "geoPolygonQuery": {
           "$ref": "#/definitions/luceneserverGeoPolygonQuery"
+        },
+        "spanNearQuery": {
+          "$ref": "#/definitions/luceneserverSpanNearQuery"
         }
       },
       "description": "Defines a full query consisting of a QueryNode which may be one of several types."
@@ -4549,7 +4562,8 @@
         "MATCH_PHRASE_PREFIX",
         "PREFIX",
         "CONSTANT_SCORE_QUERY",
-        "GEO_POLYGON"
+        "GEO_POLYGON",
+        "SPAN_NEAR_QUERY"
       ],
       "default": "NONE",
       "description": "Defines different types of QueryNodes."

--- a/grpc-gateway/luceneserver.swagger.json
+++ b/grpc-gateway/luceneserver.swagger.json
@@ -2702,7 +2702,7 @@
       },
       "description": "Query that produces a score of 1.0 (modifiable by query boost value) for documents that match the filter query."
     },
-    "luceneserverSpanNearQuery": {
+    "luceneserverSpanQuery": {
       "type": "object",
       "properties": {
         "filter": {
@@ -4501,8 +4501,8 @@
         "geoPolygonQuery": {
           "$ref": "#/definitions/luceneserverGeoPolygonQuery"
         },
-        "spanNearQuery": {
-          "$ref": "#/definitions/luceneserverSpanNearQuery"
+        "spanQuery": {
+          "$ref": "#/definitions/luceneserverSpanQuery"
         }
       },
       "description": "Defines a full query consisting of a QueryNode which may be one of several types."
@@ -4563,7 +4563,7 @@
         "PREFIX",
         "CONSTANT_SCORE_QUERY",
         "GEO_POLYGON",
-        "SPAN_NEAR_QUERY"
+        "SPAN_QUERY"
       ],
       "default": "NONE",
       "description": "Defines different types of QueryNodes."

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
@@ -17,20 +17,8 @@ package com.yelp.nrtsearch.server.luceneserver;
 
 import static com.yelp.nrtsearch.server.luceneserver.analysis.AnalyzerCreator.isAnalyzerDefined;
 
-import com.yelp.nrtsearch.server.grpc.ExistsQuery;
-import com.yelp.nrtsearch.server.grpc.FunctionFilterQuery;
-import com.yelp.nrtsearch.server.grpc.GeoBoundingBoxQuery;
-import com.yelp.nrtsearch.server.grpc.GeoPointQuery;
-import com.yelp.nrtsearch.server.grpc.GeoPolygonQuery;
-import com.yelp.nrtsearch.server.grpc.GeoRadiusQuery;
-import com.yelp.nrtsearch.server.grpc.MatchOperator;
-import com.yelp.nrtsearch.server.grpc.MatchPhraseQuery;
-import com.yelp.nrtsearch.server.grpc.MatchQuery;
-import com.yelp.nrtsearch.server.grpc.MultiMatchQuery;
+import com.yelp.nrtsearch.server.grpc.*;
 import com.yelp.nrtsearch.server.grpc.MultiMatchQuery.MatchType;
-import com.yelp.nrtsearch.server.grpc.PrefixQuery;
-import com.yelp.nrtsearch.server.grpc.RangeQuery;
-import com.yelp.nrtsearch.server.grpc.RewriteMethod;
 import com.yelp.nrtsearch.server.luceneserver.analysis.AnalyzerCreator;
 import com.yelp.nrtsearch.server.luceneserver.doc.DocLookup;
 import com.yelp.nrtsearch.server.luceneserver.field.FieldDef;
@@ -74,6 +62,9 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.join.QueryBitSetProducer;
 import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.search.join.ToParentBlockJoinQuery;
+import org.apache.lucene.search.spans.SpanNearQuery;
+import org.apache.lucene.search.spans.SpanQuery;
+import org.apache.lucene.search.spans.SpanTermQuery;
 import org.apache.lucene.search.suggest.document.CompletionQuery;
 import org.apache.lucene.search.suggest.document.FuzzyCompletionQuery;
 import org.apache.lucene.search.suggest.document.MyContextQuery;
@@ -177,6 +168,8 @@ public class QueryNodeMapper {
         return getPrefixQuery(query.getPrefixQuery(), state);
       case CONSTANTSCOREQUERY:
         return getConstantScoreQuery(query.getConstantScoreQuery(), state, docLookup);
+      case SPANNEARQUERY:
+        return getSpanNearQuery(query.getSpanNearQuery());
       case GEOPOLYGONQUERY:
         return getGeoPolygonQuery(query.getGeoPolygonQuery(), state);
       case QUERYNODE_NOT_SET:
@@ -642,5 +635,37 @@ public class QueryNodeMapper {
       DocLookup docLookup) {
     Query filterQuery = getQuery(constantScoreQueryGrpc.getFilter(), indexState, docLookup);
     return new ConstantScoreQuery(filterQuery);
+  }
+
+  private SpanNearQuery getSpanNearQuery(
+      com.yelp.nrtsearch.server.grpc.SpanNearQuery protoSpanNearQuery) {
+    List<SpanQuery> clauses = new ArrayList<>();
+
+    for (com.yelp.nrtsearch.server.grpc.SpanQuery protoClause :
+        protoSpanNearQuery.getClausesList()) {
+      SpanQuery luceneClause = convertToLuceneSpanQuery(protoClause);
+      if (luceneClause != null) {
+        clauses.add(luceneClause);
+      }
+    }
+
+    SpanQuery[] clausesArray = clauses.toArray(new SpanQuery[0]);
+    int slop = protoSpanNearQuery.getSlop();
+    boolean inOrder = protoSpanNearQuery.getInOrder();
+
+    return new SpanNearQuery(clausesArray, slop, inOrder);
+  }
+
+  private SpanQuery convertToLuceneSpanQuery(
+      com.yelp.nrtsearch.server.grpc.SpanQuery protoSpanQuery) {
+    com.yelp.nrtsearch.server.grpc.TermQuery termQuery = protoSpanQuery.getSpanTermQuery();
+    if (termQuery != null) {
+      return new SpanTermQuery(new Term(termQuery.getField(), termQuery.getTextValue()));
+    }
+    com.yelp.nrtsearch.server.grpc.SpanNearQuery spanNearQuery = protoSpanQuery.getSpanNearQuery();
+    if (spanNearQuery != null) {
+      return getSpanNearQuery(spanNearQuery);
+    }
+    throw new IllegalArgumentException("Unsupported Span Query: " + protoSpanQuery);
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/query/SpanNearQueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/query/SpanNearQueryTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2023 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.search.query;
+
+import static org.junit.Assert.assertEquals;
+
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest.MultiValuedField;
+import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
+import com.yelp.nrtsearch.server.grpc.Query;
+import com.yelp.nrtsearch.server.grpc.SearchRequest;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import com.yelp.nrtsearch.server.grpc.SearchResponse.Hit;
+import com.yelp.nrtsearch.server.grpc.SpanNearQuery;
+import com.yelp.nrtsearch.server.grpc.SpanQuery;
+import com.yelp.nrtsearch.server.grpc.TermQuery;
+import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class SpanNearQueryTest extends ServerTestCase {
+  @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  protected List<String> getIndices() {
+    return Collections.singletonList(DEFAULT_TEST_INDEX);
+  }
+
+  protected FieldDefRequest getIndexDef(String name) throws IOException {
+    return getFieldsFromResourceFile("/search/query/registerFieldsSpanNearQuery.json");
+  }
+
+  protected void initIndex(String name) throws Exception {
+    List<String> textValues =
+        List.of(
+            "The quick brown fox jumps over the lazy dog",
+            "The quick brown fox jumps over the quick lazy dog",
+            "The quick brown fox jumps over the lazy fox");
+    List<AddDocumentRequest> docs = new ArrayList<>();
+    int index = 0;
+    for (String textValue : textValues) {
+      AddDocumentRequest request =
+          AddDocumentRequest.newBuilder()
+              .setIndexName(name)
+              .putFields(
+                  "doc_id", MultiValuedField.newBuilder().addValue(Integer.toString(index)).build())
+              .putFields("text_field", MultiValuedField.newBuilder().addValue(textValue).build())
+              .build();
+      docs.add(request);
+      index++;
+    }
+    addDocuments(docs.stream());
+  }
+
+  private SearchRequest getSearchRequest(SpanNearQuery spanNearQuery) {
+    return SearchRequest.newBuilder()
+        .setIndexName(DEFAULT_TEST_INDEX)
+        .setTopHits(10)
+        .addRetrieveFields("doc_id")
+        .setQuery(Query.newBuilder().setSpanNearQuery(spanNearQuery).build())
+        .build();
+  }
+
+  @Test
+  public void testNearSpanQuery() {
+    SpanNearQuery spanNearQuery =
+        SpanNearQuery.newBuilder()
+            .addClauses(
+                SpanQuery.newBuilder()
+                    .setField("text_field")
+                    .setSpanTermQuery(
+                        TermQuery.newBuilder().setField("text_field").setTextValue("jumps").build())
+                    .build())
+            .addClauses(
+                SpanQuery.newBuilder()
+                    .setField("text_field")
+                    .setSpanTermQuery(
+                        TermQuery.newBuilder().setField("text_field").setTextValue("dog").build())
+                    .build())
+            .setSlop(3)
+            .setInOrder(true)
+            .build();
+
+    SearchResponse response =
+        getGrpcServer().getBlockingStub().search(getSearchRequest(spanNearQuery));
+
+    assertIds(response, 0);
+  }
+
+  @Test
+  public void testNearSpanQueryOrderFalse() {
+    SpanNearQuery spanNearQuery =
+        SpanNearQuery.newBuilder()
+            .addClauses(
+                SpanQuery.newBuilder()
+                    .setField("text_field")
+                    .setSpanTermQuery(
+                        TermQuery.newBuilder().setField("text_field").setTextValue("dog").build())
+                    .build())
+            .addClauses(
+                SpanQuery.newBuilder()
+                    .setField("text_field")
+                    .setSpanTermQuery(
+                        TermQuery.newBuilder().setField("text_field").setTextValue("jumps").build())
+                    .build())
+            .setSlop(4)
+            .setInOrder(false)
+            .build();
+
+    SearchResponse response =
+        getGrpcServer().getBlockingStub().search(getSearchRequest(spanNearQuery));
+
+    assertIds(response, 0, 1);
+  }
+
+  @Test
+  public void testNearSpanQueryOrderTrueNoResults() {
+    SpanNearQuery spanNearQuery =
+        SpanNearQuery.newBuilder()
+            .addClauses(
+                SpanQuery.newBuilder()
+                    .setField("text_field")
+                    .setSpanTermQuery(
+                        TermQuery.newBuilder().setField("text_field").setTextValue("jumps").build())
+                    .build())
+            .addClauses(
+                SpanQuery.newBuilder()
+                    .setField("text_field")
+                    .setSpanTermQuery(
+                        TermQuery.newBuilder().setField("text_field").setTextValue("dog").build())
+                    .build())
+            .setSlop(2)
+            .setInOrder(true)
+            .build();
+
+    SearchResponse response =
+        getGrpcServer().getBlockingStub().search(getSearchRequest(spanNearQuery));
+
+    assertEquals(0, response.getHitsCount());
+  }
+
+  private void assertIds(SearchResponse response, int... ids) {
+    Set<Integer> uniqueIds = new HashSet<>();
+    for (int id : ids) {
+      uniqueIds.add(id);
+    }
+    assertEquals(uniqueIds.size(), response.getHitsCount());
+
+    Set<Integer> responseIds = new HashSet<>();
+    for (Hit hit : response.getHitsList()) {
+      responseIds.add(
+          Integer.parseInt(hit.getFieldsOrThrow("doc_id").getFieldValue(0).getTextValue()));
+    }
+    assertEquals(uniqueIds, responseIds);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/query/SpanNearQueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/query/SpanNearQueryTest.java
@@ -71,12 +71,12 @@ public class SpanNearQueryTest extends ServerTestCase {
     addDocuments(docs.stream());
   }
 
-  private SearchRequest getSearchRequest(SpanNearQuery spanNearQuery) {
+  private SearchRequest getSearchRequest(SpanQuery spanQuery) {
     return SearchRequest.newBuilder()
         .setIndexName(DEFAULT_TEST_INDEX)
         .setTopHits(10)
         .addRetrieveFields("doc_id")
-        .setQuery(Query.newBuilder().setSpanNearQuery(spanNearQuery).build())
+        .setQuery(Query.newBuilder().setSpanQuery(spanQuery).build())
         .build();
   }
 
@@ -86,13 +86,11 @@ public class SpanNearQueryTest extends ServerTestCase {
         SpanNearQuery.newBuilder()
             .addClauses(
                 SpanQuery.newBuilder()
-                    .setField("text_field")
                     .setSpanTermQuery(
                         TermQuery.newBuilder().setField("text_field").setTextValue("jumps").build())
                     .build())
             .addClauses(
                 SpanQuery.newBuilder()
-                    .setField("text_field")
                     .setSpanTermQuery(
                         TermQuery.newBuilder().setField("text_field").setTextValue("dog").build())
                     .build())
@@ -100,8 +98,10 @@ public class SpanNearQueryTest extends ServerTestCase {
             .setInOrder(true)
             .build();
 
+    SpanQuery outerSpanQuery = SpanQuery.newBuilder().setSpanNearQuery(spanNearQuery).build();
+
     SearchResponse response =
-        getGrpcServer().getBlockingStub().search(getSearchRequest(spanNearQuery));
+        getGrpcServer().getBlockingStub().search(getSearchRequest(outerSpanQuery));
 
     assertIds(response, 0);
   }
@@ -112,13 +112,11 @@ public class SpanNearQueryTest extends ServerTestCase {
         SpanNearQuery.newBuilder()
             .addClauses(
                 SpanQuery.newBuilder()
-                    .setField("text_field")
                     .setSpanTermQuery(
                         TermQuery.newBuilder().setField("text_field").setTextValue("dog").build())
                     .build())
             .addClauses(
                 SpanQuery.newBuilder()
-                    .setField("text_field")
                     .setSpanTermQuery(
                         TermQuery.newBuilder().setField("text_field").setTextValue("jumps").build())
                     .build())
@@ -126,8 +124,10 @@ public class SpanNearQueryTest extends ServerTestCase {
             .setInOrder(false)
             .build();
 
+    SpanQuery outerSpanQuery = SpanQuery.newBuilder().setSpanNearQuery(spanNearQuery).build();
+
     SearchResponse response =
-        getGrpcServer().getBlockingStub().search(getSearchRequest(spanNearQuery));
+        getGrpcServer().getBlockingStub().search(getSearchRequest(outerSpanQuery));
 
     assertIds(response, 0, 1);
   }
@@ -138,22 +138,21 @@ public class SpanNearQueryTest extends ServerTestCase {
         SpanNearQuery.newBuilder()
             .addClauses(
                 SpanQuery.newBuilder()
-                    .setField("text_field")
                     .setSpanTermQuery(
                         TermQuery.newBuilder().setField("text_field").setTextValue("jumps").build())
                     .build())
             .addClauses(
                 SpanQuery.newBuilder()
-                    .setField("text_field")
                     .setSpanTermQuery(
                         TermQuery.newBuilder().setField("text_field").setTextValue("dog").build())
                     .build())
             .setSlop(2)
             .setInOrder(true)
             .build();
+    SpanQuery outerSpanQuery = SpanQuery.newBuilder().setSpanNearQuery(spanNearQuery).build();
 
     SearchResponse response =
-        getGrpcServer().getBlockingStub().search(getSearchRequest(spanNearQuery));
+        getGrpcServer().getBlockingStub().search(getSearchRequest(outerSpanQuery));
 
     assertEquals(0, response.getHitsCount());
   }

--- a/src/test/resources/search/query/registerFieldsSpanNearQuery.json
+++ b/src/test/resources/search/query/registerFieldsSpanNearQuery.json
@@ -1,0 +1,19 @@
+{
+  "indexName": "test_index",
+  "field": [
+    {
+      "name": "doc_id",
+      "type": "_ID",
+      "search": true,
+      "storeDocValues": true
+    },
+    {
+      "name": "text_field",
+      "type": "TEXT",
+      "search": true,
+      "tokenize": true,
+      "multiValued": true,
+      "storeDocValues": true
+    }
+  ]
+}


### PR DESCRIPTION
There's a whole bunch of other Span queries that can be nested inside a SnapNearQuery: https://lucene.apache.org/core/8_7_0/core/index.html?org/apache/lucene/search/spans/SpanNearQuery.html

They are not in the requirements to support for now. We can add them whenever they are needed.