### PR TITLE
Verify index id for replication by default

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java
@@ -189,7 +189,7 @@ public class LuceneServerConfiguration {
     savePluginBeforeUnzip = configReader.getBoolean("savePluginBeforeUnzip", false);
     enableGlobalBucketAccess = configReader.getBoolean("enableGlobalBucketAccess", false);
     lowPriorityCopyPercentage = configReader.getInteger("lowPriorityCopyPercentage", 0);
-    verifyReplicationIndexId = configReader.getBoolean("verifyReplicationIndexId", false);
+    verifyReplicationIndexId = configReader.getBoolean("verifyReplicationIndexId", true);
 
     List<String> indicesWithOverrides = configReader.getKeysOrEmpty("indexLiveSettingsOverrides");
     Map<String, IndexLiveSettings> liveSettingsMap = new HashMap<>();

--- a/src/test/java/com/yelp/nrtsearch/server/config/LuceneServerConfigurationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/LuceneServerConfigurationTest.java
@@ -199,13 +199,13 @@ public class LuceneServerConfigurationTest {
   public void testVerifyReplicationIndexId_default() {
     String config = "nodeName: \"lucene_server_foo\"";
     LuceneServerConfiguration luceneConfig = getForConfig(config);
-    assertFalse(luceneConfig.getVerifyReplicationIndexId());
+    assertTrue(luceneConfig.getVerifyReplicationIndexId());
   }
 
   @Test
   public void testVerifyReplicationIndexId_set() {
-    String config = "verifyReplicationIndexId: true";
+    String config = "verifyReplicationIndexId: false";
     LuceneServerConfiguration luceneConfig = getForConfig(config);
-    assertTrue(luceneConfig.getVerifyReplicationIndexId());
+    assertFalse(luceneConfig.getVerifyReplicationIndexId());
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/GrpcServer.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/GrpcServer.java
@@ -265,9 +265,7 @@ public class GrpcServer {
       // Create a server, add service, start, and register for automatic graceful shutdown.
       Server server =
           ServerBuilder.forPort(port)
-              .addService(
-                  new LuceneServer.ReplicationServerImpl(
-                      globalState, configuration.getVerifyReplicationIndexId()))
+              .addService(new LuceneServer.ReplicationServerImpl(globalState, false))
               .compressorRegistry(LuceneServerStubBuilder.COMPRESSOR_REGISTRY)
               .decompressorRegistry(LuceneServerStubBuilder.DECOMPRESSOR_REGISTRY)
               .build()

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/TestServer.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/TestServer.java
@@ -50,6 +50,7 @@ import com.yelp.nrtsearch.server.grpc.SearchResponse.Hit;
 import com.yelp.nrtsearch.server.luceneserver.GlobalState;
 import com.yelp.nrtsearch.server.luceneserver.IndexState;
 import com.yelp.nrtsearch.server.luceneserver.ShardState;
+import com.yelp.nrtsearch.server.luceneserver.index.IndexStateManager;
 import com.yelp.nrtsearch.server.utils.FileUtil;
 import io.findify.s3mock.S3Mock;
 import io.grpc.Server;
@@ -604,7 +605,8 @@ public class TestServer {
   }
 
   public void registerWithPrimary(String indexName, long timeoutMs) throws IOException {
-    ShardState shardState = getGlobalState().getIndex(indexName).getShard(0);
+    IndexStateManager indexStateManager = getGlobalState().getIndexStateManager(indexName);
+    ShardState shardState = indexStateManager.getCurrent().getShard(0);
     if (!shardState.isReplica()) {
       throw new IllegalStateException("Must be called on replica index");
     }
@@ -613,6 +615,7 @@ public class TestServer {
         AddReplicaRequest.newBuilder()
             .setMagicNumber(BINARY_MAGIC)
             .setIndexName(indexName)
+            .setIndexId(indexStateManager.getIndexId())
             .setReplicaId(ShardState.REPLICA_ID)
             .setHostName("localhost")
             .setPort(getGlobalState().getReplicationPort())

--- a/src/test/resources/yelp_reviews/primary/lucene_server_configuration.yaml
+++ b/src/test/resources/yelp_reviews/primary/lucene_server_configuration.yaml
@@ -8,3 +8,4 @@ threadPoolConfiguration:
   maxSearchingThreads: 4
   maxIndexingThreads: 18
 fileSendDelay: false
+verifyReplicationIndexId: false

--- a/src/test/resources/yelp_reviews/replica/lucene_server_configuration.yaml
+++ b/src/test/resources/yelp_reviews/replica/lucene_server_configuration.yaml
@@ -7,3 +7,4 @@ indexDir: "replica_index_base"
 threadPoolConfiguration:
   maxSearchingThreads: 16
   maxIndexingThreads: 4
+verifyReplicationIndexId: false


### PR DESCRIPTION
Change the default value for `verifyReplicationIndexId` to `true`. Fix issues in tests.