### PR TITLE
Add float vector script param

### DIFF
--- a/clientlib/src/main/java/com/yelp/nrtsearch/server/utils/ScriptParamsUtils.java
+++ b/clientlib/src/main/java/com/yelp/nrtsearch/server/utils/ScriptParamsUtils.java
@@ -73,6 +73,21 @@ public class ScriptParamsUtils {
   }
 
   /**
+   * Decode a {@link com.yelp.nrtsearch.server.grpc.Script.ParamFloatVectorValue} message into an
+   * equivalent float array.
+   *
+   * @param vectorValue vector message
+   * @return float array
+   */
+  public static float[] decodeFloatVector(Script.ParamFloatVectorValue vectorValue) {
+    float[] vector = new float[vectorValue.getValuesCount()];
+    for (int i = 0; i < vectorValue.getValuesCount(); i++) {
+      vector[i] = vectorValue.getValues(i);
+    }
+    return vector;
+  }
+
+  /**
    * Decode a {@link com.yelp.nrtsearch.server.grpc.Script.ParamValue} message into an equivalent
    * java native type.
    *
@@ -100,6 +115,8 @@ public class ScriptParamsUtils {
         return decodeList(value.getListValue());
       case STRUCTVALUE:
         return decodeStruct(value.getStructValue());
+      case FLOATVECTORVALUE:
+        return decodeFloatVector(value.getFloatVectorValue());
       default:
         throw new IllegalArgumentException(
             "Unknown script parameter type: " + value.getParamValuesCase().name());
@@ -143,6 +160,21 @@ public class ScriptParamsUtils {
   }
 
   /**
+   * Encode an array of floating point values into a vector script parameter message, filling the
+   * values of the given {@link
+   * com.yelp.nrtsearch.server.grpc.Script.ParamFloatVectorValue.Builder}.
+   *
+   * @param vectorBuilder vector message to fill
+   * @param vector array of float values
+   */
+  public static void encodeFloatVector(
+      Script.ParamFloatVectorValue.Builder vectorBuilder, float[] vector) {
+    for (float value : vector) {
+      vectorBuilder.addValues(value);
+    }
+  }
+
+  /**
    * Encode a java native type value into an equivalent {@link
    * com.yelp.nrtsearch.server.grpc.Script.ParamValue}.
    *
@@ -182,6 +214,10 @@ public class ScriptParamsUtils {
             "Error converting native map to ParamStructValue Message: " + item, e);
       }
       return Script.ParamValue.newBuilder().setStructValue(builder).build();
+    } else if (item instanceof float[]) {
+      Script.ParamFloatVectorValue.Builder builder = Script.ParamFloatVectorValue.newBuilder();
+      encodeFloatVector(builder, (float[]) item);
+      return Script.ParamValue.newBuilder().setFloatVectorValue(builder).build();
     } else if (item instanceof Iterable) {
       Script.ParamListValue.Builder builder = Script.ParamListValue.newBuilder();
       @SuppressWarnings("unchecked")

--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -679,6 +679,7 @@ message Script {
             ParamNullValue nullValue = 7;
             ParamListValue listValue = 8;
             ParamStructValue structValue = 9;
+            ParamFloatVectorValue floatVectorValue = 10;
         }
     }
 
@@ -695,6 +696,10 @@ message Script {
     // list parameter value
     message ParamListValue {
         repeated ParamValue values = 1;
+    }
+
+    message ParamFloatVectorValue {
+        repeated float values = 1;
     }
 
     map<string, ParamValue> params = 7; // parameters passed into script execution

--- a/clientlib/src/test/java/com/yelp/nrtsearch/server/utils/ScriptParamsUtilsTest.java
+++ b/clientlib/src/test/java/com/yelp/nrtsearch/server/utils/ScriptParamsUtilsTest.java
@@ -586,4 +586,47 @@ public class ScriptParamsUtilsTest {
     params.put("struct", Script.ParamValue.newBuilder().build());
     ScriptParamsUtils.decodeParams(params);
   }
+
+  @Test
+  public void testEncodeFloatVector() {
+    float[] vector = new float[] {1.0F, 2.0F, 3.0F};
+    Script.ParamFloatVectorValue.Builder builder = Script.ParamFloatVectorValue.newBuilder();
+    ScriptParamsUtils.encodeFloatVector(builder, vector);
+    Script.ParamFloatVectorValue vectorValue = builder.build();
+    assertEquals(3, vectorValue.getValuesCount());
+    assertEquals(1.0F, vectorValue.getValues(0), Math.ulp(1.0F));
+    assertEquals(2.0F, vectorValue.getValues(1), Math.ulp(2.0F));
+    assertEquals(3.0F, vectorValue.getValues(2), Math.ulp(3.0F));
+  }
+
+  @Test
+  public void testEncodeFloatVector_empty() {
+    float[] vector = new float[0];
+    Script.ParamFloatVectorValue.Builder builder = Script.ParamFloatVectorValue.newBuilder();
+    ScriptParamsUtils.encodeFloatVector(builder, vector);
+    Script.ParamFloatVectorValue vectorValue = builder.build();
+    assertEquals(0, vectorValue.getValuesCount());
+  }
+
+  @Test
+  public void testDecodeFloatVector() {
+    Script.ParamFloatVectorValue vectorValue =
+        Script.ParamFloatVectorValue.newBuilder()
+            .addValues(1.0F)
+            .addValues(2.0F)
+            .addValues(3.0F)
+            .build();
+    float[] vector = ScriptParamsUtils.decodeFloatVector(vectorValue);
+    assertEquals(3, vector.length);
+    assertEquals(1.0F, vector[0], Math.ulp(1.0F));
+    assertEquals(2.0F, vector[1], Math.ulp(2.0F));
+    assertEquals(3.0F, vector[2], Math.ulp(3.0F));
+  }
+
+  @Test
+  public void testDecodeFloatVector_empty() {
+    Script.ParamFloatVectorValue vectorValue = Script.ParamFloatVectorValue.newBuilder().build();
+    float[] vector = ScriptParamsUtils.decodeFloatVector(vectorValue);
+    assertEquals(0, vector.length);
+  }
 }


### PR DESCRIPTION
Add a script parameter type for a float vector. This is used to provide a `float[]` to the script. The advantage is that this type can be used for vector based computations more efficiently than a `List<Float>`.