### PR TITLE
Increase vector size limit to 4096

### DIFF
--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/VectorFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/VectorFieldDefTest.java
@@ -768,14 +768,14 @@ public class VectorFieldDefTest extends ServerTestCase {
         Field.newBuilder()
             .setName("vector")
             .setType(FieldType.VECTOR)
-            .setVectorDimensions(2049)
+            .setVectorDimensions(4097)
             .setStoreDocValues(true)
             .build();
     try {
       new VectorFieldDef("vector", field);
       fail();
     } catch (IllegalArgumentException e) {
-      assertEquals("Vector dimension must be <= 2048 for doc values", e.getMessage());
+      assertEquals("Vector dimension must be <= 4096", e.getMessage());
     }
   }
 
@@ -785,7 +785,7 @@ public class VectorFieldDefTest extends ServerTestCase {
         Field.newBuilder()
             .setName("vector")
             .setType(FieldType.VECTOR)
-            .setVectorDimensions(1025)
+            .setVectorDimensions(4097)
             .setSearch(true)
             .setVectorSimilarity("cosine")
             .build();
@@ -793,7 +793,7 @@ public class VectorFieldDefTest extends ServerTestCase {
       new VectorFieldDef("vector", field);
       fail();
     } catch (IllegalArgumentException e) {
-      assertEquals("Vector dimension must be <= 1024 for search", e.getMessage());
+      assertEquals("Vector dimension must be <= 4096", e.getMessage());
     }
   }
 


### PR DESCRIPTION
RP-11388

Lucene has made the max vector dimensions a property of the codec. We override the function to set it to 4096.

There are some risks with bigger vectors - there is a lot of discussion in https://github.com/apache/lucene/issues/11507. These are the most relevant points from the issue:
1. Bigger vectors require lot more memory.
2. Each added dimension makes the floating point errors larger and sometimes also returns NaN.
3. Lucene's default limit is still 1024 - they can still make changes in the future keeping this in mind.

I thought about not having a limit to allow for easy experimentation, but the above risks are significant. I also considered keeping the limit and make it configurable, but I fear it would effectively be no limit - when needed users will increase it. 
I think it's reasonable to still have a limit but increase it to 4096 (same as Elasticsearch). This should allow large enough vector sizes required for experimentation today and not have too much of a risk of performance/correctness/future changes.