### PR TITLE
Switch github workflows to use main and v0.x branches

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       branch:
         description: 'The branch to run the job on'
-        default: master
+        default: main
         required: false
         type: string
 

--- a/.github/workflows/gradle_main.yml
+++ b/.github/workflows/gradle_main.yml
@@ -5,12 +5,12 @@ name: Java CI with Gradle for master branch
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:
-    uses: Yelp/nrtsearch/.github/workflows/gradle.yml@master
+    uses: Yelp/nrtsearch/.github/workflows/gradle.yml@main
     with:
-      branch: master
+      branch: main

--- a/.github/workflows/gradle_v0.x.yml
+++ b/.github/workflows/gradle_v0.x.yml
@@ -1,16 +1,16 @@
 # This workflow will build a Java project with Gradle
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: Java CI with Gradle for 1.0.0-SNAPSHOT branch
+name: Java CI with Gradle for v0.x branch
 
 on:
   push:
-    branches: [ 1.0.0-SNAPSHOT ]
+    branches: [ v0.x ]
   pull_request:
-    branches: [ 1.0.0-SNAPSHOT ]
+    branches: [ v0.x ]
 
 jobs:
   build:
-    uses: Yelp/nrtsearch/.github/workflows/gradle.yml@1.0.0-SNAPSHOT
+    uses: Yelp/nrtsearch/.github/workflows/gradle.yml@v0.x
     with:
-      branch: 1.0.0-SNAPSHOT
+      branch: v0.x


### PR DESCRIPTION
Switch the github workflows to use main and v0.x branches instead of master and 1.0.0-SNAPSHOT.