### PR TITLE
Use more strict string check for metadata name matching

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexBackupUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexBackupUtils.java
@@ -37,7 +37,7 @@ public class IndexBackupUtils {
   }
 
   public static boolean isMetadata(String resourceName) {
-    return resourceName.contains("_metadata");
+    return resourceName.endsWith("_metadata");
   }
 
   public static boolean isBackendGlobalState(String resourceName) {


### PR DESCRIPTION
Using `contains` means this will match an index that contains `_metadata` as part of its name. Making the match more strict to avoid false positives.