### PR TITLE
Rework interface for processing stored field values

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/BooleanFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/BooleanFieldDef.java
@@ -19,15 +19,13 @@ import static com.yelp.nrtsearch.server.luceneserver.analysis.AnalyzerCreator.ha
 
 import com.yelp.nrtsearch.server.grpc.FacetType;
 import com.yelp.nrtsearch.server.grpc.Field;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import com.yelp.nrtsearch.server.grpc.TermInSetQuery;
 import com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues;
 import com.yelp.nrtsearch.server.luceneserver.field.properties.TermQueryable;
 import java.io.IOException;
 import java.util.List;
-import org.apache.lucene.document.Document;
-import org.apache.lucene.document.FieldType;
-import org.apache.lucene.document.NumericDocValuesField;
-import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.*;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
@@ -133,6 +131,12 @@ public class BooleanFieldDef extends IndexableFieldDef implements TermQueryable 
     }
     throw new IllegalStateException(
         String.format("Unsupported doc value type %s for field %s", docValuesType, this.getName()));
+  }
+
+  @Override
+  public SearchResponse.Hit.FieldValue getStoredFieldValue(StoredValue value) {
+    boolean booleanValue = value.getIntValue() == 1;
+    return SearchResponse.Hit.FieldValue.newBuilder().setBooleanValue(booleanValue).build();
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/DateTimeFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/DateTimeFieldDef.java
@@ -17,10 +17,8 @@ package com.yelp.nrtsearch.server.luceneserver.field;
 
 import static com.yelp.nrtsearch.server.luceneserver.analysis.AnalyzerCreator.hasAnalyzer;
 
-import com.yelp.nrtsearch.server.grpc.FacetType;
+import com.yelp.nrtsearch.server.grpc.*;
 import com.yelp.nrtsearch.server.grpc.Field;
-import com.yelp.nrtsearch.server.grpc.RangeQuery;
-import com.yelp.nrtsearch.server.grpc.SortType;
 import com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues;
 import com.yelp.nrtsearch.server.luceneserver.field.properties.RangeQueryable;
 import com.yelp.nrtsearch.server.luceneserver.field.properties.Sortable;
@@ -35,10 +33,7 @@ import java.time.format.DateTimeParseException;
 import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoField;
 import java.util.List;
-import org.apache.lucene.document.Document;
-import org.apache.lucene.document.LongPoint;
-import org.apache.lucene.document.NumericDocValuesField;
-import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.*;
 import org.apache.lucene.facet.FacetField;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesType;
@@ -296,6 +291,11 @@ public class DateTimeFieldDef extends IndexableFieldDef implements Sortable, Ran
     }
     throw new IllegalStateException(
         String.format("Unsupported doc value type %s for field %s", docValuesType, this.getName()));
