### PR TITLE
Restructure locations of yelp reviews test and util classes

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -47,7 +47,7 @@ jobs:
         name: jacoco-report
         path: build/reports/jacoco/
     - name: Yelp Reviews Perf test
-      run: ./gradlew clean installDist :test -PincludePerfTests=* --tests "com.yelp.nrtsearch.server.YelpReviewsTest.runYelpReviews" --info
+      run: ./gradlew clean installDist :test -PincludePerfTests=* --tests "com.yelp.nrtsearch.yelp_reviews.YelpReviewsTest.runYelpReviews" --info
     - name: Merge behavior tests
       run: ./gradlew clean installDist :test -PincludePerfTests=* --tests "com.yelp.nrtsearch.server.grpc.MergeBehaviorTests" --info
     - name: Long running tests

--- a/README.md
+++ b/README.md
@@ -159,5 +159,5 @@ This should create a src/main/docs/index.html file that can be seen in your loca
 This tool indexes yelp reviews available at [Yelp dataset challenge](https://www.yelp.com/dataset). It runs a default version with only 1k reviews of the `reviews.json` or you could download the yelp dataset and place the review.json in the user.home dir and the tool will use that instead. The complete review.json should have close to 7Million reviews. The tool runs multi-threaded indexing and a search thread in parallel reporting the `totalHits`.  Command to run this specific test:
 
 ```
-./gradlew clean installDist :test -PincludePerfTests=* --tests "com.yelp.nrtsearch.server.YelpReviewsTest.runYelpReviews" --info
+./gradlew clean installDist :test -PincludePerfTests=* --tests "com.yelp.nrtsearch.yelp_reviews.YelpReviewsTest.runYelpReviews" --info
 ```

--- a/src/test/java/com/yelp/nrtsearch/yelp_reviews/YelpReviewsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/yelp_reviews/YelpReviewsTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.yelp.nrtsearch.server;
+package com.yelp.nrtsearch.yelp_reviews;
 
 import com.google.gson.Gson;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -40,8 +40,8 @@ import com.yelp.nrtsearch.server.grpc.SettingsResponse;
 import com.yelp.nrtsearch.server.grpc.StartIndexRequest;
 import com.yelp.nrtsearch.server.grpc.StartIndexResponse;
 import com.yelp.nrtsearch.server.grpc.TransferStatusCode;
-import com.yelp.nrtsearch.server.utils.OneDocBuilder;
-import com.yelp.nrtsearch.server.utils.ParallelDocumentIndexer;
+import com.yelp.nrtsearch.yelp_reviews.utils.OneDocBuilder;
+import com.yelp.nrtsearch.yelp_reviews.utils.ParallelDocumentIndexer;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.File;

--- a/src/test/java/com/yelp/nrtsearch/yelp_reviews/utils/DocumentGeneratorAndIndexer.java
+++ b/src/test/java/com/yelp/nrtsearch/yelp_reviews/utils/DocumentGeneratorAndIndexer.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.yelp.nrtsearch.server.utils;
+package com.yelp.nrtsearch.yelp_reviews.utils;
 
 import com.google.gson.Gson;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;

--- a/src/test/java/com/yelp/nrtsearch/yelp_reviews/utils/IndexerTask.java
+++ b/src/test/java/com/yelp/nrtsearch/yelp_reviews/utils/IndexerTask.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.yelp.nrtsearch.server.utils;
+package com.yelp.nrtsearch.yelp_reviews.utils;
 
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.AddDocumentResponse;

--- a/src/test/java/com/yelp/nrtsearch/yelp_reviews/utils/OneDocBuilder.java
+++ b/src/test/java/com/yelp/nrtsearch/yelp_reviews/utils/OneDocBuilder.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.yelp.nrtsearch.server.utils;
+package com.yelp.nrtsearch.yelp_reviews.utils;
 
 import com.google.gson.Gson;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;

--- a/src/test/java/com/yelp/nrtsearch/yelp_reviews/utils/ParallelDocumentIndexer.java
+++ b/src/test/java/com/yelp/nrtsearch/yelp_reviews/utils/ParallelDocumentIndexer.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.yelp.nrtsearch.server.utils;
+package com.yelp.nrtsearch.yelp_reviews.utils;
 
 import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
 import java.io.BufferedReader;


### PR DESCRIPTION
Move the location of the `YelpReviewTest`. Also move some utility classes from main to test that are only used by this test.