### PR TITLE
Update mmap preload usage and config

### DIFF
--- a/docs/server_configuration.rst
+++ b/docs/server_configuration.rst
@@ -234,3 +234,22 @@ Example server configuration
      - int
      - Maximum number of in-flight chunks sent by the primary.
      - 2000
+
+.. list-table:: `Index Data Preload Configuration <https://github.com/Yelp/nrtsearch/blob/main/src/main/java/com/yelp/nrtsearch/server/config/IndexPreloadConfig.java>`_ (``preload.*``)
+   :widths: 25 10 50 25
+   :header-rows: 1
+
+   * - Property
+     - Type
+     - Description
+     - Default
+
+   * - enabled
+     - bool
+     - If opening index files with an MMapDirectory should preload the data into the OS page cache
+     - false
+
+   * - extensions
+     - list
+     - List of index file extensions to preload. Including '*' will preload all files.
+     - ['*']

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/DirectoryFactory.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/DirectoryFactory.java
@@ -20,73 +20,13 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
-import java.util.Set;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
-import org.apache.lucene.store.FSLockFactory;
-import org.apache.lucene.store.FileSwitchDirectory;
-import org.apache.lucene.store.IOContext;
-import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.store.LockFactory;
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.store.NIOFSDirectory;
-import org.apache.lucene.util.IOUtils;
 
 /** A factory to open a {@link Directory} from a provided filesystem path. */
 public abstract class DirectoryFactory {
-
-  /**
-   * MMapDirectory implementation to split file access between this and a separate MMapDirectory
-   * implementation based on a provided list of file extensions. This is mainly intended to allow
-   * selective file preloading.
-   */
-  public static class SplitMMapDirectory extends MMapDirectory {
-    private final MMapDirectory splitToDirectory;
-    private final Set<String> extensions;
-
-    /**
-     * Constructor.
-     *
-     * @param lockFactory lock factory, should be the same as used by the provided directory
-     * @param splitToDirectory input requests that have one of the provided file extensions use this
-     *     directory implementation
-     * @param extensions extensions to route to provided directory
-     * @throws IOException on filesystem issues
-     */
-    public SplitMMapDirectory(
-        LockFactory lockFactory, MMapDirectory splitToDirectory, Set<String> extensions)
-        throws IOException {
-      super(splitToDirectory.getDirectory(), lockFactory);
-      this.splitToDirectory = splitToDirectory;
-      this.extensions = extensions;
-    }
-
-    @Override
-    public IndexInput openInput(String name, IOContext context) throws IOException {
-      if (shouldSplit(name)) {
-        // need to check this against the primary directory
-        ensureOpen();
-        ensureCanRead(name);
-        return splitToDirectory.openInput(name, context);
-      }
-      return super.openInput(name, context);
-    }
-
-    @Override
-    public synchronized void close() throws IOException {
-      IOUtils.close(super::close, splitToDirectory);
-    }
-
-    boolean shouldSplit(String name) {
-      String extension = FileSwitchDirectory.getExtension(name);
-      return extensions.contains(extension);
-    }
-
-    /** Get directory implementation used when file matches one of the specified extentions. */
-    public MMapDirectory getSplitToDirectory() {
-      return splitToDirectory;
-    }
-  }
 
   /** Sole constructor. */
   public DirectoryFactory() {}
@@ -108,29 +48,20 @@ public abstract class DirectoryFactory {
       return new DirectoryFactory() {
         @Override
         public Directory open(Path path, IndexPreloadConfig preloadConfig) throws IOException {
-          return FSDirectory.open(path);
+          Directory directory = FSDirectory.open(path);
+          if (directory instanceof MMapDirectory mMapDirectory) {
+            mMapDirectory.setPreload(preloadConfig.preloadPredicate());
+          }
+          return directory;
         }
       };
     } else if (dirImpl.equals("MMapDirectory")) {
       return new DirectoryFactory() {
         @Override
         public Directory open(Path path, IndexPreloadConfig preloadConfig) throws IOException {
-          LockFactory lockFactory = FSLockFactory.getDefault();
-          MMapDirectory mMapDirectory = new MMapDirectory(path, lockFactory);
-          // no preloading
-          if (!preloadConfig.getShouldPreload()) {
-            return mMapDirectory;
-          }
-
-          // all preloading
-          if (preloadConfig.getPreloadAll()) {
-            mMapDirectory.setPreload(true);
-            return mMapDirectory;
-          }
-
-          // some preloading
-          mMapDirectory.setPreload(true);
-          return new SplitMMapDirectory(lockFactory, mMapDirectory, preloadConfig.getExtensions());
+          MMapDirectory mMapDirectory = new MMapDirectory(path);
+          mMapDirectory.setPreload(preloadConfig.preloadPredicate());
+          return mMapDirectory;
         }
       };
     } else if (dirImpl.equals("NIOFSDirectory")) {


### PR DESCRIPTION
The new version of lucene lets you specify a predicate for determining which files should be preloaded by an `MMapDirectory`. This lets us simplify our usage and remove the `SplitMMapDirectory`.

Preloading is now compatible with using `FSDirectory`. If the directory implementation is an `MMapDirectory`, it will get configured for preloading.

Additionally:
- The config has been updated to use the 'preload.` prefix. This will make it cleaner to add more properties (for example, using the context as part of the decision)
- The default value is now `false`. This feature has some large resource implications and should be deliberately enabled. Since we default to `FSDirectory`, preload would have been disabled by default prior to this change.