+  }
+
+  @Override
+  public SearchResponse.Hit.FieldValue getStoredFieldValue(StoredValue value) {
+    return SearchResponse.Hit.FieldValue.newBuilder().setLongValue(value.getLongValue()).build();
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/DoubleFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/DoubleFieldDef.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.server.luceneserver.field;
 
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.RangeQuery;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +25,7 @@ import java.util.function.LongToDoubleFunction;
 import org.apache.lucene.document.DoubleDocValuesField;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.StoredValue;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
@@ -83,6 +85,13 @@ public class DoubleFieldDef extends NumberFieldDef {
   @Override
   protected Number getSortMissingValue(boolean missingLast) {
     return missingLast ? Double.POSITIVE_INFINITY : Double.NEGATIVE_INFINITY;
+  }
+
+  @Override
+  public SearchResponse.Hit.FieldValue getStoredFieldValue(StoredValue value) {
+    return SearchResponse.Hit.FieldValue.newBuilder()
+        .setDoubleValue(value.getDoubleValue())
+        .build();
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/FloatFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/FloatFieldDef.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.server.luceneserver.field;
 
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.RangeQuery;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +25,7 @@ import java.util.function.LongToDoubleFunction;
 import org.apache.lucene.document.FloatDocValuesField;
 import org.apache.lucene.document.FloatPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.StoredValue;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
@@ -83,6 +85,11 @@ public class FloatFieldDef extends NumberFieldDef {
   @Override
   protected Number getSortMissingValue(boolean missingLast) {
     return missingLast ? Float.POSITIVE_INFINITY : Float.NEGATIVE_INFINITY;
+  }
+
+  @Override
+  public SearchResponse.Hit.FieldValue getStoredFieldValue(StoredValue value) {
+    return SearchResponse.Hit.FieldValue.newBuilder().setFloatValue(value.getFloatValue()).build();
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/IdFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/IdFieldDef.java
@@ -16,6 +16,7 @@
 package com.yelp.nrtsearch.server.luceneserver.field;
 
 import com.yelp.nrtsearch.server.grpc.Field;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues;
 import com.yelp.nrtsearch.server.luceneserver.field.properties.TermQueryable;
 import java.io.IOException;
@@ -24,6 +25,7 @@ import java.util.stream.Collectors;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.StoredValue;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
@@ -119,6 +121,11 @@ public class IdFieldDef extends IndexableFieldDef implements TermQueryable {
     }
     throw new IllegalStateException(
         String.format("Unsupported doc value type %s for field %s", docValuesType, this.getName()));
+  }
+
+  @Override
+  public SearchResponse.Hit.FieldValue getStoredFieldValue(StoredValue value) {
+    return SearchResponse.Hit.FieldValue.newBuilder().setTextValue(value.getStringValue()).build();
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/IndexableFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/IndexableFieldDef.java
@@ -16,6 +16,7 @@
 package com.yelp.nrtsearch.server.luceneserver.field;
 
 import com.yelp.nrtsearch.server.grpc.Field;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import com.yelp.nrtsearch.server.luceneserver.AddDocumentHandler;
 import com.yelp.nrtsearch.server.luceneserver.IndexState;
 import com.yelp.nrtsearch.server.luceneserver.ServerCodec;
@@ -29,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.StoredValue;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.similarities.Similarity;
@@ -193,8 +195,7 @@ public abstract class IndexableFieldDef extends FieldDef {
   }
 
   /**
-   * Get if this field data is stored in the index. This data must be accessible via {@link
-   * #getStored(Document)}.
+   * Get if this field data is stored in the index.
    *
    * @return if this field is stored in the index
    */
@@ -258,14 +259,14 @@ public abstract class IndexableFieldDef extends FieldDef {
   }
 
   /**
-   * Get the field values stored in the index when the property store=true. Retrieve the String
-   * values from the document and perform any needed post processing.
+   * Transform a value from this fields index stored fields to a {@link
+   * SearchResponse.Hit.FieldValue}. This will be called once for each value that was stored.
    *
-   * @param document lucene document
-   * @return String representations of stored field values
+   * @param value stored field value
+   * @return hit field value for response
    */
-  public String[] getStored(Document document) {
-    return document.getValues(getName());
+  public SearchResponse.Hit.FieldValue getStoredFieldValue(StoredValue value) {
+    throw new UnsupportedOperationException("Stored values not supported for field: " + getName());
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/IntFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/IntFieldDef.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.server.luceneserver.field;
 
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.RangeQuery;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +25,7 @@ import java.util.function.LongToDoubleFunction;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.StoredValue;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
@@ -77,6 +79,11 @@ public class IntFieldDef extends NumberFieldDef {
   @Override
   protected Number getSortMissingValue(boolean missingLast) {
     return missingLast ? Integer.MAX_VALUE : Integer.MIN_VALUE;
+  }
+
+  @Override
+  public SearchResponse.Hit.FieldValue getStoredFieldValue(StoredValue value) {
+    return SearchResponse.Hit.FieldValue.newBuilder().setIntValue(value.getIntValue()).build();
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/LongFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/LongFieldDef.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.server.luceneserver.field;
 
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.RangeQuery;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +25,7 @@ import java.util.function.LongToDoubleFunction;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.StoredValue;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
@@ -77,6 +79,11 @@ public class LongFieldDef extends NumberFieldDef {
   @Override
   protected Number getSortMissingValue(boolean missingLast) {
     return missingLast ? Long.MAX_VALUE : Long.MIN_VALUE;
+  }
+
+  @Override
+  public SearchResponse.Hit.FieldValue getStoredFieldValue(StoredValue value) {
+    return SearchResponse.Hit.FieldValue.newBuilder().setLongValue(value.getLongValue()).build();
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/TextBaseFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/TextBaseFieldDef.java
@@ -15,11 +15,8 @@
  */
 package com.yelp.nrtsearch.server.luceneserver.field;
 
-import com.yelp.nrtsearch.server.grpc.FacetType;
+import com.yelp.nrtsearch.server.grpc.*;
 import com.yelp.nrtsearch.server.grpc.Field;
-import com.yelp.nrtsearch.server.grpc.IndexOptions;
-import com.yelp.nrtsearch.server.grpc.TermVectors;
-import com.yelp.nrtsearch.server.grpc.TextDocValuesType;
 import com.yelp.nrtsearch.server.luceneserver.Constants;
 import com.yelp.nrtsearch.server.luceneserver.analysis.AnalyzerCreator;
 import com.yelp.nrtsearch.server.luceneserver.doc.DocValuesFactory;
@@ -37,11 +34,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.document.BinaryDocValuesField;
-import org.apache.lucene.document.Document;
+import org.apache.lucene.document.*;
 import org.apache.lucene.document.FieldType;
-import org.apache.lucene.document.SortedDocValuesField;
-import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.facet.FacetField;
 import org.apache.lucene.facet.sortedset.SortedSetDocValuesFacetField;
 import org.apache.lucene.index.BinaryDocValues;
@@ -220,6 +214,11 @@ public abstract class TextBaseFieldDef extends IndexableFieldDef
     } else {
       return DocValuesFactory.getBinaryDocValues(getName(), docValuesType, context);
     }
+  }
+
+  @Override
+  public SearchResponse.Hit.FieldValue getStoredFieldValue(StoredValue value) {
+    return SearchResponse.Hit.FieldValue.newBuilder().setTextValue(value.getStringValue()).build();
   }
 
   @Override

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/DoubleFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/DoubleFieldDefTest.java
@@ -54,6 +54,11 @@ public class DoubleFieldDefTest extends ServerTestCase {
     Map<String, AddDocumentRequest.MultiValuedField> fieldsMap = new HashMap<>();
     fieldsMap.put(
         fieldName, AddDocumentRequest.MultiValuedField.newBuilder().addValue(value).build());
+    fieldsMap.put(
+        "single_stored", AddDocumentRequest.MultiValuedField.newBuilder().addValue(value).build());
+    fieldsMap.put(
+        "multi_stored",
+        AddDocumentRequest.MultiValuedField.newBuilder().addValue(value).addValue("15").build());
     return fieldsMap;
   }
 
@@ -90,6 +95,87 @@ public class DoubleFieldDefTest extends ServerTestCase {
                 .setTopHits(10)
                 .addRetrieveFields(fieldName)
                 .build());
+  }
+
+  @Test
+  public void testStoredFields() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(DEFAULT_TEST_INDEX)
+                    .setTopHits(10)
+                    .addRetrieveFields("single_stored")
+                    .addRetrieveFields("multi_stored")
+                    .addRetrieveFields("single_none_stored")
+                    .addRetrieveFields("multi_none_stored")
+                    .setQuery(Query.newBuilder().build())
+                    .build());
+    assertEquals(6, response.getHitsCount());
+    SearchResponse.Hit hit = response.getHits(0);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(
+        Double.NEGATIVE_INFINITY,
+        hit.getFieldsOrThrow("single_stored").getFieldValue(0).getDoubleValue(),
+        0);
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(
+        Double.NEGATIVE_INFINITY,
+        hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getDoubleValue(),
+        0);
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getDoubleValue(), 0);
+
+    hit = response.getHits(1);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getDoubleValue(), 0);
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(1, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getDoubleValue(), 0);
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getDoubleValue(), 0);
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
+
+    hit = response.getHits(2);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(10, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getDoubleValue(), 0);
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(10, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getDoubleValue(), 0);
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getDoubleValue(), 0);
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
+
+    hit = response.getHits(3);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(20, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getDoubleValue(), 0);
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(20, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getDoubleValue(), 0);
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getDoubleValue(), 0);
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
+
+    hit = response.getHits(4);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(30, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getDoubleValue(), 0);
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(30, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getDoubleValue(), 0);
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getDoubleValue(), 0);
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
+
+    hit = response.getHits(5);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(
+        Double.POSITIVE_INFINITY,
+        hit.getFieldsOrThrow("single_stored").getFieldValue(0).getDoubleValue(),
+        0);
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(
+        Double.POSITIVE_INFINITY,
+        hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getDoubleValue(),
+        0);
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getDoubleValue(), 0);
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/FloatFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/FloatFieldDefTest.java
@@ -54,6 +54,11 @@ public class FloatFieldDefTest extends ServerTestCase {
     Map<String, AddDocumentRequest.MultiValuedField> fieldsMap = new HashMap<>();
     fieldsMap.put(
         fieldName, AddDocumentRequest.MultiValuedField.newBuilder().addValue(value).build());
+    fieldsMap.put(
+        "single_stored", AddDocumentRequest.MultiValuedField.newBuilder().addValue(value).build());
+    fieldsMap.put(
+        "multi_stored",
+        AddDocumentRequest.MultiValuedField.newBuilder().addValue(value).addValue("15").build());
     return fieldsMap;
   }
 
