### PR TITLE
Update grpc version to 1.66 and protobuf to 3.25.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,7 @@ dependencies {
 
     testImplementation "junit:junit:${project.ext.junitVersion}"
     testImplementation "io.grpc:grpc-testing:${rootProject.grpcVersion}"
+    testImplementation "io.grpc:grpc-inprocess:${rootProject.grpcVersion}"
     testImplementation "org.mockito:mockito-core:${project.ext.mockitoVersion}"
     testImplementation "org.apache.lucene:lucene-test-framework:${luceneVersion}"
     testImplementation "org.locationtech.spatial4j:spatial4j:${spatial4jVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ System.setProperty("org.gradle.internal.publish.checksums.insecure", "True")
 
 def luceneVersion = '9.11.1'
 project.ext.slf4jVersion = '2.0.16'
-project.ext.grpcVersion = '1.60.2'
+project.ext.grpcVersion = '1.66.0'
 project.ext.lz4Version = '1.8.0'
 project.ext.mockitoVersion = '5.12.0'
 project.ext.jacksonYamlVersion = '2.17.2'

--- a/clientlib/build.gradle
+++ b/clientlib/build.gradle
@@ -30,11 +30,12 @@ startScripts.enabled = false
 def _artifactId = 'clientlib'
 
 // Dependency versions
-def protobufVersion = '3.25.1'
+def protobufVersion = '3.25.3'
 def protocVersion = protobufVersion
 
 dependencies {
     //grpc deps
+    api "com.google.api.grpc:proto-google-common-protos:2.41.0"
     implementation "io.grpc:grpc-protobuf:${rootProject.grpcVersion}"
     implementation "io.grpc:grpc-stub:${rootProject.grpcVersion}"
     implementation "io.grpc:grpc-okhttp:${rootProject.grpcVersion}"


### PR DESCRIPTION
RP-11378

Update grpc dependency to 1.66 and protobuf to 3.25.3. The grpc-core dependency was changed from api to implementation is some of the grpc dependencies, requiring adding grpc-inprocess and proto-google-common-protos. I've added proto-google-common-protos as an api dependency in clientlib so that users of the clientlib don't have to add this separately. The grpc-inprocess dependency is used for tests only, so it should be fine to keep it under testImplementation.