### PR TITLE
Add updated versions of nrt_utils snapshot/restore commands

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/nrt/state/NrtFileMetaData.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/nrt/state/NrtFileMetaData.java
@@ -15,6 +15,8 @@
  */
 package com.yelp.nrtsearch.server.luceneserver.nrt.state;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -31,6 +33,8 @@ import org.apache.lucene.replicator.nrt.FileMetaData;
  * primaryId and timeString.
  */
 @JsonDeserialize(using = NrtFileMetaDataDeserializer.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class NrtFileMetaData extends FileMetaData {
 
   public String primaryId;

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/nrt/state/NrtPointState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/nrt/state/NrtPointState.java
@@ -16,6 +16,8 @@
 package com.yelp.nrtsearch.server.luceneserver.nrt.state;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -26,6 +28,8 @@ import org.apache.lucene.replicator.nrt.CopyState;
 import org.apache.lucene.replicator.nrt.FileMetaData;
 
 /** State of a single NRT point, including the files and metadata associated with it. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public final class NrtPointState {
 
   public Map<String, NrtFileMetaData> files;

--- a/src/main/java/com/yelp/nrtsearch/server/remote/RemoteBackend.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/RemoteBackend.java
@@ -145,10 +145,12 @@ public interface RemoteBackend extends PluginDownloader {
    *
    * @param service service name
    * @param indexIdentifier unique index identifier
-   * @param nrtPointState NRT point state to upload
+   * @param nrtPointState NRT point state
+   * @param data point state data to upload
    * @throws IOException on error uploading point state
    */
-  void uploadPointState(String service, String indexIdentifier, NrtPointState nrtPointState)
+  void uploadPointState(
+      String service, String indexIdentifier, NrtPointState nrtPointState, byte[] data)
       throws IOException;
 
   /**
@@ -156,8 +158,8 @@ public interface RemoteBackend extends PluginDownloader {
    *
    * @param service service name
    * @param indexIdentifier unique index identifier
-   * @return downloaded NRT point state
+   * @return input stream of point state data
    * @throws IOException on error downloading point state
    */
-  NrtPointState downloadPointState(String service, String indexIdentifier) throws IOException;
+  InputStream downloadPointState(String service, String indexIdentifier) throws IOException;
 }

--- a/src/main/java/com/yelp/nrtsearch/server/remote/RemoteUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/RemoteUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.remote;
+
+import com.yelp.nrtsearch.server.luceneserver.nrt.state.NrtPointState;
+import com.yelp.nrtsearch.server.luceneserver.state.StateUtils;
+import com.yelp.nrtsearch.server.utils.JsonUtils;
+import java.io.IOException;
+
+public class RemoteUtils {
+
+  private RemoteUtils() {}
+
+  /**
+   * Convert a {@link NrtPointState} to a UTF-8 encoded byte array.
+   *
+   * @param pointState point state
+   * @return UTF-8 encoded byte array
+   * @throws IOException on error converting to UTF-8
+   */
+  public static byte[] pointStateToUtf8(NrtPointState pointState) throws IOException {
+    String jsonString = JsonUtils.objectToJsonStr(pointState);
+    return StateUtils.toUTF8(jsonString);
+  }
+
+  /**
+   * Convert a UTF-8 encoded byte array to a {@link NrtPointState}.
+   *
+   * @param data UTF-8 encoded byte array
+   * @return NrtPointState
+   * @throws IOException on error converting from UTF-8
+   */
+  public static NrtPointState pointStateFromUtf8(byte[] data) throws IOException {
+    String jsonString = StateUtils.fromUTF8(data);
+    return JsonUtils.readValue(jsonString, NrtPointState.class);
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/utils/JsonUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/server/utils/JsonUtils.java
@@ -46,4 +46,17 @@ public class JsonUtils {
   public static <T> T convertValue(Object fromValue, Class<T> toValueType) {
     return OBJECT_MAPPER.convertValue(fromValue, toValueType);
   }
+
+  /**
+   * Read the provided json string into the provided class type.
+   *
+   * @param content json string
+   * @param valueType class type
+   * @return instance of the class type
+   * @param <T> class type
+   * @throws IOException on error reading the json string
+   */
+  public static <T> T readValue(String content, Class<T> valueType) throws IOException {
+    return OBJECT_MAPPER.readValue(content, valueType);
+  }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/utils/TimeStringUtil.java
+++ b/src/main/java/com/yelp/nrtsearch/server/utils/TimeStringUtil.java
@@ -15,6 +15,7 @@
  */
 package com.yelp.nrtsearch.server.utils;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -57,5 +58,45 @@ public class TimeStringUtil {
     } catch (Exception e) {
       return false;
     }
+  }
+
+  /**
+   * Format the given time as a UTC time string formatted as yyyyMMddHHmmssSSS.
+   *
+   * @param time time to format
+   * @return formatted time string
+   */
+  public static String formatTimeStringMs(Instant time) {
+    return MSEC_FORMATTER.format(time.atZone(ZoneId.of("UTC")));
+  }
+
+  /**
+   * Format the given time as a UTC time string formatted as yyyyMMddHHmmss.
+   *
+   * @param time time to format
+   * @return formatted time string
+   */
+  public static String formatTimeStringSec(Instant time) {
+    return SEC_FORMATTER.format(time.atZone(ZoneId.of("UTC")));
+  }
+
+  /**
+   * Parse the given UTC time string of the form yyyyMMddHHmmssSSS as an Instant.
+   *
+   * @param timeString time string to parse
+   * @return parsed Instant
+   */
+  public static Instant parseTimeStringMs(String timeString) {
+    return LocalDateTime.parse(timeString, MSEC_FORMATTER).atZone(ZoneId.of("UTC")).toInstant();
+  }
+
+  /**
+   * Parse the given UTC time string of the form yyyyMMddHHmmss as an Instant.
+   *
+   * @param timeString time string to parse
+   * @return parsed Instant
+   */
+  public static Instant parseTimeStringSec(String timeString) {
+    return LocalDateTime.parse(timeString, SEC_FORMATTER).atZone(ZoneId.of("UTC")).toInstant();
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/NrtUtilsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/NrtUtilsCommand.java
@@ -15,6 +15,10 @@
  */
 package com.yelp.nrtsearch.tools.nrt_utils;
 
+import com.yelp.nrtsearch.tools.nrt_utils.backup.CleanupSnapshotsCommand;
+import com.yelp.nrtsearch.tools.nrt_utils.backup.ListSnapshotsCommand;
+import com.yelp.nrtsearch.tools.nrt_utils.backup.RestoreCommand;
+import com.yelp.nrtsearch.tools.nrt_utils.backup.SnapshotCommand;
 import com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental.DeleteIncrementalSnapshotsCommand;
 import com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental.IncrementalDataCleanupCommand;
 import com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental.ListIncrementalSnapshotsCommand;
@@ -29,12 +33,16 @@ import picocli.CommandLine;
     name = "nrt_utils",
     synopsisSubcommandLabel = "COMMAND",
     subcommands = {
+      CleanupSnapshotsCommand.class,
       DeleteIncrementalSnapshotsCommand.class,
       GetRemoteStateCommand.class,
       IncrementalDataCleanupCommand.class,
       ListIncrementalSnapshotsCommand.class,
+      ListSnapshotsCommand.class,
       PutRemoteStateCommand.class,
+      RestoreCommand.class,
       RestoreIncrementalCommand.class,
+      SnapshotCommand.class,
       SnapshotIncrementalCommand.class,
       UpdateGlobalIndexStateCommand.class,
       CommandLine.HelpCommand.class

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/BackupCommandUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/BackupCommandUtils.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.backup;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class BackupCommandUtils {
+  public static final String SNAPSHOT_INDEX_STATE = "index_state";
+  public static final String SNAPSHOT_POINT_STATE = "index_point_state";
+  public static final String SNAPSHOT_WARMING_QUERIES = "index_warming_queries";
+  public static final String SNAPSHOT_DIR = "snapshots";
+  public static final String METADATA_DIR = "metadata";
+
+  private BackupCommandUtils() {}
+
+  /**
+   * Get the root S3 key for snapshots. If a snapshotRoot is provided, it will be used. Otherwise,
+   * this defaults to serviceName/snapshots/
+   *
+   * @param snapshotRoot snapshot root key, or null
+   * @param serviceName nrtsearch cluster service name
+   * @return snapshot root key, with trailing slash
+   */
+  public static String getSnapshotRoot(String snapshotRoot, String serviceName) {
+    if (snapshotRoot == null && serviceName == null) {
+      throw new IllegalArgumentException("Must specify snapshotRoot or serviceName");
+    }
+    String root = snapshotRoot == null ? serviceName + "/" + SNAPSHOT_DIR + "/" : snapshotRoot;
+    if (!root.endsWith("/")) {
+      root += "/";
+    }
+    return root;
+  }
+
+  /**
+   * Get the root key for index data for a specific snapshot time string.
+   *
+   * @param snapshotRoot root key for all snapshots
+   * @param indexResource index resource (name-timeString)
+   * @param timeStringMs snapshot time string of the form yyyyMMddHHmmssSSS
+   * @return root key for snapshot data
+   */
+  public static String getSnapshotIndexDataRoot(
+      String snapshotRoot, String indexResource, String timeStringMs) {
+    return snapshotRoot + indexResource + "/" + timeStringMs + "/";
+  }
+
+  /**
+   * Get the S3 key for metadata object for a specific snapshot time string.
+   *
+   * @param snapshotRoot root key for all snapshots
+   * @param indexResource index resource (name-timeString)
+   * @param timeStringMs snapshot time string of the form yyyyMMddHHmmssSSS
+   * @return key for snapshot metadata
+   */
+  public static String getSnapshotIndexMetadataKey(
+      String snapshotRoot, String indexResource, String timeStringMs) {
+    return snapshotRoot + METADATA_DIR + "/" + indexResource + "/" + timeStringMs;
+  }
+
+  /**
+   * Get the S3 key prefix for metadata objects for an index resource.
+   *
+   * @param snapshotRoot root key for all snapshots
+   * @param indexResource index resource (name-timeString)
+   * @return key prefix for snapshot metadata
+   */
+  public static String getSnapshotIndexMetadataPrefix(String snapshotRoot, String indexResource) {
+    return snapshotRoot + METADATA_DIR + "/" + indexResource + "/";
+  }
+
+  /**
+   * Delete a list of keys from s3, with a bulk delete request.
+   *
+   * @param s3Client s3 client
+   * @param bucketName s3 bucket
+   * @param keys keys to delete
+   */
+  static void deleteObjects(AmazonS3 s3Client, String bucketName, List<String> keys) {
+    System.out.println("Batch deleting objects, size: " + keys.size());
+    DeleteObjectsRequest multiObjectDeleteRequest =
+        new DeleteObjectsRequest(bucketName).withKeys(keys.toArray(new String[0])).withQuiet(true);
+    s3Client.deleteObjects(multiObjectDeleteRequest);
+  }
+
+  /**
+   * Parse an interval string into a numeric interval in ms. The string must be in a form 10s, 5h,
+   * etc. Numeric component must be positive. The units component must be one of (s)econds,
+   * (m)inutes, (h)ours, (d)ays.
+   *
+   * @param interval interval string
+   * @return interval in ms
+   */
+  static long getTimeIntervalMs(String interval) {
+    String trimmed = interval.trim();
+    if (trimmed.length() < 2) {
+      throw new IllegalArgumentException("Invalid time interval: " + trimmed);
+    }
+    char endChar = trimmed.charAt(trimmed.length() - 1);
+    long numberVal = Long.parseLong(trimmed.substring(0, trimmed.length() - 1));
+
+    if (numberVal < 1) {
+      throw new IllegalArgumentException("Time interval must be > 0");
+    }
+
+    switch (endChar) {
+      case 's':
+        return TimeUnit.SECONDS.toMillis(numberVal);
+      case 'm':
+        return TimeUnit.MINUTES.toMillis(numberVal);
+      case 'h':
+        return TimeUnit.HOURS.toMillis(numberVal);
+      case 'd':
+        return TimeUnit.DAYS.toMillis(numberVal);
+      default:
+        throw new IllegalArgumentException("Unknown time unit: " + endChar);
+    }
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/CleanupSnapshotsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/CleanupSnapshotsCommand.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.backup;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.google.common.annotations.VisibleForTesting;
+import com.yelp.nrtsearch.server.remote.s3.S3Backend;
+import com.yelp.nrtsearch.server.utils.TimeStringUtil;
+import com.yelp.nrtsearch.tools.nrt_utils.state.StateCommandUtils;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = CleanupSnapshotsCommand.CLEANUP_SNAPSHOTS,
+    description = "Delete snapshots of index data.")
+public class CleanupSnapshotsCommand implements Callable<Integer> {
+  public static final String CLEANUP_SNAPSHOTS = "cleanupSnapshots";
+  private static final int DELETE_BATCH_SIZE = 1000;
+
+  @CommandLine.Option(
+      names = {"-s", "--serviceName"},
+      description = "Name of nrtsearch cluster",
+      required = true)
+  private String serviceName;
+
+  @CommandLine.Option(
+      names = {"-i", "--indexName"},
+      description = "Name of cluster index",
+      required = true)
+  private String indexName;
+
+  @CommandLine.Option(
+      names = {"--exactResourceName"},
+      description = "If index resource name already has unique identifier")
+  private boolean exactResourceName;
+
+  @CommandLine.Option(
+      names = {"-b", "--bucketName"},
+      description = "Name of bucket containing state files",
+      required = true)
+  private String bucketName;
+
+  @CommandLine.Option(
+      names = {"--region"},
+      description = "AWS region name, such as us-west-1, us-west-2, us-east-1")
+  private String region;
+
+  @CommandLine.Option(
+      names = {"-c", "--credsFile"},
+      description =
+          "File holding AWS credentials; Will use DefaultCredentialProvider if this is unset.")
+  private String credsFile;
+
+  @CommandLine.Option(
+      names = {"-p", "--credsProfile"},
+      description = "Profile to use from creds file; Neglected when credsFile is unset.",
+      defaultValue = "default")
+  private String credsProfile;
+
+  @CommandLine.Option(
+      names = {"--snapshotRoot"},
+      description = "Root s3 snapshot path, defaults to <serviceName>/snapshots/")
+  private String snapshotRoot;
+
+  @CommandLine.Option(
+      names = {"-d", "--deleteAfter"},
+      description =
+          "Delete snapshot data that is older than this, in the form <#><unit> "
+              + "with valid units (s)econds, (m)inutes, (h)ours, (d)ays. (60m, 7h, 3d, etc.)",
+      required = true)
+  private String deleteAfter;
+
+  @CommandLine.Option(
+      names = {"--minSnapshots"},
+      description =
+          "Minimum number of latest snapshots to keep, regardless of age. default: ${DEFAULT-VALUE}",
+      defaultValue = "1")
+  private int minSnapshots;
+
+  @CommandLine.Option(
+      names = {"--dryRun"},
+      description = "Print file deletions, instead of applying to S3")
+  private boolean dryRun;
+
+  @CommandLine.Option(
+      names = {"--maxRetry"},
+      description = "Maximum number of retry attempts for S3 failed requests",
+      defaultValue = "20")
+  private int maxRetry;
+
+  private AmazonS3 s3Client;
+
+  record TimestampAndTimeString(long timestampMs, String timeString) {}
+
+  @VisibleForTesting
+  void setS3Client(AmazonS3 s3Client) {
+    this.s3Client = s3Client;
+  }
+
+  @Override
+  public Integer call() throws Exception {
+    if (s3Client == null) {
+      s3Client =
+          StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
+    }
+    S3Backend s3Backend = new S3Backend(bucketName, false, s3Client);
+
+    long deleteAfterMs = BackupCommandUtils.getTimeIntervalMs(deleteAfter);
+    long minTimestampMs = System.currentTimeMillis() - deleteAfterMs;
+    System.out.println("minTimestampMs: " + minTimestampMs);
+
+    String resolvedIndexResource =
+        StateCommandUtils.getResourceName(s3Backend, serviceName, indexName, exactResourceName);
+    String resolvedSnapshotRoot = BackupCommandUtils.getSnapshotRoot(snapshotRoot, serviceName);
+    List<TimestampAndTimeString> snapshotTimestamps =
+        getSnapshotTimestamps(s3Client, resolvedIndexResource, resolvedSnapshotRoot);
+    System.out.println("Found metadata: " + snapshotTimestamps);
+
+    if (minSnapshots > 0 && !snapshotTimestamps.isEmpty()) {
+      // timestamps are sorted in natural order
+      int index = Math.max(0, snapshotTimestamps.size() - minSnapshots);
+      if (snapshotTimestamps.get(index).timestampMs < minTimestampMs) {
+        minTimestampMs = snapshotTimestamps.get(index).timestampMs;
+      }
+      System.out.println("Adjusted min timestamp: " + minTimestampMs);
+    }
+
+    final long finalMinTimestampMs = minTimestampMs;
+    List<TimestampAndTimeString> deleteTimestamps =
+        snapshotTimestamps.stream()
+            .filter(l -> l.timestampMs < finalMinTimestampMs)
+            .collect(Collectors.toList());
+
+    deleteSnapshotMetadata(s3Client, resolvedIndexResource, resolvedSnapshotRoot, deleteTimestamps);
+    deleteSnapshotIndexData(s3Client, resolvedIndexResource, resolvedSnapshotRoot, minTimestampMs);
+
+    return 0;
+  }
+
+  private void deleteSnapshotIndexData(
+      AmazonS3 s3Client,
+      String resolvedIndexResource,
+      String resolvedSnapshotRoot,
+      long minTimestampMs) {
+    String dataPrefix = getIndexSnapshotDataPrefix(resolvedSnapshotRoot, resolvedIndexResource);
+    ListObjectsV2Request req =
+        new ListObjectsV2Request()
+            .withBucketName(bucketName)
+            .withDelimiter("/")
+            .withPrefix(dataPrefix);
+    ListObjectsV2Result result = s3Client.listObjectsV2(req);
+    List<String> dataPrefixes = result.getCommonPrefixes();
+    System.out.println("Data prefixes: " + dataPrefixes);
+
+    List<String> deletePrefixes = new ArrayList<>();
+    for (String prefix : dataPrefixes) {
+      String[] splits = prefix.split("/");
+      String timeString = splits[splits.length - 1];
+      if (TimeStringUtil.isTimeStringMs(timeString)) {
+        long dataTimestamp = TimeStringUtil.parseTimeStringMs(timeString).toEpochMilli();
+        if (dataTimestamp < minTimestampMs) {
+          deletePrefixes.add(prefix);
+        }
+      } else {
+        System.out.println("Skipping invalid timestamp: " + timeString);
+      }
+    }
+    deletePrefixes(s3Client, deletePrefixes);
+  }
+
+  private void deletePrefixes(AmazonS3 s3Client, List<String> prefixes) {
+    List<String> deleteList = new ArrayList<>(DELETE_BATCH_SIZE);
+    for (String prefix : prefixes) {
+      System.out.println("Deleting data prefix: " + prefix);
+      ListObjectsV2Request req =
+          new ListObjectsV2Request().withBucketName(bucketName).withPrefix(prefix);
+      ListObjectsV2Result result;
+
+      do {
+        result = s3Client.listObjectsV2(req);
+
+        for (S3ObjectSummary objectSummary : result.getObjectSummaries()) {
+          System.out.println("Delete: " + objectSummary.getKey());
+          deleteList.add(objectSummary.getKey());
+          if (deleteList.size() == DELETE_BATCH_SIZE) {
+            if (!dryRun) {
+              BackupCommandUtils.deleteObjects(s3Client, bucketName, deleteList);
+            }
+            deleteList.clear();
+          }
+        }
+        String token = result.getNextContinuationToken();
+        req.setContinuationToken(token);
+      } while (result.isTruncated());
+    }
+    if (!deleteList.isEmpty() && !dryRun) {
+      BackupCommandUtils.deleteObjects(s3Client, bucketName, deleteList);
+    }
+  }
+
+  private void deleteSnapshotMetadata(
+      AmazonS3 s3Client,
+      String resolvedIndexResource,
+      String resolvedSnapshotRoot,
+      List<TimestampAndTimeString> versions) {
+    for (TimestampAndTimeString version : versions) {
+      String key =
+          BackupCommandUtils.getSnapshotIndexMetadataKey(
+              resolvedSnapshotRoot, resolvedIndexResource, version.timeString);
+      System.out.println("Deleting snapshot metadata: " + key);
+      if (!dryRun) {
+        s3Client.deleteObject(bucketName, key);
+      }
+    }
+  }
+
+  private List<TimestampAndTimeString> getSnapshotTimestamps(
+      AmazonS3 s3Client, String resolvedIndexResource, String resolvedSnapshotRoot) {
+    String metadataPrefix =
+        BackupCommandUtils.getSnapshotIndexMetadataPrefix(
+            resolvedSnapshotRoot, resolvedIndexResource);
+    List<TimestampAndTimeString> snapshotTimestamps = new ArrayList<>();
+
+    ListObjectsV2Request req =
+        new ListObjectsV2Request().withBucketName(bucketName).withPrefix(metadataPrefix);
+    ListObjectsV2Result result;
+
+    do {
+      result = s3Client.listObjectsV2(req);
+
+      for (S3ObjectSummary objectSummary : result.getObjectSummaries()) {
+        String snapshotSuffix = objectSummary.getKey().split(metadataPrefix)[1];
+        if (TimeStringUtil.isTimeStringMs(snapshotSuffix)) {
+          long timestampMs = TimeStringUtil.parseTimeStringMs(snapshotSuffix).toEpochMilli();
+          snapshotTimestamps.add(new TimestampAndTimeString(timestampMs, snapshotSuffix));
+        } else {
+          System.out.println("Skipping invalid timestamp: " + snapshotSuffix);
+        }
+      }
+      String token = result.getNextContinuationToken();
+      req.setContinuationToken(token);
+    } while (result.isTruncated());
+
+    snapshotTimestamps.sort(Comparator.comparingLong(e -> e.timestampMs));
+    return snapshotTimestamps;
+  }
+
+  private String getIndexSnapshotDataPrefix(
+      String resolvedSnapshotRoot, String resolvedIndexResource) {
+    return resolvedSnapshotRoot + resolvedIndexResource + "/";
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/ListSnapshotsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/ListSnapshotsCommand.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.backup;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.yelp.nrtsearch.server.utils.TimeStringUtil;
+import com.yelp.nrtsearch.tools.nrt_utils.state.StateCommandUtils;
+import java.time.format.DateTimeParseException;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = ListSnapshotsCommand.LIST_SNAPSHOTS,
+    description = "List snapshots of index data.")
+public class ListSnapshotsCommand implements Callable<Integer> {
+  public static final String LIST_SNAPSHOTS = "listSnapshots";
+
+  @CommandLine.Option(
+      names = {"-s", "--serviceName"},
+      description = "Name of nrtsearch cluster, either this on snapshotRoot must be specified")
+  private String serviceName;
+
+  @CommandLine.Option(
+      names = {"-i", "--indexPrefix"},
+      description = "Index prefix to list",
+      defaultValue = "")
+  private String indexPrefix;
+
+  @CommandLine.Option(
+      names = {"-b", "--bucketName"},
+      description = "Name of bucket containing state files",
+      required = true)
+  private String bucketName;
+
+  @CommandLine.Option(
+      names = {"--region"},
+      description = "AWS region name, such as us-west-1, us-west-2, us-east-1")
+  private String region;
+
+  @CommandLine.Option(
+      names = {"-c", "--credsFile"},
+      description =
+          "File holding AWS credentials; Will use DefaultCredentialProvider if this is unset.")
+  private String credsFile;
+
+  @CommandLine.Option(
+      names = {"-p", "--credsProfile"},
+      description = "Profile to use from creds file; Neglected when credsFile is unset.",
+      defaultValue = "default")
+  private String credsProfile;
+
+  @CommandLine.Option(
+      names = {"--snapshotRoot"},
+      description =
+          "Root s3 snapshot path, defaults to <serviceName>/snapshots/ either this or serviceName must be specified")
+  private String snapshotRoot;
+
+  @CommandLine.Option(
+      names = {"--maxRetry"},
+      description = "Maximum number of retry attempts for S3 failed requests",
+      defaultValue = "20")
+  private int maxRetry;
+
+  @Override
+  public Integer call() throws Exception {
+    AmazonS3 s3Client =
+        StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
+
+    String resolvedSnapshotRoot = BackupCommandUtils.getSnapshotRoot(snapshotRoot, serviceName);
+    String listKeyPrefix = getIndexMetadataKeyPrefix(resolvedSnapshotRoot);
+    listSnapshots(s3Client, bucketName, resolvedSnapshotRoot, listKeyPrefix);
+    return 0;
+  }
+
+  static void listSnapshots(
+      AmazonS3 s3Client, String bucketName, String snapshotRoot, String keyPrefix) {
+    ListObjectsV2Request req =
+        new ListObjectsV2Request().withBucketName(bucketName).withPrefix(keyPrefix);
+    ListObjectsV2Result result;
+    String metadataPrefix = getMetadataKeyPrefix(snapshotRoot);
+
+    System.out.println("Listing snapshots for prefix: " + keyPrefix);
+    do {
+      result = s3Client.listObjectsV2(req);
+
+      for (S3ObjectSummary objectSummary : result.getObjectSummaries()) {
+        String snapshotSuffix = objectSummary.getKey().split(metadataPrefix)[1];
+        String timestampStr = getTimestampStr(snapshotSuffix);
+        String outputSuffix = timestampStr == null ? "" : " (" + timestampStr + ")";
+        System.out.println(snapshotSuffix + outputSuffix);
+      }
+      String token = result.getNextContinuationToken();
+      req.setContinuationToken(token);
+    } while (result.isTruncated());
+  }
+
+  static String getTimestampStr(String snapshotSuffix) {
+    String[] splits = snapshotSuffix.split("/");
+    if (splits.length != 2) {
+      return null;
+    }
+    String timestampStr = splits[1];
+    try {
+      return TimeStringUtil.parseTimeStringMs(timestampStr).toString();
+    } catch (DateTimeParseException e) {
+      return null;
+    }
+  }
+
+  static String getMetadataKeyPrefix(String snapshotRoot) {
+    return snapshotRoot + BackupCommandUtils.METADATA_DIR + "/";
+  }
+
+  String getIndexMetadataKeyPrefix(String snapshotRoot) {
+    return getMetadataKeyPrefix(snapshotRoot) + indexPrefix;
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/RestoreCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/RestoreCommand.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.backup;
+
+import static com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental.IncrementalCommandUtils.fromUTF8;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.amazonaws.services.s3.transfer.Copy;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.yelp.nrtsearch.server.luceneserver.nrt.state.NrtPointState;
+import com.yelp.nrtsearch.server.luceneserver.state.BackendGlobalState;
+import com.yelp.nrtsearch.server.remote.RemoteBackend;
+import com.yelp.nrtsearch.server.remote.RemoteUtils;
+import com.yelp.nrtsearch.server.remote.s3.S3Backend;
+import com.yelp.nrtsearch.server.utils.TimeStringUtil;
+import com.yelp.nrtsearch.tools.nrt_utils.state.StateCommandUtils;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.stream.Collectors;
+import org.apache.commons.io.IOUtils;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = RestoreCommand.RESTORE,
+    description = "Restore snapshot of index data into existing cluster.")
+public class RestoreCommand implements Callable<Integer> {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  public static final String RESTORE = "restore";
+
+  @CommandLine.Option(
+      names = {"--restoreServiceName"},
+      description = "Name of nrtsearch cluster to restore data to",
+      required = true)
+  private String restoreServiceName;
+
+  @CommandLine.Option(
+      names = {"--restoreIndexName"},
+      description = "Name of restored index",
+      required = true)
+  private String restoreIndexName;
+
+  @CommandLine.Option(
+      names = {"--restoreIndexId"},
+      description =
+          "Time string (UTC) to use for restored index, must be of the form yyyyMMddHHmmssSSS. Defaults to current time.")
+  private String restoreIndexId;
+
+  @CommandLine.Option(
+      names = {"-b", "--bucketName"},
+      description = "Name of bucket containing index files",
+      required = true)
+  private String bucketName;
+
+  @CommandLine.Option(
+      names = {"--region"},
+      description = "AWS region name, such as us-west-1, us-west-2, us-east-1")
+  private String region;
+
+  @CommandLine.Option(
+      names = {"-c", "--credsFile"},
+      description =
+          "File holding AWS credentials; Will use DefaultCredentialProvider if this is unset.")
+  private String credsFile;
+
+  @CommandLine.Option(
+      names = {"-p", "--credsProfile"},
+      description = "Profile to use from creds file; Neglected when credsFile is unset.",
+      defaultValue = "default")
+  private String credsProfile;
+
+  @CommandLine.Option(
+      names = {"--snapshotIndexIdentifier"},
+      description = "Index identifier for snapshot, in the form <index_name>-<time_string>",
+      required = true)
+  private String snapshotIndexIdentifier;
+
+  @CommandLine.Option(
+      names = {"--snapshotTimeString"},
+      description =
+          "Time string of snapshot data to restore, must be of the form yyyyMMddHHmmssSSS",
+      required = true)
+  private String snapshotTimeString;
+
+  @CommandLine.Option(
+      names = {"--snapshotRoot"},
+      description =
+          "Root s3 snapshot path, defaults to <snapshotServiceName>/snapshots/ either this or snapshotServiceName must be specified")
+  private String snapshotRoot;
+
+  @CommandLine.Option(
+      names = {"--snapshotServiceName"},
+      description =
+          "Name of nrtsearch cluster for snapshot, either this or snapshotRoot must be specified")
+  private String snapshotServiceName;
+
+  @CommandLine.Option(
+      names = {"--copyThreads"},
+      description =
+          "Number of threads to use when copying index files, (default: ${DEFAULT-VALUE})",
+      defaultValue = "10")
+  int copyThreads;
+
+  @CommandLine.Option(
+      names = {"--maxRetry"},
+      description = "Maximum number of retry attempts for S3 failed requests",
+      defaultValue = "20")
+  private int maxRetry;
+
+  private AmazonS3 s3Client;
+
+  @VisibleForTesting
+  void setS3Client(AmazonS3 s3Client) {
+    this.s3Client = s3Client;
+  }
+
+  @Override
+  public Integer call() throws Exception {
+    if (s3Client == null) {
+      s3Client =
+          StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
+    }
+    S3Backend s3Backend = new S3Backend(bucketName, false, s3Client);
+
+    String resolvedSnapshotRoot =
+        BackupCommandUtils.getSnapshotRoot(snapshotRoot, snapshotServiceName);
+    String snapshotDataRoot =
+        BackupCommandUtils.getSnapshotIndexDataRoot(
+            resolvedSnapshotRoot, snapshotIndexIdentifier, snapshotTimeString);
+    String restoreIndexResource = getRestoreIndexResource();
+
+    System.out.println(
+        "String restore of index, snapshotDataRoot: "
+            + snapshotDataRoot
+            + ", restoreService: "
+            + restoreServiceName
+            + ", restoreIndex: "
+            + restoreIndexResource);
+
+    checkRestoreIndexNotExists(s3Client, restoreIndexResource);
+
+    SnapshotMetadata metadata = loadMetadata(s3Client, resolvedSnapshotRoot);
+    restoreIndexData(s3Backend, restoreIndexResource, snapshotDataRoot);
+    restoreIndexState(s3Backend, restoreIndexResource, snapshotDataRoot);
+    maybeRestoreWarmingQueries(s3Backend, restoreIndexResource, snapshotDataRoot);
+
+    System.out.println("Restore completed");
+    return 0;
+  }
+
+  private void restoreIndexData(
+      S3Backend s3Backend, String restoreIndexResource, String snapshotDataRoot)
+      throws IOException, InterruptedException {
+    S3Object pointStateObject =
+        s3Client.getObject(bucketName, snapshotDataRoot + BackupCommandUtils.SNAPSHOT_POINT_STATE);
+    byte[] pointStateBytes = IOUtils.toByteArray(pointStateObject.getObjectContent());
+    NrtPointState nrtPointState = RemoteUtils.pointStateFromUtf8(pointStateBytes);
+    String pointStateFileName = S3Backend.getPointStateFileName(nrtPointState);
+    String restorePointStatePrefix =
+        S3Backend.getIndexResourcePrefix(
+            restoreServiceName, restoreIndexResource, RemoteBackend.IndexResourceType.POINT_STATE);
+
+    String restoreDataPrefix =
+        S3Backend.getIndexDataPrefix(restoreServiceName, restoreIndexResource);
+    Set<String> backendIndexFiles =
+        nrtPointState.files.entrySet().stream()
+            .map(entry -> S3Backend.getIndexBackendFileName(entry.getKey(), entry.getValue()))
+            .collect(Collectors.toSet());
+
+    System.out.println(
+        "Restoring point state to key: " + restorePointStatePrefix + pointStateFileName);
+    ObjectMetadata objectMetadata = new ObjectMetadata();
+    objectMetadata.setContentLength(pointStateBytes.length);
+    s3Client.putObject(
+        bucketName,
+        restorePointStatePrefix + pointStateFileName,
+        new ByteArrayInputStream(pointStateBytes),
+        objectMetadata);
+
+    System.out.println("Restoring index data: " + backendIndexFiles);
+
+    ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(copyThreads);
+    TransferManager transferManager =
+        TransferManagerBuilder.standard()
+            .withS3Client(s3Client)
+            .withExecutorFactory(() -> executor)
+            .withShutDownThreadPools(true)
+            .build();
+    try {
+      List<Copy> copyJobs = new ArrayList<>();
+      for (String fileName : backendIndexFiles) {
+        CopyObjectRequest copyObjectRequest =
+            new CopyObjectRequest(
+                bucketName, snapshotDataRoot + fileName, bucketName, restoreDataPrefix + fileName);
+        final String finalFileName = fileName;
+        Copy copy =
+            transferManager.copy(
+                copyObjectRequest,
+                (transfer, state) ->
+                    System.out.println("Transfer: " + finalFileName + ", state: " + state));
+        copyJobs.add(copy);
+      }
+      for (Copy copyJob : copyJobs) {
+        copyJob.waitForCopyResult();
+      }
+    } finally {
+      transferManager.shutdownNow(false);
+    }
+    s3Backend.setCurrentResource(restorePointStatePrefix, pointStateFileName);
+  }
+
+  private void restoreIndexState(
+      S3Backend s3Backend, String restoreIndexResource, String snapshotDataRoot)
+      throws IOException {
+    String restoreIndexStatePrefix =
+        S3Backend.getIndexResourcePrefix(
+            restoreServiceName, restoreIndexResource, RemoteBackend.IndexResourceType.INDEX_STATE);
+    String stateFileName = S3Backend.getIndexStateFileName();
+
+    System.out.println("Restoring index state to key: " + restoreIndexStatePrefix + stateFileName);
+    s3Client.copyObject(
+        bucketName,
+        snapshotDataRoot + BackupCommandUtils.SNAPSHOT_INDEX_STATE,
+        bucketName,
+        restoreIndexStatePrefix + stateFileName);
+    s3Backend.setCurrentResource(restoreIndexStatePrefix, stateFileName);
+  }
+
+  private void maybeRestoreWarmingQueries(
+      S3Backend s3Backend, String restoreIndexResource, String snapshotDataRoot) {
+    String snapshotWarmingQueriesKey =
+        snapshotDataRoot + BackupCommandUtils.SNAPSHOT_WARMING_QUERIES;
+    if (!s3Client.doesObjectExist(bucketName, snapshotWarmingQueriesKey)) {
+      System.out.println("Warming queries not present in snapshot, skipping");
+      return;
+    }
+    String restoreWarmingQueriesPrefix =
+        S3Backend.getIndexResourcePrefix(
+            restoreServiceName,
+            restoreIndexResource,
+            RemoteBackend.IndexResourceType.WARMING_QUERIES);
+    String warmingQueriesFilename = S3Backend.getWarmingQueriesFileName();
+
+    System.out.println(
+        "Restoring warming queries to key: "
+            + restoreWarmingQueriesPrefix
+            + warmingQueriesFilename);
+    s3Client.copyObject(
+        bucketName,
+        snapshotWarmingQueriesKey,
+        bucketName,
+        restoreWarmingQueriesPrefix + warmingQueriesFilename);
+    s3Backend.setCurrentResource(restoreWarmingQueriesPrefix, warmingQueriesFilename);
+  }
+
+  private SnapshotMetadata loadMetadata(AmazonS3 s3Client, String snapshotRoot) throws IOException {
+    String metadataFileKey =
+        BackupCommandUtils.getSnapshotIndexMetadataKey(
+            snapshotRoot, snapshotIndexIdentifier, snapshotTimeString);
+    if (!s3Client.doesObjectExist(bucketName, metadataFileKey)) {
+      throw new IllegalArgumentException("Metadata file does not exist: " + metadataFileKey);
+    }
+    System.out.println("Loading metadata key: " + metadataFileKey);
+    S3Object stateObject = s3Client.getObject(bucketName, metadataFileKey);
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    IOUtils.copy(stateObject.getObjectContent(), byteArrayOutputStream);
+    String fileContent = fromUTF8(byteArrayOutputStream.toByteArray());
+    System.out.println("Contents: " + fileContent);
+    return OBJECT_MAPPER.readValue(fileContent, SnapshotMetadata.class);
+  }
+
+  private void checkRestoreIndexNotExists(AmazonS3 s3Client, String restoreIndexResource) {
+    String restorePrefix = restoreServiceName + "/" + restoreIndexResource;
+    ListObjectsV2Result result = s3Client.listObjectsV2(bucketName, restorePrefix);
+    List<S3ObjectSummary> objects = result.getObjectSummaries();
+    if (!objects.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Data exists at restore location, found: " + objects.get(0).getKey());
+    }
+  }
+
+  private String getRestoreIndexResource() {
+    return BackendGlobalState.getUniqueIndexName(restoreIndexName, getRestoreIndexId());
+  }
+
+  private String getRestoreIndexId() {
+    if (restoreIndexId == null) {
+      return TimeStringUtil.generateTimeStringMs();
+    } else {
+      if (!TimeStringUtil.isTimeStringMs(restoreIndexId)) {
+        throw new IllegalStateException(
+            "restoreIndexId must be a time string of the form yyyyMMddHHmmssSSS, got: "
+                + restoreIndexId);
+      }
+      return restoreIndexId;
+    }
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/SnapshotCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/SnapshotCommand.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.backup;
+
+import static com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental.IncrementalCommandUtils.toUTF8;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.transfer.Copy;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.yelp.nrtsearch.server.luceneserver.nrt.state.NrtPointState;
+import com.yelp.nrtsearch.server.remote.RemoteBackend;
+import com.yelp.nrtsearch.server.remote.RemoteUtils;
+import com.yelp.nrtsearch.server.remote.s3.S3Backend;
+import com.yelp.nrtsearch.server.utils.TimeStringUtil;
+import com.yelp.nrtsearch.tools.nrt_utils.state.StateCommandUtils;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.stream.Collectors;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = SnapshotCommand.SNAPSHOT,
+    description = "Snapshot the current version of an index to a separate location in S3.")
+public class SnapshotCommand implements Callable<Integer> {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  public static final String SNAPSHOT = "snapshot";
+
+  @CommandLine.Option(
+      names = {"-s", "--serviceName"},
+      description = "Name of nrtsearch cluster",
+      required = true)
+  private String serviceName;
+
+  @CommandLine.Option(
+      names = {"-i", "--indexName"},
+      description = "Name of cluster index",
+      required = true)
+  private String indexName;
+
+  @CommandLine.Option(
+      names = {"--exactResourceName"},
+      description = "If index resource name already has unique identifier")
+  private boolean exactResourceName;
+
+  @CommandLine.Option(
+      names = {"-b", "--bucketName"},
+      description = "Name of bucket containing state files",
+      required = true)
+  private String bucketName;
+
+  @CommandLine.Option(
+      names = {"--region"},
+      description = "AWS region name, such as us-west-1, us-west-2, us-east-1")
+  private String region;
+
+  @CommandLine.Option(
+      names = {"-c", "--credsFile"},
+      description =
+          "File holding AWS credentials; Will use DefaultCredentialProvider if this is unset.")
+  private String credsFile;
+
+  @CommandLine.Option(
+      names = {"-p", "--credsProfile"},
+      description = "Profile to use from creds file; Neglected when credsFile is unset.",
+      defaultValue = "default")
+  private String credsProfile;
+
+  @CommandLine.Option(
+      names = {"--snapshotRoot"},
+      description = "Root s3 snapshot path, defaults to <serviceName>/snapshots/")
+  private String snapshotRoot;
+
+  @CommandLine.Option(
+      names = {"--copyThreads"},
+      description =
+          "Number of threads to use when copying index files, (default: ${DEFAULT-VALUE})",
+      defaultValue = "10")
+  int copyThreads;
+
+  @CommandLine.Option(
+      names = {"--maxRetry"},
+      description = "Maximum number of retry attempts for S3 failed requests",
+      defaultValue = "20")
+  private int maxRetry;
+
+  private AmazonS3 s3Client;
+
+  @VisibleForTesting
+  void setS3Client(AmazonS3 s3Client) {
+    this.s3Client = s3Client;
+  }
+
+  @Override
+  public Integer call() throws Exception {
+    if (s3Client == null) {
+      s3Client =
+          StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
+    }
+    S3Backend s3Backend = new S3Backend(bucketName, false, s3Client);
+
+    String resolvedIndexResource =
+        StateCommandUtils.getResourceName(s3Backend, serviceName, indexName, exactResourceName);
+
+    String timeStringMs = TimeStringUtil.generateTimeStringMs();
+    String resolvedSnapshotRoot = BackupCommandUtils.getSnapshotRoot(snapshotRoot, serviceName);
+    String snapshotIndexDataRoot =
+        BackupCommandUtils.getSnapshotIndexDataRoot(
+            resolvedSnapshotRoot, resolvedIndexResource, timeStringMs);
+
+    System.out.println(
+        "Starting snapshot for index resource: "
+            + resolvedIndexResource
+            + ", snapshotIndexDataRoot: "
+            + snapshotIndexDataRoot);
+
+    long indexDataSizeBytes =
+        copyIndexData(s3Backend, resolvedIndexResource, snapshotIndexDataRoot);
+    copyIndexState(s3Backend, resolvedIndexResource, snapshotIndexDataRoot);
+    copyWarmingQueries(s3Backend, resolvedIndexResource, snapshotIndexDataRoot);
+
+    SnapshotMetadata metadata =
+        new SnapshotMetadata(serviceName, resolvedIndexResource, timeStringMs, indexDataSizeBytes);
+    writeMetadataFile(
+        s3Client,
+        bucketName,
+        BackupCommandUtils.getSnapshotIndexMetadataKey(
+            resolvedSnapshotRoot, resolvedIndexResource, timeStringMs),
+        metadata);
+
+    System.out.println("Snapshot completed");
+    return 0;
+  }
+
+  private long copyIndexData(
+      S3Backend s3Backend, String resolvedIndexResource, String snapshotIndexDataRoot)
+      throws IOException, InterruptedException {
+    if (!s3Backend.exists(
+        serviceName, resolvedIndexResource, RemoteBackend.IndexResourceType.POINT_STATE)) {
+      throw new IllegalArgumentException("No data found for index: " + resolvedIndexResource);
+    }
+    byte[] pointStateBytes =
+        s3Backend.downloadPointState(serviceName, resolvedIndexResource).readAllBytes();
+    NrtPointState nrtPointState = RemoteUtils.pointStateFromUtf8(pointStateBytes);
+    Set<String> indexDataFiles =
+        nrtPointState.files.entrySet().stream()
+            .map(entry -> S3Backend.getIndexBackendFileName(entry.getKey(), entry.getValue()))
+            .collect(Collectors.toSet());
+
+    System.out.println("Version id: " + nrtPointState.version + ", files: " + indexDataFiles);
+
+    String indexDataKeyPrefix = S3Backend.getIndexDataPrefix(serviceName, resolvedIndexResource);
+    long totalDataSizeBytes = 0;
+
+    ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(copyThreads);
+    TransferManager transferManager =
+        TransferManagerBuilder.standard()
+            .withS3Client(s3Client)
+            .withExecutorFactory(() -> executor)
+            .withShutDownThreadPools(true)
+            .build();
+    try {
+      List<Copy> copyJobs = new ArrayList<>();
+      for (String fileName : indexDataFiles) {
+        String sourceKey = indexDataKeyPrefix + fileName;
+        totalDataSizeBytes +=
+            s3Backend.getS3().getObjectMetadata(bucketName, sourceKey).getContentLength();
+        CopyObjectRequest copyObjectRequest =
+            new CopyObjectRequest(
+                bucketName, sourceKey, bucketName, snapshotIndexDataRoot + fileName);
+        final String finalFileName = fileName;
+        Copy copy =
+            transferManager.copy(
+                copyObjectRequest,
+                (transfer, state) ->
+                    System.out.println("Transfer: " + finalFileName + ", state: " + state));
+        copyJobs.add(copy);
+      }
+      for (Copy copyJob : copyJobs) {
+        copyJob.waitForCopyResult();
+      }
+    } finally {
+      transferManager.shutdownNow(false);
+    }
+
+    ObjectMetadata metadata = new ObjectMetadata();
+    metadata.setContentLength(pointStateBytes.length);
+    PutObjectRequest putObjectRequest =
+        new PutObjectRequest(
+            bucketName,
+            snapshotIndexDataRoot + BackupCommandUtils.SNAPSHOT_POINT_STATE,
+            new ByteArrayInputStream(pointStateBytes),
+            metadata);
+    s3Backend.getS3().putObject(putObjectRequest);
+    return totalDataSizeBytes;
+  }
+
+  private void copyIndexState(
+      S3Backend s3Backend, String resolvedIndexResource, String snapshotIndexDataRoot)
+      throws IOException {
+    if (!s3Backend.exists(
+        serviceName, resolvedIndexResource, RemoteBackend.IndexResourceType.INDEX_STATE)) {
+      throw new IllegalArgumentException("No state found for index: " + resolvedIndexResource);
+    }
+    String prefix =
+        S3Backend.getIndexResourcePrefix(
+            serviceName, resolvedIndexResource, RemoteBackend.IndexResourceType.INDEX_STATE);
+    String currentStateVersion = s3Backend.getCurrentResourceName(prefix);
+    System.out.println("Current index state version: " + currentStateVersion);
+
+    s3Backend
+        .getS3()
+        .copyObject(
+            bucketName,
+            prefix + currentStateVersion,
+            bucketName,
+            snapshotIndexDataRoot + BackupCommandUtils.SNAPSHOT_INDEX_STATE);
+  }
+
+  private void copyWarmingQueries(
+      S3Backend s3Backend, String resolvedIndexResource, String snapshotIndexDataRoot)
+      throws IOException {
+    if (s3Backend.exists(
+        serviceName, resolvedIndexResource, RemoteBackend.IndexResourceType.WARMING_QUERIES)) {
+      String resourcePrefix =
+          S3Backend.getIndexResourcePrefix(
+              serviceName, resolvedIndexResource, RemoteBackend.IndexResourceType.WARMING_QUERIES);
+      String currentWarmingQueriesVersion = s3Backend.getCurrentResourceName(resourcePrefix);
+      System.out.println("Current warming queries version: " + currentWarmingQueriesVersion);
+
+      s3Backend
+          .getS3()
+          .copyObject(
+              bucketName,
+              resourcePrefix + currentWarmingQueriesVersion,
+              bucketName,
+              snapshotIndexDataRoot + BackupCommandUtils.SNAPSHOT_WARMING_QUERIES);
+    } else {
+      System.out.println("No warming queries present for index, skipping copy");
+    }
+  }
+
+  private void writeMetadataFile(
+      AmazonS3 s3Client, String bucketName, String metadataFileKey, SnapshotMetadata metadata)
+      throws IOException {
+    String metadataFileStr = OBJECT_MAPPER.writeValueAsString(metadata);
+    System.out.println(
+        "Writing metadata file key: " + metadataFileKey + ", content: " + metadataFileStr);
+    byte[] fileData = toUTF8(metadataFileStr);
+    ObjectMetadata objectMetadata = new ObjectMetadata();
+    objectMetadata.setContentLength(fileData.length);
+    s3Client.putObject(
+        new PutObjectRequest(
+            bucketName, metadataFileKey, new ByteArrayInputStream(fileData), objectMetadata));
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/SnapshotMetadata.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/SnapshotMetadata.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.backup;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Jackson annotated class that contains metadata for an index snapshot. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class SnapshotMetadata {
+  private final String serviceName;
+  private final String indexName;
+  private final String timeStringMs;
+  private final long indexSizeBytes;
+
+  /**
+   * Constructor.
+   *
+   * @param serviceName nrtsearch cluster service name
+   * @param indexName index resource name (index-UUID)
+   * @param timeStringMs snapshot timestamp
+   * @param indexSizeBytes size of snapshot index data in bytes
+   */
+  @JsonCreator
+  public SnapshotMetadata(
+      @JsonProperty("serviceName") String serviceName,
+      @JsonProperty("indexName") String indexName,
+      @JsonProperty("timeStringMs") String timeStringMs,
+      @JsonProperty("indexSizeBytes") long indexSizeBytes) {
+    this.serviceName = serviceName;
+    this.indexName = indexName;
+    this.timeStringMs = timeStringMs;
+    this.indexSizeBytes = indexSizeBytes;
+  }
+
+  /** Get nrtsearch cluster service name. */
+  public String getServiceName() {
+    return serviceName;
+  }
+
+  /** Get index resource name (index-UUID). */
+  public String getIndexName() {
+    return indexName;
+  }
+
+  /** Get snapshot time string of the form yyyyMMddHHmmssSSS. */
+  public String getTimeStringMs() {
+    return timeStringMs;
+  }
+
+  /** Get size of snapshot index data in bytes. */
+  public long getIndexSizeBytes() {
+    return indexSizeBytes;
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/nrt/state/NrtFileMetaDataTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/nrt/state/NrtFileMetaDataTest.java
@@ -64,6 +64,14 @@ public class NrtFileMetaDataTest {
     assertNrtFileMetaData(nrtFileMetaData);
   }
 
+  @Test
+  public void testFromJson_unknownFields() throws JsonProcessingException {
+    String json =
+        "{\"header\":\"AQIDBAU=\",\"footer\":\"BQQDAgE=\",\"length\":10,\"checksum\":25,\"primaryId\":\"primaryId\",\"timeString\":\"timeString\",\"unknownField\":\"unknownValue\"}";
+    NrtFileMetaData nrtFileMetaData = OBJECT_MAPPER.readValue(json, NrtFileMetaData.class);
+    assertNrtFileMetaData(nrtFileMetaData);
+  }
+
   private void assertNrtFileMetaData(NrtFileMetaData nrtFileMetaData) {
     assertArrayEquals(header, nrtFileMetaData.header);
     assertArrayEquals(footer, nrtFileMetaData.footer);

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/nrt/state/NrtPointStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/nrt/state/NrtPointStateTest.java
@@ -29,21 +29,29 @@ import org.junit.Test;
 public class NrtPointStateTest {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-  final long version = 1;
-  final long gen = 3;
-  final byte[] infosBytes = new byte[] {1, 2, 3, 4, 5};
-  final long primaryGen = 5;
-  final Set<String> completedMergeFiles = Set.of("file1");
-  final String primaryId = "primaryId";
-  final FileMetaData fileMetaData =
+  static final long version = 1;
+  static final long gen = 3;
+  static final byte[] infosBytes = new byte[] {1, 2, 3, 4, 5};
+  static final long primaryGen = 5;
+  static final Set<String> completedMergeFiles = Set.of("file1");
+  static final String primaryId = "primaryId";
+  static final FileMetaData fileMetaData =
       new FileMetaData(new byte[] {6, 7, 8}, new byte[] {0, 10, 11}, 10, 25);
-  final NrtFileMetaData nrtFileMetaData =
+  static final NrtFileMetaData nrtFileMetaData =
       new NrtFileMetaData(
           new byte[] {6, 7, 8}, new byte[] {0, 10, 11}, 10, 25, "primaryId2", "timeString");
-  final String expectedJson =
+  static final String expectedJson =
       "{\"files\":{\"file3\":{\"header\":\"BgcI\",\"footer\":\"AAoL\",\"length\":10,\"checksum\":25,\"primaryId\":\"primaryId2\",\"timeString\":\"timeString\"}},\"version\":1,\"gen\":3,\"infosBytes\":\"AQIDBAU=\",\"primaryGen\":5,\"completedMergeFiles\":[\"file1\"],\"primaryId\":\"primaryId\"}";
 
-  private CopyState getCopyState() {
+  public static NrtPointState getNrtPointState() {
+    return new NrtPointState(getCopyState(), Map.of("file3", nrtFileMetaData), primaryId);
+  }
+
+  public static String getExpectedJson() {
+    return expectedJson;
+  }
+
+  private static CopyState getCopyState() {
     return new CopyState(
         Map.of("file3", fileMetaData),
         version,
@@ -92,7 +100,15 @@ public class NrtPointStateTest {
     assertNrtPointState(nrtPointState);
   }
 
-  private void assertNrtPointState(NrtPointState nrtPointState) {
+  @Test
+  public void testFromJson_unknownField() throws JsonProcessingException {
+    String json =
+        "{\"files\":{\"file3\":{\"header\":\"BgcI\",\"footer\":\"AAoL\",\"length\":10,\"checksum\":25,\"primaryId\":\"primaryId2\",\"timeString\":\"timeString\"}},\"version\":1,\"gen\":3,\"infosBytes\":\"AQIDBAU=\",\"primaryGen\":5,\"completedMergeFiles\":[\"file1\"],\"primaryId\":\"primaryId\",\"unknownField\":\"unknownValue\"}";
+    NrtPointState nrtPointState = OBJECT_MAPPER.readValue(json, NrtPointState.class);
+    assertNrtPointState(nrtPointState);
+  }
+
+  public static void assertNrtPointState(NrtPointState nrtPointState) {
     assertEquals(nrtPointState.version, version);
     assertEquals(nrtPointState.gen, gen);
     assertArrayEquals(nrtPointState.infosBytes, infosBytes);

--- a/src/test/java/com/yelp/nrtsearch/server/remote/RemoteUtilsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/remote/RemoteUtilsTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.remote;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import com.yelp.nrtsearch.server.luceneserver.nrt.state.NrtPointStateTest;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+
+public class RemoteUtilsTest {
+
+  @Test
+  public void testPointStateToUtf8() throws IOException {
+    byte[] result = RemoteUtils.pointStateToUtf8(NrtPointStateTest.getNrtPointState());
+    byte[] expected = NrtPointStateTest.getExpectedJson().getBytes(StandardCharsets.UTF_8);
+    assertArrayEquals(expected, result);
+  }
+
+  @Test
+  public void testPointStateFromUtf8() throws IOException {
+    byte[] data = NrtPointStateTest.getExpectedJson().getBytes(StandardCharsets.UTF_8);
+    NrtPointStateTest.assertNrtPointState(RemoteUtils.pointStateFromUtf8(data));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/utils/TimeStringUtilTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/utils/TimeStringUtilTest.java
@@ -78,4 +78,38 @@ public class TimeStringUtilTest {
     assertFalse(TimeStringUtil.isTimeStringSec("_3.cfs"));
     assertFalse(TimeStringUtil.isTimeStringSec("segments"));
   }
+
+  @Test
+  public void testFormatTimeStringMs() {
+    LocalDateTime localDateTime = LocalDateTime.of(2024, 8, 20, 12, 34, 56, 789000000);
+    String timeString =
+        TimeStringUtil.formatTimeStringMs(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+    assertEquals("20240820123456789", timeString);
+  }
+
+  @Test
+  public void testFormatTimeStringSec() {
+    LocalDateTime localDateTime = LocalDateTime.of(2024, 8, 20, 12, 34, 56, 789000000);
+    String timeString =
+        TimeStringUtil.formatTimeStringSec(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+    assertEquals("20240820123456", timeString);
+  }
+
+  @Test
+  public void testParseTimeStringMs() {
+    LocalDateTime localDateTime = LocalDateTime.of(2024, 8, 20, 12, 34, 56, 789000000);
+    String timeString = "20240820123456789";
+    assertEquals(
+        localDateTime.atZone(ZoneId.of("UTC")).toInstant(),
+        TimeStringUtil.parseTimeStringMs(timeString));
+  }
+
+  @Test
+  public void testParseTimeStringSec() {
+    LocalDateTime localDateTime = LocalDateTime.of(2024, 8, 20, 12, 34, 56);
+    String timeString = "20240820123456";
+    assertEquals(
+        localDateTime.atZone(ZoneId.of("UTC")).toInstant(),
+        TimeStringUtil.parseTimeStringSec(timeString));
+  }
 }

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/backup/BackupCommandUtilsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/backup/BackupCommandUtilsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.backup;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class BackupCommandUtilsTest {
+  @Test
+  public void testGetSnapshotRoot_rootProvided() {
+    assertEquals("root/", BackupCommandUtils.getSnapshotRoot("root/", null));
+    assertEquals("root/", BackupCommandUtils.getSnapshotRoot("root/", "service"));
+    assertEquals("root/", BackupCommandUtils.getSnapshotRoot("root", "service"));
+  }
+
+  @Test
+  public void testGetSnapshotRoot_serviceProvided() {
+    assertEquals(
+        "service_name/snapshots/", BackupCommandUtils.getSnapshotRoot(null, "service_name"));
+  }
+
+  @Test
+  public void testGetSnapshotRoot_neitherProvided() {
+    try {
+      BackupCommandUtils.getSnapshotRoot(null, null);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("Must specify snapshotRoot or serviceName", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testGetSnapshotIndexDataRoot() {
+    assertEquals(
+        "root/test_index/time_string/",
+        BackupCommandUtils.getSnapshotIndexDataRoot("root/", "test_index", "time_string"));
+  }
+
+  @Test
+  public void testGetSnapshotIndexMetadataKey() {
+    assertEquals(
+        "root/metadata/test_index/time_string",
+        BackupCommandUtils.getSnapshotIndexMetadataKey("root/", "test_index", "time_string"));
+  }
+
+  @Test
+  public void testGetSnapshotIndexMetadataPrefix() {
+    assertEquals(
+        "root/metadata/test_index/",
+        BackupCommandUtils.getSnapshotIndexMetadataPrefix("root/", "test_index"));
+  }
+
+  @Test
+  public void testGetTimeIntervalMs() {
+    assertEquals(1000, BackupCommandUtils.getTimeIntervalMs("1s"));
+    assertEquals(60000, BackupCommandUtils.getTimeIntervalMs("1m"));
+    assertEquals(3600000, BackupCommandUtils.getTimeIntervalMs("1h"));
+    assertEquals(86400000, BackupCommandUtils.getTimeIntervalMs("1d"));
+  }
+
+  @Test
+  public void testGetTimeIntervalMs_invalid() {
+    try {
+      BackupCommandUtils.getTimeIntervalMs("1x");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("Unknown time unit: x", e.getMessage());
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/backup/CleanupSnapshotsCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/backup/CleanupSnapshotsCommandTest.java
@@ -1,0 +1,464 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.backup;
+
+import static com.yelp.nrtsearch.server.grpc.TestServer.S3_ENDPOINT;
+import static com.yelp.nrtsearch.server.grpc.TestServer.SERVICE_NAME;
+import static com.yelp.nrtsearch.server.grpc.TestServer.TEST_BUCKET;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.yelp.nrtsearch.server.grpc.TestServer;
+import com.yelp.nrtsearch.server.utils.TimeStringUtil;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import picocli.CommandLine;
+
+public class CleanupSnapshotsCommandTest {
+  private static final long HOUR_TO_MS = 60L * 60L * 1000L;
+
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  @After
+  public void cleanup() {
+    TestServer.cleanupAll();
+  }
+
+  private AmazonS3 getS3() {
+    AmazonS3 s3 = new AmazonS3Client(new AnonymousAWSCredentials());
+    s3.setEndpoint(S3_ENDPOINT);
+    s3.createBucket(TEST_BUCKET);
+    return s3;
+  }
+
+  private CommandLine getInjectedCommand() {
+    CleanupSnapshotsCommand command = new CleanupSnapshotsCommand();
+    command.setS3Client(getS3());
+    return new CommandLine(command);
+  }
+
+  private static class TestSnapshotInfo {
+    public final long timestampMs;
+    public final Set<String> files;
+    public final boolean hasMetadata;
+
+    TestSnapshotInfo(long timestampMs, Set<String> files) {
+      this(timestampMs, files, true);
+    }
+
+    TestSnapshotInfo(long timestampMs, Set<String> files, boolean hasMetadata) {
+      this.timestampMs = timestampMs;
+      this.files = files;
+      this.hasMetadata = hasMetadata;
+    }
+  }
+
+  private List<TestSnapshotInfo> createTestSnapshotData(String indexUniqueName) throws IOException {
+    return createTestSnapshotData(indexUniqueName, true);
+  }
+
+  private List<TestSnapshotInfo> createTestSnapshotData(String indexUniqueName, boolean hasMetadata)
+      throws IOException {
+    return createTestSnapshotData(indexUniqueName, hasMetadata, SERVICE_NAME);
+  }
+
+  private List<TestSnapshotInfo> createTestSnapshotData(
+      String indexUniqueName, boolean hasMetadata, String serviceName) throws IOException {
+    long currentTime = System.currentTimeMillis() - 1;
+    List<TestSnapshotInfo> testInfo = new ArrayList<>();
+    testInfo.add(new TestSnapshotInfo(currentTime - HOUR_TO_MS, Set.of("f1", "f2", "f3")));
+    testInfo.add(new TestSnapshotInfo(currentTime - (2L * HOUR_TO_MS), Set.of("f2", "f4")));
+    testInfo.add(
+        new TestSnapshotInfo(
+            currentTime - (3L * HOUR_TO_MS), Set.of("f3", "f6", "f9"), hasMetadata));
+    testInfo.add(
+        new TestSnapshotInfo(currentTime - (4L * HOUR_TO_MS), Set.of("f10", "f11", "f12")));
+    testInfo.add(new TestSnapshotInfo(currentTime - (5L * HOUR_TO_MS), Set.of("f1", "f5", "f10")));
+    createSnapshotFiles(indexUniqueName, testInfo, serviceName);
+    return testInfo;
+  }
+
+  private void createSnapshotFiles(
+      String indexUniqueName, List<TestSnapshotInfo> snapshotInfos, String serviceName)
+      throws IOException {
+    Path metadataRootFolder = getMetadataRoot(indexUniqueName, serviceName);
+    Files.createDirectories(metadataRootFolder);
+
+    for (TestSnapshotInfo snapshotInfo : snapshotInfos) {
+      String timeString =
+          TimeStringUtil.formatTimeStringMs(Instant.ofEpochMilli(snapshotInfo.timestampMs));
+      if (snapshotInfo.hasMetadata) {
+        Path metadataFile = metadataRootFolder.resolve(timeString);
+        Files.createFile(metadataFile);
+      }
+      Path dataFolder = getIndexSnapshotDataRoot(indexUniqueName, serviceName).resolve(timeString);
+      Files.createDirectories(dataFolder);
+      for (String file : snapshotInfo.files) {
+        Path filePath = dataFolder.resolve(file);
+        Files.createFile(filePath);
+      }
+    }
+  }
+
+  private Path getMetadataRoot(String indexUniqueName, String serviceName) {
+    return folder
+        .getRoot()
+        .toPath()
+        .resolve("s3")
+        .resolve(TEST_BUCKET)
+        .resolve(serviceName)
+        .resolve(BackupCommandUtils.SNAPSHOT_DIR)
+        .resolve(BackupCommandUtils.METADATA_DIR)
+        .resolve(indexUniqueName);
+  }
+
+  private Path getIndexSnapshotDataRoot(String indexUniqueName, String serviceName) {
+    return folder
+        .getRoot()
+        .toPath()
+        .resolve("s3")
+        .resolve(TEST_BUCKET)
+        .resolve(serviceName)
+        .resolve(BackupCommandUtils.SNAPSHOT_DIR)
+        .resolve(indexUniqueName);
+  }
+
+  @Test
+  public void testDeleteSnapshots() throws IOException {
+    TestServer.initS3(folder);
+    String indexUniqueName = "test_index-" + TimeStringUtil.generateTimeStringMs();
+    List<TestSnapshotInfo> snapshotInfos = createTestSnapshotData(indexUniqueName);
+
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=" + indexUniqueName,
+            "--exactResourceName",
+            "--bucketName=" + TEST_BUCKET,
+            "--deleteAfter=210m");
+    assertEquals(0, exitCode);
+
+    verifySnapshots(
+        indexUniqueName, snapshotInfos.get(0), snapshotInfos.get(1), snapshotInfos.get(2));
+  }
+
+  @Test
+  public void testDeleteSnapshotsDryRun() throws IOException {
+    TestServer.initS3(folder);
+    String indexUniqueName = "test_index-" + TimeStringUtil.generateTimeStringMs();
+    List<TestSnapshotInfo> snapshotInfos = createTestSnapshotData(indexUniqueName);
+
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=" + indexUniqueName,
+            "--exactResourceName",
+            "--bucketName=" + TEST_BUCKET,
+            "--deleteAfter=210m",
+            "--dryRun");
+    assertEquals(0, exitCode);
+
+    verifySnapshots(
+        indexUniqueName,
+        snapshotInfos.get(0),
+        snapshotInfos.get(1),
+        snapshotInfos.get(2),
+        snapshotInfos.get(3),
+        snapshotInfos.get(4));
+  }
+
+  @Test
+  public void testDeleteSnapshotsDifferentRoot() throws IOException {
+    TestServer.initS3(folder);
+    String indexUniqueName = "test_index-" + TimeStringUtil.generateTimeStringMs();
+    List<TestSnapshotInfo> snapshotInfos =
+        createTestSnapshotData(indexUniqueName, true, "different_root");
+
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=" + indexUniqueName,
+            "--exactResourceName",
+            "--bucketName=" + TEST_BUCKET,
+            "--snapshotRoot=different_root/snapshots/",
+            "--deleteAfter=210m");
+    assertEquals(0, exitCode);
+
+    verifySnapshots(
+        indexUniqueName,
+        "different_root",
+        snapshotInfos.get(0),
+        snapshotInfos.get(1),
+        snapshotInfos.get(2));
+  }
+
+  @Test
+  public void testDeleteSnapshotsKeepsN() throws IOException {
+    TestServer.initS3(folder);
+    String indexUniqueName = "test_index-" + TimeStringUtil.generateTimeStringMs();
+    List<TestSnapshotInfo> snapshotInfos = createTestSnapshotData(indexUniqueName);
+
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=" + indexUniqueName,
+            "--exactResourceName",
+            "--bucketName=" + TEST_BUCKET,
+            "--deleteAfter=210m",
+            "--minSnapshots=4");
+    assertEquals(0, exitCode);
+
+    verifySnapshots(
+        indexUniqueName,
+        snapshotInfos.get(0),
+        snapshotInfos.get(1),
+        snapshotInfos.get(2),
+        snapshotInfos.get(3));
+  }
+
+  @Test
+  public void testDeleteSnapshotsKeepMore() throws IOException {
+    TestServer.initS3(folder);
+    String indexUniqueName = "test_index-" + TimeStringUtil.generateTimeStringMs();
+    List<TestSnapshotInfo> snapshotInfos = createTestSnapshotData(indexUniqueName);
+
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=" + indexUniqueName,
+            "--exactResourceName",
+            "--bucketName=" + TEST_BUCKET,
+            "--deleteAfter=210m",
+            "--minSnapshots=7");
+    assertEquals(0, exitCode);
+
+    verifySnapshots(
+        indexUniqueName,
+        snapshotInfos.get(0),
+        snapshotInfos.get(1),
+        snapshotInfos.get(2),
+        snapshotInfos.get(3),
+        snapshotInfos.get(4));
+  }
+
+  @Test
+  public void testDeleteAllSnapshots() throws IOException, InterruptedException {
+    TestServer.initS3(folder);
+    String indexUniqueName = "test_index-" + TimeStringUtil.generateTimeStringMs();
+    List<TestSnapshotInfo> snapshotInfos = createTestSnapshotData(indexUniqueName);
+
+    CommandLine cmd = getInjectedCommand();
+
+    Thread.sleep(2000);
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=" + indexUniqueName,
+            "--exactResourceName",
+            "--bucketName=" + TEST_BUCKET,
+            "--deleteAfter=1s",
+            "--minSnapshots=0");
+    assertEquals(0, exitCode);
+
+    verifySnapshots(indexUniqueName);
+  }
+
+  @Test
+  public void testOnlyKeepN() throws IOException, InterruptedException {
+    TestServer.initS3(folder);
+    String indexUniqueName = "test_index-" + TimeStringUtil.generateTimeStringMs();
+    List<TestSnapshotInfo> snapshotInfos = createTestSnapshotData(indexUniqueName);
+
+    CommandLine cmd = getInjectedCommand();
+
+    Thread.sleep(2000);
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=" + indexUniqueName,
+            "--exactResourceName",
+            "--bucketName=" + TEST_BUCKET,
+            "--deleteAfter=1s",
+            "--minSnapshots=1");
+    assertEquals(0, exitCode);
+
+    verifySnapshots(indexUniqueName, snapshotInfos.get(0));
+  }
+
+  @Test
+  public void testNoData() throws IOException {
+    TestServer.initS3(folder);
+    String indexUniqueName = "test_index-" + TimeStringUtil.generateTimeStringMs();
+
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=" + indexUniqueName,
+            "--exactResourceName",
+            "--bucketName=" + TEST_BUCKET,
+            "--deleteAfter=1s",
+            "--minSnapshots=1");
+    assertEquals(0, exitCode);
+
+    verifySnapshots(indexUniqueName);
+  }
+
+  @Test
+  public void testDeleteDataWithoutMetadata() throws IOException {
+    TestServer.initS3(folder);
+    String indexUniqueName = "test_index-" + TimeStringUtil.generateTimeStringMs();
+    List<TestSnapshotInfo> snapshotInfos = createTestSnapshotData(indexUniqueName, false);
+
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=" + indexUniqueName,
+            "--exactResourceName",
+            "--bucketName=" + TEST_BUCKET,
+            "--deleteAfter=150m");
+    assertEquals(0, exitCode);
+
+    verifySnapshots(indexUniqueName, snapshotInfos.get(0), snapshotInfos.get(1));
+  }
+
+  @Test
+  public void testKeepDataWithoutMetadata() throws IOException {
+    TestServer.initS3(folder);
+    String indexUniqueName = "test_index-" + TimeStringUtil.generateTimeStringMs();
+    List<TestSnapshotInfo> snapshotInfos = createTestSnapshotData(indexUniqueName, false);
+
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=" + indexUniqueName,
+            "--exactResourceName",
+            "--bucketName=" + TEST_BUCKET,
+            "--deleteAfter=210m");
+    assertEquals(0, exitCode);
+
+    verifySnapshots(
+        indexUniqueName, snapshotInfos.get(0), snapshotInfos.get(1), snapshotInfos.get(2));
+  }
+
+  @Test
+  public void testIndexIdFromGlobalState() throws IOException {
+    TestServer server = TestServer.builder(folder).withRemoteStateBackend(false).build();
+    server.createIndex("test_index");
+    String indexUniqueName = server.getGlobalState().getDataResourceForIndex("test_index");
+    List<TestSnapshotInfo> snapshotInfos = createTestSnapshotData(indexUniqueName);
+
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=test_index",
+            "--bucketName=" + TEST_BUCKET,
+            "--deleteAfter=210m");
+    assertEquals(0, exitCode);
+
+    verifySnapshots(
+        indexUniqueName, snapshotInfos.get(0), snapshotInfos.get(1), snapshotInfos.get(2));
+  }
+
+  public void verifySnapshots(String indexUniqueName, TestSnapshotInfo... infos) {
+    verifySnapshots(indexUniqueName, SERVICE_NAME, infos);
+  }
+
+  public void verifySnapshots(
+      String indexUniqueName, String serviceName, TestSnapshotInfo... infos) {
+    Map<String, Set<String>> fileMap =
+        Stream.of(infos)
+            .collect(
+                Collectors.toMap(
+                    i -> TimeStringUtil.formatTimeStringMs(Instant.ofEpochMilli(i.timestampMs)),
+                    i -> i.files));
+
+    Set<String> expectedMetadata = new HashSet<>();
+    Set<String> expectedDataFolders = new HashSet<>();
+    Set<String> metadataVersions = new HashSet<>();
+    for (TestSnapshotInfo info : infos) {
+      String timeString = TimeStringUtil.formatTimeStringMs(Instant.ofEpochMilli(info.timestampMs));
+      if (info.hasMetadata) {
+        expectedMetadata.add(timeString);
+      }
+      expectedDataFolders.add(timeString);
+    }
+    File[] indexMetadataFiles = getMetadataRoot(indexUniqueName, serviceName).toFile().listFiles();
+    if (indexMetadataFiles != null) {
+      for (File file : indexMetadataFiles) {
+        metadataVersions.add(file.getName());
+      }
+    }
+    assertEquals(expectedMetadata, metadataVersions);
+
+    Set<String> dataFolders = new HashSet<>();
+    Path dataRoot = getIndexSnapshotDataRoot(indexUniqueName, serviceName);
+    File[] indexDataVersions = dataRoot.toFile().listFiles();
+    if (indexDataVersions != null) {
+      for (File file : indexDataVersions) {
+        dataFolders.add(file.getName());
+      }
+    }
+    assertTrue(dataFolders.containsAll(expectedDataFolders));
+
+    for (String folder : dataFolders) {
+      File[] folderFiles = dataRoot.resolve(folder).toFile().listFiles();
+      if (expectedDataFolders.contains(folder)) {
+        Set<String> fileSet = new HashSet<>();
+        for (File folderFile : folderFiles) {
+          fileSet.add(folderFile.getName());
+        }
+        assertEquals(fileMap.get(folder), fileSet);
+      } else {
+        assertEquals(0, folderFiles.length);
+      }
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/backup/SnapshotMetadataTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/backup/SnapshotMetadataTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.backup;
+
+import static org.junit.Assert.assertEquals;
+
+import com.yelp.nrtsearch.server.utils.JsonUtils;
+import java.io.IOException;
+import org.junit.Test;
+
+public class SnapshotMetadataTest {
+
+  @Test
+  public void testSnapshotMetadata() {
+    SnapshotMetadata snapshotMetadata =
+        new SnapshotMetadata("serviceName", "indexName", "timeStringMs", 1000);
+    assertEquals("serviceName", snapshotMetadata.getServiceName());
+    assertEquals("indexName", snapshotMetadata.getIndexName());
+    assertEquals("timeStringMs", snapshotMetadata.getTimeStringMs());
+    assertEquals(1000, snapshotMetadata.getIndexSizeBytes());
+  }
+
+  @Test
+  public void testToJson() throws IOException {
+    SnapshotMetadata snapshotMetadata =
+        new SnapshotMetadata("serviceName", "indexName", "timeStringMs", 1000);
+    String json = JsonUtils.objectToJsonStr(snapshotMetadata);
+    assertEquals(
+        "{\"serviceName\":\"serviceName\",\"indexName\":\"indexName\",\"timeStringMs\":\"timeStringMs\",\"indexSizeBytes\":1000}",
+        json);
+  }
+
+  @Test
+  public void testFromJson() throws IOException {
+    String json =
+        "{\"serviceName\":\"serviceName\",\"indexName\":\"indexName\",\"timeStringMs\":\"timeStringMs\",\"indexSizeBytes\":1000}";
+    SnapshotMetadata snapshotMetadata = JsonUtils.readValue(json, SnapshotMetadata.class);
+    assertEquals("serviceName", snapshotMetadata.getServiceName());
+    assertEquals("indexName", snapshotMetadata.getIndexName());
+    assertEquals("timeStringMs", snapshotMetadata.getTimeStringMs());
+    assertEquals(1000, snapshotMetadata.getIndexSizeBytes());
+  }
+
+  @Test
+  public void testFromJson_unknownFields() throws IOException {
+    String json =
+        "{\"serviceName\":\"serviceName\",\"indexName\":\"indexName\",\"timeStringMs\":\"timeStringMs\",\"indexSizeBytes\":1000,\"unknownField\":\"unknownValue\"}";
+    SnapshotMetadata snapshotMetadata = JsonUtils.readValue(json, SnapshotMetadata.class);
+    assertEquals("serviceName", snapshotMetadata.getServiceName());
+    assertEquals("indexName", snapshotMetadata.getIndexName());
+    assertEquals("timeStringMs", snapshotMetadata.getTimeStringMs());
+    assertEquals(1000, snapshotMetadata.getIndexSizeBytes());
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/backup/SnapshotRestoreCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/backup/SnapshotRestoreCommandTest.java
@@ -1,0 +1,504 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.backup;
+
+import static com.yelp.nrtsearch.server.grpc.TestServer.S3_ENDPOINT;
+import static com.yelp.nrtsearch.server.grpc.TestServer.SERVICE_NAME;
+import static com.yelp.nrtsearch.server.grpc.TestServer.TEST_BUCKET;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
+import com.yelp.nrtsearch.server.config.IndexStartConfig.IndexDataLocationType;
+import com.yelp.nrtsearch.server.grpc.BackupWarmingQueriesRequest;
+import com.yelp.nrtsearch.server.grpc.CreateIndexRequest;
+import com.yelp.nrtsearch.server.grpc.IndexStateInfo;
+import com.yelp.nrtsearch.server.grpc.Mode;
+import com.yelp.nrtsearch.server.grpc.RestoreIndex;
+import com.yelp.nrtsearch.server.grpc.TestServer;
+import com.yelp.nrtsearch.server.luceneserver.nrt.state.NrtPointState;
+import com.yelp.nrtsearch.server.luceneserver.state.BackendGlobalState;
+import com.yelp.nrtsearch.server.luceneserver.state.StateUtils;
+import com.yelp.nrtsearch.server.remote.RemoteBackend;
+import com.yelp.nrtsearch.server.remote.RemoteUtils;
+import com.yelp.nrtsearch.server.remote.s3.S3Backend;
+import com.yelp.nrtsearch.server.utils.TimeStringUtil;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.io.IOUtils;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import picocli.CommandLine;
+
+public class SnapshotRestoreCommandTest {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  @After
+  public void cleanup() {
+    TestServer.cleanupAll();
+  }
+
+  private AmazonS3 getS3() {
+    AmazonS3 s3 = new AmazonS3Client(new AnonymousAWSCredentials());
+    s3.setEndpoint(S3_ENDPOINT);
+    s3.createBucket(TEST_BUCKET);
+    return s3;
+  }
+
+  private CommandLine getInjectedSnapshotCommand() {
+    SnapshotCommand command = new SnapshotCommand();
+    command.setS3Client(getS3());
+    return new CommandLine(command);
+  }
+
+  private CommandLine getInjectedRestoreCommand() {
+    RestoreCommand command = new RestoreCommand();
+    command.setS3Client(getS3());
+    return new CommandLine(command);
+  }
+
+  private TestServer getTestServer() throws IOException {
+    TestServer server =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.REMOTE)
+            .withRemoteStateBackend(false)
+            .build();
+    server.createSimpleIndex("test_index");
+    server.startPrimaryIndex("test_index", -1, null);
+    server.addSimpleDocs("test_index", 1, 2);
+    server.refresh("test_index");
+    server.commit("test_index");
+    return server;
+  }
+
+  private void createWarmingQueries(TestServer server) throws IOException {
+    TestServer replica =
+        TestServer.builder(folder)
+            .withAutoStartConfig(
+                true, Mode.REPLICA, server.getReplicationPort(), IndexDataLocationType.REMOTE)
+            .withRemoteStateBackend(false)
+            .withAdditionalConfig(String.join("\n", "warmer:", "  maxWarmingQueries: 10"))
+            .build();
+    replica
+        .getClient()
+        .getBlockingStub()
+        .backupWarmingQueries(
+            BackupWarmingQueriesRequest.newBuilder()
+                .setIndex("test_index")
+                .setServiceName(SERVICE_NAME)
+                .setNumQueriesThreshold(0)
+                .setUptimeMinutesThreshold(0)
+                .build());
+  }
+
+  @Test
+  public void testSnapshot() throws IOException {
+    TestServer server = getTestServer();
+    CommandLine cmd = getInjectedSnapshotCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=test_index",
+            "--bucketName=" + TEST_BUCKET);
+    assertEquals(0, exitCode);
+
+    assertSnapshotFiles(
+        getS3(),
+        server.getGlobalState().getDataResourceForIndex("test_index"),
+        SERVICE_NAME + "/" + BackupCommandUtils.SNAPSHOT_DIR,
+        false);
+  }
+
+  @Test
+  public void testSnapshotDifferentRoot() throws IOException {
+    TestServer server = getTestServer();
+    CommandLine cmd = getInjectedSnapshotCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=test_index",
+            "--bucketName=" + TEST_BUCKET,
+            "--snapshotRoot=different/root/");
+    assertEquals(0, exitCode);
+
+    assertSnapshotFiles(
+        getS3(),
+        server.getGlobalState().getDataResourceForIndex("test_index"),
+        "different/root",
+        false);
+  }
+
+  @Test
+  public void testSnapshotWarmingQueries() throws IOException {
+    TestServer server = getTestServer();
+    createWarmingQueries(server);
+    CommandLine cmd = getInjectedSnapshotCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=test_index",
+            "--bucketName=" + TEST_BUCKET);
+    assertEquals(0, exitCode);
+
+    assertSnapshotFiles(
+        getS3(),
+        server.getGlobalState().getDataResourceForIndex("test_index"),
+        SERVICE_NAME + "/" + BackupCommandUtils.SNAPSHOT_DIR,
+        true);
+  }
+
+  @Test
+  public void testSnapshotWarmingQueriesDifferentRoot() throws IOException {
+    TestServer server = getTestServer();
+    createWarmingQueries(server);
+    CommandLine cmd = getInjectedSnapshotCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=test_index",
+            "--bucketName=" + TEST_BUCKET,
+            "--snapshotRoot=different/root/");
+    assertEquals(0, exitCode);
+
+    assertSnapshotFiles(
+        getS3(),
+        server.getGlobalState().getDataResourceForIndex("test_index"),
+        "different/root",
+        true);
+  }
+
+  @Test
+  public void testRestore() throws IOException {
+    TestServer server = getTestServer();
+    CommandLine cmd = getInjectedSnapshotCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=test_index",
+            "--bucketName=" + TEST_BUCKET);
+    assertEquals(0, exitCode);
+
+    String indexResource = server.getGlobalState().getDataResourceForIndex("test_index");
+    List<String> timeStrings =
+        getSnapshotTimeStrings(
+            getS3(), indexResource, SERVICE_NAME + "/" + BackupCommandUtils.SNAPSHOT_DIR);
+    assertEquals(1, timeStrings.size());
+    String snapshotTimeString = timeStrings.get(0);
+
+    String restoreId = TimeStringUtil.generateTimeStringMs();
+    CommandLine restoreCmd = getInjectedRestoreCommand();
+    exitCode =
+        restoreCmd.execute(
+            "--restoreServiceName=" + SERVICE_NAME,
+            "--restoreIndexName=restore_index",
+            "--restoreIndexId=" + restoreId,
+            "--bucketName=" + TEST_BUCKET,
+            "--snapshotServiceName=" + SERVICE_NAME,
+            "--snapshotIndexIdentifier=" + indexResource,
+            "--snapshotTimeString=" + snapshotTimeString);
+    assertEquals(0, exitCode);
+    assertRestoreFiles(
+        getS3(),
+        SERVICE_NAME,
+        BackendGlobalState.getUniqueIndexName("restore_index", restoreId),
+        false);
+  }
+
+  @Test
+  public void testRestoreDifferentCluster() throws IOException {
+    TestServer server = getTestServer();
+    CommandLine cmd = getInjectedSnapshotCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=test_index",
+            "--bucketName=" + TEST_BUCKET);
+    assertEquals(0, exitCode);
+
+    String indexResource = server.getGlobalState().getDataResourceForIndex("test_index");
+    List<String> timeStrings =
+        getSnapshotTimeStrings(
+            getS3(), indexResource, SERVICE_NAME + "/" + BackupCommandUtils.SNAPSHOT_DIR);
+    assertEquals(1, timeStrings.size());
+    String snapshotTimeString = timeStrings.get(0);
+
+    String restoreId = TimeStringUtil.generateTimeStringMs();
+    CommandLine restoreCmd = getInjectedRestoreCommand();
+    exitCode =
+        restoreCmd.execute(
+            "--restoreServiceName=other_service",
+            "--restoreIndexName=restore_index",
+            "--restoreIndexId=" + restoreId,
+            "--bucketName=" + TEST_BUCKET,
+            "--snapshotServiceName=" + SERVICE_NAME,
+            "--snapshotIndexIdentifier=" + indexResource,
+            "--snapshotTimeString=" + snapshotTimeString);
+    assertEquals(0, exitCode);
+    assertRestoreFiles(
+        getS3(),
+        "other_service",
+        BackendGlobalState.getUniqueIndexName("restore_index", restoreId),
+        false);
+  }
+
+  @Test
+  public void testRestoreWarmingQueries() throws IOException {
+    TestServer server = getTestServer();
+    createWarmingQueries(server);
+    CommandLine cmd = getInjectedSnapshotCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=test_index",
+            "--bucketName=" + TEST_BUCKET);
+    assertEquals(0, exitCode);
+
+    String indexResource = server.getGlobalState().getDataResourceForIndex("test_index");
+    List<String> timeStrings =
+        getSnapshotTimeStrings(
+            getS3(), indexResource, SERVICE_NAME + "/" + BackupCommandUtils.SNAPSHOT_DIR);
+    assertEquals(1, timeStrings.size());
+    String snapshotTimeString = timeStrings.get(0);
+
+    String restoreId = TimeStringUtil.generateTimeStringMs();
+    CommandLine restoreCmd = getInjectedRestoreCommand();
+    exitCode =
+        restoreCmd.execute(
+            "--restoreServiceName=" + SERVICE_NAME,
+            "--restoreIndexName=restore_index",
+            "--restoreIndexId=" + restoreId,
+            "--bucketName=" + TEST_BUCKET,
+            "--snapshotServiceName=" + SERVICE_NAME,
+            "--snapshotIndexIdentifier=" + indexResource,
+            "--snapshotTimeString=" + snapshotTimeString);
+    assertEquals(0, exitCode);
+    assertRestoreFiles(
+        getS3(),
+        SERVICE_NAME,
+        BackendGlobalState.getUniqueIndexName("restore_index", restoreId),
+        true);
+  }
+
+  @Test
+  public void testRestoreDocs() throws IOException {
+    TestServer server = getTestServer();
+    CommandLine cmd = getInjectedSnapshotCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--indexName=test_index",
+            "--bucketName=" + TEST_BUCKET);
+    assertEquals(0, exitCode);
+
+    String indexResource = server.getGlobalState().getDataResourceForIndex("test_index");
+    List<String> timeStrings =
+        getSnapshotTimeStrings(
+            getS3(), indexResource, SERVICE_NAME + "/" + BackupCommandUtils.SNAPSHOT_DIR);
+    assertEquals(1, timeStrings.size());
+    String snapshotTimeString = timeStrings.get(0);
+
+    String restoreId = TimeStringUtil.generateTimeStringMs();
+    CommandLine restoreCmd = getInjectedRestoreCommand();
+    exitCode =
+        restoreCmd.execute(
+            "--restoreServiceName=" + SERVICE_NAME,
+            "--restoreIndexName=restore_index",
+            "--restoreIndexId=" + restoreId,
+            "--bucketName=" + TEST_BUCKET,
+            "--snapshotServiceName=" + SERVICE_NAME,
+            "--snapshotIndexIdentifier=" + indexResource,
+            "--snapshotTimeString=" + snapshotTimeString);
+    assertEquals(0, exitCode);
+
+    server.createIndex(
+        CreateIndexRequest.newBuilder()
+            .setIndexName("restore_index")
+            .setExistsWithId(restoreId)
+            .build());
+    server.startPrimaryIndex(
+        "restore_index",
+        -1,
+        RestoreIndex.newBuilder()
+            .setServiceName(SERVICE_NAME)
+            .setResourceName("restore_index")
+            .build());
+    server.verifySimpleDocs("test_index", 2);
+    server.verifySimpleDocs("restore_index", 2);
+  }
+
+  private void assertSnapshotFiles(
+      AmazonS3 s3Client, String indexResource, String snapshotRoot, boolean withWarming)
+      throws IOException {
+    List<String> timeStrings = getSnapshotTimeStrings(s3Client, indexResource, snapshotRoot);
+    assertEquals(1, timeStrings.size());
+    String snapshotTimeString = timeStrings.get(0);
+
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, s3Client);
+    NrtPointState pointState =
+        RemoteUtils.pointStateFromUtf8(
+            s3Backend.downloadPointState(SERVICE_NAME, indexResource).readAllBytes());
+    assertEquals(Set.of("_0.cfe", "_0.si", "_0.cfs"), pointState.files.keySet());
+    Set<String> pointBackendFiles =
+        pointState.files.entrySet().stream()
+            .map(e -> S3Backend.getIndexBackendFileName(e.getKey(), e.getValue()))
+            .collect(Collectors.toSet());
+
+    Set<String> snapshotFiles =
+        getSnapshotFiles(s3Client, indexResource, snapshotTimeString, snapshotRoot);
+    Set<String> expectedFiles =
+        Sets.union(
+            pointBackendFiles,
+            Set.of(
+                BackupCommandUtils.SNAPSHOT_POINT_STATE, BackupCommandUtils.SNAPSHOT_INDEX_STATE));
+    if (withWarming) {
+      expectedFiles =
+          Sets.union(expectedFiles, Set.of(BackupCommandUtils.SNAPSHOT_WARMING_QUERIES));
+    }
+    assertEquals(expectedFiles, snapshotFiles);
+
+    assertSnapshotMetadata(s3Client, indexResource, snapshotRoot, snapshotTimeString);
+  }
+
+  private void assertSnapshotMetadata(
+      AmazonS3 s3Client, String indexResource, String snapshotRoot, String snapshotTimeString) {
+    SnapshotMetadata snapshotMetadata =
+        getSnapshotMetadata(s3Client, indexResource, snapshotTimeString, snapshotRoot);
+    assertEquals(SERVICE_NAME, snapshotMetadata.getServiceName());
+    assertTrue(snapshotMetadata.getIndexName().startsWith("test_index-"));
+    assertEquals(snapshotTimeString, String.valueOf(snapshotMetadata.getTimeStringMs()));
+    assertTrue(snapshotMetadata.getIndexSizeBytes() > 0);
+  }
+
+  private void assertRestoreFiles(
+      AmazonS3 s3Client, String serviceName, String indexResource, boolean withWarming)
+      throws IOException {
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, s3Client);
+    Set<String> expectedIndexFiles = Set.of("_0.cfe", "_0.si", "_0.cfs");
+
+    NrtPointState pointState =
+        RemoteUtils.pointStateFromUtf8(
+            s3Backend.downloadPointState(serviceName, indexResource).readAllBytes());
+    assertEquals(expectedIndexFiles, pointState.files.keySet());
+    Set<String> localPointFiles =
+        pointState.files.entrySet().stream().map(Map.Entry::getKey).collect(Collectors.toSet());
+    Set<String> backendPointFiles =
+        pointState.files.entrySet().stream()
+            .map(e -> S3Backend.getIndexBackendFileName(e.getKey(), e.getValue()))
+            .collect(Collectors.toSet());
+
+    String restoredDataKeyPrefix = S3Backend.getIndexDataPrefix(serviceName, indexResource);
+
+    Set<String> restoredFiles = getFiles(s3Client, restoredDataKeyPrefix);
+    assertEquals(backendPointFiles, restoredFiles);
+
+    assertEquals(expectedIndexFiles, localPointFiles);
+
+    IndexStateInfo indexStateInfo =
+        StateUtils.indexStateFromUTF8(
+            s3Backend.downloadIndexState(serviceName, indexResource).readAllBytes());
+    assertEquals("test_index", indexStateInfo.getIndexName());
+    assertEquals(3, indexStateInfo.getFieldsMap().size());
+
+    boolean warmingQueriesExist =
+        s3Backend.exists(
+            serviceName, indexResource, RemoteBackend.IndexResourceType.WARMING_QUERIES);
+    if (withWarming) {
+      assertTrue(warmingQueriesExist);
+      String warmingQueriesPrefix =
+          S3Backend.getIndexResourcePrefix(
+              serviceName, indexResource, RemoteBackend.IndexResourceType.WARMING_QUERIES);
+      String warmingQueriesVersionId = s3Backend.getCurrentResourceName(warmingQueriesPrefix);
+      assertTrue(
+          s3Client.doesObjectExist(TEST_BUCKET, warmingQueriesPrefix + warmingQueriesVersionId));
+    } else {
+      assertFalse(warmingQueriesExist);
+    }
+  }
+
+  private Set<String> getSnapshotFiles(
+      AmazonS3 s3Client, String indexResource, String timeString, String snapshotRoot) {
+    String snapshotKeyPrefix = String.join("/", snapshotRoot, indexResource, timeString, "");
+    return getFiles(s3Client, snapshotKeyPrefix);
+  }
+
+  private SnapshotMetadata getSnapshotMetadata(
+      AmazonS3 s3Client, String indexResource, String timeString, String snapshotRoot) {
+    String snapshotMetadataKey =
+        String.join("/", snapshotRoot, BackupCommandUtils.METADATA_DIR, indexResource, timeString);
+    S3Object stateObject = s3Client.getObject(TEST_BUCKET, snapshotMetadataKey);
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    try {
+      IOUtils.copy(stateObject.getObjectContent(), byteArrayOutputStream);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    String fileContent = StateUtils.fromUTF8(byteArrayOutputStream.toByteArray());
+    try {
+      return OBJECT_MAPPER.readValue(fileContent, SnapshotMetadata.class);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private List<String> getSnapshotTimeStrings(
+      AmazonS3 s3Client, String indexResource, String snapshotRoot) {
+    String indexMetadataKeyPrefix =
+        String.join("/", snapshotRoot, BackupCommandUtils.METADATA_DIR, indexResource, "");
+    ListObjectsV2Result result = s3Client.listObjectsV2(TEST_BUCKET, indexMetadataKeyPrefix);
+    List<String> timeStrings = new ArrayList<>();
+    for (S3ObjectSummary summary : result.getObjectSummaries()) {
+      String baseName = summary.getKey().split(indexMetadataKeyPrefix)[1];
+      timeStrings.add(baseName);
+    }
+    return timeStrings;
+  }
+
+  private Set<String> getFiles(AmazonS3 s3Client, String prefix) {
+    ListObjectsV2Result result = s3Client.listObjectsV2(TEST_BUCKET, prefix);
+    Set<String> files = new HashSet<>();
+    for (S3ObjectSummary summary : result.getObjectSummaries()) {
+      String baseName = summary.getKey().split(prefix)[1];
+      files.add(baseName);
+    }
+    return files;
+  }
+}


### PR DESCRIPTION
Port the legacy nrt_utils snapshot/restore commands to work with the new backend file structure.

Commands:
- `snapshot` - Copy the index data, point state, index state, and warming queries to an indepent location in s3 (default: `<service_name>/snapshots/<index_name>-<index_time_string_ms>/<snapshot_time_string_ms>`)
- `restore` - Copy snapshotted data/state into an existing cluster. This does not add the index to the cluster state, that must be done separately using the create api or updating the global state with the nrt_utils command.
- `listSnapshots` - List snapshots available for an index prefix in S3
- `cleanupSnapshots` - Delete old snapshot data based on age and a minimum number to retain

For more information on these commands, see the original PR https://github.com/Yelp/nrtsearch/pull/474

## Other changes
- The interface for downloading/updating point state with the `RemoteBackend` has been changed to use binary data. This let the data be copied directly for snapshot/restore and more closely matches the interface for the other index resources.