@@ -90,6 +95,87 @@ public class FloatFieldDefTest extends ServerTestCase {
                 .setTopHits(10)
                 .addRetrieveFields(fieldName)
                 .build());
+  }
+
+  @Test
+  public void testStoredFields() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(DEFAULT_TEST_INDEX)
+                    .setTopHits(10)
+                    .addRetrieveFields("single_stored")
+                    .addRetrieveFields("multi_stored")
+                    .addRetrieveFields("single_none_stored")
+                    .addRetrieveFields("multi_none_stored")
+                    .setQuery(Query.newBuilder().build())
+                    .build());
+    assertEquals(6, response.getHitsCount());
+    SearchResponse.Hit hit = response.getHits(0);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(
+        Float.NEGATIVE_INFINITY,
+        hit.getFieldsOrThrow("single_stored").getFieldValue(0).getFloatValue(),
+        0);
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(
+        Float.NEGATIVE_INFINITY,
+        hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getFloatValue(),
+        0);
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getFloatValue(), 0);
+
+    hit = response.getHits(1);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getFloatValue(), 0);
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(1, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getFloatValue(), 0);
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getFloatValue(), 0);
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
+
+    hit = response.getHits(2);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(10, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getFloatValue(), 0);
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(10, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getFloatValue(), 0);
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getFloatValue(), 0);
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
+
+    hit = response.getHits(3);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(20, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getFloatValue(), 0);
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(20, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getFloatValue(), 0);
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getFloatValue(), 0);
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
+
+    hit = response.getHits(4);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(30, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getFloatValue(), 0);
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(30, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getFloatValue(), 0);
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getFloatValue(), 0);
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
+
+    hit = response.getHits(5);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(
+        Float.POSITIVE_INFINITY,
+        hit.getFieldsOrThrow("single_stored").getFieldValue(0).getFloatValue(),
+        0);
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(
+        Float.POSITIVE_INFINITY,
+        hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getFloatValue(),
+        0);
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getFloatValue(), 0);
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/IdFieldTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/IdFieldTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.field;
+
+import static org.junit.Assert.assertEquals;
+
+import com.yelp.nrtsearch.server.grpc.*;
+import com.yelp.nrtsearch.server.luceneserver.ServerTestCase;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class IdFieldTest extends ServerTestCase {
+  @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  @Override
+  public FieldDefRequest getIndexDef(String name) throws IOException {
+    return getFieldsFromResourceFile("/field/registerFieldsIdStored.json");
+  }
+
+  @Override
+  public void initIndex(String name) throws Exception {
+    List<AddDocumentRequest> requestList = new ArrayList<>();
+    requestList.add(
+        AddDocumentRequest.newBuilder()
+            .setIndexName(name)
+            .putFields("id", AddDocumentRequest.MultiValuedField.newBuilder().addValue("1").build())
+            .build());
+    requestList.add(
+        AddDocumentRequest.newBuilder()
+            .setIndexName(name)
+            .putFields("id", AddDocumentRequest.MultiValuedField.newBuilder().addValue("2").build())
+            .build());
+    requestList.add(
+        AddDocumentRequest.newBuilder()
+            .setIndexName(name)
+            .putFields("id", AddDocumentRequest.MultiValuedField.newBuilder().addValue("3").build())
+            .build());
+    addDocuments(requestList.stream());
+  }
+
+  @Test
+  public void testStoredFields() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(DEFAULT_TEST_INDEX)
+                    .setTopHits(3)
+                    .addRetrieveFields("id")
+                    .setQuery(Query.newBuilder().build())
+                    .build());
+    assertEquals(3, response.getHitsCount());
+    SearchResponse.Hit hit = response.getHits(0);
+    assertEquals(1, hit.getFieldsOrThrow("id").getFieldValueCount());
+    assertEquals("1", hit.getFieldsOrThrow("id").getFieldValue(0).getTextValue());
+
+    hit = response.getHits(1);
+    assertEquals(1, hit.getFieldsOrThrow("id").getFieldValueCount());
+    assertEquals("2", hit.getFieldsOrThrow("id").getFieldValue(0).getTextValue());
+
+    hit = response.getHits(2);
+    assertEquals(1, hit.getFieldsOrThrow("id").getFieldValueCount());
+    assertEquals("3", hit.getFieldsOrThrow("id").getFieldValue(0).getTextValue());
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/IntFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/IntFieldDefTest.java
@@ -54,6 +54,11 @@ public class IntFieldDefTest extends ServerTestCase {
     Map<String, AddDocumentRequest.MultiValuedField> fieldsMap = new HashMap<>();
     fieldsMap.put(
         fieldName, AddDocumentRequest.MultiValuedField.newBuilder().addValue(value).build());
+    fieldsMap.put(
+        "single_stored", AddDocumentRequest.MultiValuedField.newBuilder().addValue(value).build());
+    fieldsMap.put(
+        "multi_stored",
+        AddDocumentRequest.MultiValuedField.newBuilder().addValue(value).addValue("15").build());
     return fieldsMap;
   }
 
