### PR TITLE
Cleanup and remove some old config options

### DIFF
--- a/docker-compose-config/lucene_server_configuration_primary.yaml
+++ b/docker-compose-config/lucene_server_configuration_primary.yaml
@@ -7,9 +7,6 @@ indexDir: "/user/app/primary_index_base"
 threadPoolConfiguration:
   maxSearchingThreads: 4
   maxIndexingThreads: 18
-fileSendDelay: false
 botoCfgPath: "/user/app/boto.cfg"
 bucketName: "nrtsearch-bucket"
 serviceName: "nrtsearch-service-test"
-restoreState: False
-downloadAsStream: "true"

--- a/docker-compose-config/lucene_server_configuration_replica.yaml
+++ b/docker-compose-config/lucene_server_configuration_replica.yaml
@@ -10,5 +10,4 @@ threadPoolConfiguration:
 botoCfgPath: "/user/app/boto.cfg"
 bucketName: "nrtsearch-bucket"
 serviceName: "nrtsearch-service-test"
-restoreState: False
 downloadAsStream: "true"

--- a/docs/server_configuration.rst
+++ b/docs/server_configuration.rst
@@ -21,12 +21,9 @@ Example server configuration
   threadPoolConfiguration:
     maxSearchingThreads: 4
     maxIndexingThreads: 18
-  fileSendDelay: false
   botoCfgPath: "/user/app/boto.cfg"
   bucketName: "nrtsearch-bucket"
   serviceName: "nrtsearch-service-test"
-  restoreState: False
-  downloadAsStream: "true"
 
 
 .. list-table:: `LuceneServerConfiguration <https://github.com/Yelp/nrtsearch/blob/master/src/main/java/com/yelp/nrtsearch/server/config/LuceneServerConfiguration.java>`_
@@ -83,20 +80,10 @@ Example server configuration
      - Path to AWS credentials (if using S3 for remote storage); Will use the DefaultAWSCredentialsProviderChain if omitted.
      - null
 
-   * - downloadAsStream
-     - bool
-     - If enabled, the content downloader will perform a streaming extraction of tar archives from remote storage to disk. Otherwise, the downloader will only extract after finishing downloading the archive to disk.
-     - true
-
-   * - restoreState
-     - bool
-     - Enables loading state from external storage on startup
-     - false
-
    * - deadlineCancellation
      - bool
      - Enables gRPC deadline based cancellation of requests. A request is cancelled early if it exceeds the deadline. Currently only supported by the search endpoint.
-     - false
+     - true
 
    * - lowPriorityCopyPercentage
      - int
@@ -109,14 +96,9 @@ Example server configuration
      - []
 
    * - pluginSearchPath
-     - str
-     - Search paths for plugins. These paths are separated by the system path separator character (; on Windows, : on Mac and Unix). The server will try to find the first directory in the search path matching a given plugin. 
+     - str or list
+     - Search paths for plugins. This can either be a single string or a list of strings. The server will try to find the first directory in the search path containing a given plugin.
      - plugins
-
-   * - publishJvmMetrics
-     - bool
-     - If enabled, registers JVM metrics with prometheus. 
-     - true
 
    * - useKeepAliveForReplication
      - bool

--- a/src/main/java/com/yelp/nrtsearch/server/plugins/PluginsService.java
+++ b/src/main/java/com/yelp/nrtsearch/server/plugins/PluginsService.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,9 +102,7 @@ public class PluginsService {
    * OS path separator.
    */
   List<File> getPluginSearchPath() {
-    return Stream.of(config.getPluginSearchPath().split(File.pathSeparator))
-        .map(File::new)
-        .collect(Collectors.toList());
+    return config.getPluginSearchPath().stream().map(File::new).collect(Collectors.toList());
   }
 
   /**

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerTest.java
@@ -1268,8 +1268,8 @@ public class LuceneServerTest {
   }
 
   @Test
-  public void testCancellationDefaultDisabled() {
-    assertFalse(DeadlineUtils.getCancellationEnabled());
+  public void testCancellationDefaultEnabled() {
+    assertTrue(DeadlineUtils.getCancellationEnabled());
   }
 
   public static void checkHits(SearchResponse.Hit hit) {

--- a/src/test/java/com/yelp/nrtsearch/server/plugins/PluginsServiceTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/plugins/PluginsServiceTest.java
@@ -16,6 +16,7 @@
 package com.yelp.nrtsearch.server.plugins;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
@@ -45,6 +46,14 @@ public class PluginsServiceTest {
     return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
   }
 
+  private LuceneServerConfiguration getConfigWithSearchPaths(String... paths) {
+    StringBuilder config = new StringBuilder("pluginSearchPath:").append("\n");
+    for (String path : paths) {
+      config.append("  - ").append(path).append("\n");
+    }
+    return new LuceneServerConfiguration(new ByteArrayInputStream(config.toString().getBytes()));
+  }
+
   private CollectorRegistry getCollectorRegistry() {
     return new CollectorRegistry();
   }
@@ -60,14 +69,9 @@ public class PluginsServiceTest {
 
   @Test
   public void testGetMultiPluginSearchPath() {
-    String searchPath =
-        "some1/plugin1/path1"
-            + File.pathSeparator
-            + "some2/plugin2/path2"
-            + File.pathSeparator
-            + "some3/plugin3/path3"
-            + File.pathSeparator;
-    LuceneServerConfiguration config = getConfigWithSearchPath(searchPath);
+    LuceneServerConfiguration config =
+        getConfigWithSearchPaths(
+            "some1/plugin1/path1", "some2/plugin2/path2", "some3/plugin3/path3");
     PluginsService pluginsService = new PluginsService(config, null, getCollectorRegistry());
     List<File> expectedPaths = new ArrayList<>();
     expectedPaths.add(new File("some1/plugin1/path1"));
@@ -200,7 +204,7 @@ public class PluginsServiceTest {
     CollectorRegistry collectorRegistry = getCollectorRegistry();
     PluginsService pluginsService = new PluginsService(getEmptyConfig(), null, collectorRegistry);
     Plugin loadedPlugin = pluginsService.getPluginInstance(LoadTestPlugin.class);
-    assertEquals(null, ((LoadTestPlugin) loadedPlugin).collectorRegistry);
+    assertNull(((LoadTestPlugin) loadedPlugin).collectorRegistry);
   }
 
   @Test

--- a/src/test/resources/yelp_reviews/primary/lucene_server_configuration.yaml
+++ b/src/test/resources/yelp_reviews/primary/lucene_server_configuration.yaml
@@ -7,5 +7,4 @@ indexDir: "primary_index_base"
 threadPoolConfiguration:
   maxSearchingThreads: 4
   maxIndexingThreads: 18
-fileSendDelay: false
 verifyReplicationIndexId: false


### PR DESCRIPTION
Cleanup some config option usage
- remove `restoreState`
- remove `downloadAsStream`
- remove `fileSendDelay`
- remove `publishJvmMetrics`
- change default of `deadlineCancellation` to true
- change `pluginSearchPath` to accept a single value or a list of values, instead of using a path separator