### PR TITLE
fix ATOM sort and searchAfter

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/AtomFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/AtomFieldDef.java
@@ -26,6 +26,7 @@ import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedSetSortField;
+import org.apache.lucene.util.BytesRef;
 
 /** Field class for 'ATOM' field type. Uses {@link KeywordAnalyzer} for text analysis. */
 public class AtomFieldDef extends TextBaseFieldDef implements Sortable {
@@ -50,7 +51,7 @@ public class AtomFieldDef extends TextBaseFieldDef implements Sortable {
 
   @Override
   public Object parseLastValue(String value) {
-    return value;
+    return new BytesRef(value);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/SortFieldCollector.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/collectors/SortFieldCollector.java
@@ -30,6 +30,7 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopFieldCollector;
 import org.apache.lucene.search.TopFieldDocs;
+import org.apache.lucene.util.BytesRef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,8 +90,14 @@ public class SortFieldCollector extends DocCollector {
     LastHitInfo.Builder lastHitBuilder = LastHitInfo.newBuilder();
     lastHitBuilder.setLastDocId(lastHit.doc);
     for (Object fv : fd.fields) {
-      stateBuilder.addLastFieldValues(fv.toString());
-      lastHitBuilder.addLastFieldValues(fv.toString());
+      String fvstr;
+      if (fv instanceof BytesRef) {
+        fvstr = ((BytesRef) fv).utf8ToString();
+      } else {
+        fvstr = fv.toString();
+      }
+      stateBuilder.addLastFieldValues(fvstr);
+      lastHitBuilder.addLastFieldValues(fvstr);
     }
     stateBuilder.setLastHitInfo(lastHitBuilder.build());
   }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/sort/SortParser.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/sort/SortParser.java
@@ -31,6 +31,7 @@ import java.util.function.BiFunction;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
+import org.apache.lucene.util.BytesRef;
 
 /**
  * Class to handle creation of a {@link Sort} used to sort documents by field values for queries.
@@ -195,7 +196,11 @@ public class SortParser {
         break;
       case STRING:
       case STRING_VAL:
-        fieldValue.setTextValue((String) sortValue);
+        if (sortValue instanceof BytesRef) {
+          fieldValue.setTextValue(((BytesRef) sortValue).utf8ToString());
+        } else {
+          fieldValue.setTextValue((String) sortValue);
+        }
         break;
       case CUSTOM:
         // could be anything, try to determine from value class


### PR DESCRIPTION
Sort with ATOM was broken. There was a recent fix to use SORTED doc value by default.
However, ATOM is still broken due to conversion between BytesRef and String here https://github.com/taoyyu/nrtsearch/blob/3b366075766d80033c05dd5c66c872def56f831a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/sort/SortParser.java#L156

And we have to convert the String to BytesRef for searchAfter.

Added some tests for it.