@@ -90,6 +95,79 @@ public class IntFieldDefTest extends ServerTestCase {
                 .setTopHits(10)
                 .addRetrieveFields(fieldName)
                 .build());
+  }
+
+  @Test
+  public void testStoredFields() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(DEFAULT_TEST_INDEX)
+                    .setTopHits(10)
+                    .addRetrieveFields("single_stored")
+                    .addRetrieveFields("multi_stored")
+                    .addRetrieveFields("single_none_stored")
+                    .addRetrieveFields("multi_none_stored")
+                    .setQuery(Query.newBuilder().build())
+                    .build());
+    assertEquals(6, response.getHitsCount());
+    SearchResponse.Hit hit = response.getHits(0);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(
+        Integer.MIN_VALUE, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getIntValue());
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(
+        Integer.MIN_VALUE, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getIntValue());
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getIntValue());
+
+    hit = response.getHits(1);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getIntValue());
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(1, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getIntValue());
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getIntValue());
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
+
+    hit = response.getHits(2);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(10, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getIntValue());
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(10, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getIntValue());
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getIntValue());
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
+
+    hit = response.getHits(3);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(20, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getIntValue());
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(20, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getIntValue());
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getIntValue());
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
+
+    hit = response.getHits(4);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(30, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getIntValue());
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(30, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getIntValue());
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getIntValue());
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
+
+    hit = response.getHits(5);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(
+        Integer.MAX_VALUE, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getIntValue());
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(
+        Integer.MAX_VALUE, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getIntValue());
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getIntValue());
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/LongFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/LongFieldDefTest.java
@@ -49,6 +49,11 @@ public class LongFieldDefTest extends ServerTestCase {
     Map<String, AddDocumentRequest.MultiValuedField> fieldsMap = new HashMap<>();
     fieldsMap.put(
         fieldName, AddDocumentRequest.MultiValuedField.newBuilder().addValue(value).build());
+    fieldsMap.put(
+        "single_stored", AddDocumentRequest.MultiValuedField.newBuilder().addValue(value).build());
+    fieldsMap.put(
+        "multi_stored",
+        AddDocumentRequest.MultiValuedField.newBuilder().addValue(value).addValue("15").build());
     return fieldsMap;
   }
 
