### PR TITLE
Add nrt_utils commands to get/set/list backend resource versions

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
@@ -270,8 +270,13 @@ public class S3Backend implements RemoteBackend {
     return currentResourceExists(prefix);
   }
 
-  @VisibleForTesting
-  static String getGlobalStateResourcePrefix(String service) {
+  /**
+   * Get the S3 prefix for the service global resource.
+   *
+   * @param service service name
+   * @return S3 prefix
+   */
+  public static String getGlobalStateResourcePrefix(String service) {
     return String.format(GLOBAL_STATE_PREFIX_FORMAT, service, GLOBAL_STATE);
   }
 

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/NrtUtilsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/NrtUtilsCommand.java
@@ -25,7 +25,10 @@ import com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental.ListIncrementalSnap
 import com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental.RestoreIncrementalCommand;
 import com.yelp.nrtsearch.tools.nrt_utils.legacy.incremental.SnapshotIncrementalCommand;
 import com.yelp.nrtsearch.tools.nrt_utils.state.GetRemoteStateCommand;
+import com.yelp.nrtsearch.tools.nrt_utils.state.GetResourceVersionCommand;
+import com.yelp.nrtsearch.tools.nrt_utils.state.ListResourceVersions;
 import com.yelp.nrtsearch.tools.nrt_utils.state.PutRemoteStateCommand;
+import com.yelp.nrtsearch.tools.nrt_utils.state.SetResourceVersionCommand;
 import com.yelp.nrtsearch.tools.nrt_utils.state.UpdateGlobalIndexStateCommand;
 import picocli.CommandLine;
 
@@ -36,12 +39,15 @@ import picocli.CommandLine;
       CleanupSnapshotsCommand.class,
       DeleteIncrementalSnapshotsCommand.class,
       GetRemoteStateCommand.class,
+      GetResourceVersionCommand.class,
       IncrementalDataCleanupCommand.class,
       ListIncrementalSnapshotsCommand.class,
+      ListResourceVersions.class,
       ListSnapshotsCommand.class,
       PutRemoteStateCommand.class,
       RestoreCommand.class,
       RestoreIncrementalCommand.class,
+      SetResourceVersionCommand.class,
       SnapshotCommand.class,
       SnapshotIncrementalCommand.class,
       UpdateGlobalIndexStateCommand.class,

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetResourceVersionCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetResourceVersionCommand.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.state;
+
+import static com.yelp.nrtsearch.tools.nrt_utils.state.StateCommandUtils.NOT_SET;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.google.common.annotations.VisibleForTesting;
+import com.yelp.nrtsearch.server.remote.RemoteBackend;
+import com.yelp.nrtsearch.server.remote.s3.S3Backend;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = GetResourceVersionCommand.GET_RESOURCE_VERSION,
+    description = "Fetch current index resource or global state version from S3")
+public class GetResourceVersionCommand implements Callable<Integer> {
+  public static final String GET_RESOURCE_VERSION = "getResourceVersion";
+
+  @CommandLine.Option(
+      names = {"-s", "--serviceName"},
+      description = "Name of nrtsearch cluster",
+      required = true)
+  private String serviceName;
+
+  @CommandLine.Option(
+      names = {"-t", "--indexResourceType"},
+      description =
+          "Type of index resource, must be set when not requesting global state. One of: "
+              + "INDEX_STATE, POINT_STATE, WARMING_QUERIES")
+  private String resourceType;
+
+  @CommandLine.Option(
+      names = {"-r", "--resourceName"},
+      description =
+          "Resource name, should be index name or \""
+              + StateCommandUtils.GLOBAL_STATE_RESOURCE
+              + "\"",
+      required = true)
+  private String resourceName;
+
+  @CommandLine.Option(
+      names = {"--exactResourceName"},
+      description = "If resource name already has unique identifier")
+  private boolean exactResourceName;
+
+  @CommandLine.Option(
+      names = {"-b", "--bucketName"},
+      description = "Name of bucket containing state files",
+      required = true)
+  private String bucketName;
+
+  @CommandLine.Option(
+      names = {"--region"},
+      description = "AWS region name, such as us-west-1, us-west-2, us-east-1")
+  private String region;
+
+  @CommandLine.Option(
+      names = {"-c", "--credsFile"},
+      description =
+          "File holding AWS credentials; Will use DefaultCredentialProvider if this is unset.")
+  private String credsFile;
+
+  @CommandLine.Option(
+      names = {"-p", "--credsProfile"},
+      description = "Profile to use from creds file; Neglected when credsFile is unset.",
+      defaultValue = "default")
+  private String credsProfile;
+
+  @CommandLine.Option(
+      names = {"--maxRetry"},
+      description = "Maximum number of retry attempts for S3 failed requests",
+      defaultValue = "20")
+  private int maxRetry;
+
+  private AmazonS3 s3Client;
+
+  @VisibleForTesting
+  void setS3Client(AmazonS3 s3Client) {
+    this.s3Client = s3Client;
+  }
+
+  @Override
+  public Integer call() throws Exception {
+    if (s3Client == null) {
+      s3Client =
+          StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
+    }
+    S3Backend s3Backend = new S3Backend(bucketName, false, s3Client);
+    String resolvedResourceName =
+        StateCommandUtils.getResourceName(s3Backend, serviceName, resourceName, exactResourceName);
+
+    String version = NOT_SET;
+    if (StateCommandUtils.isGlobalState(resolvedResourceName)) {
+      if (s3Backend.exists(serviceName, RemoteBackend.GlobalResourceType.GLOBAL_STATE)) {
+        String prefix = S3Backend.getGlobalStateResourcePrefix(serviceName);
+        version = s3Backend.getCurrentResourceName(prefix);
+      }
+    } else {
+      RemoteBackend.IndexResourceType indexResourceType =
+          StateCommandUtils.parseIndexResourceType(resourceType);
+      if (s3Backend.exists(serviceName, resolvedResourceName, indexResourceType)) {
+        String prefix =
+            S3Backend.getIndexResourcePrefix(serviceName, resolvedResourceName, indexResourceType);
+        version = s3Backend.getCurrentResourceName(prefix);
+      }
+    }
+    System.out.println("Version: " + version);
+    return 0;
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/ListResourceVersions.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/ListResourceVersions.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.state;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.google.common.annotations.VisibleForTesting;
+import com.yelp.nrtsearch.server.remote.RemoteBackend;
+import com.yelp.nrtsearch.server.remote.s3.S3Backend;
+import com.yelp.nrtsearch.server.utils.TimeStringUtil;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = ListResourceVersions.LIST_RESOURCE_VERSIONS,
+    description = "List index resource or global state versions in S3 by prefix")
+public class ListResourceVersions implements Callable<Integer> {
+  public static final String LIST_RESOURCE_VERSIONS = "listResourceVersions";
+  public static final int MAX_LIST_SIZE = 1000;
+
+  @CommandLine.Option(
+      names = {"-s", "--serviceName"},
+      description = "Name of nrtsearch cluster",
+      required = true)
+  private String serviceName;
+
+  @CommandLine.Option(
+      names = {"-t", "--indexResourceType"},
+      description =
+          "Type of index resource, must be set when not requesting global state. One of: "
+              + "INDEX_STATE, POINT_STATE, WARMING_QUERIES")
+  private String resourceType;
+
+  @CommandLine.Option(
+      names = {"--versionPrefix"},
+      description = "Prefix of versions to list, default: \"\"",
+      defaultValue = "")
+  private String versionPrefix;
+
+  @CommandLine.Option(
+      names = {"-r", "--resourceName"},
+      description =
+          "Resource name, should be index name or \""
+              + StateCommandUtils.GLOBAL_STATE_RESOURCE
+              + "\"",
+      required = true)
+  private String resourceName;
+
+  @CommandLine.Option(
+      names = {"--exactResourceName"},
+      description = "If resource name already has unique identifier")
+  private boolean exactResourceName;
+
+  @CommandLine.Option(
+      names = {"-b", "--bucketName"},
+      description = "Name of bucket containing state files",
+      required = true)
+  private String bucketName;
+
+  @CommandLine.Option(
+      names = {"--region"},
+      description = "AWS region name, such as us-west-1, us-west-2, us-east-1")
+  private String region;
+
+  @CommandLine.Option(
+      names = {"-c", "--credsFile"},
+      description =
+          "File holding AWS credentials; Will use DefaultCredentialProvider if this is unset.")
+  private String credsFile;
+
+  @CommandLine.Option(
+      names = {"-p", "--credsProfile"},
+      description = "Profile to use from creds file; Neglected when credsFile is unset.",
+      defaultValue = "default")
+  private String credsProfile;
+
+  @CommandLine.Option(
+      names = {"--maxRetry"},
+      description = "Maximum number of retry attempts for S3 failed requests",
+      defaultValue = "20")
+  private int maxRetry;
+
+  private AmazonS3 s3Client;
+
+  @VisibleForTesting
+  void setS3Client(AmazonS3 s3Client) {
+    this.s3Client = s3Client;
+  }
+
+  @Override
+  public Integer call() throws Exception {
+    if (s3Client == null) {
+      s3Client =
+          StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
+    }
+    S3Backend s3Backend = new S3Backend(bucketName, false, s3Client);
+    String resolvedResourceName =
+        StateCommandUtils.getResourceName(s3Backend, serviceName, resourceName, exactResourceName);
+
+    String prefix;
+    if (StateCommandUtils.isGlobalState(resolvedResourceName)) {
+      prefix = S3Backend.getGlobalStateResourcePrefix(serviceName);
+    } else {
+      RemoteBackend.IndexResourceType indexResourceType =
+          StateCommandUtils.parseIndexResourceType(resourceType);
+      prefix =
+          S3Backend.getIndexResourcePrefix(serviceName, resolvedResourceName, indexResourceType);
+    }
+    String listPrefix = prefix + versionPrefix;
+    System.out.println(
+        "Listing versions for "
+            + resolvedResourceName
+            + " with prefix "
+            + listPrefix
+            + " (max "
+            + MAX_LIST_SIZE
+            + ")");
+    ListObjectsRequest listObjectsRequest =
+        new ListObjectsRequest()
+            .withBucketName(bucketName)
+            .withPrefix(listPrefix)
+            .withMaxKeys(MAX_LIST_SIZE);
+    ObjectListing listing = s3Backend.getS3().listObjects(listObjectsRequest);
+    listing
+        .getObjectSummaries()
+        .forEach(
+            object -> {
+              String suffix = object.getKey().split(prefix)[1];
+              printVersion(suffix);
+            });
+    return 0;
+  }
+
+  private static void printVersion(String keySuffix) {
+    String timestampStr = "";
+    String[] splits = keySuffix.split("-");
+    if (splits.length > 1) {
+      String timeString = splits[0];
+      if (TimeStringUtil.isTimeStringSec(timeString)) {
+        timestampStr = " (" + TimeStringUtil.parseTimeStringSec(timeString).toString() + ")";
+      }
+    }
+    System.out.println(keySuffix + timestampStr);
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/SetResourceVersionCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/SetResourceVersionCommand.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.state;
+
+import static com.yelp.nrtsearch.tools.nrt_utils.state.StateCommandUtils.NOT_SET;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.google.common.annotations.VisibleForTesting;
+import com.yelp.nrtsearch.server.remote.RemoteBackend;
+import com.yelp.nrtsearch.server.remote.s3.S3Backend;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = SetResourceVersionCommand.SET_RESOURCE_VERSION,
+    description = "Set current index resource or global state version in S3")
+public class SetResourceVersionCommand implements Callable<Integer> {
+  public static final String SET_RESOURCE_VERSION = "setResourceVersion";
+
+  @CommandLine.Option(
+      names = {"-s", "--serviceName"},
+      description = "Name of nrtsearch cluster",
+      required = true)
+  private String serviceName;
+
+  @CommandLine.Option(
+      names = {"-t", "--indexResourceType"},
+      description =
+          "Type of index resource, must be set when not requesting global state. One of: "
+              + "INDEX_STATE, POINT_STATE, WARMING_QUERIES")
+  private String resourceType;
+
+  @CommandLine.Option(
+      names = {"-r", "--resourceName"},
+      description =
+          "Resource name, should be index name or \""
+              + StateCommandUtils.GLOBAL_STATE_RESOURCE
+              + "\"",
+      required = true)
+  private String resourceName;
+
+  @CommandLine.Option(
+      names = {"--exactResourceName"},
+      description = "If resource name already has unique identifier")
+  private boolean exactResourceName;
+
+  @CommandLine.Option(
+      names = {"--resourceVersion"},
+      description = "Version to set for resource",
+      required = true)
+  private String resourceVersion;
+
+  @CommandLine.Option(
+      names = {"-b", "--bucketName"},
+      description = "Name of bucket containing state files",
+      required = true)
+  private String bucketName;
+
+  @CommandLine.Option(
+      names = {"--region"},
+      description = "AWS region name, such as us-west-1, us-west-2, us-east-1")
+  private String region;
+
+  @CommandLine.Option(
+      names = {"-c", "--credsFile"},
+      description =
+          "File holding AWS credentials; Will use DefaultCredentialProvider if this is unset.")
+  private String credsFile;
+
+  @CommandLine.Option(
+      names = {"-p", "--credsProfile"},
+      description = "Profile to use from creds file; Neglected when credsFile is unset.",
+      defaultValue = "default")
+  private String credsProfile;
+
+  @CommandLine.Option(
+      names = {"--maxRetry"},
+      description = "Maximum number of retry attempts for S3 failed requests",
+      defaultValue = "20")
+  private int maxRetry;
+
+  private AmazonS3 s3Client;
+
+  @VisibleForTesting
+  void setS3Client(AmazonS3 s3Client) {
+    this.s3Client = s3Client;
+  }
+
+  @Override
+  public Integer call() throws Exception {
+    if (s3Client == null) {
+      s3Client =
+          StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
+    }
+    S3Backend s3Backend = new S3Backend(bucketName, false, s3Client);
+    String resolvedResourceName =
+        StateCommandUtils.getResourceName(s3Backend, serviceName, resourceName, exactResourceName);
+
+    String prefix;
+    String previousVersion = NOT_SET;
+    if (StateCommandUtils.isGlobalState(resolvedResourceName)) {
+      prefix = S3Backend.getGlobalStateResourcePrefix(serviceName);
+      if (s3Backend.exists(serviceName, RemoteBackend.GlobalResourceType.GLOBAL_STATE)) {
+        previousVersion = s3Backend.getCurrentResourceName(prefix);
+      }
+    } else {
+      RemoteBackend.IndexResourceType indexResourceType =
+          StateCommandUtils.parseIndexResourceType(resourceType);
+      prefix =
+          S3Backend.getIndexResourcePrefix(serviceName, resolvedResourceName, indexResourceType);
+      if (s3Backend.exists(serviceName, resolvedResourceName, indexResourceType)) {
+        previousVersion = s3Backend.getCurrentResourceName(prefix);
+      }
+    }
+    if (!s3Client.doesObjectExist(bucketName, prefix + resourceVersion)) {
+      throw new IllegalArgumentException("Resource version does not exist: " + resourceVersion);
+    }
+    System.out.println("Previous version: " + previousVersion);
+    s3Backend.setCurrentResource(prefix, resourceVersion);
+    return 0;
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/StateCommandUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/StateCommandUtils.java
@@ -42,6 +42,7 @@ import java.nio.file.Paths;
 
 public class StateCommandUtils {
   public static final String GLOBAL_STATE_RESOURCE = "global_state";
+  public static final String NOT_SET = "not_set";
 
   private StateCommandUtils() {}
 
@@ -255,5 +256,21 @@ public class StateCommandUtils {
         BackendGlobalState.getUniqueIndexName(resource, indexGlobalState.getId());
     System.out.println("Index state resource: " + resolvedResource);
     return resolvedResource;
+  }
+
+  /**
+   * Parse input string into index resource type.
+   *
+   * @param resourceType input string
+   * @return index resource type
+   * @throws IllegalArgumentException if invalid resource type name
+   */
+  public static RemoteBackend.IndexResourceType parseIndexResourceType(String resourceType) {
+    return switch (resourceType) {
+      case "INDEX_STATE" -> RemoteBackend.IndexResourceType.INDEX_STATE;
+      case "POINT_STATE" -> RemoteBackend.IndexResourceType.POINT_STATE;
+      case "WARMING_QUERIES" -> RemoteBackend.IndexResourceType.WARMING_QUERIES;
+      default -> throw new IllegalArgumentException("Invalid index resource type: " + resourceType);
+    };
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetResourceVersionCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetResourceVersionCommandTest.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.state;
+
+import static com.yelp.nrtsearch.server.grpc.TestServer.S3_ENDPOINT;
+import static com.yelp.nrtsearch.server.grpc.TestServer.SERVICE_NAME;
+import static com.yelp.nrtsearch.server.grpc.TestServer.TEST_BUCKET;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.yelp.nrtsearch.server.config.IndexStartConfig;
+import com.yelp.nrtsearch.server.grpc.Mode;
+import com.yelp.nrtsearch.server.grpc.TestServer;
+import com.yelp.nrtsearch.server.luceneserver.state.BackendGlobalState;
+import com.yelp.nrtsearch.server.remote.RemoteBackend;
+import com.yelp.nrtsearch.server.remote.s3.S3Backend;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import picocli.CommandLine;
+
+public class GetResourceVersionCommandTest {
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  final PrintStream originalOut = System.out;
+  final PrintStream originalErr = System.err;
+  final ByteArrayOutputStream out = new ByteArrayOutputStream();
+  final ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+  @Before
+  public void setUpStreams() {
+    out.reset();
+    err.reset();
+    System.setOut(new PrintStream(out));
+    System.setErr(new PrintStream(err));
+  }
+
+  @After
+  public void cleanup() {
+    System.setOut(originalOut);
+    System.setErr(originalErr);
+    TestServer.cleanupAll();
+  }
+
+  private AmazonS3 getS3() {
+    AmazonS3 s3 = new AmazonS3Client(new AnonymousAWSCredentials());
+    s3.setEndpoint(S3_ENDPOINT);
+    s3.createBucket(TEST_BUCKET);
+    return s3;
+  }
+
+  private CommandLine getInjectedCommand() {
+    GetResourceVersionCommand command = new GetResourceVersionCommand();
+    command.setS3Client(getS3());
+    return new CommandLine(command);
+  }
+
+  private TestServer getTestServer() throws IOException {
+    TestServer server =
+        TestServer.builder(folder)
+            .withAutoStartConfig(
+                true, Mode.PRIMARY, 0, IndexStartConfig.IndexDataLocationType.LOCAL)
+            .withRemoteStateBackend(false)
+            .build();
+    server.createSimpleIndex("test_index");
+    return server;
+  }
+
+  @Test
+  public void testNotSet_globalState() throws IOException {
+    TestServer.initS3(folder);
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=" + StateCommandUtils.GLOBAL_STATE_RESOURCE);
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("Version: not_set"));
+  }
+
+  @Test
+  public void testNotSet_indexState() throws IOException {
+    TestServer.initS3(folder);
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=INDEX_STATE");
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("Version: not_set"));
+  }
+
+  @Test
+  public void testNotSet_pointState() throws IOException {
+    TestServer.initS3(folder);
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=POINT_STATE");
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("Version: not_set"));
+  }
+
+  @Test
+  public void testNotSet_warmingQueries() throws IOException {
+    TestServer.initS3(folder);
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=WARMING_QUERIES");
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("Version: not_set"));
+  }
+
+  @Test
+  public void testSet_globalState() throws IOException {
+    TestServer.initS3(folder);
+    S3Backend backend = new S3Backend(TEST_BUCKET, false, getS3());
+    String prefix = S3Backend.getGlobalStateResourcePrefix(SERVICE_NAME);
+    backend.setCurrentResource(prefix, "version1");
+
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=" + StateCommandUtils.GLOBAL_STATE_RESOURCE);
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("Version: version1"));
+  }
+
+  @Test
+  public void testSet_indexState() throws IOException {
+    TestServer.initS3(folder);
+    S3Backend backend = new S3Backend(TEST_BUCKET, false, getS3());
+    String prefix =
+        S3Backend.getIndexResourcePrefix(
+            SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.INDEX_STATE);
+    backend.setCurrentResource(prefix, "version1");
+
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=INDEX_STATE");
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("Version: version1"));
+  }
+
+  @Test
+  public void testSet_pointState() throws IOException {
+    TestServer.initS3(folder);
+    S3Backend backend = new S3Backend(TEST_BUCKET, false, getS3());
+    String prefix =
+        S3Backend.getIndexResourcePrefix(
+            SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.POINT_STATE);
+    backend.setCurrentResource(prefix, "version1");
+
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=POINT_STATE");
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("Version: version1"));
+  }
+
+  @Test
+  public void testSet_warmingQueries() throws IOException {
+    TestServer.initS3(folder);
+    S3Backend backend = new S3Backend(TEST_BUCKET, false, getS3());
+    String prefix =
+        S3Backend.getIndexResourcePrefix(
+            SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.WARMING_QUERIES);
+    backend.setCurrentResource(prefix, "version1");
+
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=WARMING_QUERIES");
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("Version: version1"));
+  }
+
+  @Test
+  public void testGetResourceFromGlobalState() throws IOException {
+    TestServer server = getTestServer();
+    server.startPrimaryIndex("test_index", -1, null);
+    S3Backend backend = new S3Backend(TEST_BUCKET, false, getS3());
+    String indexId = server.getGlobalState().getIndexStateManager("test_index").getIndexId();
+    String prefix =
+        S3Backend.getIndexResourcePrefix(
+            SERVICE_NAME,
+            BackendGlobalState.getUniqueIndexName("test_index", indexId),
+            RemoteBackend.IndexResourceType.INDEX_STATE);
+    String expectedVersion = backend.getCurrentResourceName(prefix);
+
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index",
+            "--indexResourceType=INDEX_STATE");
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("Version: " + expectedVersion));
+  }
+
+  @Test
+  public void testGetResourceFromGlobalState_notFound() throws IOException {
+    TestServer.initS3(folder);
+    S3Backend backend = new S3Backend(TEST_BUCKET, false, getS3());
+    String prefix =
+        S3Backend.getIndexResourcePrefix(
+            SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.INDEX_STATE);
+    backend.setCurrentResource(prefix, "version1");
+
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--indexResourceType=INDEX_STATE");
+    assertEquals(1, exitCode);
+    assertTrue(
+        err.toString()
+            .startsWith(
+                "java.lang.IllegalArgumentException: Unable to load global state for cluster: \"test_server\""));
+  }
+
+  @Test
+  public void testInvalidIndexResourceType() throws IOException {
+    TestServer.initS3(folder);
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=INVALID");
+    assertEquals(1, exitCode);
+    assertTrue(
+        err.toString()
+            .startsWith(
+                "java.lang.IllegalArgumentException: Invalid index resource type: INVALID"));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/ListResourceVersionsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/ListResourceVersionsTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.state;
+
+import static com.yelp.nrtsearch.server.grpc.TestServer.S3_ENDPOINT;
+import static com.yelp.nrtsearch.server.grpc.TestServer.SERVICE_NAME;
+import static com.yelp.nrtsearch.server.grpc.TestServer.TEST_BUCKET;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.yelp.nrtsearch.server.config.IndexStartConfig;
+import com.yelp.nrtsearch.server.grpc.Mode;
+import com.yelp.nrtsearch.server.grpc.TestServer;
+import com.yelp.nrtsearch.server.luceneserver.state.BackendGlobalState;
+import com.yelp.nrtsearch.server.remote.RemoteBackend;
+import com.yelp.nrtsearch.server.remote.s3.S3Backend;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import picocli.CommandLine;
+
+public class ListResourceVersionsTest {
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  final PrintStream originalOut = System.out;
+  final PrintStream originalErr = System.err;
+  final ByteArrayOutputStream out = new ByteArrayOutputStream();
+  final ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+  @Before
+  public void setUpStreams() {
+    out.reset();
+    err.reset();
+    System.setOut(new PrintStream(out));
+    System.setErr(new PrintStream(err));
+  }
+
+  @After
+  public void cleanup() {
+    System.setOut(originalOut);
+    System.setErr(originalErr);
+    TestServer.cleanupAll();
+  }
+
+  private AmazonS3 getS3() {
+    AmazonS3 s3 = new AmazonS3Client(new AnonymousAWSCredentials());
+    s3.setEndpoint(S3_ENDPOINT);
+    s3.createBucket(TEST_BUCKET);
+    return s3;
+  }
+
+  private CommandLine getInjectedCommand() {
+    ListResourceVersions command = new ListResourceVersions();
+    command.setS3Client(getS3());
+    return new CommandLine(command);
+  }
+
+  private TestServer getTestServer() throws IOException {
+    TestServer server =
+        TestServer.builder(folder)
+            .withAutoStartConfig(
+                true, Mode.PRIMARY, 0, IndexStartConfig.IndexDataLocationType.LOCAL)
+            .withRemoteStateBackend(false)
+            .build();
+    server.createSimpleIndex("test_index");
+    return server;
+  }
+
+  @Test
+  public void testListResourceVersions() throws IOException {
+    TestServer.initS3(folder);
+    CommandLine cmd = getInjectedCommand();
+    String prefix =
+        S3Backend.getIndexResourcePrefix(
+            SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.INDEX_STATE);
+    AmazonS3 s3 = getS3();
+    String version1 = S3Backend.getIndexStateFileName();
+    s3.putObject(TEST_BUCKET, prefix + version1, "test");
+    String version2 = S3Backend.getIndexStateFileName();
+    s3.putObject(TEST_BUCKET, prefix + version2, "test");
+    String version3 = S3Backend.getIndexStateFileName();
+    s3.putObject(TEST_BUCKET, prefix + version3, "test");
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=INDEX_STATE");
+    assertEquals(0, exitCode);
+    String output = out.toString();
+    assertTrue(output.contains(version1 + " ("));
+    assertTrue(output.contains(version2 + " ("));
+    assertTrue(output.contains(version3 + " ("));
+  }
+
+  @Test
+  public void testListResourceVersions_versionPrefix() throws IOException, InterruptedException {
+    TestServer.initS3(folder);
+    CommandLine cmd = getInjectedCommand();
+    String prefix =
+        S3Backend.getIndexResourcePrefix(
+            SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.INDEX_STATE);
+    AmazonS3 s3 = getS3();
+    String version1 = S3Backend.getIndexStateFileName();
+    s3.putObject(TEST_BUCKET, prefix + version1, "test");
+    Thread.sleep(2000);
+    String version2 = S3Backend.getIndexStateFileName();
+    s3.putObject(TEST_BUCKET, prefix + version2, "test");
+    Thread.sleep(2000);
+    String version3 = S3Backend.getIndexStateFileName();
+    s3.putObject(TEST_BUCKET, prefix + version3, "test");
+    String versionPrefix = version2.split("-")[0];
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=INDEX_STATE",
+            "--versionPrefix=" + versionPrefix);
+    assertEquals(0, exitCode);
+    String output = out.toString();
+    assertFalse(output.contains(version1 + " ("));
+    assertTrue(output.contains(version2 + " ("));
+    assertFalse(output.contains(version3 + " ("));
+  }
+
+  @Test
+  public void testListResourceVersions_unexpectedFormat() throws IOException {
+    TestServer.initS3(folder);
+    CommandLine cmd = getInjectedCommand();
+    String prefix =
+        S3Backend.getIndexResourcePrefix(
+            SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.INDEX_STATE);
+    AmazonS3 s3 = getS3();
+    String version1 = S3Backend.getIndexStateFileName();
+    s3.putObject(TEST_BUCKET, prefix + version1, "test");
+    String version2 = "unexpected";
+    s3.putObject(TEST_BUCKET, prefix + version2, "test");
+    String version3 = S3Backend.getIndexStateFileName();
+    s3.putObject(TEST_BUCKET, prefix + version3, "test");
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=INDEX_STATE");
+    assertEquals(0, exitCode);
+    String output = out.toString();
+    assertTrue(output.contains(version1 + " ("));
+    assertTrue(output.contains(version2));
+    assertTrue(output.contains(version3 + " ("));
+  }
+
+  @Test
+  public void testListResourceNoVersions() throws IOException {
+    TestServer.initS3(folder);
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=INDEX_STATE");
+    assertEquals(0, exitCode);
+    assertTrue(
+        out.toString()
+            .contains(
+                "Listing versions for test_index-id with prefix test_server/test_index-id/state/ (max 1000)"));
+  }
+
+  @Test
+  public void testListResourceVersionsFromGlobalState() throws IOException {
+    TestServer server = getTestServer();
+    server.startPrimaryIndex("test_index", -1, null);
+    S3Backend backend = new S3Backend(TEST_BUCKET, false, getS3());
+    String indexId = server.getGlobalState().getIndexStateManager("test_index").getIndexId();
+    String prefix =
+        S3Backend.getIndexResourcePrefix(
+            SERVICE_NAME,
+            BackendGlobalState.getUniqueIndexName("test_index", indexId),
+            RemoteBackend.IndexResourceType.INDEX_STATE);
+    String currentVersion = backend.getCurrentResourceName(prefix);
+    AmazonS3 s3 = getS3();
+    String version1 = S3Backend.getIndexStateFileName();
+    s3.putObject(TEST_BUCKET, prefix + version1, "test");
+    String version2 = S3Backend.getIndexStateFileName();
+    s3.putObject(TEST_BUCKET, prefix + version2, "test");
+    String version3 = S3Backend.getIndexStateFileName();
+    s3.putObject(TEST_BUCKET, prefix + version3, "test");
+
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index",
+            "--indexResourceType=INDEX_STATE");
+    assertEquals(0, exitCode);
+    String output = out.toString();
+    assertTrue(output.contains(currentVersion + " ("));
+    assertTrue(output.contains(version1 + " ("));
+    assertTrue(output.contains(version2 + " ("));
+    assertTrue(output.contains(version3 + " ("));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/SetResourceVersionCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/SetResourceVersionCommandTest.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.tools.nrt_utils.state;
+
+import static com.yelp.nrtsearch.server.grpc.TestServer.S3_ENDPOINT;
+import static com.yelp.nrtsearch.server.grpc.TestServer.SERVICE_NAME;
+import static com.yelp.nrtsearch.server.grpc.TestServer.TEST_BUCKET;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.yelp.nrtsearch.server.config.IndexStartConfig;
+import com.yelp.nrtsearch.server.grpc.Mode;
+import com.yelp.nrtsearch.server.grpc.TestServer;
+import com.yelp.nrtsearch.server.luceneserver.state.BackendGlobalState;
+import com.yelp.nrtsearch.server.remote.RemoteBackend;
+import com.yelp.nrtsearch.server.remote.s3.S3Backend;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import picocli.CommandLine;
+
+public class SetResourceVersionCommandTest {
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  final PrintStream originalOut = System.out;
+  final PrintStream originalErr = System.err;
+  final ByteArrayOutputStream out = new ByteArrayOutputStream();
+  final ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+  @Before
+  public void setUpStreams() {
+    out.reset();
+    err.reset();
+    System.setOut(new PrintStream(out));
+    System.setErr(new PrintStream(err));
+  }
+
+  @After
+  public void cleanup() {
+    System.setOut(originalOut);
+    System.setErr(originalErr);
+    TestServer.cleanupAll();
+  }
+
+  private AmazonS3 getS3() {
+    AmazonS3 s3 = new AmazonS3Client(new AnonymousAWSCredentials());
+    s3.setEndpoint(S3_ENDPOINT);
+    s3.createBucket(TEST_BUCKET);
+    return s3;
+  }
+
+  private CommandLine getInjectedCommand() {
+    SetResourceVersionCommand command = new SetResourceVersionCommand();
+    command.setS3Client(getS3());
+    return new CommandLine(command);
+  }
+
+  private TestServer getTestServer() throws IOException {
+    TestServer server =
+        TestServer.builder(folder)
+            .withAutoStartConfig(
+                true, Mode.PRIMARY, 0, IndexStartConfig.IndexDataLocationType.LOCAL)
+            .withRemoteStateBackend(false)
+            .build();
+    server.createSimpleIndex("test_index");
+    return server;
+  }
+
+  @Test
+  public void testSetResourceVersion_globalState() throws IOException {
+    TestServer.initS3(folder);
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, getS3());
+    String prefix = S3Backend.getGlobalStateResourcePrefix(SERVICE_NAME);
+    getS3().putObject(TEST_BUCKET, prefix + "version1", "version_data");
+
+    CommandLine cmd = getInjectedCommand();
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=" + StateCommandUtils.GLOBAL_STATE_RESOURCE,
+            "--resourceVersion=version1");
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("Previous version: not_set"));
+
+    assertEquals("version1", s3Backend.getCurrentResourceName(prefix));
+  }
+
+  @Test
+  public void testSetResourceVersion_indexState() throws IOException {
+    TestServer.initS3(folder);
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, getS3());
+    String prefix =
+        S3Backend.getIndexResourcePrefix(
+            SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.INDEX_STATE);
+    getS3().putObject(TEST_BUCKET, prefix + "version1", "version_data");
+
+    CommandLine cmd = getInjectedCommand();
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=INDEX_STATE",
+            "--resourceVersion=version1");
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("Previous version: not_set"));
+
+    assertEquals("version1", s3Backend.getCurrentResourceName(prefix));
+  }
+
+  @Test
+  public void testSetResourceVersion_pointState() throws IOException {
+    TestServer.initS3(folder);
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, getS3());
+    String prefix =
+        S3Backend.getIndexResourcePrefix(
+            SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.POINT_STATE);
+    getS3().putObject(TEST_BUCKET, prefix + "version1", "version_data");
+
+    CommandLine cmd = getInjectedCommand();
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=POINT_STATE",
+            "--resourceVersion=version1");
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("Previous version: not_set"));
+
+    assertEquals("version1", s3Backend.getCurrentResourceName(prefix));
+  }
+
+  @Test
+  public void testSetResourceVersion_warmingQueries() throws IOException {
+    TestServer.initS3(folder);
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, getS3());
+    String prefix =
+        S3Backend.getIndexResourcePrefix(
+            SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.WARMING_QUERIES);
+    getS3().putObject(TEST_BUCKET, prefix + "version1", "version_data");
+
+    CommandLine cmd = getInjectedCommand();
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=WARMING_QUERIES",
+            "--resourceVersion=version1");
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("Previous version: not_set"));
+
+    assertEquals("version1", s3Backend.getCurrentResourceName(prefix));
+  }
+
+  @Test
+  public void testUpdateResourceVersion_globalState() throws IOException {
+    TestServer.initS3(folder);
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, getS3());
+    String prefix = S3Backend.getGlobalStateResourcePrefix(SERVICE_NAME);
+    s3Backend.setCurrentResource(prefix, "version0");
+    getS3().putObject(TEST_BUCKET, prefix + "version1", "version_data");
+
+    CommandLine cmd = getInjectedCommand();
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=" + StateCommandUtils.GLOBAL_STATE_RESOURCE,
+            "--resourceVersion=version1");
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("Previous version: version0"));
+
+    assertEquals("version1", s3Backend.getCurrentResourceName(prefix));
+  }
+
+  @Test
+  public void testUpdateResourceVersion_indexState() throws IOException {
+    TestServer.initS3(folder);
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, getS3());
+    String prefix =
+        S3Backend.getIndexResourcePrefix(
+            SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.INDEX_STATE);
+    s3Backend.setCurrentResource(prefix, "version0");
+    getS3().putObject(TEST_BUCKET, prefix + "version1", "version_data");
+
+    CommandLine cmd = getInjectedCommand();
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=INDEX_STATE",
+            "--resourceVersion=version1");
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("Previous version: version0"));
+
+    assertEquals("version1", s3Backend.getCurrentResourceName(prefix));
+  }
+
+  @Test
+  public void testUpdateResourceVersion_pointState() throws IOException {
+    TestServer.initS3(folder);
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, getS3());
+    String prefix =
+        S3Backend.getIndexResourcePrefix(
+            SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.POINT_STATE);
+    s3Backend.setCurrentResource(prefix, "version0");
+    getS3().putObject(TEST_BUCKET, prefix + "version1", "version_data");
+
+    CommandLine cmd = getInjectedCommand();
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=POINT_STATE",
+            "--resourceVersion=version1");
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("Previous version: version0"));
+
+    assertEquals("version1", s3Backend.getCurrentResourceName(prefix));
+  }
+
+  @Test
+  public void testUpdateResourceVersion_warmingQueries() throws IOException {
+    TestServer.initS3(folder);
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, getS3());
+    String prefix =
+        S3Backend.getIndexResourcePrefix(
+            SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.WARMING_QUERIES);
+    s3Backend.setCurrentResource(prefix, "version0");
+    getS3().putObject(TEST_BUCKET, prefix + "version1", "version_data");
+
+    CommandLine cmd = getInjectedCommand();
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=WARMING_QUERIES",
+            "--resourceVersion=version1");
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("Previous version: version0"));
+
+    assertEquals("version1", s3Backend.getCurrentResourceName(prefix));
+  }
+
+  @Test
+  public void testSetResourceNotExist() throws IOException {
+    TestServer.initS3(folder);
+    CommandLine cmd = getInjectedCommand();
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=INDEX_STATE",
+            "--resourceVersion=version1");
+    assertEquals(1, exitCode);
+    assertTrue(
+        err.toString()
+            .contains(
+                "java.lang.IllegalArgumentException: Resource version does not exist: version1"));
+  }
+
+  @Test
+  public void testSetResourceFromGlobalState() throws IOException {
+    TestServer server = getTestServer();
+    server.startPrimaryIndex("test_index", -1, null);
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, getS3());
+    String indexId = server.getGlobalState().getIndexStateManager("test_index").getIndexId();
+    String prefix =
+        S3Backend.getIndexResourcePrefix(
+            SERVICE_NAME,
+            BackendGlobalState.getUniqueIndexName("test_index", indexId),
+            RemoteBackend.IndexResourceType.INDEX_STATE);
+    String expectedPreviousVersion = s3Backend.getCurrentResourceName(prefix);
+    getS3().putObject(TEST_BUCKET, prefix + "version1", "version_data");
+
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index",
+            "--indexResourceType=INDEX_STATE",
+            "--resourceVersion=version1");
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("Previous version: " + expectedPreviousVersion));
+
+    assertEquals("version1", s3Backend.getCurrentResourceName(prefix));
+  }
+
+  @Test
+  public void testSetResourceFromGlobalState_notFound() throws IOException {
+    TestServer.initS3(folder);
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--indexResourceType=INDEX_STATE",
+            "--resourceVersion=version1");
+    assertEquals(1, exitCode);
+    assertTrue(
+        err.toString()
+            .contains(
+                "java.lang.IllegalArgumentException: Unable to load global state for cluster: \"test_server\""));
+  }
+
+  @Test
+  public void testInvalidIndexResourceType() throws IOException {
+    TestServer.initS3(folder);
+    CommandLine cmd = getInjectedCommand();
+
+    int exitCode =
+        cmd.execute(
+            "--serviceName=" + SERVICE_NAME,
+            "--bucketName=" + TEST_BUCKET,
+            "--resourceName=test_index-id",
+            "--exactResourceName",
+            "--indexResourceType=INVALID",
+            "--resourceVersion=version1");
+    assertEquals(1, exitCode);
+    assertTrue(
+        err.toString()
+            .startsWith(
+                "java.lang.IllegalArgumentException: Invalid index resource type: INVALID"));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/StateCommandUtilsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/StateCommandUtilsTest.java
@@ -343,4 +343,27 @@ public class StateCommandUtilsTest {
     assertTrue(StateCommandUtils.isGlobalState(StateCommandUtils.GLOBAL_STATE_RESOURCE));
     assertFalse(StateCommandUtils.isGlobalState("test_index"));
   }
+
+  @Test
+  public void testParseIndexResourceType() {
+    assertEquals(
+        RemoteBackend.IndexResourceType.INDEX_STATE,
+        StateCommandUtils.parseIndexResourceType("INDEX_STATE"));
+    assertEquals(
+        RemoteBackend.IndexResourceType.POINT_STATE,
+        StateCommandUtils.parseIndexResourceType("POINT_STATE"));
+    assertEquals(
+        RemoteBackend.IndexResourceType.WARMING_QUERIES,
+        StateCommandUtils.parseIndexResourceType("WARMING_QUERIES"));
+  }
+
+  @Test
+  public void testParseIndexResourceType_invalid() {
+    try {
+      StateCommandUtils.parseIndexResourceType("INVALID");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("Invalid index resource type: INVALID", e.getMessage());
+    }
+  }
 }


### PR DESCRIPTION
Adds new cli commands to `nrt_utils` for interacting with the version backend resource (global state, index state, nrt point state, warming queries)

## getResourceVersion
Get the current version for a resource. This is the version stored in the `_current` object in S3 that references the current resource value object. If there is no current resource, `not_set` is returned.

## setResourceVersion
Set the current version for a resource. This sets the value stored in the `_current` object in S3 that references the current resource value object. The command checks that the new version object exists before updating the reference.

## listResourceVersions
List the resource values from S3. A `versionPrefix` can be provided to filter by the time string prefix. Only the first 1000 entries are printed. I think this is ok for now and the prefix can be used to drill down to certain time ranges.