### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,23 +36,23 @@ def _artifactId = 'server'
 System.setProperty("org.gradle.internal.publish.checksums.insecure", "True")
 
 def luceneVersion = '9.11.1'
-project.ext.slf4jVersion = '2.0.0-alpha1'
+project.ext.slf4jVersion = '2.0.16'
 project.ext.grpcVersion = '1.46.0'
-project.ext.lz4Version = '1.7.0'
+project.ext.lz4Version = '1.8.0'
 project.ext.mockitoVersion = '5.12.0'
-project.ext.jacksonYamlVersion = '2.15.0'
+project.ext.jacksonYamlVersion = '2.17.2'
 project.ext.junitVersion = '4.13.2'
-def log4jVersion = '2.18.0'
-def disruptorVersion = '3.2.1'
-def gsonVersion = '2.9.0'
-def snakeYamlVersion = '2.0'
-def spatial4jVersion = '0.7'
+def log4jVersion = '2.23.1'
+def disruptorVersion = '4.0.0'
+def gsonVersion = '2.11.0'
+def snakeYamlVersion = '2.2'
+def spatial4jVersion = '0.8'
 def s3mockVersion = '0.2.6'
-def commonsCompressVersion = '1.21'
-def awsJavaSdkVersion = '1.12.457'
+def commonsCompressVersion = '1.27.0'
+def awsJavaSdkVersion = '1.12.768'
 def guiceVersion = '7.0.0'