@@ -85,6 +90,79 @@ public class LongFieldDefTest extends ServerTestCase {
                 .setTopHits(10)
                 .addRetrieveFields(fieldName)
                 .build());
+  }
+
+  @Test
+  public void testStoredFields() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(DEFAULT_TEST_INDEX)
+                    .setTopHits(10)
+                    .addRetrieveFields("single_stored")
+                    .addRetrieveFields("multi_stored")
+                    .addRetrieveFields("single_none_stored")
+                    .addRetrieveFields("multi_none_stored")
+                    .setQuery(Query.newBuilder().build())
+                    .build());
+    assertEquals(6, response.getHitsCount());
+    SearchResponse.Hit hit = response.getHits(0);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(
+        Long.MIN_VALUE, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getLongValue());
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(
+        Long.MIN_VALUE, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getLongValue());
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getLongValue());
+
+    hit = response.getHits(1);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getLongValue());
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(1, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getLongValue());
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getLongValue());
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
+
+    hit = response.getHits(2);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(10, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getLongValue());
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(10, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getLongValue());
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getLongValue());
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
+
+    hit = response.getHits(3);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(20, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getLongValue());
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(20, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getLongValue());
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getLongValue());
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
+
+    hit = response.getHits(4);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(30, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getLongValue());
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(30, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getLongValue());
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getLongValue());
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
+
+    hit = response.getHits(5);
+    assertEquals(1, hit.getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(
+        Long.MAX_VALUE, hit.getFieldsOrThrow("single_stored").getFieldValue(0).getLongValue());
+    assertEquals(2, hit.getFieldsOrThrow("multi_stored").getFieldValueCount());
+    assertEquals(
+        Long.MAX_VALUE, hit.getFieldsOrThrow("multi_stored").getFieldValue(0).getLongValue());
+    assertEquals(15, hit.getFieldsOrThrow("multi_stored").getFieldValue(1).getLongValue());
+    assertEquals(0, hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
+    assertEquals(0, hit.getFieldsOrThrow("multi_none_stored").getFieldValueCount());
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/PolygonFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/PolygonFieldDefTest.java
@@ -19,7 +19,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.google.gson.Gson;
+import com.google.protobuf.ListValue;
 import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
 import com.google.type.LatLng;
 import com.yelp.nrtsearch.server.grpc.*;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest.MultiValuedField;
@@ -66,9 +68,198 @@ public class PolygonFieldDefTest extends ServerTestCase {
             .setIndexName(name)
             .putFields("doc_id", MultiValuedField.newBuilder().addValue("1").build())
             .putFields("polygon", MultiValuedField.newBuilder().addValue(gson.toJson(doc)).build())
+            .putFields(
+                "single_stored", MultiValuedField.newBuilder().addValue(gson.toJson(doc)).build())
             .build();
     docs.add(docRequest);
     addDocuments(docs.stream());
+  }
+
+  @Test
+  public void testStoredFields() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(DEFAULT_TEST_INDEX)
+                    .setTopHits(3)
+                    .addRetrieveFields("single_stored")
+                    .addRetrieveFields("single_none_stored")
+                    .setQuery(Query.newBuilder().build())
+                    .build());
+    assertEquals(1, response.getHitsCount());
+
+    Struct expectedStruct =
+        Struct.newBuilder()
+            .putFields(
+                "coordinates",
+                Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder()
+                            .addValues(
+                                Value.newBuilder()
+                                    .setListValue(
+                                        ListValue.newBuilder()
+                                            .addValues(
+                                                Value.newBuilder()
+                                                    .setListValue(
+                                                        ListValue.newBuilder()
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(100.0)
+                                                                    .build())
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(0.0)
+                                                                    .build())
+                                                            .build())
+                                                    .build())
+                                            .addValues(
+                                                Value.newBuilder()
+                                                    .setListValue(
+                                                        ListValue.newBuilder()
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(101.0)
+                                                                    .build())
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(0.0)
+                                                                    .build())
+                                                            .build())
+                                                    .build())
+                                            .addValues(
+                                                Value.newBuilder()
+                                                    .setListValue(
+                                                        ListValue.newBuilder()
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(101.0)
+                                                                    .build())
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(1.0)
+                                                                    .build())
+                                                            .build())
+                                                    .build())
+                                            .addValues(
+                                                Value.newBuilder()
+                                                    .setListValue(
+                                                        ListValue.newBuilder()
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(100.0)
+                                                                    .build())
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(1.0)
+                                                                    .build())
+                                                            .build())
+                                                    .build())
+                                            .addValues(
+                                                Value.newBuilder()
+                                                    .setListValue(
+                                                        ListValue.newBuilder()
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(100.0)
+                                                                    .build())
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(0.0)
+                                                                    .build())
+                                                            .build())
+                                                    .build())
+                                            .build())
+                                    .build())
+                            .addValues(
+                                Value.newBuilder()
+                                    .setListValue(
+                                        ListValue.newBuilder()
+                                            .addValues(
+                                                Value.newBuilder()
+                                                    .setListValue(
+                                                        ListValue.newBuilder()
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(100.2)
+                                                                    .build())
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(0.2)
+                                                                    .build())
+                                                            .build())
+                                                    .build())
+                                            .addValues(
+                                                Value.newBuilder()
+                                                    .setListValue(
+                                                        ListValue.newBuilder()
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(100.8)
+                                                                    .build())
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(0.2)
+                                                                    .build())
+                                                            .build())
+                                                    .build())
+                                            .addValues(
+                                                Value.newBuilder()
+                                                    .setListValue(
+                                                        ListValue.newBuilder()
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(100.8)
+                                                                    .build())
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(0.8)
+                                                                    .build())
+                                                            .build())
+                                                    .build())
+                                            .addValues(
+                                                Value.newBuilder()
+                                                    .setListValue(
+                                                        ListValue.newBuilder()
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(100.2)
+                                                                    .build())
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(0.8)
+                                                                    .build())
+                                                            .build())
+                                                    .build())
+                                            .addValues(
+                                                Value.newBuilder()
+                                                    .setListValue(
+                                                        ListValue.newBuilder()
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(100.2)
+                                                                    .build())
+                                                            .addValues(
+                                                                Value.newBuilder()
+                                                                    .setNumberValue(0.2)
+                                                                    .build())
+                                                            .build())
+                                                    .build())
+                                            .build())
+                                    .build())
+                            .build())
+                    .build())
+            .putFields("type", Value.newBuilder().setStringValue("Polygon").build())
+            .build();
+
+    assertEquals(1, response.getHits(0).getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(
+        expectedStruct,
+        response.getHits(0).getFieldsOrThrow("single_stored").getFieldValue(0).getStructValue());
+    assertEquals(
+        0, response.getHits(0).getFieldsOrThrow("single_none_stored").getFieldValueCount());
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/VectorFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/VectorFieldDefTest.java
@@ -447,7 +447,7 @@ public class VectorFieldDefTest extends ServerTestCase {
         List.of(0.25f, 0.5f, 0.75f, 0.1f),
         VectorSimilarityFunction.COSINE,
         1.0f,
-        0.001);
+        0.01);
   }
 
   @Test

