### PR TITLE
Improve field interface for providing codec formats

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/ContextSuggestFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/ContextSuggestFieldDef.java
@@ -23,7 +23,9 @@ import com.yelp.nrtsearch.server.luceneserver.suggest.protocol.ContextSuggestFie
 import java.util.List;
 import java.util.Optional;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.search.suggest.document.Completion99PostingsFormat;
 import org.apache.lucene.search.suggest.document.ContextSuggestField;
 
 public class ContextSuggestFieldDef extends IndexableFieldDef {
@@ -113,7 +115,7 @@ public class ContextSuggestFieldDef extends IndexableFieldDef {
   }
 
   @Override
-  public String getPostingsFormat() {
-    return "Completion99";
+  public PostingsFormat getPostingsFormat() {
+    return new Completion99PostingsFormat();
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/IndexableFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/IndexableFieldDef.java
@@ -18,7 +18,6 @@ package com.yelp.nrtsearch.server.luceneserver.field;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.luceneserver.AddDocumentHandler;
 import com.yelp.nrtsearch.server.luceneserver.IndexState;
-import com.yelp.nrtsearch.server.luceneserver.ServerCodec;
 import com.yelp.nrtsearch.server.luceneserver.doc.LoadedDocValues;
 import com.yelp.nrtsearch.server.luceneserver.similarity.SimilarityCreator;
 import com.yelp.nrtsearch.server.utils.StructValueTransformer;
@@ -27,6 +26,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.DocValuesType;
@@ -46,8 +47,8 @@ public abstract class IndexableFieldDef extends FieldDef {
   private final boolean isStored;
   private final boolean isMultiValue;
   private final boolean isSearchable;
-  private final String postingsFormat;
-  private final String docValuesFormat;
+  private final PostingsFormat postingsFormat;
+  private final DocValuesFormat docValuesFormat;
   private final Similarity similarity;
 
   private final Map<String, IndexableFieldDef> childFields;
@@ -85,12 +86,12 @@ public abstract class IndexableFieldDef extends FieldDef {
 
     postingsFormat =
         requestField.getPostingsFormat().isEmpty()
-            ? ServerCodec.DEFAULT_POSTINGS_FORMAT
-            : requestField.getPostingsFormat();
+            ? null
+            : PostingsFormat.forName(requestField.getPostingsFormat());
     docValuesFormat =
         requestField.getDocValuesFormat().isEmpty()
-            ? ServerCodec.DEFAULT_DOC_VALUES_FORMAT
-            : requestField.getDocValuesFormat();
+            ? null
+            : DocValuesFormat.forName(requestField.getDocValuesFormat());
 
     String similarityStr = requestField.getSimilarity();
     Map<String, Object> similarityParams =
@@ -324,18 +325,18 @@ public abstract class IndexableFieldDef extends FieldDef {
   /**
    * Get the postings format that should be used for this field.
    *
-   * @return posting format for this field
+   * @return posting format for this field, or null to use codec default
    */
-  public String getPostingsFormat() {
+  public PostingsFormat getPostingsFormat() {
     return postingsFormat;
   }
 
   /**
    * Get the doc values format that should be used for this field.
    *
-   * @return doc values format for this field
+   * @return doc values format for this field, or null to use codec default
    */
-  public String getDocValuesFormat() {
+  public DocValuesFormat getDocValuesFormat() {
     return docValuesFormat;
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/ServerCodecTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/ServerCodecTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
+
+import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.luceneserver.field.FieldDef;
+import com.yelp.nrtsearch.server.luceneserver.field.IndexableFieldDef;
+import com.yelp.nrtsearch.server.luceneserver.field.VectorFieldDef;
+import com.yelp.nrtsearch.server.luceneserver.index.IndexStateManager;
+import com.yelp.nrtsearch.server.luceneserver.similarity.SimilarityCreator;
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.Set;
+import org.apache.lucene.backward_codecs.lucene80.Lucene80DocValuesFormat;
+import org.apache.lucene.backward_codecs.lucene90.Lucene90HnswVectorsFormat;
+import org.apache.lucene.backward_codecs.lucene90.Lucene90PostingsFormat;
+import org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99PostingsFormat;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ServerCodecTest {
+
+  @BeforeClass
+  public static void beforeClass() {
+    SimilarityCreator.initialize(
+        new LuceneServerConfiguration(new ByteArrayInputStream("name: node1".getBytes())),
+        List.of());
+  }
+
+  private IndexStateManager getManager(FieldDef fieldDef) {
+    IndexStateManager mockStateManager = mock(IndexStateManager.class);
+    IndexState mockIndexState = mock(IndexState.class);
+    when(mockStateManager.getCurrent()).thenReturn(mockIndexState);
+    when(mockIndexState.getField("field")).thenReturn(fieldDef);
+    when(mockIndexState.getInternalFacetFieldNames()).thenReturn(Set.of("internal_field"));
+    return mockStateManager;
+  }
+
+  @Test
+  public void testPostingFormat_default() {
+    IndexableFieldDef mockFieldDef = mock(IndexableFieldDef.class);
+    when(mockFieldDef.getPostingsFormat()).thenReturn(null);
+    IndexStateManager mockStateManager = getManager(mockFieldDef);
+    ServerCodec serverCodec = new ServerCodec(mockStateManager);
+    assertTrue(serverCodec.getPostingsFormatForField("field") instanceof Lucene99PostingsFormat);
+    verify(mockFieldDef, times(1)).getPostingsFormat();
+    verifyNoMoreInteractions(mockFieldDef);
+  }
+
+  @Test
+  public void testPostingFormat_provided() {
+    IndexableFieldDef mockFieldDef = mock(IndexableFieldDef.class);
+    when(mockFieldDef.getPostingsFormat()).thenReturn(new Lucene90PostingsFormat());
+    IndexStateManager mockStateManager = getManager(mockFieldDef);
+    ServerCodec serverCodec = new ServerCodec(mockStateManager);
+    assertTrue(serverCodec.getPostingsFormatForField("field") instanceof Lucene90PostingsFormat);
+    verify(mockFieldDef, times(1)).getPostingsFormat();
+    verifyNoMoreInteractions(mockFieldDef);
+  }
+
+  @Test
+  public void testPostingFormat_notIndexable() {
+    FieldDef mockFieldDef = mock(FieldDef.class);
+    IndexStateManager mockStateManager = getManager(mockFieldDef);
+    ServerCodec serverCodec = new ServerCodec(mockStateManager);
+    try {
+      serverCodec.getPostingsFormatForField("field");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("Field \"field\" is not indexable"));
+    }
+    verifyNoInteractions(mockFieldDef);
+  }
+
+  @Test
+  public void testPostingFormat_internalField() {
+    FieldDef mockFieldDef = mock(FieldDef.class);
+    IndexStateManager mockStateManager = getManager(mockFieldDef);
+    ServerCodec serverCodec = new ServerCodec(mockStateManager);
+    assertTrue(
+        serverCodec.getPostingsFormatForField("internal_field") instanceof Lucene99PostingsFormat);
+    verifyNoInteractions(mockFieldDef);
+  }
+
+  @Test
+  public void testDocValuesFormat_default() {
+    IndexableFieldDef mockFieldDef = mock(IndexableFieldDef.class);
+    when(mockFieldDef.getDocValuesFormat()).thenReturn(null);
+    IndexStateManager mockStateManager = getManager(mockFieldDef);
+    ServerCodec serverCodec = new ServerCodec(mockStateManager);
+    assertTrue(serverCodec.getDocValuesFormatForField("field") instanceof Lucene90DocValuesFormat);
+    verify(mockFieldDef, times(1)).getDocValuesFormat();
+    verifyNoMoreInteractions(mockFieldDef);
+  }
+
+  @Test
+  public void testDocValuesFormat_provided() {
+    IndexableFieldDef mockFieldDef = mock(IndexableFieldDef.class);
+    when(mockFieldDef.getDocValuesFormat()).thenReturn(new Lucene80DocValuesFormat());
+    IndexStateManager mockStateManager = getManager(mockFieldDef);
+    ServerCodec serverCodec = new ServerCodec(mockStateManager);
+    assertTrue(serverCodec.getDocValuesFormatForField("field") instanceof Lucene80DocValuesFormat);
+    verify(mockFieldDef, times(1)).getDocValuesFormat();
+    verifyNoMoreInteractions(mockFieldDef);
+  }
+
+  @Test
+  public void testDocValuesFormat_notIndexable() {
+    FieldDef mockFieldDef = mock(FieldDef.class);
+    IndexStateManager mockStateManager = getManager(mockFieldDef);
+    ServerCodec serverCodec = new ServerCodec(mockStateManager);
+    try {
+      serverCodec.getDocValuesFormatForField("field");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("Field \"field\" is not indexable"));
+    }
+    verifyNoInteractions(mockFieldDef);
+  }
+
+  @Test
+  public void testDocValuesFormat_internalField() {
+    FieldDef mockFieldDef = mock(FieldDef.class);
+    IndexStateManager mockStateManager = getManager(mockFieldDef);
+    ServerCodec serverCodec = new ServerCodec(mockStateManager);
+    assertTrue(
+        serverCodec.getDocValuesFormatForField("internal_field")
+            instanceof Lucene90DocValuesFormat);
+    verifyNoInteractions(mockFieldDef);
+  }
+
+  @Test
+  public void testKnnVectorsFormat_default() {
+    VectorFieldDef mockFieldDef = mock(VectorFieldDef.class);
+    when(mockFieldDef.getVectorsFormat()).thenReturn(null);
+    IndexStateManager mockStateManager = getManager(mockFieldDef);
+    ServerCodec serverCodec = new ServerCodec(mockStateManager);
+    assertTrue(
+        serverCodec.getKnnVectorsFormatForField("field") instanceof Lucene99HnswVectorsFormat);
+    verify(mockFieldDef, times(1)).getVectorsFormat();
+    verifyNoMoreInteractions(mockFieldDef);
+  }
+
+  @Test
+  public void testKnnVectorsFormat_provided() {
+    VectorFieldDef mockFieldDef = mock(VectorFieldDef.class);
+    when(mockFieldDef.getVectorsFormat()).thenReturn(new Lucene90HnswVectorsFormat());
+    IndexStateManager mockStateManager = getManager(mockFieldDef);
+    ServerCodec serverCodec = new ServerCodec(mockStateManager);
+    assertTrue(
+        serverCodec.getKnnVectorsFormatForField("field") instanceof Lucene90HnswVectorsFormat);
+    verify(mockFieldDef, times(1)).getVectorsFormat();
+    verifyNoMoreInteractions(mockFieldDef);
+  }
+
+  @Test
+  public void testKnnVectorsFormat_notVectorField() {
+    FieldDef mockFieldDef = mock(FieldDef.class);
+    IndexStateManager mockStateManager = getManager(mockFieldDef);
+    ServerCodec serverCodec = new ServerCodec(mockStateManager);
+    assertTrue(
+        serverCodec.getKnnVectorsFormatForField("field") instanceof Lucene99HnswVectorsFormat);
+    verifyNoInteractions(mockFieldDef);
+  }
+}


### PR DESCRIPTION
Currently, an `IndexableFieldDef` can provide a string for the doc value/posting formats for the `ServerCodec` to use for that field. The format then gets loaded by name. This has some disadvantages:
- We can only load codecs provided by Lucene
- Codecs can only be used with the default parameters

The interface has been changed so that fields can provide a format implementation for doc values and postings, allowing much more control. A field may also return a `null` format to use the codec default.