### PR TITLE
Use upload-artifact v4 action

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -53,7 +53,7 @@ jobs:
           git push
         fi
     - name: Upload JaCoCo coverage report
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: jacoco-report
         path: build/reports/jacoco/


### PR DESCRIPTION
Switch to the v4 version of upload-artifact for our github workflow. Versions 1 and 2 have been deprecated https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/