--- a/src/test/resources/field/registerFieldsAtom.json
+++ b/src/test/resources/field/registerFieldsAtom.json
@@ -39,6 +39,32 @@
       "search": true,
       "multiValued": true,
       "storeDocValues": true
+    },
+    {
+      "name": "single_stored",
+      "type": "ATOM",
+      "search": true,
+      "store": true
+    },
+    {
+      "name": "multi_stored",
+      "type": "ATOM",
+      "search": true,
+      "multiValued": true,
+      "store": true
+    },
+    {
+      "name": "single_none_stored",
+      "type": "ATOM",
+      "search": true,
+      "store": true
+    },
+    {
+      "name": "multi_none_stored",
+      "type": "ATOM",
+      "search": true,
+      "multiValued": true,
+      "store": true
     }
   ]
 }

--- a/src/test/resources/field/registerFieldsBoolean.json
+++ b/src/test/resources/field/registerFieldsBoolean.json
@@ -50,6 +50,32 @@
       "type": "BOOLEAN",
       "multiValued": true,
       "storeDocValues": true
+    },
+    {
+      "name": "single_stored",
+      "type": "BOOLEAN",
+      "search": true,
+      "store": true
+    },
+    {
+      "name": "multi_stored",
+      "type": "BOOLEAN",
+      "search": true,
+      "multiValued": true,
+      "store": true
+    },
+    {
+      "name": "single_none_stored",
+      "type": "BOOLEAN",
+      "search": true,
+      "store": true
+    },
+    {
+      "name": "multi_none_stored",
+      "type": "BOOLEAN",
+      "search": true,
+      "multiValued": true,
+      "store": true
     }
   ]
 }