-def prometheusClientVersion = '0.8.0'
-def fastutilVersion = '8.5.6'
+def prometheusClientVersion = '0.16.0'
+def fastutilVersion = '8.5.14'
 
 dependencies {
 
@@ -63,20 +63,20 @@ dependencies {
 
     //logging deps
     implementation "org.slf4j:slf4j-api:${project.ext.slf4jVersion}"
-    implementation "org.apache.logging.log4j:log4j-slf4j18-impl:${log4jVersion}"
+    implementation "org.apache.logging.log4j:log4j-slf4j2-impl:${log4jVersion}"
     implementation "org.apache.logging.log4j:log4j-api:${log4jVersion}"
     implementation "org.apache.logging.log4j:log4j-core:${log4jVersion}"
     implementation "com.lmax:disruptor:${disruptorVersion}"
 
 
     implementation "com.google.code.gson:gson:${gsonVersion}"
-    implementation 'commons-io:commons-io:2.7'
+    implementation 'commons-io:commons-io:2.16.1'
     implementation "org.yaml:snakeyaml:${snakeYamlVersion}"
     implementation "org.apache.commons:commons-compress:${commonsCompressVersion}"
     implementation "com.amazonaws:aws-java-sdk-core:${awsJavaSdkVersion}"
     implementation "com.amazonaws:aws-java-sdk-s3:${awsJavaSdkVersion}"
     runtimeOnly "com.amazonaws:aws-java-sdk-sts:${awsJavaSdkVersion}"
-    implementation "javax.xml.bind:jaxb-api:2.3.1"
+    implementation "jakarta.xml.bind:jakarta.xml.bind-api:4.0.2"
     implementation "com.google.inject:guice:${guiceVersion}"
     implementation "org.lz4:lz4-java:${project.ext.lz4Version}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${project.ext.jacksonYamlVersion}"
@@ -100,8 +100,8 @@ dependencies {
     implementation "org.apache.lucene:lucene-join:${luceneVersion}"
 
     //cli deps
-    implementation 'info.picocli:picocli:4.0.4'
-    implementation 'org.apache.commons:commons-csv:1.7'
+    implementation 'info.picocli:picocli:4.7.6'
+    implementation 'org.apache.commons:commons-csv:1.11.0'
 
     // gRPC deps
     implementation "io.grpc:grpc-services:${project.ext.grpcVersion}"
@@ -113,9 +113,9 @@ dependencies {
     testImplementation "org.mockito:mockito-core:${project.ext.mockitoVersion}"
     testImplementation "org.apache.lucene:lucene-test-framework:${luceneVersion}"
     testImplementation "org.locationtech.spatial4j:spatial4j:${spatial4jVersion}"
-    testImplementation "io.findify:s3mock_2.12:${s3mockVersion}"
+    testImplementation "io.findify:s3mock_2.13:${s3mockVersion}"
 
-    testImplementation "org.assertj:assertj-core:3.19.0"
+    testImplementation "org.assertj:assertj-core:3.26.3"
 
     api project(':clientlib')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ System.setProperty("org.gradle.internal.publish.checksums.insecure", "True")
 
 def luceneVersion = '9.11.1'
 project.ext.slf4jVersion = '2.0.16'
-project.ext.grpcVersion = '1.46.0'
+project.ext.grpcVersion = '1.60.2'
 project.ext.lz4Version = '1.8.0'
 project.ext.mockitoVersion = '5.12.0'
 project.ext.jacksonYamlVersion = '2.17.2'

--- a/clientlib/build.gradle
+++ b/clientlib/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 
     // examples/advanced need this for JsonFormat
     api "com.google.protobuf:protobuf-java-util:${protobufVersion}"
-//    compileOnly 'org.apache.tomcat:annotations-api:6.0.53'
+
     runtimeOnly "io.grpc:grpc-netty-shaded:${rootProject.grpcVersion}"
 
     //test deps

--- a/clientlib/build.gradle
+++ b/clientlib/build.gradle
@@ -30,7 +30,7 @@ startScripts.enabled = false
 def _artifactId = 'clientlib'
 
 // Dependency versions
-def protobufVersion = '3.25.3'
+def protobufVersion = '3.25.1'
 def protocVersion = protobufVersion
 
 dependencies {
@@ -48,7 +48,7 @@ dependencies {
 
     // examples/advanced need this for JsonFormat
     api "com.google.protobuf:protobuf-java-util:${protobufVersion}"
-
+//    compileOnly 'org.apache.tomcat:annotations-api:6.0.53'
     runtimeOnly "io.grpc:grpc-netty-shaded:${rootProject.grpcVersion}"
 
     //test deps

--- a/clientlib/build.gradle
+++ b/clientlib/build.gradle
@@ -30,7 +30,7 @@ startScripts.enabled = false
 def _artifactId = 'clientlib'
 
 // Dependency versions
-def protobufVersion = '3.24.3'
+def protobufVersion = '3.25.3'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/example-plugin/build.gradle
+++ b/example-plugin/build.gradle
@@ -30,11 +30,11 @@ repositories {
 }
 
 ext {
-    assertjVersion = '3.19.0'
+    assertjVersion = '3.26.3'
     grpcVersion = "1.46.0"
     junitVersion = "4.13.2"
     nrtsearchVersion = "1.+"
-    protobufVersion = "3.24.3"
+    protobufVersion = "3.25.3"
 }
 
 dependencies {

--- a/example-plugin/build.gradle
+++ b/example-plugin/build.gradle
@@ -31,10 +31,10 @@ repositories {
 
 ext {
     assertjVersion = '3.26.3'
-    grpcVersion = "1.60.2"
+    grpcVersion = "1.46.0"
     junitVersion = "4.13.2"
     nrtsearchVersion = "1.+"
-    protobufVersion = "3.25.1"
+    protobufVersion = "3.24.3"
 }
 
 dependencies {

--- a/example-plugin/build.gradle
+++ b/example-plugin/build.gradle
@@ -31,10 +31,10 @@ repositories {
 
 ext {
     assertjVersion = '3.26.3'
-    grpcVersion = "1.46.0"
+    grpcVersion = "1.60.2"
     junitVersion = "4.13.2"
     nrtsearchVersion = "1.+"
-    protobufVersion = "3.25.3"
+    protobufVersion = "3.25.1"
 }
 
 dependencies {

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/DirSizeCollector.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/DirSizeCollector.java
@@ -18,13 +18,13 @@ package com.yelp.nrtsearch.server.monitoring;
 import com.yelp.nrtsearch.server.luceneserver.GlobalState;
 import io.prometheus.client.Collector;
 import io.prometheus.client.GaugeMetricFamily;
-import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.file.PathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,9 +55,11 @@ public class DirSizeCollector extends Collector {
       Set<String> indexNames = globalState.getIndexNames();
       for (String indexName : indexNames) {
         Path indexDataPath = globalState.getIndexDir(indexName);
-        File indexDataFile = indexDataPath.toFile();
-        if (indexDataFile.exists()) {
-          long dirSizeBytes = FileUtils.sizeOfDirectory(indexDataFile);
+        if (Files.exists(indexDataPath)) {
+          if (Files.isSymbolicLink(indexDataPath)) {
+            indexDataPath = Files.readSymbolicLink(indexDataPath);
+          }
+          long dirSizeBytes = PathUtils.sizeOfDirectory(indexDataPath);
           indexDirSize.addMetric(Collections.singletonList(indexName), (double) dirSizeBytes);
         }
       }

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/ServerMetrics.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/ServerMetrics.java
@@ -37,7 +37,7 @@ class ServerMetrics {
       Counter.build()
           .namespace("grpc")
           .subsystem("server")
-          .name("started_total")
+          .name("started")
           .labelNames("grpc_type", "grpc_service", "grpc_method", "serviceName", "nodeName")
           .help("Total number of RPCs started on the server.");
 
@@ -45,7 +45,7 @@ class ServerMetrics {
       Counter.build()
           .namespace("grpc")
           .subsystem("server")
-          .name("handled_total")
+          .name("handled")
           .labelNames("grpc_type", "grpc_service", "grpc_method", "serviceName", "nodeName", "code")
           .help("Total number of RPCs completed on the server, regardless of success or failure.");
 
@@ -63,7 +63,7 @@ class ServerMetrics {
       Counter.build()
           .namespace("grpc")
           .subsystem("server")
-          .name("msg_received_total")
+          .name("msg_received")
           .labelNames("grpc_type", "grpc_service", "grpc_method", "serviceName", "nodeName")
           .help("Total number of stream messages received from the client.");
 
@@ -71,7 +71,7 @@ class ServerMetrics {
       Counter.build()
           .namespace("grpc")
           .subsystem("server")
-          .name("msg_sent_total")
+          .name("msg_sent")
           .labelNames("grpc_type", "grpc_service", "grpc_method", "serviceName", "nodeName")
           .help("Total number of stream messages sent by the server.");
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -996,15 +996,17 @@ public class LuceneServerTest {
 
   @Test
   public void testMetrics() {
+    System.setProperty("PROMETHEUS_DISABLE_CREATED_SERIES", "true");
     HttpBody response = grpcServer.getBlockingStub().metrics(Empty.newBuilder().build());
     HashSet expectedSampleNames =
         new HashSet(
             Arrays.asList(
-                "grpc_server_started_total",
-                "grpc_server_handled_total",
                 "grpc_server_msg_received_total",
-                "grpc_server_msg_sent_total",
-                "grpc_server_handled_latency_seconds"));
+                "grpc_server_handled_latency_seconds",
+                "grpc_server_handled_total",
+                "grpc_server_started_total",
+                "grpc_server_started_created",
+                "grpc_server_msg_sent_total"));
     assertEquals("text/plain", response.getContentType());
     String data = new String(response.getData().toByteArray());
     String[] arr = data.split("\n");

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -996,7 +996,6 @@ public class LuceneServerTest {
 
   @Test
   public void testMetrics() {
-    System.setProperty("PROMETHEUS_DISABLE_CREATED_SERIES", "true");
     HttpBody response = grpcServer.getBlockingStub().metrics(Empty.newBuilder().build());
     HashSet expectedSampleNames =
         new HashSet(


### PR DESCRIPTION
RP-11378

Update most dependencies to the latest versions. gRPC and protobuf dependencies are the latest workable versions. Bumping gRPC beyond 1.60.2 is throwing errors like this:
```
/nail/home/sarthakn/nrtsearch/clientlib/build/generated/source/proto/main/java/com/yelp/nrtsearch/server/grpc/MultiFunctionScoreQuery.java:3039: error: type argument com.google.type.LatLng.Builder is not within bounds of type-variable BType
              com.google.type.LatLng, com.google.type.LatLng.Builder, com.google.type.LatLngOrBuilder>(
                                                            ^
  where BType is a type-variable:
    BType extends com.google.protobuf.GeneratedMessage.Builder declared in class SingleFieldBuilder
```
I will work on bumping these gRPC and protobuf versions separately. I have added some comments to explain the code changes required.