### PR TITLE
Use primitive types for doc value loading

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/doc/LoadedDocValues.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/doc/LoadedDocValues.java
@@ -15,10 +15,12 @@
  */
 package com.yelp.nrtsearch.server.luceneserver.doc;
 
-import com.google.gson.Gson;
+import static org.apache.lucene.util.ArrayUtil.oversize;
+
 import com.google.protobuf.ByteString;
 import com.google.protobuf.ListValue;
 import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
 import com.google.protobuf.util.JsonFormat;
 import com.google.type.LatLng;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
@@ -38,6 +40,7 @@ import java.util.function.LongFunction;
 import java.util.stream.Collectors;
 import org.apache.lucene.geo.GeoEncodingUtils;
 import org.apache.lucene.index.*;
+import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
 
@@ -63,16 +66,6 @@ import org.apache.lucene.util.NumericUtils;
  */
 public abstract class LoadedDocValues<T> extends AbstractList<T> {
   // long decoders
-  private static final LongFunction<Boolean> BOOL_DECODER = (longValue) -> longValue == 1;
-  private static final LongFunction<Integer> INT_DECODER = (longValue) -> (int) longValue;
-  private static final LongFunction<Long> LONG_DECODER = (longValue) -> longValue;
-  private static final LongFunction<Float> FLOAT_DECODER =
-      (longValue) -> Float.intBitsToFloat((int) longValue);
-  private static final LongFunction<Float> SORTED_FLOAT_DECODER =
-      (longValue) -> NumericUtils.sortableIntToFloat((int) longValue);
-  private static final LongFunction<Double> DOUBLE_DECODER = Double::longBitsToDouble;
-  private static final LongFunction<Double> SORTED_DOUBLE_DECODER =
-      NumericUtils::sortableLongToDouble;
   private static final LongFunction<Instant> DATE_DECODER = Instant::ofEpochMilli;
   private static final LongFunction<GeoPoint> GEO_POINT_DECODER =
       (longValue) ->
@@ -84,9 +77,6 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
   // copy the target buffer, as the original BytesRef buffer will be reused
   private static final Function<BytesRef, BytesRef> BYTES_REF_DECODER = BytesRef::deepCopyOf;
   private static final Function<BytesRef, String> STRING_DECODER = BytesRef::utf8ToString;
-
-  // Gson decoder to deserilize string to objects
-  private static final Gson gson = new Gson();
 
   public abstract void setDocId(int docID) throws IOException;
 
@@ -125,69 +115,259 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
     public int size() {
       return value == null ? 0 : 1;
     }
-
-    public T getValue() {
-      return get(0);
-    }
   }
 