--- a/src/test/resources/field/registerFieldsDateTime.json
+++ b/src/test/resources/field/registerFieldsDateTime.json
@@ -27,6 +27,36 @@
       "dateTimeFormat": "yyyy-MM-dd HH:mm:ss",
       "storeDocValues": true,
       "search": true
+    },
+    {
+      "name": "single_stored",
+      "type": "DATE_TIME",
+      "dateTimeFormat": "epoch_millis",
+      "search": true,
+      "store": true
+    },
+    {
+      "name": "multi_stored",
+      "type": "DATE_TIME",
+      "dateTimeFormat": "epoch_millis",
+      "search": true,
+      "multiValued": true,
+      "store": true
+    },
+    {
+      "name": "single_none_stored",
+      "type": "DATE_TIME",
+      "dateTimeFormat": "epoch_millis",
+      "search": true,
+      "store": true
+    },
+    {
+      "name": "multi_none_stored",
+      "type": "DATE_TIME",
+      "dateTimeFormat": "epoch_millis",
+      "search": true,
+      "multiValued": true,
+      "store": true
     }
   ]
 }

--- a/src/test/resources/field/registerFieldsDouble.json
+++ b/src/test/resources/field/registerFieldsDouble.json
@@ -7,6 +7,32 @@
             "storeDocValues": true,
             "multiValued": false,
             "search": true
+        },
+        {
+            "name": "single_stored",
+            "type": "DOUBLE",
+            "search": true,
+            "store": true
+        },
+        {
+            "name": "multi_stored",
+            "type": "DOUBLE",
+            "search": true,
+            "multiValued": true,
+            "store": true
+        },
+        {
+            "name": "single_none_stored",
+            "type": "DOUBLE",
+            "search": true,
+            "store": true
+        },
+        {
+            "name": "multi_none_stored",
+            "type": "DOUBLE",
+            "search": true,
+            "multiValued": true,
+            "store": true
         }
     ]
 }

