### PR TITLE
Make sorted the default docvalue type for atom fields

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
@@ -534,7 +534,9 @@ enum FacetType {
 
 enum TextDocValuesType {
     TEXT_DOC_VALUES_TYPE_UNSPECIFIED = 0;
+    // Binary docvalues support text longer than 32766 bytes and are good when most values are unique or you need to use aggregations on the field.
     TEXT_DOC_VALUES_TYPE_BINARY = 1;
+    // Sorted docvalues only store values shorter than 32766 bytes and are better when most values are not unique.
     TEXT_DOC_VALUES_TYPE_SORTED = 2;
 }
 
@@ -577,7 +579,7 @@ message Field {
     string vectorSimilarity = 31;
     // Indexing options for search enabled VECTOR field type. This is optional, defaulting to HNSW with m=16, ef_construction=100 when not set.
     VectorIndexingOptions vectorIndexingOptions = 32;
-    //  Specify docvalues type for TEXT/ATOM field types. This is optional, defaulting to SORTED for TEXT and BINARY for ATOM when not set. Multivalued fields will always use SORTED_SET.
+    //  Specify docvalues type for TEXT/ATOM field types. This is optional, defaulting to SORTED when not set. Multivalued fields will always use SORTED_SET.
     TextDocValuesType textDocValuesType = 33;
 }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/AtomFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/AtomFieldDef.java
@@ -19,12 +19,10 @@ import static com.yelp.nrtsearch.server.luceneserver.analysis.AnalyzerCreator.ha
 
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.SortType;
-import com.yelp.nrtsearch.server.grpc.TextDocValuesType;
 import com.yelp.nrtsearch.server.luceneserver.field.properties.Sortable;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.document.FieldType;
-import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedSetSortField;
@@ -56,21 +54,6 @@ public class AtomFieldDef extends TextBaseFieldDef implements Sortable {
   @Override
   public String getType() {
     return "ATOM";
-  }
-
-  @Override
-  protected DocValuesType parseDocValuesType(Field requestField) {
-    if (!requestField.getStoreDocValues()) {
-      return DocValuesType.NONE;
-    }
-    if (requestField.getMultiValued()) {
-      // Binary doc values are not supported for multivalued fields
-      return DocValuesType.SORTED_SET;
-    }
-    if (requestField.getTextDocValuesType() == TextDocValuesType.TEXT_DOC_VALUES_TYPE_SORTED) {
-      return DocValuesType.SORTED;
-    }
-    return DocValuesType.BINARY;
   }
 
   @Override

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/AtomFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/AtomFieldDefTest.java
@@ -19,9 +19,11 @@ import static org.junit.Assert.assertEquals;
 
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.Field;
+import com.yelp.nrtsearch.server.grpc.TextDocValuesType;
 import com.yelp.nrtsearch.server.luceneserver.similarity.SimilarityCreator;
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
+import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -103,5 +105,39 @@ public class AtomFieldDefTest {
     assertEquals(
         IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS,
         fieldDef.getFieldType().indexOptions());
+  }
+
+  @Test
+  public void testDocValueType_none() {
+    AtomFieldDef fieldDef = createFieldDef(Field.newBuilder().setStoreDocValues(false).build());
+    assertEquals(DocValuesType.NONE, fieldDef.getDocValuesType());
+  }
+
+  @Test
+  public void testDocValueType_default() {
+    AtomFieldDef fieldDef = createFieldDef(Field.newBuilder().setStoreDocValues(true).build());
+    assertEquals(DocValuesType.SORTED, fieldDef.getDocValuesType());
+  }
+
+  @Test
+  public void testDocValueType_sorted() {
+    AtomFieldDef fieldDef =
+        createFieldDef(
+            Field.newBuilder()
+                .setStoreDocValues(true)
+                .setTextDocValuesType(TextDocValuesType.TEXT_DOC_VALUES_TYPE_SORTED)
+                .build());
+    assertEquals(DocValuesType.SORTED, fieldDef.getDocValuesType());
+  }
+
+  @Test
+  public void testDocValueType_binary() {
+    AtomFieldDef fieldDef =
+        createFieldDef(
+            Field.newBuilder()
+                .setStoreDocValues(true)
+                .setTextDocValuesType(TextDocValuesType.TEXT_DOC_VALUES_TYPE_BINARY)
+                .build());
+    assertEquals(DocValuesType.BINARY, fieldDef.getDocValuesType());
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/TextFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/TextFieldDefTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.field;
+
+import static org.junit.Assert.*;
+
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.grpc.Field;
+import com.yelp.nrtsearch.server.grpc.TextDocValuesType;
+import com.yelp.nrtsearch.server.luceneserver.similarity.SimilarityCreator;
+import java.io.ByteArrayInputStream;
+import java.util.Collections;
+import org.apache.lucene.index.DocValuesType;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TextFieldDefTest {
+
+  @BeforeClass
+  public static void init() {
+    String configStr = "node: node1";
+    LuceneServerConfiguration configuration =
+        new LuceneServerConfiguration(new ByteArrayInputStream(configStr.getBytes()));
+    SimilarityCreator.initialize(configuration, Collections.emptyList());
+  }
+
+  private TextFieldDef createFieldDef(Field field) {
+    return new TextFieldDef("test_field", field);
+  }
+
+  @Test
+  public void testDocValueType_none() {
+    TextFieldDef fieldDef = createFieldDef(Field.newBuilder().setStoreDocValues(false).build());
+    assertEquals(DocValuesType.NONE, fieldDef.getDocValuesType());
+  }
+
+  @Test
+  public void testDocValueType_default() {
+    TextFieldDef fieldDef = createFieldDef(Field.newBuilder().setStoreDocValues(true).build());
+    assertEquals(DocValuesType.SORTED, fieldDef.getDocValuesType());
+  }
+
+  @Test
+  public void testDocValueType_sorted() {
+    TextFieldDef fieldDef =
+        createFieldDef(
+            Field.newBuilder()
+                .setStoreDocValues(true)
+                .setTextDocValuesType(TextDocValuesType.TEXT_DOC_VALUES_TYPE_SORTED)
+                .build());
+    assertEquals(DocValuesType.SORTED, fieldDef.getDocValuesType());
+  }
+
+  @Test
+  public void testDocValueType_binary() {
+    TextFieldDef fieldDef =
+        createFieldDef(
+            Field.newBuilder()
+                .setStoreDocValues(true)
+                .setTextDocValuesType(TextDocValuesType.TEXT_DOC_VALUES_TYPE_BINARY)
+                .build());
+    assertEquals(DocValuesType.BINARY, fieldDef.getDocValuesType());
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
@@ -192,9 +192,8 @@ public class ScoreScriptTest {
       try {
         LoadedDocValues<?> idDocValues = getDoc().get("doc_id");
         assertEquals("doc_id size", 1, idDocValues.size());
-        assertEquals(
-            "doc_id class", LoadedDocValues.SingleBinaryString.class, idDocValues.getClass());
-        String id = ((LoadedDocValues.SingleBinaryString) idDocValues).get(0);
+        assertEquals("doc_id class", LoadedDocValues.SingleString.class, idDocValues.getClass());
+        String id = ((LoadedDocValues.SingleString) idDocValues).get(0);
 
         List<Integer> expectedLicenseNo = null;
         List<Integer> expectedCount = null;
@@ -355,9 +354,8 @@ public class ScoreScriptTest {
       try {
         LoadedDocValues<?> idDocValues = getDoc().get("doc_id");
         assertEquals("doc_id size", 1, idDocValues.size());
-        assertEquals(
-            "doc_id class", LoadedDocValues.SingleBinaryString.class, idDocValues.getClass());
-        String id = ((LoadedDocValues.SingleBinaryString) idDocValues).get(0);
+        assertEquals("doc_id class", LoadedDocValues.SingleString.class, idDocValues.getClass());
+        String id = ((LoadedDocValues.SingleString) idDocValues).get(0);
 
         List<Integer> expectedLicenseNo = null;
         List<String> expectedVendorName = null;
@@ -465,9 +463,8 @@ public class ScoreScriptTest {
       try {
         LoadedDocValues<?> idDocValues = getDoc().get("doc_id");
         assertEquals("doc_id size", 1, idDocValues.size());
-        assertEquals(
-            "doc_id class", LoadedDocValues.SingleBinaryString.class, idDocValues.getClass());
-        String id = ((LoadedDocValues.SingleBinaryString) idDocValues).get(0);
+        assertEquals("doc_id class", LoadedDocValues.SingleString.class, idDocValues.getClass());
+        String id = ((LoadedDocValues.SingleString) idDocValues).get(0);
 
         if (id.equals("1")) {
           assertEquals(0.516, get_score(), 0.001);
@@ -497,8 +494,7 @@ public class ScoreScriptTest {
       try {
         LoadedDocValues<?> idDocValues = getDoc().get("doc_id");
         assertEquals("doc_id size", 1, idDocValues.size());
-        assertEquals(
-            "doc_id class", LoadedDocValues.SingleBinaryString.class, idDocValues.getClass());
+        assertEquals("doc_id class", LoadedDocValues.SingleString.class, idDocValues.getClass());
         assertEquals("doc_id exists", 1, idDocValues.size());
 
         assertEmptyDocValues("license_no", getDoc());
@@ -537,8 +533,7 @@ public class ScoreScriptTest {
       try {
         LoadedDocValues<?> idDocValues = getDoc().get("doc_id");
         assertEquals("doc_id size", 1, idDocValues.size());
-        assertEquals(
-            "doc_id class", LoadedDocValues.SingleBinaryString.class, idDocValues.getClass());
+        assertEquals("doc_id class", LoadedDocValues.SingleString.class, idDocValues.getClass());
         assertEquals("doc_id exists", 1, idDocValues.size());
 
         assertEmptyDocValues("license_no", getDoc());
@@ -567,8 +562,7 @@ public class ScoreScriptTest {
       try {
         LoadedDocValues<?> idDocValues = getDoc().get("doc_id");
         assertEquals("doc_id size", 1, idDocValues.size());
-        assertEquals(
-            "doc_id class", LoadedDocValues.SingleBinaryString.class, idDocValues.getClass());
+        assertEquals("doc_id class", LoadedDocValues.SingleString.class, idDocValues.getClass());
         assertEquals("doc_id exists", 1, idDocValues.size());
 
         try {
@@ -685,9 +679,8 @@ public class ScoreScriptTest {
 
         LoadedDocValues<?> idDocValues = getDoc().get("doc_id");
         assertEquals("doc_id size", 1, idDocValues.size());
-        assertEquals(
-            "doc_id class", LoadedDocValues.SingleBinaryString.class, idDocValues.getClass());
-        String id = ((LoadedDocValues.SingleBinaryString) idDocValues).get(0);
+        assertEquals("doc_id class", LoadedDocValues.SingleString.class, idDocValues.getClass());
+        String id = ((LoadedDocValues.SingleString) idDocValues).get(0);
 
         LoadedDocValues<?> docValues = getDoc().get(vectorFieldName);
         assertNotNull(vectorFieldName + " is null", docValues);

--- a/src/test/resources/field/eager_global_ordinals.json
+++ b/src/test/resources/field/eager_global_ordinals.json
@@ -4,15 +4,13 @@
     {
       "name": "atom_field",
       "type": "ATOM",
-      "storeDocValues": true,
-      "textDocValuesType": "TEXT_DOC_VALUES_TYPE_SORTED"
+      "storeDocValues": true
     },
     {
       "name": "eager_atom_field",
       "type": "ATOM",
       "storeDocValues": true,
-      "eagerFieldGlobalOrdinals": true,
-      "textDocValuesType": "TEXT_DOC_VALUES_TYPE_SORTED"
+      "eagerFieldGlobalOrdinals": true
     },
     {
       "name": "atom_field_multi",

--- a/src/test/resources/search/OrdinalsRegisterFields.json
+++ b/src/test/resources/search/OrdinalsRegisterFields.json
@@ -5,8 +5,7 @@
       "name": "value",
       "type": "ATOM",
       "storeDocValues": true,
-      "eagerFieldGlobalOrdinals": true,
-      "textDocValuesType": "TEXT_DOC_VALUES_TYPE_SORTED"
+      "eagerFieldGlobalOrdinals": true
     },
     {
       "name": "value_multi",

--- a/src/test/resources/search/collection/terms_ordinal.json
+++ b/src/test/resources/search/collection/terms_ordinal.json
@@ -23,14 +23,12 @@
     {
       "name": "value",
       "type": "ATOM",
-      "storeDocValues": true,
-      "textDocValuesType": "TEXT_DOC_VALUES_TYPE_SORTED"
+      "storeDocValues": true
     },
     {
       "name": "value_order",
       "type": "ATOM",
-      "storeDocValues": true,
-      "textDocValuesType": "TEXT_DOC_VALUES_TYPE_SORTED"
+      "storeDocValues": true
     },
     {
       "name": "value_multi",


### PR DESCRIPTION
RP-11462

This is a follow-up from the discussion in #677. Sorted is the default docvalue type for text fields, making it the default for atom as well. This makes the docvalue type consistent for atom and text. Sorted is required to use ordinals which are more efficient for aggregations. If needed, the `textDocValuesType` field can be used to specify binary docvalue type.

I have added some comments to help decide the docvalue type as well.