-  public static final class SingleBoolean extends SingleNumericValue<Boolean> {
+  public static final class SingleBoolean extends LoadedDocValues<Boolean> {
+    private final NumericDocValues docValues;
+    private boolean value;
+    private boolean isSet;
+
     public SingleBoolean(NumericDocValues docValues) {
-      super(docValues, BOOL_DECODER);
+      this.docValues = docValues;
+      this.isSet = false;
+    }
+
+    @Override
+    public void setDocId(int docID) throws IOException {
+      if (docValues.advanceExact(docID)) {
+        value = docValues.longValue() == 1;
+        isSet = true;
+      } else {
+        isSet = false;
+      }
+    }
+
+    @Override
+    public Boolean get(int index) {
+      return getBoolean(index);
+    }
+
+    public boolean getBoolean(int index) {
+      if (!isSet) {
+        throw new IllegalStateException("No doc values for document");
+      } else if (index != 0) {
+        throw new IndexOutOfBoundsException("No doc value for index: " + index);
+      }
+      return value;
+    }
+
+    @Override
+    public int size() {
+      return isSet ? 1 : 0;
+    }
+
+    public boolean getValue() {
+      return getBoolean(0);
     }
 
     public SearchResponse.Hit.FieldValue toFieldValue(int index) {
-      return SearchResponse.Hit.FieldValue.newBuilder().setBooleanValue(get(index)).build();
+      return SearchResponse.Hit.FieldValue.newBuilder().setBooleanValue(getBoolean(index)).build();
     }
   }
 
-  public static final class SingleInteger extends SingleNumericValue<Integer> {
+  public static final class SingleInteger extends LoadedDocValues<Integer> {
+    private final NumericDocValues docValues;
+    private int value;
+    private boolean isSet;
+
     public SingleInteger(NumericDocValues docValues) {
-      super(docValues, INT_DECODER);
+      this.docValues = docValues;
+      this.isSet = false;
+    }
+
+    @Override
+    public void setDocId(int docID) throws IOException {
+      if (docValues.advanceExact(docID)) {
+        value = (int) docValues.longValue();
+        isSet = true;
+      } else {
+        isSet = false;
+      }
+    }
+
+    @Override
+    public Integer get(int index) {
+      return getInt(index);
+    }
+
+    public int getInt(int index) {
+      if (!isSet) {
+        throw new IllegalStateException("No doc values for document");
+      } else if (index != 0) {
+        throw new IndexOutOfBoundsException("No doc value for index: " + index);
+      }
+      return value;
+    }
+
+    @Override
+    public int size() {
+      return isSet ? 1 : 0;
+    }
+
+    public int getValue() {
+      return getInt(0);
     }
 
     @Override
     public SearchResponse.Hit.FieldValue toFieldValue(int index) {
-      return SearchResponse.Hit.FieldValue.newBuilder().setIntValue(get(index)).build();
+      return SearchResponse.Hit.FieldValue.newBuilder().setIntValue(getInt(index)).build();
     }
   }
 
-  public static final class SingleLong extends SingleNumericValue<Long> {
+  public static final class SingleLong extends LoadedDocValues<Long> {
+    private final NumericDocValues docValues;
+    private long value;
+    private boolean isSet;
+
     public SingleLong(NumericDocValues docValues) {
-      super(docValues, LONG_DECODER);
+      this.docValues = docValues;
+      this.isSet = false;
+    }
+
+    @Override
+    public void setDocId(int docID) throws IOException {
+      if (docValues.advanceExact(docID)) {
+        value = docValues.longValue();
+        isSet = true;
+      } else {
+        isSet = false;
+      }
+    }
+
+    @Override
+    public Long get(int index) {
+      return getLong(index);
+    }
+
+    public long getLong(int index) {
+      if (!isSet) {
+        throw new IllegalStateException("No doc values for document");
+      } else if (index != 0) {
+        throw new IndexOutOfBoundsException("No doc value for index: " + index);
+      }
+      return value;
+    }
+
+    @Override
+    public int size() {
+      return isSet ? 1 : 0;
+    }
+
+    public long getValue() {
+      return getLong(0);
     }
 
     @Override
     public SearchResponse.Hit.FieldValue toFieldValue(int index) {
-      return SearchResponse.Hit.FieldValue.newBuilder().setLongValue(get(index)).build();
+      return SearchResponse.Hit.FieldValue.newBuilder().setLongValue(getLong(index)).build();
     }
   }
 
-  public static final class SingleFloat extends SingleNumericValue<Float> {
+  public static final class SingleFloat extends LoadedDocValues<Float> {
+    private final NumericDocValues docValues;
+    private float value;
+    private boolean isSet;
+
     public SingleFloat(NumericDocValues docValues) {
-      super(docValues, FLOAT_DECODER);
+      this.docValues = docValues;
+      this.isSet = false;
+    }
+
+    @Override
+    public void setDocId(int docID) throws IOException {
+      if (docValues.advanceExact(docID)) {
+        value = Float.intBitsToFloat((int) docValues.longValue());
+        isSet = true;
+      } else {
+        isSet = false;
+      }
+    }
+
+    @Override
+    public Float get(int index) {
+      return getFloat(index);
+    }
+
+    public float getFloat(int index) {
+      if (!isSet) {
+        throw new IllegalStateException("No doc values for document");
+      } else if (index != 0) {
+        throw new IndexOutOfBoundsException("No doc value for index: " + index);
+      }
+      return value;
+    }
+
+    @Override
+    public int size() {
+      return isSet ? 1 : 0;
+    }
+
+    public float getValue() {
+      return getFloat(0);
     }
 
     @Override
     public SearchResponse.Hit.FieldValue toFieldValue(int index) {
-      return SearchResponse.Hit.FieldValue.newBuilder().setFloatValue(get(index)).build();
+      return SearchResponse.Hit.FieldValue.newBuilder().setFloatValue(getFloat(index)).build();
     }
   }
 
-  public static final class SingleDouble extends SingleNumericValue<Double> {
+  public static final class SingleDouble extends LoadedDocValues<Double> {
+    private final NumericDocValues docValues;
+    private double value;
+    private boolean isSet;
+
     public SingleDouble(NumericDocValues docValues) {
-      super(docValues, DOUBLE_DECODER);
+      this.docValues = docValues;
+      this.isSet = false;
+    }
+
+    @Override
+    public void setDocId(int docID) throws IOException {
+      if (docValues.advanceExact(docID)) {
+        value = Double.longBitsToDouble(docValues.longValue());
+        isSet = true;
+      } else {
+        isSet = false;
+      }
+    }
+
+    @Override
+    public Double get(int index) {
+      return getDouble(index);
+    }
+
+    public double getDouble(int index) {
+      if (!isSet) {
+        throw new IllegalStateException("No doc values for document");
+      } else if (index != 0) {
+        throw new IndexOutOfBoundsException("No doc value for index: " + index);
+      }
+      return value;
+    }
+
+    @Override
+    public int size() {
+      return isSet ? 1 : 0;
+    }
+
+    public double getValue() {
+      return getDouble(0);
     }
 
     @Override
     public SearchResponse.Hit.FieldValue toFieldValue(int index) {
-      return SearchResponse.Hit.FieldValue.newBuilder().setDoubleValue(get(index)).build();
+      return SearchResponse.Hit.FieldValue.newBuilder().setDoubleValue(getDouble(index)).build();
     }
   }
 
   public static final class SingleDateTime extends SingleNumericValue<Instant> {
     public SingleDateTime(NumericDocValues docValues) {
       super(docValues, DATE_DECODER);
+    }
+
+    public Instant getValue() {
+      return get(0);
     }
 
     @Override
@@ -217,7 +397,6 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
           values.add(decoder.apply(docValues.nextValue()));
         }
       }
-      values.trimToSize();
     }
 
     @Override
@@ -236,58 +415,277 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
     }
   }
 
-  public static final class SortedBooleans extends SortedNumericValues<Boolean> {
+  public static final class SortedBooleans extends LoadedDocValues<Boolean> {
+    private final SortedNumericDocValues docValues;
+    private boolean[] values = new boolean[0];
+    private int size;
+
     public SortedBooleans(SortedNumericDocValues docValues) {
-      super(docValues, BOOL_DECODER);
+      this.docValues = docValues;
+      this.size = 0;
+    }
+
+    @Override
+    public void setDocId(int docID) throws IOException {
+      if (docValues.advanceExact(docID)) {
+        size = docValues.docValueCount();
+        values = grow(values, size);
+        for (int i = 0; i < size; ++i) {
+          values[i] = docValues.nextValue() == 1;
+        }
+      } else {
+        size = 0;
+      }
+    }
+
+    @Override
+    public Boolean get(int index) {
+      return getBoolean(index);
+    }
+
+    public boolean getBoolean(int index) {
+      if (size == 0) {
+        throw new IllegalStateException("No doc values for document");
+      } else if (index < 0 || index >= size) {
+        throw new IndexOutOfBoundsException("No doc value for index: " + index);
+      }
+      return values[index];
+    }
+
+    @Override
+    public int size() {
+      return size;
+    }
+
+    public boolean getValue() {
+      return getBoolean(0);
     }
 
     @Override
     public SearchResponse.Hit.FieldValue toFieldValue(int index) {
-      return SearchResponse.Hit.FieldValue.newBuilder().setBooleanValue(get(index)).build();
+      return SearchResponse.Hit.FieldValue.newBuilder().setBooleanValue(getBoolean(index)).build();
+    }
+
+    // Lucene ArrayUtil does not have grow functions for boolean[], added here for support
+    static boolean[] grow(boolean[] array, int minSize) {
+      assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
+      if (array.length < minSize) {
+        return growExact(array, oversize(minSize, 1));
+      } else return array;
+    }
+
+    static boolean[] growExact(boolean[] array, int newLength) {
+      boolean[] copy = new boolean[newLength];
+      System.arraycopy(array, 0, copy, 0, array.length);
+      return copy;
     }
   }
 
-  public static final class SortedIntegers extends SortedNumericValues<Integer> {
+  public static final class SortedIntegers extends LoadedDocValues<Integer> {
+    private final SortedNumericDocValues docValues;
+    private int[] values = new int[0];
+    private int size;
+
     public SortedIntegers(SortedNumericDocValues docValues) {
-      super(docValues, INT_DECODER);
+      this.docValues = docValues;
+      this.size = 0;
+    }
+
+    @Override
+    public void setDocId(int docID) throws IOException {
+      if (docValues.advanceExact(docID)) {
+        size = docValues.docValueCount();
+        values = ArrayUtil.grow(values, size);
+        for (int i = 0; i < size; ++i) {
+          values[i] = (int) docValues.nextValue();
+        }
+      } else {
+        size = 0;
+      }
+    }
+
+    @Override
+    public Integer get(int index) {
+      return getInt(index);
+    }
+
+    public int getInt(int index) {
+      if (size == 0) {
+        throw new IllegalStateException("No doc values for document");
+      } else if (index < 0 || index >= size) {
+        throw new IndexOutOfBoundsException("No doc value for index: " + index);
+      }
+      return values[index];
+    }
+
+    @Override
+    public int size() {
+      return size;
+    }
+
+    public int getValue() {
+      return getInt(0);
     }
 
     @Override
     public SearchResponse.Hit.FieldValue toFieldValue(int index) {
-      return SearchResponse.Hit.FieldValue.newBuilder().setIntValue(get(index)).build();
+      return SearchResponse.Hit.FieldValue.newBuilder().setIntValue(getInt(index)).build();
     }
   }
 
-  public static final class SortedLongs extends SortedNumericValues<Long> {
+  public static final class SortedLongs extends LoadedDocValues<Long> {
+    private final SortedNumericDocValues docValues;
+    private long[] values = new long[0];
+    private int size;
+
     public SortedLongs(SortedNumericDocValues docValues) {
-      super(docValues, LONG_DECODER);
+      this.docValues = docValues;
+      this.size = 0;
+    }
+
+    @Override
+    public void setDocId(int docID) throws IOException {
+      if (docValues.advanceExact(docID)) {
+        size = docValues.docValueCount();
+        values = ArrayUtil.grow(values, size);
+        for (int i = 0; i < size; ++i) {
+          values[i] = docValues.nextValue();
+        }
+      } else {
+        size = 0;
+      }
+    }
+
+    @Override
+    public Long get(int index) {
+      return getLong(index);
+    }
+
+    public long getLong(int index) {
+      if (size == 0) {
+        throw new IllegalStateException("No doc values for document");
+      } else if (index < 0 || index >= size) {
+        throw new IndexOutOfBoundsException("No doc value for index: " + index);
+      }
+      return values[index];
+    }
+
+    @Override
+    public int size() {
+      return size;
+    }
+
+    public long getValue() {
+      return getLong(0);
     }
 
     @Override
     public SearchResponse.Hit.FieldValue toFieldValue(int index) {
-      return SearchResponse.Hit.FieldValue.newBuilder().setLongValue(get(index)).build();
+      return SearchResponse.Hit.FieldValue.newBuilder().setLongValue(getLong(index)).build();
     }
   }
 
-  public static final class SortedFloats extends SortedNumericValues<Float> {
+  public static final class SortedFloats extends LoadedDocValues<Float> {
+    private final SortedNumericDocValues docValues;
+    private float[] values = new float[0];
+    private int size;
+
     public SortedFloats(SortedNumericDocValues docValues) {
-      super(docValues, SORTED_FLOAT_DECODER);
+      this.docValues = docValues;
+      this.size = 0;
+    }
+
+    @Override
+    public void setDocId(int docID) throws IOException {
+      if (docValues.advanceExact(docID)) {
+        size = docValues.docValueCount();
+        values = ArrayUtil.grow(values, size);
+        for (int i = 0; i < size; ++i) {
+          values[i] = NumericUtils.sortableIntToFloat((int) docValues.nextValue());
+        }
+      } else {
+        size = 0;
+      }
+    }
+
+    @Override
+    public Float get(int index) {
+      return getFloat(index);
+    }
+
+    public float getFloat(int index) {
+      if (size == 0) {
+        throw new IllegalStateException("No doc values for document");
+      } else if (index < 0 || index >= size) {
+        throw new IndexOutOfBoundsException("No doc value for index: " + index);
+      }
+      return values[index];
+    }
+
+    @Override
+    public int size() {
+      return size;
+    }
+
+    public float getValue() {
+      return getFloat(0);
     }
 
     @Override
     public SearchResponse.Hit.FieldValue toFieldValue(int index) {
-      return SearchResponse.Hit.FieldValue.newBuilder().setFloatValue(get(index)).build();
+      return SearchResponse.Hit.FieldValue.newBuilder().setFloatValue(getFloat(index)).build();
     }
   }
 
-  public static final class SortedDoubles extends SortedNumericValues<Double> {
+  public static final class SortedDoubles extends LoadedDocValues<Double> {
+    private final SortedNumericDocValues docValues;
+    private double[] values = new double[0];
+    private int size;
+
     public SortedDoubles(SortedNumericDocValues docValues) {
-      super(docValues, SORTED_DOUBLE_DECODER);
+      this.docValues = docValues;
+      this.size = 0;
+    }
+
+    @Override
+    public void setDocId(int docID) throws IOException {
+      if (docValues.advanceExact(docID)) {
+        size = docValues.docValueCount();
+        values = ArrayUtil.grow(values, size);
+        for (int i = 0; i < size; ++i) {
+          values[i] = NumericUtils.sortableLongToDouble(docValues.nextValue());
+        }
+      } else {
+        size = 0;
+      }
+    }
+
+    @Override
+    public Double get(int index) {
+      return getDouble(index);
+    }
+
+    public double getDouble(int index) {
+      if (size == 0) {
+        throw new IllegalStateException("No doc values for document");
+      } else if (index < 0 || index >= size) {
+        throw new IndexOutOfBoundsException("No doc value for index: " + index);
+      }
+      return values[index];
+    }
+
+    @Override
+    public int size() {
+      return size;
+    }
+
+    public double getValue() {
+      return getDouble(0);
     }
 
     @Override
     public SearchResponse.Hit.FieldValue toFieldValue(int index) {
-      return SearchResponse.Hit.FieldValue.newBuilder().setDoubleValue(get(index)).build();
+      return SearchResponse.Hit.FieldValue.newBuilder().setDoubleValue(getDouble(index)).build();
     }
   }
 
@@ -319,6 +717,10 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
       super(docValues, GEO_POINT_DECODER);
     }
 
+    public GeoPoint getValue() {
+      return get(0);
+    }
+
     @Override
     public SearchResponse.Hit.FieldValue toFieldValue(int index) {
       GeoPoint point = get(index);
@@ -337,6 +739,10 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
   public static final class SortedDateTimes extends SortedNumericValues<Instant> {
     public SortedDateTimes(SortedNumericDocValues docValues) {
       super(docValues, DATE_DECODER);
+    }
+
+    public Instant getValue() {
+      return get(0);
     }
 
     @Override
@@ -362,7 +768,7 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
         JsonFormat.parser().merge(jsonString, builder);
         value =
             builder.getValuesList().stream()
-                .map(e -> e.getStructValue())
+                .map(Value::getStructValue)
                 .collect(Collectors.toList());
       } else {
         value = null;
@@ -379,6 +785,10 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
       } catch (IndexOutOfBoundsException e) {
         throw new RuntimeException(e);
       }
+    }
+
+    public Struct getValue() {
+      return get(0);
     }
 
     @Override
@@ -426,15 +836,15 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
     public int size() {
       return value == null ? 0 : 1;
     }
-
-    public T getValue() {
-      return get(0);
-    }
   }
 
   public static final class SingleBinary extends SingleBinaryBase<BytesRef> {
     public SingleBinary(BinaryDocValues docValues) {
       super(docValues, BYTES_REF_DECODER);
+    }
+
+    public BytesRef getValue() {
+      return get(0);
     }
 
     @Override
@@ -448,6 +858,10 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
   public static final class SingleBinaryString extends SingleBinaryBase<String> {
     public SingleBinaryString(BinaryDocValues docValues) {
       super(docValues, STRING_DECODER);
+    }
+
+    public String getValue() {
+      return get(0);
     }
 
     @Override
@@ -516,7 +930,10 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
           ord = docValues.nextOrd();
         }
       }
-      values.trimToSize();
+    }
+
+    public String getValue() {
+      return get(0);
     }
 
     @Override

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SingleBooleanTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SingleBooleanTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.doc;
+
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertNoDocValues;
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertOutOfBounds;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import java.io.IOException;
+import org.apache.lucene.index.NumericDocValues;
+import org.junit.Test;
+
+public class SingleBooleanTest {
+
+  private void verifyUnset(LoadedDocValues.SingleBoolean loadedData) {
+    assertEquals(0, loadedData.size());
+    assertNoDocValues(() -> loadedData.get(0));
+    assertNoDocValues(loadedData::getValue);
+    assertNoDocValues(() -> loadedData.getBoolean(0));
+    assertNoDocValues(() -> loadedData.toFieldValue(0));
+  }
+
+  private void verifySetToValue(LoadedDocValues.SingleBoolean loadedData, boolean value) {
+    assertEquals(1, loadedData.size());
+    assertEquals(value, loadedData.get(0));
+    assertEquals(value, loadedData.getValue());
+    assertEquals(value, loadedData.getBoolean(0));
+    assertEquals(
+        SearchResponse.Hit.FieldValue.newBuilder().setBooleanValue(value).build(),
+        loadedData.toFieldValue(0));
+  }
+
+  @Test
+  public void testNotSet() {
+    LoadedDocValues.SingleBoolean loadedData = new LoadedDocValues.SingleBoolean(null);
+    assertEquals(0, loadedData.size());
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetValue() throws IOException {
+    NumericDocValues mockDocValues = mock(NumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt())).thenReturn(true, true, false);
+    when(mockDocValues.longValue()).thenReturn(1L, 0L);
+
+    LoadedDocValues.SingleBoolean loadedData = new LoadedDocValues.SingleBoolean(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(loadedData, true);
+
+    loadedData.setDocId(1);
+    verifySetToValue(loadedData, false);
+
+    loadedData.setDocId(2);
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetDocValuesOutOfBounds() throws IOException {
+    NumericDocValues mockDocValues = mock(NumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt())).thenReturn(true);
+    when(mockDocValues.longValue()).thenReturn(1L);
+
+    LoadedDocValues.SingleBoolean loadedData = new LoadedDocValues.SingleBoolean(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(loadedData, true);
+
+    assertOutOfBounds(() -> loadedData.get(-1));
+    assertOutOfBounds(() -> loadedData.getBoolean(-1));
+    assertOutOfBounds(() -> loadedData.toFieldValue(-1));
+
+    assertOutOfBounds(() -> loadedData.get(1));
+    assertOutOfBounds(() -> loadedData.getBoolean(1));
+    assertOutOfBounds(() -> loadedData.toFieldValue(1));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SingleDoubleTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SingleDoubleTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.doc;
+
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertNoDocValues;
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertOutOfBounds;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import java.io.IOException;
+import org.apache.lucene.index.NumericDocValues;
+import org.junit.Test;
+
+public class SingleDoubleTest {
+
+  private void verifyUnset(LoadedDocValues.SingleDouble loadedData) {
+    assertEquals(0, loadedData.size());
+    assertNoDocValues(() -> loadedData.get(0));
+    assertNoDocValues(loadedData::getValue);
+    assertNoDocValues(() -> loadedData.getDouble(0));
+    assertNoDocValues(() -> loadedData.toFieldValue(0));
+  }
+
+  private void verifySetToValue(LoadedDocValues.SingleDouble loadedData, double value) {
+    assertEquals(1, loadedData.size());
+    assertEquals(value, loadedData.get(0), 0.0);
+    assertEquals(value, loadedData.getValue(), 0.0);
+    assertEquals(value, loadedData.getDouble(0), 0.0);
+    assertEquals(
+        SearchResponse.Hit.FieldValue.newBuilder().setDoubleValue(value).build(),
+        loadedData.toFieldValue(0));
+  }
+
+  @Test
+  public void testNotSet() {
+    LoadedDocValues.SingleDouble loadedData = new LoadedDocValues.SingleDouble(null);
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetValue() throws IOException {
+    NumericDocValues mockDocValues = mock(NumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt()))
+        .thenReturn(true, true, true, true, true, true, false);
+    when(mockDocValues.longValue())
+        .thenReturn(
+            Double.doubleToRawLongBits(Double.NEGATIVE_INFINITY),
+            Double.doubleToRawLongBits(15.0),
+            Double.doubleToRawLongBits(Double.POSITIVE_INFINITY),
+            Double.doubleToRawLongBits(Double.NaN),
+            Double.doubleToRawLongBits(Double.MAX_VALUE),
+            Double.doubleToRawLongBits(Double.MIN_VALUE));
+
+    LoadedDocValues.SingleDouble loadedData = new LoadedDocValues.SingleDouble(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(loadedData, Double.NEGATIVE_INFINITY);
+
+    loadedData.setDocId(1);
+    verifySetToValue(loadedData, 15.0);
+
+    loadedData.setDocId(2);
+    verifySetToValue(loadedData, Double.POSITIVE_INFINITY);
+
+    loadedData.setDocId(3);
+    verifySetToValue(loadedData, Double.NaN);
+
+    loadedData.setDocId(4);
+    verifySetToValue(loadedData, Double.MAX_VALUE);
+
+    loadedData.setDocId(5);
+    verifySetToValue(loadedData, Double.MIN_VALUE);
+
+    loadedData.setDocId(6);
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetDocValuesOutOfBounds() throws IOException {
+    NumericDocValues mockDocValues = mock(NumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt())).thenReturn(true);
+    when(mockDocValues.longValue()).thenReturn(Double.doubleToRawLongBits(15.0f));
+
+    LoadedDocValues.SingleDouble loadedData = new LoadedDocValues.SingleDouble(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(loadedData, 15.0);
+
+    assertOutOfBounds(() -> loadedData.get(-1));
+    assertOutOfBounds(() -> loadedData.getDouble(-1));
+    assertOutOfBounds(() -> loadedData.toFieldValue(-1));
+
+    assertOutOfBounds(() -> loadedData.get(1));
+    assertOutOfBounds(() -> loadedData.getDouble(1));
+    assertOutOfBounds(() -> loadedData.toFieldValue(1));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SingleFloatTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SingleFloatTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.doc;
+
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertNoDocValues;
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertOutOfBounds;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import java.io.IOException;
+import org.apache.lucene.index.NumericDocValues;
+import org.junit.Test;
+
+public class SingleFloatTest {
+
+  private void verifyUnset(LoadedDocValues.SingleFloat loadedData) {
+    assertEquals(0, loadedData.size());
+    assertNoDocValues(() -> loadedData.get(0));
+    assertNoDocValues(loadedData::getValue);
+    assertNoDocValues(() -> loadedData.getFloat(0));
+    assertNoDocValues(() -> loadedData.toFieldValue(0));
+  }
+
+  private void verifySetToValue(LoadedDocValues.SingleFloat loadedData, float value) {
+    assertEquals(1, loadedData.size());
+    assertEquals(value, loadedData.get(0), 0.0);
+    assertEquals(value, loadedData.getValue(), 0.0);
+    assertEquals(value, loadedData.getFloat(0), 0.0);
+    assertEquals(
+        SearchResponse.Hit.FieldValue.newBuilder().setFloatValue(value).build(),
+        loadedData.toFieldValue(0));
+  }
+
+  @Test
+  public void testNotSet() {
+    LoadedDocValues.SingleFloat loadedData = new LoadedDocValues.SingleFloat(null);
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetValue() throws IOException {
+    NumericDocValues mockDocValues = mock(NumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt()))
+        .thenReturn(true, true, true, true, true, true, false);
+    when(mockDocValues.longValue())
+        .thenReturn(
+            (long) Float.floatToRawIntBits(Float.NEGATIVE_INFINITY),
+            (long) Float.floatToRawIntBits(15.0f),
+            (long) Float.floatToRawIntBits(Float.POSITIVE_INFINITY),
+            (long) Float.floatToRawIntBits(Float.NaN),
+            (long) Float.floatToRawIntBits(Float.MAX_VALUE),
+            (long) Float.floatToRawIntBits(Float.MIN_VALUE));
+
+    LoadedDocValues.SingleFloat loadedData = new LoadedDocValues.SingleFloat(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(loadedData, Float.NEGATIVE_INFINITY);
+
+    loadedData.setDocId(1);
+    verifySetToValue(loadedData, 15.0f);
+
+    loadedData.setDocId(2);
+    verifySetToValue(loadedData, Float.POSITIVE_INFINITY);
+
+    loadedData.setDocId(3);
+    verifySetToValue(loadedData, Float.NaN);
+
+    loadedData.setDocId(4);
+    verifySetToValue(loadedData, Float.MAX_VALUE);
+
+    loadedData.setDocId(5);
+    verifySetToValue(loadedData, Float.MIN_VALUE);
+
+    loadedData.setDocId(6);
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetDocValuesOutOfBounds() throws IOException {
+    NumericDocValues mockDocValues = mock(NumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt())).thenReturn(true);
+    when(mockDocValues.longValue()).thenReturn((long) Float.floatToRawIntBits(15.0f));
+
+    LoadedDocValues.SingleFloat loadedData = new LoadedDocValues.SingleFloat(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(loadedData, 15.0f);
+
+    assertOutOfBounds(() -> loadedData.get(-1));
+    assertOutOfBounds(() -> loadedData.getFloat(-1));
+    assertOutOfBounds(() -> loadedData.toFieldValue(-1));
+
+    assertOutOfBounds(() -> loadedData.get(1));
+    assertOutOfBounds(() -> loadedData.getFloat(1));
+    assertOutOfBounds(() -> loadedData.toFieldValue(1));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SingleIntegerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SingleIntegerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.doc;
+
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertNoDocValues;
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertOutOfBounds;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import java.io.IOException;
+import org.apache.lucene.index.NumericDocValues;
+import org.junit.Test;
+
+public class SingleIntegerTest {
+
+  private void verifyUnset(LoadedDocValues.SingleInteger loadedData) {
+    assertEquals(0, loadedData.size());
+    assertNoDocValues(() -> loadedData.get(0));
+    assertNoDocValues(loadedData::getValue);
+    assertNoDocValues(() -> loadedData.getInt(0));
+    assertNoDocValues(() -> loadedData.toFieldValue(0));
+  }
+
+  private void verifySetToValue(LoadedDocValues.SingleInteger loadedData, int value) {
+    assertEquals(1, loadedData.size());
+    assertEquals(value, loadedData.get(0).intValue());
+    assertEquals(value, loadedData.getValue());
+    assertEquals(value, loadedData.getInt(0));
+    assertEquals(
+        SearchResponse.Hit.FieldValue.newBuilder().setIntValue(value).build(),
+        loadedData.toFieldValue(0));
+  }
+
+  @Test
+  public void testNotSet() {
+    LoadedDocValues.SingleInteger loadedData = new LoadedDocValues.SingleInteger(null);
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetValue() throws IOException {
+    NumericDocValues mockDocValues = mock(NumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt())).thenReturn(true, true, true, false);
+    when(mockDocValues.longValue())
+        .thenReturn((long) Integer.MAX_VALUE, 15L, (long) Integer.MIN_VALUE);
+
+    LoadedDocValues.SingleInteger loadedData = new LoadedDocValues.SingleInteger(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(loadedData, Integer.MAX_VALUE);
+
+    loadedData.setDocId(1);
+    verifySetToValue(loadedData, 15);
+
+    loadedData.setDocId(2);
+    verifySetToValue(loadedData, Integer.MIN_VALUE);
+
+    loadedData.setDocId(3);
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetDocValuesOutOfBounds() throws IOException {
+    NumericDocValues mockDocValues = mock(NumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt())).thenReturn(true);
+    when(mockDocValues.longValue()).thenReturn(15L);
+
+    LoadedDocValues.SingleInteger loadedData = new LoadedDocValues.SingleInteger(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(loadedData, 15);
+
+    assertOutOfBounds(() -> loadedData.get(-1));
+    assertOutOfBounds(() -> loadedData.getInt(-1));
+    assertOutOfBounds(() -> loadedData.toFieldValue(-1));
+
+    assertOutOfBounds(() -> loadedData.get(1));
+    assertOutOfBounds(() -> loadedData.getInt(1));
+    assertOutOfBounds(() -> loadedData.toFieldValue(1));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SingleLongTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SingleLongTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.doc;
+
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertNoDocValues;
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertOutOfBounds;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import java.io.IOException;
+import org.apache.lucene.index.NumericDocValues;
+import org.junit.Test;
+
+public class SingleLongTest {
+
+  private void verifyUnset(LoadedDocValues.SingleLong loadedData) {
+    assertEquals(0, loadedData.size());
+    assertNoDocValues(() -> loadedData.get(0));
+    assertNoDocValues(loadedData::getValue);
+    assertNoDocValues(() -> loadedData.getLong(0));
+    assertNoDocValues(() -> loadedData.toFieldValue(0));
+  }
+
+  private void verifySetToValue(LoadedDocValues.SingleLong loadedData, long value) {
+    assertEquals(1, loadedData.size());
+    assertEquals(value, loadedData.get(0).longValue());
+    assertEquals(value, loadedData.getValue());
+    assertEquals(value, loadedData.getLong(0));
+    assertEquals(
+        SearchResponse.Hit.FieldValue.newBuilder().setLongValue(value).build(),
+        loadedData.toFieldValue(0));
+  }
+
+  @Test
+  public void testNotSet() {
+    LoadedDocValues.SingleLong loadedData = new LoadedDocValues.SingleLong(null);
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetValue() throws IOException {
+    NumericDocValues mockDocValues = mock(NumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt())).thenReturn(true, true, true, false);
+    when(mockDocValues.longValue()).thenReturn(Long.MAX_VALUE, 15L, Long.MIN_VALUE);
+
+    LoadedDocValues.SingleLong loadedData = new LoadedDocValues.SingleLong(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(loadedData, Long.MAX_VALUE);
+
+    loadedData.setDocId(1);
+    verifySetToValue(loadedData, 15L);
+
+    loadedData.setDocId(2);
+    verifySetToValue(loadedData, Long.MIN_VALUE);
+
+    loadedData.setDocId(3);
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetDocValuesOutOfBounds() throws IOException {
+    NumericDocValues mockDocValues = mock(NumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt())).thenReturn(true);
+    when(mockDocValues.longValue()).thenReturn(15L);
+
+    LoadedDocValues.SingleLong loadedData = new LoadedDocValues.SingleLong(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(loadedData, 15L);
+
+    assertOutOfBounds(() -> loadedData.get(-1));
+    assertOutOfBounds(() -> loadedData.getLong(-1));
+    assertOutOfBounds(() -> loadedData.toFieldValue(-1));
+
+    assertOutOfBounds(() -> loadedData.get(1));
+    assertOutOfBounds(() -> loadedData.getLong(1));
+    assertOutOfBounds(() -> loadedData.toFieldValue(1));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SortedBooleansTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SortedBooleansTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.doc;
+
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertNoDocValues;
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertOutOfBounds;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import java.io.IOException;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.junit.Test;
+
+public class SortedBooleansTest {
+
+  private void verifyUnset(LoadedDocValues.SortedBooleans loadedData) {
+    assertEquals(0, loadedData.size());
+    assertNoDocValues(() -> loadedData.get(0));
+    assertNoDocValues(loadedData::getValue);
+    assertNoDocValues(() -> loadedData.getBoolean(0));
+    assertNoDocValues(() -> loadedData.toFieldValue(0));
+  }
+
+  private void verifySetToValue(LoadedDocValues.SortedBooleans loadedData, boolean... values) {
+    assertEquals(values.length, loadedData.size());
+    assertEquals(values[0], loadedData.getValue());
+    for (int i = 0; i < values.length; i++) {
+      assertEquals(values[i], loadedData.get(i));
+      assertEquals(values[i], loadedData.getBoolean(i));
+      assertEquals(
+          SearchResponse.Hit.FieldValue.newBuilder().setBooleanValue(values[i]).build(),
+          loadedData.toFieldValue(i));
+    }
+  }
+
+  @Test
+  public void testNotSet() {
+    LoadedDocValues.SortedBooleans loadedData = new LoadedDocValues.SortedBooleans(null);
+    assertEquals(0, loadedData.size());
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetValue() throws IOException {
+    SortedNumericDocValues mockDocValues = mock(SortedNumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt())).thenReturn(true, true, true, false);
+    when(mockDocValues.docValueCount()).thenReturn(1, 2, 1);
+    when(mockDocValues.nextValue()).thenReturn(1L, 0L, 1L, 0L);
+
+    LoadedDocValues.SortedBooleans loadedData = new LoadedDocValues.SortedBooleans(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(loadedData, true);
+
+    loadedData.setDocId(1);
+    verifySetToValue(loadedData, false, true);
+
+    loadedData.setDocId(2);
+    verifySetToValue(loadedData, false);
+
+    loadedData.setDocId(3);
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetDocValuesOutOfBounds() throws IOException {
+    SortedNumericDocValues mockDocValues = mock(SortedNumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt())).thenReturn(true);
+    when(mockDocValues.docValueCount()).thenReturn(2);
+    when(mockDocValues.nextValue()).thenReturn(1L, 0L);
+
+    LoadedDocValues.SortedBooleans loadedData = new LoadedDocValues.SortedBooleans(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(loadedData, true, false);
+
+    assertOutOfBounds(() -> loadedData.get(-1));
+    assertOutOfBounds(() -> loadedData.getBoolean(-1));
+    assertOutOfBounds(() -> loadedData.toFieldValue(-1));
+
+    assertOutOfBounds(() -> loadedData.get(2));
+    assertOutOfBounds(() -> loadedData.getBoolean(2));
+    assertOutOfBounds(() -> loadedData.toFieldValue(2));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SortedDoublesTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SortedDoublesTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.doc;
+
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertNoDocValues;
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertOutOfBounds;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import java.io.IOException;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.util.NumericUtils;
+import org.junit.Test;
+
+public class SortedDoublesTest {
+
+  private void verifyUnset(LoadedDocValues.SortedDoubles loadedData) {
+    assertEquals(0, loadedData.size());
+    assertNoDocValues(() -> loadedData.get(0));
+    assertNoDocValues(loadedData::getValue);
+    assertNoDocValues(() -> loadedData.getDouble(0));
+    assertNoDocValues(() -> loadedData.toFieldValue(0));
+  }
+
+  private void verifySetToValue(LoadedDocValues.SortedDoubles loadedData, double... values) {
+    assertEquals(values.length, loadedData.size());
+    assertEquals(values[0], loadedData.getValue(), 0.0);
+    for (int i = 0; i < values.length; i++) {
+      assertEquals(values[i], loadedData.get(i), 0.0);
+      assertEquals(values[i], loadedData.getDouble(i), 0.0);
+      assertEquals(
+          SearchResponse.Hit.FieldValue.newBuilder().setDoubleValue(values[i]).build(),
+          loadedData.toFieldValue(i));
+    }
+  }
+
+  @Test
+  public void testNotSet() {
+    LoadedDocValues.SortedDoubles loadedData = new LoadedDocValues.SortedDoubles(null);
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetValue() throws IOException {
+    SortedNumericDocValues mockDocValues = mock(SortedNumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt())).thenReturn(true, true, true, false);
+    when(mockDocValues.docValueCount()).thenReturn(6, 10, 3);
+    when(mockDocValues.nextValue())
+        .thenReturn(
+            NumericUtils.doubleToSortableLong(Double.NEGATIVE_INFINITY),
+            NumericUtils.doubleToSortableLong(15.0f),
+            NumericUtils.doubleToSortableLong(Double.POSITIVE_INFINITY),
+            NumericUtils.doubleToSortableLong(Double.NaN),
+            NumericUtils.doubleToSortableLong(Double.MAX_VALUE),
+            NumericUtils.doubleToSortableLong(Double.MIN_VALUE),
+            NumericUtils.doubleToSortableLong(0),
+            NumericUtils.doubleToSortableLong(1),
+            NumericUtils.doubleToSortableLong(2),
+            NumericUtils.doubleToSortableLong(3),
+            NumericUtils.doubleToSortableLong(4),
+            NumericUtils.doubleToSortableLong(5),
+            NumericUtils.doubleToSortableLong(6),
+            NumericUtils.doubleToSortableLong(7),
+            NumericUtils.doubleToSortableLong(8),
+            NumericUtils.doubleToSortableLong(9),
+            NumericUtils.doubleToSortableLong(-1),
+            NumericUtils.doubleToSortableLong(-2),
+            NumericUtils.doubleToSortableLong(-3));
+
+    LoadedDocValues.SortedDoubles loadedData = new LoadedDocValues.SortedDoubles(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(
+        loadedData,
+        Double.NEGATIVE_INFINITY,
+        15.0,
+        Double.POSITIVE_INFINITY,
+        Double.NaN,
+        Double.MAX_VALUE,
+        Double.MIN_VALUE);
+
+    loadedData.setDocId(1);
+    verifySetToValue(loadedData, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+    loadedData.setDocId(2);
+    verifySetToValue(loadedData, -1, -2, -3);
+
+    loadedData.setDocId(3);
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetDocValuesOutOfBounds() throws IOException {
+    SortedNumericDocValues mockDocValues = mock(SortedNumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt())).thenReturn(true);
+    when(mockDocValues.docValueCount()).thenReturn(2);
+    when(mockDocValues.nextValue())
+        .thenReturn(
+            NumericUtils.doubleToSortableLong(15.0), NumericUtils.doubleToSortableLong(16.0));
+
+    LoadedDocValues.SortedDoubles loadedData = new LoadedDocValues.SortedDoubles(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(loadedData, 15.0, 16.0);
+
+    assertOutOfBounds(() -> loadedData.get(-1));
+    assertOutOfBounds(() -> loadedData.getDouble(-1));
+    assertOutOfBounds(() -> loadedData.toFieldValue(-1));
+
+    assertOutOfBounds(() -> loadedData.get(2));
+    assertOutOfBounds(() -> loadedData.getDouble(2));
+    assertOutOfBounds(() -> loadedData.toFieldValue(2));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SortedFloatsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SortedFloatsTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.doc;
+
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertNoDocValues;
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertOutOfBounds;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import java.io.IOException;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.util.NumericUtils;
+import org.junit.Test;
+
+public class SortedFloatsTest {
+
+  private void verifyUnset(LoadedDocValues.SortedFloats loadedData) {
+    assertEquals(0, loadedData.size());
+    assertNoDocValues(() -> loadedData.get(0));
+    assertNoDocValues(loadedData::getValue);
+    assertNoDocValues(() -> loadedData.getFloat(0));
+    assertNoDocValues(() -> loadedData.toFieldValue(0));
+  }
+
+  private void verifySetToValue(LoadedDocValues.SortedFloats loadedData, float... values) {
+    assertEquals(values.length, loadedData.size());
+    assertEquals(values[0], loadedData.getValue(), 0.0);
+    for (int i = 0; i < values.length; i++) {
+      assertEquals(values[i], loadedData.get(i), 0.0);
+      assertEquals(values[i], loadedData.getFloat(i), 0.0);
+      assertEquals(
+          SearchResponse.Hit.FieldValue.newBuilder().setFloatValue(values[i]).build(),
+          loadedData.toFieldValue(i));
+    }
+  }
+
+  @Test
+  public void testNotSet() {
+    LoadedDocValues.SortedFloats loadedData = new LoadedDocValues.SortedFloats(null);
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetValue() throws IOException {
+    SortedNumericDocValues mockDocValues = mock(SortedNumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt())).thenReturn(true, true, true, false);
+    when(mockDocValues.docValueCount()).thenReturn(6, 10, 3);
+    when(mockDocValues.nextValue())
+        .thenReturn(
+            (long) NumericUtils.floatToSortableInt(Float.NEGATIVE_INFINITY),
+            (long) NumericUtils.floatToSortableInt(15.0f),
+            (long) NumericUtils.floatToSortableInt(Float.POSITIVE_INFINITY),
+            (long) NumericUtils.floatToSortableInt(Float.NaN),
+            (long) NumericUtils.floatToSortableInt(Float.MAX_VALUE),
+            (long) NumericUtils.floatToSortableInt(Float.MIN_VALUE),
+            (long) NumericUtils.floatToSortableInt(0),
+            (long) NumericUtils.floatToSortableInt(1),
+            (long) NumericUtils.floatToSortableInt(2),
+            (long) NumericUtils.floatToSortableInt(3),
+            (long) NumericUtils.floatToSortableInt(4),
+            (long) NumericUtils.floatToSortableInt(5),
+            (long) NumericUtils.floatToSortableInt(6),
+            (long) NumericUtils.floatToSortableInt(7),
+            (long) NumericUtils.floatToSortableInt(8),
+            (long) NumericUtils.floatToSortableInt(9),
+            (long) NumericUtils.floatToSortableInt(-1),
+            (long) NumericUtils.floatToSortableInt(-2),
+            (long) NumericUtils.floatToSortableInt(-3));
+
+    LoadedDocValues.SortedFloats loadedData = new LoadedDocValues.SortedFloats(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(
+        loadedData,
+        Float.NEGATIVE_INFINITY,
+        15.0f,
+        Float.POSITIVE_INFINITY,
+        Float.NaN,
+        Float.MAX_VALUE,
+        Float.MIN_VALUE);
+
+    loadedData.setDocId(1);
+    verifySetToValue(loadedData, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+    loadedData.setDocId(2);
+    verifySetToValue(loadedData, -1, -2, -3);
+
+    loadedData.setDocId(3);
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetDocValuesOutOfBounds() throws IOException {
+    SortedNumericDocValues mockDocValues = mock(SortedNumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt())).thenReturn(true);
+    when(mockDocValues.docValueCount()).thenReturn(2);
+    when(mockDocValues.nextValue())
+        .thenReturn(
+            (long) NumericUtils.floatToSortableInt(15.0f),
+            (long) NumericUtils.floatToSortableInt(16.0f));
+
+    LoadedDocValues.SortedFloats loadedData = new LoadedDocValues.SortedFloats(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(loadedData, 15.0f, 16.0f);
+
+    assertOutOfBounds(() -> loadedData.get(-1));
+    assertOutOfBounds(() -> loadedData.getFloat(-1));
+    assertOutOfBounds(() -> loadedData.toFieldValue(-1));
+
+    assertOutOfBounds(() -> loadedData.get(2));
+    assertOutOfBounds(() -> loadedData.getFloat(2));
+    assertOutOfBounds(() -> loadedData.toFieldValue(2));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SortedIntegersTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SortedIntegersTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.doc;
+
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertNoDocValues;
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertOutOfBounds;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import java.io.IOException;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.junit.Test;
+
+public class SortedIntegersTest {
+
+  private void verifyUnset(LoadedDocValues.SortedIntegers loadedData) {
+    assertEquals(0, loadedData.size());
+    assertNoDocValues(() -> loadedData.get(0));
+    assertNoDocValues(loadedData::getValue);
+    assertNoDocValues(() -> loadedData.getInt(0));
+    assertNoDocValues(() -> loadedData.toFieldValue(0));
+  }
+
+  private void verifySetToValue(LoadedDocValues.SortedIntegers loadedData, int... values) {
+    assertEquals(values.length, loadedData.size());
+    assertEquals(values[0], loadedData.getValue());
+    for (int i = 0; i < values.length; i++) {
+      assertEquals(values[i], loadedData.get(i).intValue());
+      assertEquals(values[i], loadedData.getInt(i));
+      assertEquals(
+          SearchResponse.Hit.FieldValue.newBuilder().setIntValue(values[i]).build(),
+          loadedData.toFieldValue(i));
+    }
+  }
+
+  @Test
+  public void testNotSet() {
+    LoadedDocValues.SortedIntegers loadedData = new LoadedDocValues.SortedIntegers(null);
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetValue() throws IOException {
+    SortedNumericDocValues mockDocValues = mock(SortedNumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt())).thenReturn(true, true, true, false);
+    when(mockDocValues.docValueCount()).thenReturn(3, 10, 2);
+    when(mockDocValues.nextValue())
+        .thenReturn(
+            (long) Integer.MAX_VALUE,
+            15L,
+            (long) Integer.MIN_VALUE,
+            0L,
+            1L,
+            2L,
+            3L,
+            4L,
+            5L,
+            6L,
+            7L,
+            8L,
+            9L,
+            -1L,
+            -2L);
+
+    LoadedDocValues.SortedIntegers loadedData = new LoadedDocValues.SortedIntegers(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(loadedData, Integer.MAX_VALUE, 15, Integer.MIN_VALUE);
+
+    loadedData.setDocId(1);
+    verifySetToValue(loadedData, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+    loadedData.setDocId(2);
+    verifySetToValue(loadedData, -1, -2);
+
+    loadedData.setDocId(3);
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetDocValuesOutOfBounds() throws IOException {
+    SortedNumericDocValues mockDocValues = mock(SortedNumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt())).thenReturn(true);
+    when(mockDocValues.docValueCount()).thenReturn(2);
+    when(mockDocValues.nextValue()).thenReturn((long) 15, (long) 16);
+
+    LoadedDocValues.SortedIntegers loadedData = new LoadedDocValues.SortedIntegers(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(loadedData, 15, 16);
+
+    assertOutOfBounds(() -> loadedData.get(-1));
+    assertOutOfBounds(() -> loadedData.getInt(-1));
+    assertOutOfBounds(() -> loadedData.toFieldValue(-1));
+
+    assertOutOfBounds(() -> loadedData.get(2));
+    assertOutOfBounds(() -> loadedData.getInt(2));
+    assertOutOfBounds(() -> loadedData.toFieldValue(2));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SortedLongsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/SortedLongsTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.doc;
+
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertNoDocValues;
+import static com.yelp.nrtsearch.server.luceneserver.doc.TestUtils.assertOutOfBounds;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import java.io.IOException;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.junit.Test;
+
+public class SortedLongsTest {
+
+  private void verifyUnset(LoadedDocValues.SortedLongs loadedData) {
+    assertEquals(0, loadedData.size());
+    assertNoDocValues(() -> loadedData.get(0));
+    assertNoDocValues(loadedData::getValue);
+    assertNoDocValues(() -> loadedData.getLong(0));
+    assertNoDocValues(() -> loadedData.toFieldValue(0));
+  }
+
+  private void verifySetToValue(LoadedDocValues.SortedLongs loadedData, long... values) {
+    assertEquals(values.length, loadedData.size());
+    assertEquals(values[0], loadedData.getValue());
+    for (int i = 0; i < values.length; i++) {
+      assertEquals(values[i], loadedData.get(i).longValue());
+      assertEquals(values[i], loadedData.getLong(i));
+      assertEquals(
+          SearchResponse.Hit.FieldValue.newBuilder().setLongValue(values[i]).build(),
+          loadedData.toFieldValue(i));
+    }
+  }
+
+  @Test
+  public void testNotSet() {
+    LoadedDocValues.SortedLongs loadedData = new LoadedDocValues.SortedLongs(null);
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetValue() throws IOException {
+    SortedNumericDocValues mockDocValues = mock(SortedNumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt())).thenReturn(true, true, true, false);
+    when(mockDocValues.docValueCount()).thenReturn(3, 10, 2);
+    when(mockDocValues.nextValue())
+        .thenReturn(
+            Long.MAX_VALUE, 15L, Long.MIN_VALUE, 0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, -1L, -2L);
+
+    LoadedDocValues.SortedLongs loadedData = new LoadedDocValues.SortedLongs(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(loadedData, Long.MAX_VALUE, 15L, Long.MIN_VALUE);
+
+    loadedData.setDocId(1);
+    verifySetToValue(loadedData, 0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L);
+
+    loadedData.setDocId(2);
+    verifySetToValue(loadedData, -1L, -2L);
+
+    loadedData.setDocId(3);
+    verifyUnset(loadedData);
+  }
+
+  @Test
+  public void testSetDocValuesOutOfBounds() throws IOException {
+    SortedNumericDocValues mockDocValues = mock(SortedNumericDocValues.class);
+    when(mockDocValues.advanceExact(anyInt())).thenReturn(true);
+    when(mockDocValues.docValueCount()).thenReturn(2);
+    when(mockDocValues.nextValue()).thenReturn(15L, 16L);
+
+    LoadedDocValues.SortedLongs loadedData = new LoadedDocValues.SortedLongs(mockDocValues);
+    loadedData.setDocId(0);
+    verifySetToValue(loadedData, 15L, 16L);
+
+    assertOutOfBounds(() -> loadedData.get(-1));
+    assertOutOfBounds(() -> loadedData.getLong(-1));
+    assertOutOfBounds(() -> loadedData.toFieldValue(-1));
+
+    assertOutOfBounds(() -> loadedData.get(2));
+    assertOutOfBounds(() -> loadedData.getLong(2));
+    assertOutOfBounds(() -> loadedData.toFieldValue(2));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/TestUtils.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/doc/TestUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.luceneserver.doc;
+
+import static org.junit.Assert.*;
+
+public class TestUtils {
+
+  public static void assertNoDocValues(Runnable r) {
+    try {
+      r.run();
+      fail();
+    } catch (IllegalStateException e) {
+      assertEquals("No doc values for document", e.getMessage());
+    }
+  }
+
+  public static void assertOutOfBounds(Runnable r) {
+    try {
+      r.run();
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      assertTrue(e.getMessage().startsWith("No doc value for index: "));
+    }
+  }
+}


### PR DESCRIPTION
Change `LoadedDocValues` implementation for basic types (boolean, int, long, float, double) to load as primitive types. This prevents all the loaded data from being boxed on load. This will reduce garbage when only some of the values are accessed. If also makes future optimizations possible (avoiding boxing for aggregations, etc).

Also, the `getValue` method structure has been made consistent.