--- a/src/test/resources/field/registerFieldsFloat.json
+++ b/src/test/resources/field/registerFieldsFloat.json
@@ -7,6 +7,32 @@
             "storeDocValues": true,
             "multiValued": false,
             "search": true
+        },
+        {
+            "name": "single_stored",
+            "type": "FLOAT",
+            "search": true,
+            "store": true
+        },
+        {
+            "name": "multi_stored",
+            "type": "FLOAT",
+            "search": true,
+            "multiValued": true,
+            "store": true
+        },
+        {
+            "name": "single_none_stored",
+            "type": "FLOAT",
+            "search": true,
+            "store": true
+        },
+        {
+            "name": "multi_none_stored",
+            "type": "FLOAT",
+            "search": true,
+            "multiValued": true,
+            "store": true
         }
     ]
 }

--- a/src/test/resources/field/registerFieldsIdStored.json
+++ b/src/test/resources/field/registerFieldsIdStored.json
@@ -1,0 +1,10 @@
+{
+    "indexName": "test_index",
+    "field": [
+        {
+            "name": "id",
+            "type": "_ID",
+            "store": true
+        }
+    ]
+}

--- a/src/test/resources/field/registerFieldsInt.json
+++ b/src/test/resources/field/registerFieldsInt.json
@@ -7,6 +7,32 @@
             "storeDocValues": true,
             "multiValued": false,
             "search": true
+        },
+        {
+            "name": "single_stored",
+            "type": "INT",
+            "search": true,
+            "store": true
+        },
+        {
+            "name": "multi_stored",
+            "type": "INT",
+            "search": true,
+            "multiValued": true,
+            "store": true
+        },
+        {
+            "name": "single_none_stored",
+            "type": "INT",
+            "search": true,
+            "store": true
+        },
+        {
+            "name": "multi_none_stored",
+            "type": "INT",
+            "search": true,
+            "multiValued": true,
+            "store": true
         }
     ]
 }

--- a/src/test/resources/field/registerFieldsLong.json
+++ b/src/test/resources/field/registerFieldsLong.json
@@ -7,6 +7,32 @@
             "storeDocValues": true,
             "multiValued": false,
             "search": true
+        },
+        {
+            "name": "single_stored",
+            "type": "LONG",
+            "search": true,
+            "store": true
+        },
+        {
+            "name": "multi_stored",
+            "type": "LONG",
+            "search": true,
+            "multiValued": true,
+            "store": true
+        },
+        {
+            "name": "single_none_stored",
+            "type": "LONG",
+            "search": true,
+            "store": true
+        },
+        {
+            "name": "multi_none_stored",
+            "type": "LONG",
+            "search": true,
+            "multiValued": true,
+            "store": true
         }
     ]
 }

--- a/src/test/resources/field/registerFieldsObject.json
+++ b/src/test/resources/field/registerFieldsObject.json
@@ -80,6 +80,45 @@
           ]
         }
       ]
+    },
+    {
+      "name": "delivery_areas_stored",
+      "type": "OBJECT",
+      "search": true,
+      "store": true,
+      "childFields": [
+        {
+          "name": "hours",
+          "type": "INT",
+          "search": true,
+          "storeDocValues": true
+        },
+        {
+          "name": "zipcode",
+          "type": "ATOM",
+          "search": true,
+          "storeDocValues": true
+        },
+        {
+          "name": "partner",
+          "type": "OBJECT",
+          "search": true,
+          "childFields": [
+            {
+              "name": "partner_id",
+              "type": "ATOM",
+              "search": true,
+              "storeDocValues": true
+            },
+            {
+              "name": "partner_name",
+              "type": "ATOM",
+              "search": true,
+              "storeDocValues": true
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/test/resources/field/registerFieldsPolygon.json
+++ b/src/test/resources/field/registerFieldsPolygon.json
@@ -14,6 +14,18 @@
       "store": false,
       "storeDocValues": true,
       "multiValued": true
+    },
+    {
+      "name": "single_stored",
+      "type": "POLYGON",
+      "search": true,
+      "store": true
+    },
+    {
+      "name": "single_none_stored",
+      "type": "POLYGON",
+      "search": true,
+      "store": true
     }
   ]
 }


### PR DESCRIPTION
Rework the interface for how `FieldDef`s process stored field values for adding to the response. Previously, this would only be provided as an array of strings. Now, the `FieldDef` processes each `StoredValue` individually and returns a `FieldValue` with the proper typed field set. This allows the values returned in the search response to be identical for stored fields and doc value loading.