### PR TITLE
Update prometheus to 1.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,14 +51,15 @@ def s3mockVersion = '0.2.6'
 def commonsCompressVersion = '1.27.0'
 def awsJavaSdkVersion = '1.12.768'
 def guiceVersion = '7.0.0'
-def prometheusClientVersion = '0.16.0'
+def prometheusClientVersion = '1.3.1'
 def fastutilVersion = '8.5.14'
 
 dependencies {
 
     //prometheus (metrics) deps
-    implementation "io.prometheus:simpleclient_servlet:${prometheusClientVersion}"
-    implementation "io.prometheus:simpleclient_hotspot:${prometheusClientVersion}"
+    implementation "io.prometheus:prometheus-metrics-core:${prometheusClientVersion}"
+    implementation "io.prometheus:prometheus-metrics-instrumentation-jvm:${prometheusClientVersion}"
+    implementation "io.prometheus:prometheus-metrics-exposition-formats:${prometheusClientVersion}"
     implementation "io.grpc:grpc-netty-shaded:${rootProject.grpcVersion}"
 
     //logging deps

--- a/src/main/java/com/yelp/nrtsearch/LuceneServerModule.java
+++ b/src/main/java/com/yelp/nrtsearch/LuceneServerModule.java
@@ -22,7 +22,7 @@ import com.google.inject.Singleton;
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.grpc.LuceneServer;
 import com.yelp.nrtsearch.server.module.S3Module;
-import io.prometheus.client.CollectorRegistry;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -46,8 +46,8 @@ public class LuceneServerModule extends AbstractModule {
   @Inject
   @Singleton
   @Provides
-  public CollectorRegistry providesCollectorRegistry() {
-    return new CollectorRegistry();
+  public PrometheusRegistry providesPrometheusRegistry() {
+    return new PrometheusRegistry();
   }
 
   @Inject

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/DeadlineUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/DeadlineUtils.java
@@ -48,7 +48,7 @@ public class DeadlineUtils {
     if (cancellationEnabled) {
       Deadline deadline = Context.current().getDeadline();
       if (deadline != null && deadline.isExpired()) {
-        DeadlineMetrics.nrtDeadlineCancelCount.labels(operation).inc();
+        DeadlineMetrics.nrtDeadlineCancelCount.labelValues(operation).inc();
         throw Status.CANCELLED
             .withDescription("Request deadline exceeded: " + message)
             .asRuntimeException();
@@ -61,7 +61,7 @@ public class DeadlineUtils {
     if (cancellationEnabled) {
       Deadline deadline = Context.current().getDeadline();
       if (deadline != null && deadline.isExpired()) {
-        DeadlineMetrics.nrtDeadlineCancelCount.labels(operation).inc();
+        DeadlineMetrics.nrtDeadlineCancelCount.labelValues(operation).inc();
         throw Status.CANCELLED
             .withDescription(
                 "Request deadline exceeded: "

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/CopyFilesHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/CopyFilesHandler.java
@@ -106,10 +106,12 @@ public class CopyFilesHandler implements Handler<CopyFiles, TransferStatus> {
 
     // record metrics for merge copy
     if (job.getFailed()) {
-      NrtMetrics.nrtMergeFailure.labels(indexName).inc();
+      NrtMetrics.nrtMergeFailure.labelValues(indexName).inc();
     } else {
-      NrtMetrics.nrtMergeTime.labels(indexName).observe((System.nanoTime() - startNS) / 1000000.0);
-      NrtMetrics.nrtMergeSize.labels(indexName).observe(job.getTotalBytesCopied());
+      NrtMetrics.nrtMergeTime
+          .labelValues(indexName)
+          .observe((System.nanoTime() - startNS) / 1000000.0);
+      NrtMetrics.nrtMergeSize.labelValues(indexName).observe(job.getTotalBytesCopied());
     }
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/NRTPrimaryNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/NRTPrimaryNode.java
@@ -201,8 +201,8 @@ public class NRTPrimaryNode extends PrimaryNode {
     // about?
     long version = getCopyStateVersion();
     logMessage("send flushed version=" + version + " replica count " + replicasInfos.size());
-    NrtMetrics.searcherVersion.labels(indexName).set(version);
-    NrtMetrics.nrtPrimaryPointCount.labels(indexName).inc();
+    NrtMetrics.searcherVersion.labelValues(indexName).set(version);
+    NrtMetrics.nrtPrimaryPointCount.labelValues(indexName).inc();
 
     // Notify current replicas:
     Iterator<ReplicaDetails> it = replicasInfos.iterator();
@@ -342,7 +342,7 @@ public class NRTPrimaryNode extends PrimaryNode {
       return;
     }
 
-    NrtMetrics.nrtMergeCopyStartCount.labels(indexName).inc();
+    NrtMetrics.nrtMergeCopyStartCount.labelValues(indexName).inc();
 
     long maxMergePreCopyDurationSec = getCurrentMaxMergePreCopyDurationSec();
     Deadline deadline;
@@ -428,9 +428,9 @@ public class NRTPrimaryNode extends PrimaryNode {
 
       // record metrics for this merge
       NrtMetrics.nrtPrimaryMergeTime
-          .labels(indexName)
+          .labelValues(indexName)
           .observe((System.nanoTime() - mergeStartNS) / 1000000.0);
-      NrtMetrics.nrtMergeCopyEndCount.labels(indexName).inc();
+      NrtMetrics.nrtMergeCopyEndCount.labelValues(indexName).inc();
     }
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/NRTReplicaNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/NRTReplicaNode.java
@@ -250,11 +250,13 @@ public class NRTReplicaNode extends ReplicaNode {
 
     // record metrics for this nrt point
     if (job.getFailed()) {
-      NrtMetrics.nrtPointFailure.labels(indexName).inc();
+      NrtMetrics.nrtPointFailure.labelValues(indexName).inc();
     } else {
-      NrtMetrics.nrtPointTime.labels(indexName).observe((System.nanoTime() - startNS) / 1000000.0);
-      NrtMetrics.nrtPointSize.labels(indexName).observe(job.getTotalBytesCopied());
-      NrtMetrics.searcherVersion.labels(indexName).set(job.getCopyState().version);
+      NrtMetrics.nrtPointTime
+          .labelValues(indexName)
+          .observe((System.nanoTime() - startNS) / 1000000.0);
+      NrtMetrics.nrtPointSize.labelValues(indexName).observe(job.getTotalBytesCopied());
+      NrtMetrics.searcherVersion.labelValues(indexName).set(job.getCopyState().version);
     }
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/SimpleCopyJob.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/SimpleCopyJob.java
@@ -301,7 +301,7 @@ public class SimpleCopyJob extends CopyJob {
     public void onNext(RawFileChunk value) {
       // buffer all file chunks, this is bounded by the max in flight config value
       pendingChunks.add(value);
-      NrtMetrics.nrtAckedCopyMB.labels(indexName).inc(value.getSerializedSize() * BYTES_TO_MB);
+      NrtMetrics.nrtAckedCopyMB.labelValues(indexName).inc(value.getSerializedSize() * BYTES_TO_MB);
     }
 
     @Override

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/NrtIndexWriter.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/NrtIndexWriter.java
@@ -50,6 +50,6 @@ public class NrtIndexWriter extends IndexWriter {
    */
   @Override
   protected void doBeforeFlush() throws IOException {
-    IndexMetrics.flushCount.labels(indexName).inc();
+    IndexMetrics.flushCount.labelValues(indexName).inc();
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/Configuration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/Configuration.java
@@ -15,18 +15,18 @@
  */
 package com.yelp.nrtsearch.server.monitoring;
 
-import io.prometheus.client.CollectorRegistry;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
 
 /**
  * Holds information about which metrics should be kept track of during rpc calls. Can be used to
  * turn on more elaborate and expensive metrics, such as latency histograms.
  */
 public class Configuration {
-  private static double[] DEFAULT_LATENCY_BUCKETS =
+  private static final double[] DEFAULT_LATENCY_BUCKETS =
       new double[] {.001, .005, .01, .05, 0.075, .1, .25, .5, 1, 2, 5, 10};
 
   private final boolean isIncludeLatencyHistograms;
-  private final CollectorRegistry collectorRegistry;
+  private final PrometheusRegistry prometheusRegistry;
   private final double[] latencyBuckets;
 
   /**
@@ -36,7 +36,7 @@ public class Configuration {
   public static com.yelp.nrtsearch.server.monitoring.Configuration cheapMetricsOnly() {
     return new com.yelp.nrtsearch.server.monitoring.Configuration(
         false /* isIncludeLatencyHistograms */,
-        CollectorRegistry.defaultRegistry,
+        PrometheusRegistry.defaultRegistry,
         DEFAULT_LATENCY_BUCKETS);
   }
 
@@ -48,18 +48,18 @@ public class Configuration {
   public static com.yelp.nrtsearch.server.monitoring.Configuration allMetrics() {
     return new com.yelp.nrtsearch.server.monitoring.Configuration(
         true /* isIncludeLatencyHistograms */,
-        CollectorRegistry.defaultRegistry,
+        PrometheusRegistry.defaultRegistry,
         DEFAULT_LATENCY_BUCKETS);
   }
 
   /**
    * Returns a copy {@link com.yelp.nrtsearch.server.monitoring.Configuration} with the difference
-   * that Prometheus metrics are recorded using the supplied {@link CollectorRegistry}.
+   * that Prometheus metrics are recorded using the supplied {@link PrometheusRegistry}.
    */
-  public com.yelp.nrtsearch.server.monitoring.Configuration withCollectorRegistry(
-      CollectorRegistry collectorRegistry) {
+  public com.yelp.nrtsearch.server.monitoring.Configuration withPrometheusRegistry(
+      PrometheusRegistry prometheusRegistry) {
     return new com.yelp.nrtsearch.server.monitoring.Configuration(
-        isIncludeLatencyHistograms, collectorRegistry, latencyBuckets);
+        isIncludeLatencyHistograms, prometheusRegistry, latencyBuckets);
   }
 
   /**
@@ -68,7 +68,7 @@ public class Configuration {
    */
   public com.yelp.nrtsearch.server.monitoring.Configuration withLatencyBuckets(double[] buckets) {
     return new com.yelp.nrtsearch.server.monitoring.Configuration(
-        isIncludeLatencyHistograms, collectorRegistry, buckets);
+        isIncludeLatencyHistograms, prometheusRegistry, buckets);
   }
 
   /** Returns whether or not latency histograms for calls should be included. */
@@ -76,9 +76,9 @@ public class Configuration {
     return isIncludeLatencyHistograms;
   }
 
-  /** Returns the {@link CollectorRegistry} used to record stats. */
-  public CollectorRegistry getCollectorRegistry() {
-    return collectorRegistry;
+  /** Returns the {@link PrometheusRegistry} used to record stats. */
+  public PrometheusRegistry getPrometheusRegistry() {
+    return prometheusRegistry;
   }
 
   /** Returns the histogram buckets to use for latency metrics. */
@@ -88,10 +88,10 @@ public class Configuration {
 
   private Configuration(
       boolean isIncludeLatencyHistograms,
-      CollectorRegistry collectorRegistry,
+      PrometheusRegistry prometheusRegistry,
       double[] latencyBuckets) {
     this.isIncludeLatencyHistograms = isIncludeLatencyHistograms;
-    this.collectorRegistry = collectorRegistry;
+    this.prometheusRegistry = prometheusRegistry;
     this.latencyBuckets = latencyBuckets;
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/DeadlineMetrics.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/DeadlineMetrics.java
@@ -15,24 +15,24 @@
  */
 package com.yelp.nrtsearch.server.monitoring;
 
-import io.prometheus.client.CollectorRegistry;
-import io.prometheus.client.Counter;
+import io.prometheus.metrics.core.metrics.Counter;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
 
 public class DeadlineMetrics {
 
   public static final Counter nrtDeadlineCancelCount =
-      Counter.build()
+      Counter.builder()
           .name("nrt_deadline_cancel_count")
           .help("Number of requests canceled from expired deadlines.")
           .labelNames("operation")
-          .create();
+          .build();
 
   /**
    * Add all deadline metrics to the collector registry.
    *
    * @param registry collector registry
    */
-  public static void register(CollectorRegistry registry) {
+  public static void register(PrometheusRegistry registry) {
     registry.register(nrtDeadlineCancelCount);
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/LuceneServerMonitoringServerInterceptor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/LuceneServerMonitoringServerInterceptor.java
@@ -28,12 +28,9 @@ public class LuceneServerMonitoringServerInterceptor implements ServerIntercepto
   private final Configuration configuration;
   private final ServerMetrics.Factory serverMetricsFactory;
 
-  public static LuceneServerMonitoringServerInterceptor create(
-      Configuration configuration, String serviceName, String nodeName) {
+  public static LuceneServerMonitoringServerInterceptor create(Configuration configuration) {
     return new LuceneServerMonitoringServerInterceptor(
-        Clock.systemDefaultZone(),
-        configuration,
-        new ServerMetrics.Factory(configuration, serviceName, nodeName));
+        Clock.systemDefaultZone(), configuration, new ServerMetrics.Factory(configuration));
   }
 
   private LuceneServerMonitoringServerInterceptor(

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/NrtMetrics.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/NrtMetrics.java
@@ -15,10 +15,10 @@
  */
 package com.yelp.nrtsearch.server.monitoring;
 
-import io.prometheus.client.CollectorRegistry;
-import io.prometheus.client.Counter;
-import io.prometheus.client.Gauge;
-import io.prometheus.client.Summary;
+import io.prometheus.metrics.core.metrics.Counter;
+import io.prometheus.metrics.core.metrics.Gauge;
+import io.prometheus.metrics.core.metrics.Summary;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
 
 /**
  * Class for managing collection of nrt related metrics. Collects metrics on publishing of new nrt
@@ -26,105 +26,105 @@ import io.prometheus.client.Summary;
  */
 public class NrtMetrics {
   public static final Gauge searcherVersion =
-      Gauge.build()
+      Gauge.builder()
           .name("nrt_searcher_version")
           .help("Current searcher version.")
           .labelNames("index")
-          .create();
+          .build();
 
   public static final Counter nrtPrimaryPointCount =
-      Counter.build()
+      Counter.builder()
           .name("nrt_primary_point_count")
           .help("Number of nrt points created on the primary.")
           .labelNames("index")
-          .create();
+          .build();
   public static final Summary nrtPrimaryMergeTime =
-      Summary.build()
+      Summary.builder()
           .name("nrt_primary_merge_time_ms")
           .help("Time to copy data for merge (ms).")
           .quantile(0.5, 0.05)
           .quantile(0.95, 0.01)
           .quantile(0.99, 0.01)
           .labelNames("index")
-          .create();
+          .build();
 
   public static final Counter nrtPointFailure =
-      Counter.build()
+      Counter.builder()
           .name("nrt_point_failure_count")
           .help("Number of failed nrt point copies")
           .labelNames("index")
-          .create();
+          .build();
   public static final Summary nrtPointSize =
-      Summary.build()
+      Summary.builder()
           .name("nrt_point_copy_size")
           .help("Data copied for nrt points.")
           .quantile(0.5, 0.05)
           .quantile(0.95, 0.01)
           .quantile(0.99, 0.01)
           .labelNames("index")
-          .create();
+          .build();
   public static final Summary nrtPointTime =
-      Summary.build()
+      Summary.builder()
           .name("nrt_point_copy_time_ms")
           .help("Time to copy data for nrt point (ms).")
           .quantile(0.5, 0.05)
           .quantile(0.95, 0.01)
           .quantile(0.99, 0.01)
           .labelNames("index")
-          .create();
+          .build();
 
   public static final Counter nrtMergeFailure =
-      Counter.build()
+      Counter.builder()
           .name("nrt_merge_failure_count")
           .help("Number of failed merge copies.")
           .labelNames("index")
-          .create();
+          .build();
   public static final Summary nrtMergeSize =
-      Summary.build()
+      Summary.builder()
           .name("nrt_merge_copy_size")
           .help("Data copied for merges.")
           .quantile(0.5, 0.05)
           .quantile(0.95, 0.01)
           .quantile(0.99, 0.01)
           .labelNames("index")
-          .create();
+          .build();
   public static final Summary nrtMergeTime =
-      Summary.build()
+      Summary.builder()
           .name("nrt_merge_copy_time_ms")
           .help("Time to copy data for merge (ms).")
           .quantile(0.5, 0.05)
           .quantile(0.95, 0.01)
           .quantile(0.99, 0.01)
           .labelNames("index")
-          .create();
+          .build();
 
   public static final Counter nrtMergeCopyStartCount =
-      Counter.build()
+      Counter.builder()
           .name("nrt_merge_copy_start_count")
           .help("Number of merge copies started")
           .labelNames("index")
-          .create();
+          .build();
 
   public static final Counter nrtMergeCopyEndCount =
-      Counter.build()
+      Counter.builder()
           .name("nrt_merge_copy_end_count")
           .help("Number of merge copies ended")
           .labelNames("index")
-          .create();
+          .build();
 
   public static final Counter nrtAckedCopyMB =
-      Counter.build()
+      Counter.builder()
           .name("nrt_acked_copy_mb")
           .help("Total acked data copied.")
           .labelNames("index")
-          .create();
+          .build();
 
   /**
    * Add all nrt metrics to the collector registry.
    *
    * @param registry collector registry
    */
-  public static void register(CollectorRegistry registry) {
+  public static void register(PrometheusRegistry registry) {
     registry.register(searcherVersion);
     registry.register(nrtPrimaryPointCount);
     registry.register(nrtPrimaryMergeTime);

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/ProcStatCollector.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/ProcStatCollector.java
@@ -15,25 +15,46 @@
  */
 package com.yelp.nrtsearch.server.monitoring;
 
-import io.prometheus.client.Collector;
-import io.prometheus.client.GaugeMetricFamily;
+import io.prometheus.metrics.core.metrics.Gauge;
+import io.prometheus.metrics.model.registry.MultiCollector;
+import io.prometheus.metrics.model.snapshots.MetricSnapshot;
+import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Collect stat metrics for this process from procfs. */
-public class ProcStatCollector extends Collector {
+public class ProcStatCollector implements MultiCollector {
   private static final Logger logger = LoggerFactory.getLogger(ProcStatCollector.class);
   private static final String STAT_PATH_FORMAT = "/proc/%d/stat";
   private static final int MINOR_FAULT_INDEX = 9;
   private static final int CHILD_MINOR_FAULT_INDEX = 10;
   private static final int MAJOR_FAULT_INDEX = 11;
   private static final int CHILD_MAJOR_FAULT_INDEX = 12;
+  private static final Gauge minorFaults =
+      Gauge.builder()
+          .name("nrt_stat_minor_faults")
+          .help("Total number of minor page faults.")
+          .build();
+  private static final Gauge childMinorFaults =
+      Gauge.builder()
+          .name("nrt_stat_child_minor_faults")
+          .help("Total number of minor page faults by waited-for children.")
+          .build();
+  private static final Gauge majorFaults =
+      Gauge.builder()
+          .name("nrt_stat_major_faults")
+          .help("Total number of major page faults.")
+          .build();
+  private static final Gauge childMajorFaults =
+      Gauge.builder()
+          .name("nrt_stat_child_major_faults")
+          .help("Total number of major page faults by waited-for children.")
+          .build();
 
   private final File statFile;
   private boolean collectStat;
@@ -45,9 +66,9 @@ public class ProcStatCollector extends Collector {
   }
 
   @Override
-  public List<MetricFamilySamples> collect() {
+  public MetricSnapshots collect() {
     if (collectStat) {
-      List<MetricFamilySamples> mfs = new ArrayList<>();
+      List<MetricSnapshot> metrics = new ArrayList<>();
 
       List<String> lines;
       try {
@@ -55,44 +76,32 @@ public class ProcStatCollector extends Collector {
       } catch (IOException e) {
         logger.warn("Error reading stat info", e);
         collectStat = false;
-        return Collections.emptyList();
+        return new MetricSnapshots();
       }
 
       try {
         for (String line : lines) {
           String[] components = line.split("\\s+");
           if (components.length > CHILD_MAJOR_FAULT_INDEX) {
-            mfs.add(
-                new GaugeMetricFamily(
-                    "nrt_stat_minor_faults",
-                    "Total number of minor page faults",
-                    Double.parseDouble(components[MINOR_FAULT_INDEX])));
-            mfs.add(
-                new GaugeMetricFamily(
-                    "nrt_stat_child_minor_faults",
-                    "Total number of minor page faults by waited-for children",
-                    Double.parseDouble(components[CHILD_MINOR_FAULT_INDEX])));
-            mfs.add(
-                new GaugeMetricFamily(
-                    "nrt_stat_major_faults",
-                    "Total number of major page faults",
-                    Double.parseDouble(components[MAJOR_FAULT_INDEX])));
-            mfs.add(
-                new GaugeMetricFamily(
-                    "nrt_stat_child_major_faults",
-                    "Total number of major page faults by waited-for children",
-                    Double.parseDouble(components[CHILD_MAJOR_FAULT_INDEX])));
+            minorFaults.set(Double.parseDouble(components[MINOR_FAULT_INDEX]));
+            childMinorFaults.set(Double.parseDouble(components[CHILD_MINOR_FAULT_INDEX]));
+            majorFaults.set(Double.parseDouble(components[MAJOR_FAULT_INDEX]));
+            childMajorFaults.set(Double.parseDouble(components[CHILD_MAJOR_FAULT_INDEX]));
           }
         }
+        metrics.add(minorFaults.collect());
+        metrics.add(childMinorFaults.collect());
+        metrics.add(majorFaults.collect());
+        metrics.add(childMajorFaults.collect());
       } catch (Exception e) {
         logger.warn("Error parsing stat result", e);
         collectStat = false;
-        return Collections.emptyList();
+        return new MetricSnapshots();
       }
 
-      return mfs;
+      return new MetricSnapshots(metrics);
     } else {
-      return Collections.emptyList();
+      return new MetricSnapshots();
     }
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/plugins/MetricsPlugin.java
+++ b/src/main/java/com/yelp/nrtsearch/server/plugins/MetricsPlugin.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.server.plugins;
 
-import io.prometheus.client.CollectorRegistry;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
 
 /**
  * Plugin interface that allows plugin to register their prometheus metrics in Nrtsearch prometheus
@@ -24,7 +24,7 @@ import io.prometheus.client.CollectorRegistry;
 public interface MetricsPlugin {
 
   /**
-   * @param collectorRegistry Nrtsearch Prometheus collector registry.
+   * @param prometheusRegistry Nrtsearch Prometheus collector registry.
    */
-  void registerMetrics(CollectorRegistry collectorRegistry);
+  void registerMetrics(PrometheusRegistry prometheusRegistry);
 }

--- a/src/main/java/com/yelp/nrtsearch/server/plugins/PluginsService.java
+++ b/src/main/java/com/yelp/nrtsearch/server/plugins/PluginsService.java
@@ -17,7 +17,7 @@ package com.yelp.nrtsearch.server.plugins;
 
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.remote.PluginDownloader;
-import io.prometheus.client.CollectorRegistry;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -43,7 +43,7 @@ public class PluginsService {
   private static final Logger logger = LoggerFactory.getLogger(PluginsService.class);
 
   private final LuceneServerConfiguration config;
-  private final CollectorRegistry collectorRegistry;
+  private final PrometheusRegistry prometheusRegistry;
   private final List<PluginDescriptor> loadedPluginDescriptors = new ArrayList<>();
 
   private final PluginDownloader pluginDownloader;
@@ -51,9 +51,9 @@ public class PluginsService {
   public PluginsService(
       LuceneServerConfiguration config,
       PluginDownloader pluginDownloader,
-      CollectorRegistry collectorRegistry) {
+      PrometheusRegistry prometheusRegistry) {
     this.config = config;
-    this.collectorRegistry = collectorRegistry;
+    this.prometheusRegistry = prometheusRegistry;
     this.pluginDownloader = pluginDownloader;
   }
 
@@ -193,7 +193,7 @@ public class PluginsService {
               .getDeclaredConstructor(new Class[] {LuceneServerConfiguration.class})
               .newInstance(config);
       if (plugin instanceof MetricsPlugin) {
-        ((MetricsPlugin) plugin).registerMetrics(collectorRegistry);
+        ((MetricsPlugin) plugin).registerMetrics(prometheusRegistry);
       }
       return plugin;
     } catch (Exception e) {

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/CustomFieldTypeTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/CustomFieldTypeTest.java
@@ -28,7 +28,7 @@ import com.yelp.nrtsearch.server.plugins.FieldTypePlugin;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import io.grpc.StatusRuntimeException;
 import io.grpc.testing.GrpcCleanupRule;
-import io.prometheus.client.CollectorRegistry;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -60,7 +60,7 @@ public class CustomFieldTypeTest {
   @Rule public final TemporaryFolder folder = new TemporaryFolder();
 
   private GrpcServer grpcServer;
-  private CollectorRegistry collectorRegistry;
+  private PrometheusRegistry prometheusRegistry;
 
   @After
   public void tearDown() throws IOException {
@@ -75,16 +75,16 @@ public class CustomFieldTypeTest {
 
   @Before
   public void setUp() throws IOException {
-    collectorRegistry = new CollectorRegistry();
-    grpcServer = setUpGrpcServer(collectorRegistry);
+    prometheusRegistry = new PrometheusRegistry();
+    grpcServer = setUpGrpcServer(prometheusRegistry);
   }
 
-  private GrpcServer setUpGrpcServer(CollectorRegistry collectorRegistry) throws IOException {
+  private GrpcServer setUpGrpcServer(PrometheusRegistry prometheusRegistry) throws IOException {
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     return new GrpcServer(
-        collectorRegistry,
+        prometheusRegistry,
         grpcCleanup,
         luceneServerConfiguration,
         folder,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/DeadlineUtilsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/DeadlineUtilsTest.java
@@ -176,6 +176,6 @@ public class DeadlineUtilsTest {
   }
 
   private int getCancelMetricCount() {
-    return (int) DeadlineMetrics.nrtDeadlineCancelCount.labels("TEST").get();
+    return (int) DeadlineMetrics.nrtDeadlineCancelCount.labelValues("TEST").get();
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerIdFieldTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/LuceneServerIdFieldTest.java
@@ -24,7 +24,7 @@ import com.yelp.nrtsearch.server.LuceneServerTestConfigurationFactory;
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import io.grpc.StatusRuntimeException;
 import io.grpc.testing.GrpcCleanupRule;
-import io.prometheus.client.CollectorRegistry;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -69,16 +69,16 @@ public class LuceneServerIdFieldTest {
 
   @Before
   public void setUp() throws IOException {
-    CollectorRegistry collectorRegistry = new CollectorRegistry();
-    grpcServer = setUpGrpcServer(collectorRegistry);
+    PrometheusRegistry prometheusRegistry = new PrometheusRegistry();
+    grpcServer = setUpGrpcServer(prometheusRegistry);
   }
 
-  private GrpcServer setUpGrpcServer(CollectorRegistry collectorRegistry) throws IOException {
+  private GrpcServer setUpGrpcServer(PrometheusRegistry prometheusRegistry) throws IOException {
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     return new GrpcServer(
-        collectorRegistry,
+        prometheusRegistry,
         grpcCleanup,
         luceneServerConfiguration,
         folder,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/MergeBehaviorTests.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/MergeBehaviorTests.java
@@ -24,7 +24,7 @@ import com.yelp.nrtsearch.server.LuceneServerTestConfigurationFactory;
 import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
 import com.yelp.nrtsearch.server.luceneserver.state.BackendGlobalState;
 import io.grpc.testing.GrpcCleanupRule;
-import io.prometheus.client.CollectorRegistry;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -79,16 +79,16 @@ public class MergeBehaviorTests {
 
   @Before
   public void setUp() throws IOException {
-    CollectorRegistry collectorRegistry = new CollectorRegistry();
-    grpcServer = setUpGrpcServer(collectorRegistry);
+    PrometheusRegistry prometheusRegistry = new PrometheusRegistry();
+    grpcServer = setUpGrpcServer(prometheusRegistry);
   }
 
-  private GrpcServer setUpGrpcServer(CollectorRegistry collectorRegistry) throws IOException {
+  private GrpcServer setUpGrpcServer(PrometheusRegistry prometheusRegistry) throws IOException {
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     return new GrpcServer(
-        collectorRegistry,
+        prometheusRegistry,
         grpcCleanup,
         luceneServerConfiguration,
         folder,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/StateBackendServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/StateBackendServerTest.java
@@ -47,7 +47,7 @@ import io.grpc.ServerBuilder;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
-import io.prometheus.client.CollectorRegistry;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -223,7 +223,7 @@ public class StateBackendServerTest {
     cleanupPrimary();
     LuceneServerImpl serverImpl =
         new LuceneServerImpl(
-            getPrimaryConfig(), null, new CollectorRegistry(), Collections.emptyList());
+            getPrimaryConfig(), null, new PrometheusRegistry(), Collections.emptyList());
 
     primaryReplicationServer =
         ServerBuilder.forPort(0)
@@ -240,7 +240,7 @@ public class StateBackendServerTest {
         new LuceneServerImpl(
             getPrimaryRemoteConfig(),
             remoteBackendPrimary,
-            new CollectorRegistry(),
+            new PrometheusRegistry(),
             Collections.emptyList());
 
     primaryReplicationServer =
@@ -256,7 +256,7 @@ public class StateBackendServerTest {
     cleanupReplica();
     LuceneServerImpl serverImpl =
         new LuceneServerImpl(
-            getReplicaConfig(), null, new CollectorRegistry(), Collections.emptyList());
+            getReplicaConfig(), null, new PrometheusRegistry(), Collections.emptyList());
 
     replicaReplicationServer =
         ServerBuilder.forPort(0)
@@ -273,7 +273,7 @@ public class StateBackendServerTest {
         new LuceneServerImpl(
             getReplicaRemoteConfig(),
             remoteBackendReplica,
-            new CollectorRegistry(),
+            new PrometheusRegistry(),
             Collections.emptyList());
 
     replicaReplicationServer =

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/TestServer.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/TestServer.java
@@ -46,7 +46,7 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
-import io.prometheus.client.CollectorRegistry;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.ByteArrayInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -151,7 +151,7 @@ public class TestServer {
     remoteBackend = createRemoteBackend();
     serverImpl =
         new LuceneServerImpl(
-            configuration, remoteBackend, new CollectorRegistry(), Collections.emptyList());
+            configuration, remoteBackend, new PrometheusRegistry(), Collections.emptyList());
 
     replicationServer =
         ServerBuilder.forPort(0)

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/ServerTestCase.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/ServerTestCase.java
@@ -37,7 +37,7 @@ import com.yelp.nrtsearch.server.grpc.StartIndexRequest;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
-import io.prometheus.client.CollectorRegistry;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -80,7 +80,7 @@ public class ServerTestCase {
   @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
 
   private static GrpcServer grpcServer;
-  private static CollectorRegistry collectorRegistry;
+  private static PrometheusRegistry prometheusRegistry;
   private static GlobalState globalState;
   private static boolean initialized = false;
 
@@ -88,8 +88,8 @@ public class ServerTestCase {
     return grpcServer;
   }
 
-  public static CollectorRegistry getCollectorRegistry() {
-    return collectorRegistry;
+  public static PrometheusRegistry getPrometheusRegistry() {
+    return prometheusRegistry;
   }
 
   public static GlobalState getGlobalState() {
@@ -209,19 +209,19 @@ public class ServerTestCase {
   }
 
   public void setUpClass() throws Exception {
-    collectorRegistry = new CollectorRegistry();
-    grpcServer = setUpGrpcServer(collectorRegistry);
+    prometheusRegistry = new PrometheusRegistry();
+    grpcServer = setUpGrpcServer(prometheusRegistry);
     initIndices();
   }
 
-  private GrpcServer setUpGrpcServer(CollectorRegistry collectorRegistry) throws IOException {
+  private GrpcServer setUpGrpcServer(PrometheusRegistry prometheusRegistry) throws IOException {
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(
             Mode.STANDALONE, folder.getRoot(), getExtraConfig());
     GrpcServer server =
         new GrpcServer(
-            collectorRegistry,
+            prometheusRegistry,
             grpcCleanup,
             luceneServerConfiguration,
             folder,

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
@@ -43,7 +43,7 @@ import com.yelp.nrtsearch.server.luceneserver.geo.GeoPoint;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.plugins.ScriptPlugin;
 import io.grpc.testing.GrpcCleanupRule;
-import io.prometheus.client.CollectorRegistry;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.time.Instant;
@@ -78,7 +78,7 @@ public class ScoreScriptTest {
   @Rule public final TemporaryFolder folder = new TemporaryFolder();
 
   private GrpcServer grpcServer;
-  private CollectorRegistry collectorRegistry;
+  private PrometheusRegistry prometheusRegistry;
 
   @After
   public void tearDown() throws IOException {
@@ -93,16 +93,16 @@ public class ScoreScriptTest {
 
   @Before
   public void setUp() throws IOException {
-    collectorRegistry = new CollectorRegistry();
-    grpcServer = setUpGrpcServer(collectorRegistry);
+    prometheusRegistry = new PrometheusRegistry();
+    grpcServer = setUpGrpcServer(prometheusRegistry);
   }
 
-  private GrpcServer setUpGrpcServer(CollectorRegistry collectorRegistry) throws IOException {
+  private GrpcServer setUpGrpcServer(PrometheusRegistry prometheusRegistry) throws IOException {
     String testIndex = "test_index";
     LuceneServerConfiguration luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     return new GrpcServer(
-        collectorRegistry,
+        prometheusRegistry,
         grpcCleanup,
         luceneServerConfiguration,
         folder,

--- a/src/test/java/com/yelp/nrtsearch/server/monitoring/SearchResponseCollectorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/monitoring/SearchResponseCollectorTest.java
@@ -24,13 +24,14 @@ import com.yelp.nrtsearch.server.grpc.SearchResponse.Diagnostics;
 import com.yelp.nrtsearch.server.grpc.TotalHits;
 import com.yelp.nrtsearch.server.luceneserver.GlobalState;
 import com.yelp.nrtsearch.server.luceneserver.IndexState;
-import io.prometheus.client.Collector.MetricFamilySamples;
+import io.prometheus.metrics.model.snapshots.MetricSnapshot;
+import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -53,6 +54,15 @@ public class SearchResponseCollectorTest {
     SearchResponseCollector.updateSearchResponseMetrics(testResponse, "test_index", true);
   }
 
+  @Before
+  public void setUp() {
+    SearchResponseCollector.searchResponseSizeBytes.clear();
+    SearchResponseCollector.searchResponseTotalHits.clear();
+    SearchResponseCollector.searchStageLatencyMs.clear();
+    SearchResponseCollector.searchTimeoutCount.clear();
+    SearchResponseCollector.searchTerminatedEarlyCount.clear();
+  }
+
   @Test
   public void testVerboseMetricsDisabled() throws IOException {
     GlobalState mockGlobalState = mock(GlobalState.class);
@@ -63,12 +73,12 @@ public class SearchResponseCollectorTest {
     when(mockGlobalState.getIndex("test_index")).thenReturn(mockIndexState);
 
     SearchResponseCollector collector = new SearchResponseCollector(mockGlobalState);
-    List<MetricFamilySamples> metrics = collector.collect();
+    MetricSnapshots metrics = collector.collect();
     assertEquals(2, metrics.size());
 
-    Map<String, MetricFamilySamples> metricsMap = new HashMap<>();
-    for (MetricFamilySamples samples : metrics) {
-      metricsMap.put(samples.name, samples);
+    Map<String, MetricSnapshot> metricsMap = new HashMap<>();
+    for (MetricSnapshot metric : metrics) {
+      metricsMap.put(metric.getMetadata().getName(), metric);
     }
     assertEquals(
         Set.of("nrt_search_timeout_count", "nrt_search_terminated_early_count"),
@@ -85,12 +95,12 @@ public class SearchResponseCollectorTest {
     when(mockGlobalState.getIndex("test_index")).thenReturn(mockIndexState);
 
     SearchResponseCollector collector = new SearchResponseCollector(mockGlobalState);
-    List<MetricFamilySamples> metrics = collector.collect();
+    MetricSnapshots metrics = collector.collect();
     assertEquals(5, metrics.size());
 
-    Map<String, MetricFamilySamples> metricsMap = new HashMap<>();
-    for (MetricFamilySamples samples : metrics) {
-      metricsMap.put(samples.name, samples);
+    Map<String, MetricSnapshot> metricsMap = new HashMap<>();
+    for (MetricSnapshot metric : metrics) {
+      metricsMap.put(metric.getMetadata().getName(), metric);
     }
     assertEquals(
         Set.of(


### PR DESCRIPTION
Update to use the latest major version of the prometheus metrics library.

There were a lot of little changes to the interfaces and naming, but it still functions basically the same way.

One thing to note is that histograms will maintain data in the native and classic forms by default. This behavior can be changed with configuration https://prometheus.github.io/client_java/config/config/