### PR TITLE
Isolate nrt_utils incremental commands from core

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/NrtUtilsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/NrtUtilsCommand.java
@@ -15,11 +15,11 @@
  */
 package com.yelp.nrtsearch.tools.nrt_utils;
 
-import com.yelp.nrtsearch.tools.nrt_utils.incremental.DeleteIncrementalSnapshotsCommand;
-import com.yelp.nrtsearch.tools.nrt_utils.incremental.IncrementalDataCleanupCommand;
-import com.yelp.nrtsearch.tools.nrt_utils.incremental.ListIncrementalSnapshotsCommand;
-import com.yelp.nrtsearch.tools.nrt_utils.incremental.RestoreIncrementalCommand;
-import com.yelp.nrtsearch.tools.nrt_utils.incremental.SnapshotIncrementalCommand;
+import com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental.DeleteIncrementalSnapshotsCommand;
+import com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental.IncrementalDataCleanupCommand;
+import com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental.ListIncrementalSnapshotsCommand;
+import com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental.RestoreIncrementalCommand;
+import com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental.SnapshotIncrementalCommand;
 import com.yelp.nrtsearch.tools.nrt_utils.state.GetRemoteStateCommand;
 import com.yelp.nrtsearch.tools.nrt_utils.state.PutRemoteStateCommand;
 import com.yelp.nrtsearch.tools.nrt_utils.state.UpdateGlobalIndexStateCommand;

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/LegacyVersionManager.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/LegacyVersionManager.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.legacy;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import com.google.inject.Inject;
+import java.io.IOException;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LegacyVersionManager {
+  Logger logger = LoggerFactory.getLogger(LegacyVersionManager.class);
+
+  private final AmazonS3 s3;
+  private final String bucketName;
+
+  @Inject
+  public LegacyVersionManager(final AmazonS3 s3, final String bucketName) {
+    this.s3 = s3;
+    this.bucketName = bucketName;
+  }
+
+  /** Get S3 client. */
+  public AmazonS3 getS3() {
+    return s3;
+  }
+
+  /** Get S3 bucket name. */
+  public String getBucketName() {
+    return bucketName;
+  }
+
+  /**
+   * @param serviceName
+   * @param resourceName
+   * @return -1 if no prior versions found else most recent version number of this resource
+   * @throws IOException
+   */
+  /*
+  Gets the latest version number of a service and a resource
+  Returns: The latest version number in s3 of a service and resource
+  */
+  public long getLatestVersionNumber(String serviceName, String resourceName) throws IOException {
+    final String versionPath = String.format("%s/_version/%s", serviceName, resourceName);
+    long maxVersion = getListedLatestVersionNumber(versionPath);
+    return ensureLatestVersionNumber(versionPath, maxVersion);
+  }
+
+  /* Gets the latest listed version number in s3 */
+  long getListedLatestVersionNumber(String versionPath) throws IOException {
+    long version = -1;
+    String latestVersionFile = String.format("%s/_latest_version", versionPath);
+    if (s3.doesObjectExist(bucketName, latestVersionFile)) {
+      try (final S3Object s3Object = s3.getObject(bucketName, latestVersionFile); ) {
+        final String versionString = IOUtils.toString(s3Object.getObjectContent());
+        return Integer.valueOf(versionString);
+      }
+    }
+    return version;
+  }
+
+  /*
+  Attempts to fix s3's eventual consistency for LIST operations by
+  using immediately consistent GET operations to check for later versions
+
+  Returns: listed_version if no GETs are successful, else the actual
+      latest version.
+  */
+  long ensureLatestVersionNumber(String versionPath, long maxVersion) {
+    long versionProbe = maxVersion;
+    while (true) {
+      versionProbe += 1;
+      String probeVersion = String.format("%s/%s", versionPath, versionProbe);
+      if (!s3.doesObjectExist(bucketName, probeVersion)) {
+        break;
+      }
+    }
+    versionProbe = versionProbe - 1;
+
+    if (versionProbe != maxVersion) {
+      String latestVersionFile = String.format("%s/_latest_version", versionPath);
+      s3.putObject(bucketName, latestVersionFile, String.valueOf(versionProbe));
+    }
+    return versionProbe;
+  }
+
+  /* Blesses a particular version of a resource. */
+  public boolean blessVersion(String serviceName, String resourceName, String resourceHash) {
+    final String resourceKey = String.format("%s/%s/%s", serviceName, resourceName, resourceHash);
+    if (!s3.doesObjectExist(bucketName, resourceKey)) {
+      logger.error(
+          String.format(
+              "bless_version -- %s/%s/%s does not exist in s3",
+              serviceName, resourceName, resourceHash));
+      return false;
+    }
+    long newVersion;
+    try {
+      newVersion = getLatestVersionNumber(serviceName, resourceName) + 1;
+    } catch (IOException e) {
+      logger.error("Error while getting current latest version from s3 ", e);
+      return false;
+    }
+    if (newVersion == 0) {
+      logger.warn(
+          String.format(
+              "This is the first blessing of this resource, %s, make sure it is not a typo",
+              resourceName));
+    }
+
+    String versionPath = String.format("%s/_version/%s", serviceName, resourceName);
+    String versionKey = String.format("%s/%s", versionPath, newVersion);
+    s3.putObject(bucketName, versionKey, resourceHash);
+
+    String latestVersionKey = String.format("%s/_latest_version", versionPath);
+    s3.putObject(bucketName, latestVersionKey, String.valueOf(newVersion));
+
+    return true;
+  }
+
+  /* Deletes a particular version of a resource. */
+  public boolean deleteVersion(String serviceName, String resourceName, String resourceHash) {
+    final String resourceKey = String.format("%s/%s/%s", serviceName, resourceName, resourceHash);
+    if (!s3.doesObjectExist(bucketName, resourceKey)) {
+      logger.error(
+          "Unable to delete object: {}/{}/{} does not exist in s3",
+          serviceName,
+          resourceName,
+          resourceHash);
+      return false;
+    }
+    DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucketName, resourceKey);
+    s3.deleteObject(deleteObjectRequest);
+    return true;
+  }
+
+  /**
+   * @param serviceName name of cluster or service
+   * @param resource name of index or resource
+   * @param version name or versionHash of specific entity/file within namespace
+   *     serviceName/resource
+   * @throws IOException
+   */
+  public String getVersionString(
+      final String serviceName, final String resource, final String version) throws IOException {
+    final String absoluteResourcePath =
+        String.format("%s/_version/%s/%s", serviceName, resource, version);
+    try (final S3Object s3Object = s3.getObject(bucketName, absoluteResourcePath)) {
+      return IOUtils.toString(s3Object.getObjectContent());
+    }
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/incremental/IncrementalDataCleanupCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/incremental/IncrementalDataCleanupCommand.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.yelp.nrtsearch.tools.nrt_utils.incremental;
+package com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
@@ -23,8 +23,8 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
-import com.yelp.nrtsearch.server.backup.VersionManager;
-import com.yelp.nrtsearch.tools.nrt_utils.state.StateCommandUtils;
+import com.yelp.nrtsearch.tools.nrt_utils.legacy.LegacyVersionManager;
+import com.yelp.nrtsearch.tools.nrt_utils.legacy.state.LegacyStateCommandUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -34,7 +34,8 @@ import picocli.CommandLine;
 
 @CommandLine.Command(
     name = IncrementalDataCleanupCommand.INC_DATA_CLEANUP,
-    description = "Delete incremental backup index files in S3 based on given criteria")
+    description =
+        "Delete incremental backup index files in S3 based on given criteria. Legacy command for use with v0 cluster data.")
 public class IncrementalDataCleanupCommand implements Callable<Integer> {
   private static final int DELETE_BATCH_SIZE = 1000;
   public static final String LATEST_VERSION_FILE = "_latest_version";
@@ -132,12 +133,13 @@ public class IncrementalDataCleanupCommand implements Callable<Integer> {
 
     if (s3Client == null) {
       s3Client =
-          StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
+          LegacyStateCommandUtils.createS3Client(
+              bucketName, region, credsFile, credsProfile, maxRetry);
     }
-    VersionManager versionManager = new VersionManager(s3Client, bucketName);
+    LegacyVersionManager versionManager = new LegacyVersionManager(s3Client, bucketName);
 
     String resolvedIndexResource =
-        StateCommandUtils.getResourceName(
+        LegacyStateCommandUtils.getResourceName(
             versionManager, serviceName, indexName, exactResourceName);
     String indexDataResource = IncrementalCommandUtils.getIndexDataResource(resolvedIndexResource);
     long currentVersion = versionManager.getLatestVersionNumber(serviceName, indexDataResource);

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/incremental/ListIncrementalSnapshotsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/incremental/ListIncrementalSnapshotsCommand.java
@@ -13,20 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.yelp.nrtsearch.tools.nrt_utils.incremental;
+package com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
-import com.yelp.nrtsearch.tools.nrt_utils.state.StateCommandUtils;
+import com.yelp.nrtsearch.tools.nrt_utils.legacy.state.LegacyStateCommandUtils;
 import java.time.Instant;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
 @CommandLine.Command(
     name = ListIncrementalSnapshotsCommand.LIST_INCREMENTAL_SNAPSHOTS,
-    description = "List snapshots of incremental index data.")
+    description =
+        "List snapshots of incremental index data. Legacy command for use with v0 cluster data.")
 public class ListIncrementalSnapshotsCommand implements Callable<Integer> {
   public static final String LIST_INCREMENTAL_SNAPSHOTS = "listIncrementalSnapshots";
 
@@ -79,7 +80,8 @@ public class ListIncrementalSnapshotsCommand implements Callable<Integer> {
   @Override
   public Integer call() throws Exception {
     AmazonS3 s3Client =
-        StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
+        LegacyStateCommandUtils.createS3Client(
+            bucketName, region, credsFile, credsProfile, maxRetry);
 
     String resolvedSnapshotRoot =
         IncrementalCommandUtils.getSnapshotRoot(snapshotRoot, serviceName);

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/incremental/SnapshotMetadata.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/incremental/SnapshotMetadata.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.yelp.nrtsearch.tools.nrt_utils.incremental;
+package com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/state/LegacyStateCommandUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/state/LegacyStateCommandUtils.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.legacy.state;
+
+import static com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental.IncrementalCommandUtils.fromUTF8;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.auth.profile.ProfilesConfigFile;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.retry.PredefinedRetryPolicies;
+import com.amazonaws.retry.RetryPolicy;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.S3Object;
+import com.google.protobuf.util.JsonFormat;
+import com.yelp.nrtsearch.server.grpc.GlobalStateInfo;
+import com.yelp.nrtsearch.server.grpc.IndexGlobalState;
+import com.yelp.nrtsearch.tools.nrt_utils.legacy.LegacyVersionManager;
+import java.io.*;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+import net.jpountz.lz4.LZ4FrameInputStream;
+import net.jpountz.lz4.LZ4FrameOutputStream;
+import org.apache.commons.compress.archivers.ArchiveOutputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.utils.IOUtils;
+
+public class LegacyStateCommandUtils {
+  private static final String INDEX_STATE_SUFFIX = "-state";
+  private static final String GLOBAL_STATE_RESOURCE = "global_state";
+  private static final String GLOBAL_STATE_FILE = "state.json";
+
+  private LegacyStateCommandUtils() {}
+
+  /**
+   * Get an S3 client usable for remote state operations.
+   *
+   * @param bucketName s3 bucket
+   * @param region aws region, such as us-west-2, or null to detect
+   * @param credsFile file containing aws credentials, or null for default
+   * @param credsProfile profile to use from credentials file
+   * @return s3 client
+   */
+  public static AmazonS3 createS3Client(
+      String bucketName, String region, String credsFile, String credsProfile, int maxRetry) {
+    AWSCredentialsProvider awsCredentialsProvider;
+    if (credsFile != null) {
+      Path botoCfgPath = Paths.get(credsFile);
+      ProfilesConfigFile profilesConfigFile = new ProfilesConfigFile(botoCfgPath.toFile());
+      awsCredentialsProvider = new ProfileCredentialsProvider(profilesConfigFile, credsProfile);
+    } else {
+      awsCredentialsProvider = new DefaultAWSCredentialsProviderChain();
+    }
+
+    String clientRegion;
+    if (region == null) {
+      AmazonS3 s3ClientInterim =
+          AmazonS3ClientBuilder.standard().withCredentials(awsCredentialsProvider).build();
+      clientRegion = s3ClientInterim.getBucketLocation(bucketName);
+      // In useast-1, the region is returned as "US" which is an equivalent to "us-east-1"
+      // https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/Region.html#US_Standard
+      // However, this causes an UnknownHostException so we override it to the full region name
+      if (clientRegion.equals("US")) {
+        clientRegion = "us-east-1";
+      }
+    } else {
+      clientRegion = region;
+    }
+    String serviceEndpoint = String.format("s3.%s.amazonaws.com", clientRegion);
+    System.out.printf("S3 ServiceEndpoint: %s%n", serviceEndpoint);
+    RetryPolicy retryPolicy =
+        new RetryPolicy(
+            PredefinedRetryPolicies.DEFAULT_RETRY_CONDITION,
+            PredefinedRetryPolicies.DEFAULT_BACKOFF_STRATEGY,
+            maxRetry,
+            true);
+    ClientConfiguration clientConfiguration =
+        new ClientConfiguration().withRetryPolicy(retryPolicy);
+    return AmazonS3ClientBuilder.standard()
+        .withCredentials(awsCredentialsProvider)
+        .withClientConfiguration(clientConfiguration)
+        .withEndpointConfiguration(
+            new AwsClientBuilder.EndpointConfiguration(serviceEndpoint, clientRegion))
+        .build();
+  }
+
+  /**
+   * Get the contents of the state file stored in remote state.
+   *
+   * @param versionManager state version manager
+   * @param serviceName nrtsearch cluster service name
+   * @param resourceName state resource name, for index this must include unique identifier
+   * @param stateFileName name of state file in archive
+   * @return state file contents as string
+   * @throws IOException
+   */
+  public static String getStateFileContents(
+      LegacyVersionManager versionManager,
+      String serviceName,
+      String resourceName,
+      String stateFileName)
+      throws IOException {
+    String backendResourceName =
+        isBackendGlobalState(resourceName) ? resourceName : getIndexStateResource(resourceName);
+    long currentVersion = versionManager.getLatestVersionNumber(serviceName, backendResourceName);
+    if (currentVersion == -1) {
+      System.out.println(
+          "No state exists for service: " + serviceName + ", resource: " + backendResourceName);
+      return null;
+    }
+    System.out.println("Current version: " + currentVersion);
+    String versionStr =
+        versionManager.getVersionString(
+            serviceName, backendResourceName, String.valueOf(currentVersion));
+    System.out.println("Version string: " + versionStr);
+
+    String absoluteResourcePath = getStateKey(serviceName, backendResourceName, versionStr);
+    if (!versionManager
+        .getS3()
+        .doesObjectExist(versionManager.getBucketName(), absoluteResourcePath)) {
+      System.out.println("Resource does not exist: " + absoluteResourcePath);
+      return null;
+    }
+
+    String stateStr =
+        getStateFileContentsFromS3(
+            versionManager.getS3(),
+            versionManager.getBucketName(),
+            absoluteResourcePath,
+            stateFileName);
+    if (stateStr == null) {
+      System.out.println("No state file found in archive");
+    }
+    return stateStr;
+  }
+
+  /**
+   * Get the contents of a state file archive stored in S3.
+   *
+   * @param s3Client s3 client
+   * @param bucketName bucket name
+   * @param key key for state file archive
+   * @param stateFileName name of state file within archive
+   * @return contents of state file as string
+   * @throws IOException
+   */
+  public static String getStateFileContentsFromS3(
+      AmazonS3 s3Client, String bucketName, String key, String stateFileName) throws IOException {
+    S3Object stateObject = s3Client.getObject(bucketName, key);
+    InputStream contents = stateObject.getObjectContent();
+    String stateStr = null;
+    try (TarArchiveInputStream tarArchiveInputStream =
+        new TarArchiveInputStream(new LZ4FrameInputStream(contents))) {
+      for (TarArchiveEntry tarArchiveEntry = tarArchiveInputStream.getNextTarEntry();
+          tarArchiveEntry != null;
+          tarArchiveEntry = tarArchiveInputStream.getNextTarEntry()) {
+        if (tarArchiveEntry.getName().endsWith(stateFileName)) {
+          byte[] fileData = tarArchiveInputStream.readNBytes((int) tarArchiveEntry.getSize());
+          stateStr = fromUTF8(fileData);
+        }
+      }
+    }
+    return stateStr;
+  }
+
+  /**
+   * Given the data of a state file, build an archive of the expected format and return its data.
+   *
+   * @param resourceName name of index resource
+   * @param stateFileName name of state file within archive
+   * @param data UTF-8 representation of state file
+   * @return buffer containing archive data
+   * @throws IOException
+   */
+  public static byte[] buildStateFileArchive(String resourceName, String stateFileName, byte[] data)
+      throws IOException {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    try (ArchiveOutputStream archiveOutputStream =
+        new TarArchiveOutputStream(new LZ4FrameOutputStream(outputStream))) {
+      TarArchiveEntry entry = new TarArchiveEntry(resourceName + "/");
+      archiveOutputStream.putArchiveEntry(entry);
+      archiveOutputStream.closeArchiveEntry();
+
+      entry = new TarArchiveEntry(resourceName + "/" + stateFileName);
+      entry.setSize(data.length);
+      archiveOutputStream.putArchiveEntry(entry);
+      try (InputStream dataInputStream = new ByteArrayInputStream(data)) {
+        IOUtils.copy(dataInputStream, archiveOutputStream);
+      }
+      archiveOutputStream.closeArchiveEntry();
+    }
+    return outputStream.toByteArray();
+  }
+
+  /**
+   * Get the resolved resource name for a given input resource. If the given resource is an index
+   * name, the service global state is loaded to look up the index unique id. If the resource is for
+   * global state, or exactResourceName is true, it is considered to already be resolved.
+   *
+   * @param versionManager state version manager
+   * @param serviceName nrtsearch cluster service name
+   * @param resource resource name to resolve
+   * @param exactResourceName if the provided resource name is already resolved
+   * @return resolved resource name
+   * @throws IOException
+   */
+  public static String getResourceName(
+      LegacyVersionManager versionManager,
+      String serviceName,
+      String resource,
+      boolean exactResourceName)
+      throws IOException {
+    if (isBackendGlobalState(resource)) {
+      System.out.println("Global state resource");
+      return resource;
+    }
+    if (exactResourceName) {
+      System.out.println("Index state resource: " + resource);
+      return resource;
+    }
+    String globalStateContents =
+        getStateFileContents(versionManager, serviceName, GLOBAL_STATE_RESOURCE, GLOBAL_STATE_FILE);
+    if (globalStateContents == null) {
+      throw new IllegalArgumentException(
+          "Unable to load global state for cluster: \"" + serviceName + "\"");
+    }
+    GlobalStateInfo.Builder globalStateBuilder = GlobalStateInfo.newBuilder();
+    JsonFormat.parser().ignoringUnknownFields().merge(globalStateContents, globalStateBuilder);
+    GlobalStateInfo globalState = globalStateBuilder.build();
+
+    IndexGlobalState indexGlobalState = globalState.getIndicesMap().get(resource);
+    if (indexGlobalState == null) {
+      throw new IllegalArgumentException(
+          "Unable to find index: \"" + resource + "\" in cluster: \"" + serviceName + "\"");
+    }
+    if (indexGlobalState.getId().isEmpty()) {
+      throw new IllegalArgumentException("Index id is empty for index: \"" + resource + "\"");
+    }
+    String resolvedResource = getUniqueIndexName(resource, indexGlobalState.getId());
+    System.out.println("Index state resource: " + resolvedResource);
+    return resolvedResource;
+  }
+
+  /**
+   * Given an index resource (index-UUID), produce the index state resource.
+   *
+   * @param indexResource index resource
+   * @return index state resource
+   */
+  public static String getIndexStateResource(String indexResource) {
+    return indexResource + INDEX_STATE_SUFFIX;
+  }
+
+  /**
+   * Get the S3 key for an index state object.
+   *
+   * @param serviceName nrtsearch cluster service name
+   * @param indexStateResource index state resource
+   * @param versionStr version UUID
+   * @return S3 key for state object
+   */
+  public static String getStateKey(
+      String serviceName, String indexStateResource, String versionStr) {
+    return String.format("%s/%s/%s", serviceName, indexStateResource, versionStr);
+  }
+
+  /**
+   * Build unique index name from index name and instance id (UUID).
+   *
+   * @param indexName index name
+   * @param id instance id
+   * @return unique index identifier
+   * @throws NullPointerException if either parameter is null
+   */
+  public static String getUniqueIndexName(String indexName, String id) {
+    Objects.requireNonNull(indexName);
+    Objects.requireNonNull(id);
+    return indexName + "-" + id;
+  }
+
+  public static boolean isBackendGlobalState(String resourceName) {
+    return GLOBAL_STATE_RESOURCE.equals(resourceName);
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/UpdateGlobalIndexStateCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/UpdateGlobalIndexStateCommand.java
@@ -24,7 +24,7 @@ import com.yelp.nrtsearch.server.grpc.IndexGlobalState;
 import com.yelp.nrtsearch.server.luceneserver.state.BackendGlobalState;
 import com.yelp.nrtsearch.server.luceneserver.state.StateUtils;
 import com.yelp.nrtsearch.server.luceneserver.state.backend.RemoteStateBackend;
-import com.yelp.nrtsearch.tools.nrt_utils.incremental.IncrementalCommandUtils;
+import com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental.IncrementalCommandUtils;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/LegacyVersionManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/LegacyVersionManagerTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.legacy;
+
+import static org.junit.Assert.*;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.amazonaws.util.IOUtils;
+import com.yelp.nrtsearch.test_utils.AmazonS3Provider;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class LegacyVersionManagerTest {
+  private final String BUCKET_NAME = "version-manager-unittest";
+  private LegacyVersionManager versionManager;
+  private AmazonS3 s3;
+  private Path archiverDirectory;
+
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+  @Rule public final AmazonS3Provider s3Provider = new AmazonS3Provider(BUCKET_NAME);
+
+  @Before
+  public void setup() throws IOException {
+    archiverDirectory = folder.newFolder("version-manager").toPath();
+
+    s3 = s3Provider.getAmazonS3();
+    versionManager = new LegacyVersionManager(s3, BUCKET_NAME);
+  }
+
+  @Test
+  public void blessVersionNoResourceHash() {
+    boolean result = versionManager.blessVersion("testservice", "testresource", "abcdef");
+    assertEquals(false, result);
+  }
+
+  @Test
+  public void blessVersionWhenNoPrior() throws IOException {
+    s3.putObject(BUCKET_NAME, "testservice/testresource/abcdef", "foo");
+    boolean result = versionManager.blessVersion("testservice", "testresource", "abcdef");
+    assertEquals(true, result);
+
+    S3Object s3Object =
+        s3.getObject(BUCKET_NAME, "testservice/_version/testresource/_latest_version");
+    assertEquals("0", IOUtils.toString(s3Object.getObjectContent()));
+
+    s3Object = s3.getObject(BUCKET_NAME, "testservice/_version/testresource/0");
+    assertEquals("abcdef", IOUtils.toString(s3Object.getObjectContent()));
+  }
+
+  @Test
+  public void blessVersionWhenPrior() throws IOException {
+    s3.putObject(BUCKET_NAME, "testservice/testresource/abcdef", "foo");
+    s3.putObject(BUCKET_NAME, "testservice/_version/testresource/_latest_version", "0");
+    boolean result = versionManager.blessVersion("testservice", "testresource", "abcdef");
+    assertEquals(true, result);
+
+    S3Object s3Object =
+        s3.getObject(BUCKET_NAME, "testservice/_version/testresource/_latest_version");
+    assertEquals("1", IOUtils.toString(s3Object.getObjectContent()));
+
+    s3Object = s3.getObject(BUCKET_NAME, "testservice/_version/testresource/1");
+    assertEquals("abcdef", IOUtils.toString(s3Object.getObjectContent()));
+  }
+
+  @Test
+  public void blessVersionWhenLatestVersionBehind() throws IOException {
+    s3.putObject(BUCKET_NAME, "testservice/testresource/abcdef", "foo");
+    s3.putObject(BUCKET_NAME, "testservice/_version/testresource/_latest_version", "0");
+    s3.putObject(BUCKET_NAME, "testservice/_version/testresource/1", "ghijkl");
+
+    boolean result = versionManager.blessVersion("testservice", "testresource", "abcdef");
+    assertEquals(true, result);
+
+    S3Object s3Object =
+        s3.getObject(BUCKET_NAME, "testservice/_version/testresource/_latest_version");
+    assertEquals("2", IOUtils.toString(s3Object.getObjectContent()));
+
+    s3Object = s3.getObject(BUCKET_NAME, "testservice/_version/testresource/2");
+    assertEquals("abcdef", IOUtils.toString(s3Object.getObjectContent()));
+  }
+
+  @Test
+  public void deleteVersionWhenDoesntExist() throws IOException {
+    boolean result = versionManager.deleteVersion("testservice", "testresource", "abcdef");
+    assertEquals(false, result);
+  }
+
+  @Test
+  public void deleteVersionWhenExists() throws IOException {
+    String key1 = "testservice/testresource/abcdef";
+    String key2 = "testservice/testresource/other_version";
+    s3.putObject(BUCKET_NAME, key1, "foo");
+    s3.putObject(BUCKET_NAME, key2, "boo");
+    boolean result = versionManager.deleteVersion("testservice", "testresource", "abcdef");
+    assertEquals(true, result);
+
+    List<S3ObjectSummary> objects =
+        s3.listObjects(BUCKET_NAME, "testservice/testresource/").getObjectSummaries();
+
+    List<String> objectKeys =
+        objects.stream().map(S3ObjectSummary::getKey).collect(Collectors.toList());
+
+    assertTrue(objectKeys.contains(key2));
+    assertFalse(objectKeys.contains(key1));
+  }
+
+  @Test
+  public void getVersionString() throws IOException {
+    s3.putObject(BUCKET_NAME, "testservice/_version/testresource/versionHash", "0");
+    String result = versionManager.getVersionString("testservice", "testresource", "versionHash");
+    assertEquals("0", result);
+
+    s3.putObject(BUCKET_NAME, "testservice/_version/testresource/versionHash", "2");
+    result = versionManager.getVersionString("testservice", "testresource", "versionHash");
+    assertEquals("2", result);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/incremental/IncrementalDataCleanupCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/incremental/IncrementalDataCleanupCommandTest.java
@@ -13,46 +13,41 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.yelp.nrtsearch.tools.nrt_utils.incremental;
+package com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental;
 
-import static com.yelp.nrtsearch.server.grpc.TestServer.S3_ENDPOINT;
-import static com.yelp.nrtsearch.server.grpc.TestServer.SERVICE_NAME;
-import static com.yelp.nrtsearch.server.grpc.TestServer.TEST_BUCKET;
+import static com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental.IncrementalCommandUtils.toUTF8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.amazonaws.auth.AnonymousAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
-import com.yelp.nrtsearch.server.backup.VersionManager;
-import com.yelp.nrtsearch.server.config.IndexStartConfig.IndexDataLocationType;
-import com.yelp.nrtsearch.server.grpc.Mode;
-import com.yelp.nrtsearch.server.grpc.TestServer;
+import com.google.protobuf.util.JsonFormat;
+import com.yelp.nrtsearch.server.grpc.GlobalStateInfo;
+import com.yelp.nrtsearch.server.grpc.IndexGlobalState;
+import com.yelp.nrtsearch.test_utils.AmazonS3Provider;
+import com.yelp.nrtsearch.tools.nrt_utils.legacy.LegacyVersionManager;
+import com.yelp.nrtsearch.tools.nrt_utils.legacy.state.LegacyStateCommandUtils;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
 import org.apache.commons.io.IOUtils;
-import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import picocli.CommandLine;
 
 public class IncrementalDataCleanupCommandTest {
-  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+  private static final String TEST_BUCKET = "test-bucket";
+  private static final String SERVICE_NAME = "test_service";
+  private static final String GLOBAL_STATE_RESOURCE = "global_state";
 
-  @After
-  public void cleanup() {
-    TestServer.cleanupAll();
-  }
+  @Rule public final AmazonS3Provider s3Provider = new AmazonS3Provider(TEST_BUCKET);
 
   private AmazonS3 getS3() {
-    AmazonS3 s3 = new AmazonS3Client(new AnonymousAWSCredentials());
-    s3.setEndpoint(S3_ENDPOINT);
-    s3.createBucket(TEST_BUCKET);
-    return s3;
+    return s3Provider.getAmazonS3();
   }
 
   private CommandLine getInjectedCommand() {
@@ -61,28 +56,87 @@ public class IncrementalDataCleanupCommandTest {
     return new CommandLine(command);
   }
 
-  private TestServer getTestServer() throws IOException {
-    TestServer server =
-        TestServer.builder(folder)
-            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.REMOTE)
-            .withRemoteStateBackend(false)
+  private void setUpIndex() throws IOException {
+    AmazonS3 s3Client = getS3();
+    String stateFileId = UUID.randomUUID().toString();
+    GlobalStateInfo globalStateInfo =
+        GlobalStateInfo.newBuilder()
+            .putIndices(
+                "test_index",
+                IndexGlobalState.newBuilder().setId("test_id").setStarted(true).build())
             .build();
-    server.createSimpleIndex("test_index");
-    server.startPrimaryIndex("test_index", -1, null);
+    String stateStr = JsonFormat.printer().print(globalStateInfo);
+    byte[] stateData =
+        LegacyStateCommandUtils.buildStateFileArchive(
+            GLOBAL_STATE_RESOURCE, "state.json", toUTF8(stateStr));
+    ObjectMetadata metadata = new ObjectMetadata();
+    metadata.setContentLength(stateData.length);
+
+    s3Client.putObject(
+        TEST_BUCKET,
+        IncrementalCommandUtils.getDataKeyPrefix(SERVICE_NAME, GLOBAL_STATE_RESOURCE) + stateFileId,
+        new ByteArrayInputStream(stateData),
+        metadata);
+    s3Client.putObject(
+        TEST_BUCKET,
+        IncrementalCommandUtils.getVersionKeyPrefix(SERVICE_NAME, GLOBAL_STATE_RESOURCE) + "1",
+        stateFileId);
+    s3Client.putObject(
+        TEST_BUCKET,
+        IncrementalCommandUtils.getVersionKeyPrefix(SERVICE_NAME, GLOBAL_STATE_RESOURCE)
+            + IncrementalDataCleanupCommand.LATEST_VERSION_FILE,
+        "1");
+
+    writeVersion(0);
     for (int i = 0; i < 5; ++i) {
-      server.addSimpleDocs("test_index", i * 2, i * 2 + 1);
-      server.refresh("test_index");
-      server.commit("test_index");
+      writeVersion(i + 1);
       try {
         Thread.sleep(5000);
       } catch (InterruptedException ignore) {
       }
     }
-    return server;
   }
 
-  private void setCurrentVersion(AmazonS3 s3Client, TestServer server, int currentVersion) {
-    String indexResource = server.getGlobalState().getDataResourceForIndex("test_index");
+  private void writeVersion(int version) {
+    String indexUniqueId = getUniqueIndexName();
+    AmazonS3 s3Client = getS3();
+    Set<String> indexFiles = new HashSet<>();
+    indexFiles.add(String.format("segments_%d", version + 1));
+    if (version > 0) {
+      indexFiles.add(String.format("_%d.cfe", version));
+      indexFiles.add(String.format("_%d.cfs", version));
+      indexFiles.add(String.format("_%d.si", version));
+    }
+
+    String indexDataResource = IncrementalCommandUtils.getIndexDataResource(indexUniqueId);
+    String versionId = UUID.randomUUID().toString();
+    for (String indexFile : indexFiles) {
+      s3Client.putObject(
+          TEST_BUCKET,
+          IncrementalCommandUtils.getDataKeyPrefix(SERVICE_NAME, indexDataResource) + indexFile,
+          "index_data");
+    }
+    s3Client.putObject(
+        TEST_BUCKET,
+        IncrementalCommandUtils.getDataKeyPrefix(SERVICE_NAME, indexDataResource) + versionId,
+        String.join("\n", indexFiles));
+    s3Client.putObject(
+        TEST_BUCKET,
+        IncrementalCommandUtils.getVersionKeyPrefix(SERVICE_NAME, indexDataResource) + version,
+        versionId);
+    s3Client.putObject(
+        TEST_BUCKET,
+        IncrementalCommandUtils.getVersionKeyPrefix(SERVICE_NAME, indexDataResource)
+            + IncrementalDataCleanupCommand.LATEST_VERSION_FILE,
+        String.valueOf(version));
+  }
+
+  private String getUniqueIndexName() {
+    return LegacyStateCommandUtils.getUniqueIndexName("test_index", "test_id");
+  }
+
+  private void setCurrentVersion(AmazonS3 s3Client, int currentVersion) {
+    String indexResource = getUniqueIndexName();
     String versionPrefix =
         IncrementalCommandUtils.getVersionKeyPrefix(
             SERVICE_NAME, IncrementalCommandUtils.getIndexDataResource(indexResource));
@@ -90,9 +144,8 @@ public class IncrementalDataCleanupCommandTest {
     s3Client.putObject(TEST_BUCKET, currentVersionKey, String.valueOf(currentVersion));
   }
 
-  private String getAndDeleteVersion(AmazonS3 s3Client, TestServer server, int currentVersion)
-      throws IOException {
-    String indexResource = server.getGlobalState().getDataResourceForIndex("test_index");
+  private String getAndDeleteVersion(AmazonS3 s3Client, int currentVersion) throws IOException {
+    String indexResource = getUniqueIndexName();
     String versionPrefix =
         IncrementalCommandUtils.getVersionKeyPrefix(
             SERVICE_NAME, IncrementalCommandUtils.getIndexDataResource(indexResource));
@@ -103,8 +156,8 @@ public class IncrementalDataCleanupCommandTest {
     return currentId;
   }
 
-  private void putVersion(AmazonS3 s3Client, TestServer server, int version, String id) {
-    String indexResource = server.getGlobalState().getDataResourceForIndex("test_index");
+  private void putVersion(AmazonS3 s3Client, int version, String id) {
+    String indexResource = getUniqueIndexName();
     String versionPrefix =
         IncrementalCommandUtils.getVersionKeyPrefix(
             SERVICE_NAME, IncrementalCommandUtils.getIndexDataResource(indexResource));
@@ -113,7 +166,7 @@ public class IncrementalDataCleanupCommandTest {
 
   @Test
   public void testKeepsRecentVersions() throws IOException {
-    TestServer server = getTestServer();
+    setUpIndex();
     CommandLine cmd = getInjectedCommand();
 
     int exitCode =
@@ -126,12 +179,12 @@ public class IncrementalDataCleanupCommandTest {
             "--minVersions=1");
     assertEquals(0, exitCode);
 
-    assertVersions(server.getGlobalState().getDataResourceForIndex("test_index"), 0, 1, 2, 3, 4, 5);
+    assertVersions(getUniqueIndexName(), 0, 1, 2, 3, 4, 5);
   }
 
   @Test
   public void testDeletesUnneededVersions() throws IOException {
-    TestServer server = getTestServer();
+    setUpIndex();
     CommandLine cmd = getInjectedCommand();
 
     int exitCode =
@@ -144,19 +197,19 @@ public class IncrementalDataCleanupCommandTest {
             "--minVersions=1");
     assertEquals(0, exitCode);
 
-    assertVersions(server.getGlobalState().getDataResourceForIndex("test_index"), 5);
+    assertVersions(getUniqueIndexName(), 5);
   }
 
   @Test
   public void testKeepsFutureVersions() throws IOException {
-    TestServer server = getTestServer();
+    setUpIndex();
     CommandLine cmd = getInjectedCommand();
     AmazonS3 s3Client = getS3();
 
     // VersionManager will automatically advance back to the latest, so delete the next
     // version and replace after cleanup
-    setCurrentVersion(s3Client, server, 3);
-    String versionId = getAndDeleteVersion(s3Client, server, 4);
+    setCurrentVersion(s3Client, 3);
+    String versionId = getAndDeleteVersion(s3Client, 4);
 
     int exitCode =
         cmd.execute(
@@ -168,14 +221,14 @@ public class IncrementalDataCleanupCommandTest {
             "--minVersions=1");
     assertEquals(0, exitCode);
 
-    putVersion(s3Client, server, 4, versionId);
+    putVersion(s3Client, 4, versionId);
 
-    assertVersions(server.getGlobalState().getDataResourceForIndex("test_index"), 3, 4, 5);
+    assertVersions(getUniqueIndexName(), 3, 4, 5);
   }
 
   @Test
   public void testKeepsMinVersions() throws IOException {
-    TestServer server = getTestServer();
+    setUpIndex();
     CommandLine cmd = getInjectedCommand();
 
     int exitCode =
@@ -188,17 +241,15 @@ public class IncrementalDataCleanupCommandTest {
             "--minVersions=3");
     assertEquals(0, exitCode);
 
-    assertVersions(server.getGlobalState().getDataResourceForIndex("test_index"), 3, 4, 5);
+    assertVersions(getUniqueIndexName(), 3, 4, 5);
   }
 
   @Test
   public void testGracePeriod() throws IOException {
-    TestServer server = getTestServer();
+    setUpIndex();
     CommandLine cmd = getInjectedCommand();
     AmazonS3 s3Client = getS3();
-    String indexDataResource =
-        IncrementalCommandUtils.getIndexDataResource(
-            server.getGlobalState().getDataResourceForIndex("test_index"));
+    String indexDataResource = IncrementalCommandUtils.getIndexDataResource(getUniqueIndexName());
 
     Set<String> initialIndexFiles = getExistingDataFiles(s3Client, indexDataResource);
     int exitCode =
@@ -224,7 +275,7 @@ public class IncrementalDataCleanupCommandTest {
             "--gracePeriod=1s",
             "--minVersions=1");
     assertEquals(0, exitCode);
-    assertVersions(server.getGlobalState().getDataResourceForIndex("test_index"), 5);
+    assertVersions(getUniqueIndexName(), 5);
   }
 
   private void assertVersions(String indexResource, int... versions) throws IOException {
@@ -251,7 +302,7 @@ public class IncrementalDataCleanupCommandTest {
     assertEquals(expectedVersions, presentVersions);
 
     Set<String> requiredIndexFiles = new HashSet<>();
-    VersionManager versionManager = new VersionManager(s3Client, TEST_BUCKET);
+    LegacyVersionManager versionManager = new LegacyVersionManager(s3Client, TEST_BUCKET);
     for (int version : versions) {
       String versionId =
           versionManager.getVersionString(SERVICE_NAME, indexDataResource, String.valueOf(version));

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/state/LegacyStateCommandUtilsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/state/LegacyStateCommandUtilsTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.legacy.state;
+
+import static com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental.SnapshotRestoreCommandTest.createIndex;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.google.protobuf.util.JsonFormat;
+import com.yelp.nrtsearch.server.grpc.*;
+import com.yelp.nrtsearch.test_utils.AmazonS3Provider;
+import com.yelp.nrtsearch.tools.nrt_utils.legacy.LegacyVersionManager;
+import java.io.IOException;
+import java.util.UUID;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class LegacyStateCommandUtilsTest {
+  private static final String TEST_BUCKET = "test-bucket";
+  private static final String SERVICE_NAME = "test_service";
+  private static final String GLOBAL_STATE_FILE = "state.json";
+  private static final String INDEX_STATE_FILE = "index_state.json";
+  private static final String GLOBAL_STATE_RESOURCE = "global_state";
+
+  @Rule public final AmazonS3Provider s3Provider = new AmazonS3Provider(TEST_BUCKET);
+
+  private AmazonS3 getS3() {
+    return s3Provider.getAmazonS3();
+  }
+
+  private LegacyVersionManager getVersionManager() {
+    return new LegacyVersionManager(getS3(), TEST_BUCKET);
+  }
+
+  @Test
+  public void testGetStateFileContents_GlobalNotExist() throws IOException {
+    String contents =
+        LegacyStateCommandUtils.getStateFileContents(
+            getVersionManager(), SERVICE_NAME, GLOBAL_STATE_RESOURCE, GLOBAL_STATE_FILE);
+    assertNull(contents);
+  }
+
+  @Test
+  public void testGetStateFileContents_IndexNotExist() throws IOException {
+    String contents =
+        LegacyStateCommandUtils.getStateFileContents(
+            getVersionManager(), SERVICE_NAME, "test_index", INDEX_STATE_FILE);
+    assertNull(contents);
+  }
+
+  @Test
+  public void testGetStateFileContents_ResourceNotExist() throws IOException {
+    LegacyVersionManager mockVersionManager = mock(LegacyVersionManager.class);
+    String version = UUID.randomUUID().toString();
+    String indexResource = LegacyStateCommandUtils.getIndexStateResource("test_index");
+    when(mockVersionManager.getLatestVersionNumber(SERVICE_NAME, indexResource)).thenReturn(5L);
+    when(mockVersionManager.getVersionString(SERVICE_NAME, indexResource, String.valueOf(5L)))
+        .thenReturn(version);
+    when(mockVersionManager.getS3()).thenReturn(getS3());
+    when(mockVersionManager.getBucketName()).thenReturn(TEST_BUCKET);
+
+    String contents =
+        LegacyStateCommandUtils.getStateFileContents(
+            mockVersionManager, SERVICE_NAME, "test_index", INDEX_STATE_FILE);
+    assertNull(contents);
+
+    verify(mockVersionManager, times(1)).getLatestVersionNumber(SERVICE_NAME, indexResource);
+    verify(mockVersionManager, times(1))
+        .getVersionString(SERVICE_NAME, indexResource, String.valueOf(5L));
+    verify(mockVersionManager, times(1)).getS3();
+    verify(mockVersionManager, times(1)).getBucketName();
+    verifyNoMoreInteractions(mockVersionManager);
+  }
+
+  @Test
+  public void testGetStateFileContents_GlobalState() throws IOException {
+    createIndex(getS3(), UUID.randomUUID().toString());
+    String contents =
+        LegacyStateCommandUtils.getStateFileContents(
+            getVersionManager(), SERVICE_NAME, GLOBAL_STATE_RESOURCE, GLOBAL_STATE_FILE);
+    GlobalStateInfo.Builder builder = GlobalStateInfo.newBuilder();
+    JsonFormat.parser().merge(contents, builder);
+    GlobalStateInfo stateInfo = builder.build();
+    assertEquals(1, stateInfo.getIndicesMap().size());
+    assertTrue(stateInfo.getIndicesMap().containsKey("test_index"));
+    assertTrue(stateInfo.getIndicesMap().get("test_index").getStarted());
+  }
+
+  @Test
+  public void testGetStateFileContents_FileNotInTar() throws IOException {
+    createIndex(getS3(), UUID.randomUUID().toString());
+    String contents =
+        LegacyStateCommandUtils.getStateFileContents(
+            getVersionManager(), SERVICE_NAME, GLOBAL_STATE_RESOURCE, "not_state_file");
+    assertNull(contents);
+  }
+
+  @Test
+  public void testGetResourceName_GlobalState() throws IOException {
+    String resourceName =
+        LegacyStateCommandUtils.getResourceName(
+            mock(LegacyVersionManager.class), SERVICE_NAME, GLOBAL_STATE_RESOURCE, false);
+    assertEquals(GLOBAL_STATE_RESOURCE, resourceName);
+  }
+
+  @Test
+  public void testGetResourceName_GlobalStateExact() throws IOException {
+    String resourceName =
+        LegacyStateCommandUtils.getResourceName(
+            mock(LegacyVersionManager.class), SERVICE_NAME, GLOBAL_STATE_RESOURCE, true);
+    assertEquals(GLOBAL_STATE_RESOURCE, resourceName);
+  }
+
+  @Test
+  public void testGetResourceName_IndexStateExact() throws IOException {
+    String resourceName =
+        LegacyStateCommandUtils.getResourceName(
+            mock(LegacyVersionManager.class), SERVICE_NAME, "exact-resource-name", true);
+    assertEquals("exact-resource-name", resourceName);
+  }
+
+  @Test
+  public void testGetResourceName_NoGlobalState() throws IOException {
+    LegacyVersionManager versionManager = getVersionManager();
+    try {
+      LegacyStateCommandUtils.getResourceName(versionManager, SERVICE_NAME, "test_index", false);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("Unable to load global state for cluster: \"test_service\"", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testGetResourceName_IndexNotExists() throws IOException {
+    createIndex(getS3(), UUID.randomUUID().toString());
+    LegacyVersionManager versionManager = getVersionManager();
+    try {
+      LegacyStateCommandUtils.getResourceName(
+          versionManager, SERVICE_NAME, "invalid_test_index", false);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals(
+          "Unable to find index: \"invalid_test_index\" in cluster: \"test_service\"",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testGetResourceName_IndexResource() throws IOException {
+    String indexUniqueName = createIndex(getS3(), UUID.randomUUID().toString());
+    LegacyVersionManager versionManager = getVersionManager();
+    String resourceName =
+        LegacyStateCommandUtils.getResourceName(versionManager, SERVICE_NAME, "test_index", false);
+    assertEquals(indexUniqueName, resourceName);
+  }
+
+  @Test
+  public void testGetIndexStateResource() {
+    assertEquals("test_index-state", LegacyStateCommandUtils.getIndexStateResource("test_index"));
+  }
+
+  @Test
+  public void testGetStateKey() {
+    assertEquals("a/b/c", LegacyStateCommandUtils.getStateKey("a", "b", "c"));
+  }
+}


### PR DESCRIPTION
Isolate the `nrt_utils` incremental commands so they will still function on legacy data while we make S3 structure changes.
- Commands moved under the `legacy` package prefix
- Reference to core nrtsearch classes removed, functionality copied in as needed
- Tests updated to not reference core classes and not use the `TestServer`

After we make our changes, we can implement new versions of the needed commands.