### PR TITLE
Remove optional from proto definitions

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -444,13 +444,13 @@ message FuzzyQuery {
     string field = 1;
     string text = 2;
     // The maximum allowed Levenshtein Edit Distance (or number of edits). Possible values are 0, 1 and 2. Either set this or auto. Default is 2.
-    optional int32 maxEdits = 3;
+    int32 maxEdits = 3;
     // Length of common (non-fuzzy) prefix. Default is 0.
-    optional int32 prefixLength = 4;
+    int32 prefixLength = 4;
     // The maximum number of terms to match. Default is 50.
-    optional int32 maxExpansions = 5;
+    int32 maxExpansions = 5;
     // True if transpositions should be treated as a primitive edit operation. If this is false, comparisons will implement the classic Levenshtein algorithm. Default is true.
-    optional bool transpositions = 6;
+    bool transpositions = 6;
     // Method used to rewrite the query.
     RewriteMethod rewrite = 7;
     // Specifies the size to use for the TOP_TERMS* rewrite methods.
@@ -496,7 +496,7 @@ message RegexpQuery {
     // Optional flags for the regular expression
     RegexpFlag flag = 3;
     // maximum number of states that compiling the automaton for the regexp can result in. Set higher to allow more complex queries and lower to prevent memory exhaustion. Default is 10000.
-    optional int32 maxDeterminizedStates = 4;
+    int32 maxDeterminizedStates = 4;
     // Method used to rewrite the query.
     RewriteMethod rewrite = 5;
     // Specifies the size to use for the TOP_TERMS* rewrite methods.

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/QueryNodeMapper.java
@@ -720,23 +720,23 @@ public class QueryNodeMapper {
     Term term = new Term(protoFuzzyQuery.getField(), protoFuzzyQuery.getText());
 
     int maxEdits =
-        protoFuzzyQuery.hasMaxEdits() ? protoFuzzyQuery.getMaxEdits() : FuzzyQuery.defaultMaxEdits;
+        protoFuzzyQuery.getMaxEdits() != 0
+            ? protoFuzzyQuery.getMaxEdits()
+            : FuzzyQuery.defaultMaxEdits;
 
     int prefixLength =
-        protoFuzzyQuery.hasPrefixLength()
+        protoFuzzyQuery.getPrefixLength() != 0
             ? protoFuzzyQuery.getPrefixLength()
             : FuzzyQuery.defaultPrefixLength;
 
     int maxExpansions =
-        protoFuzzyQuery.hasMaxExpansions()
+        protoFuzzyQuery.getMaxExpansions() != 0
             ? protoFuzzyQuery.getMaxExpansions()
             : FuzzyQuery.defaultMaxExpansions;
 
+    // TODO: Use optional field and fix the default value setting.
     // Set the default transpositions to true, if it is not provided.
-    boolean transpositions =
-        protoFuzzyQuery.hasTranspositions()
-            ? protoFuzzyQuery.getTranspositions()
-            : FuzzyQuery.defaultTranspositions;
+    boolean transpositions = protoFuzzyQuery.getTranspositions();
 
     FuzzyQuery fuzzyQuery =
         new FuzzyQuery(term, maxEdits, prefixLength, maxExpansions, transpositions);
@@ -767,7 +767,7 @@ public class QueryNodeMapper {
         };
 
     int maxDeterminizedStates =
-        protoRegexpQuery.hasMaxDeterminizedStates()
+        protoRegexpQuery.getMaxDeterminizedStates() != 0
             ? protoRegexpQuery.getMaxDeterminizedStates()
             : Operations.DEFAULT_MAX_DETERMINIZED_STATES;
 


### PR DESCRIPTION
grpc-gateway is using verison `3.11.4` of protoc, which doesn't support `optional` fields. The support for optional field was only added in version `3.12`. This causes the build to fail.

I'm removing all the optional fields that I added earlier to get the build working and unblock others as a short term quick solution. There's an issue with setting default values for boolean fields to `true` and an issue if the value of the default is something other than `0`. I think using `optional` is the best way to handle such cases. That's why I will try to get the `grpc-gateway` working with the `3.12` proto as a long term solution so that we can use it to handle default values for different object types.