### PR TITLE
Make _ID field always searchable

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/IdFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/IdFieldDef.java
@@ -76,6 +76,11 @@ public class IdFieldDef extends IndexableFieldDef implements TermQueryable {
     fieldType.setTokenized(false);
   }
 
+  @Override
+  public boolean isSearchable() {
+    return true;
+  }
+
   /**
    * Store the docvalues if it's requested and store the string value in the document
    *

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/IdFieldTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/field/IdFieldTest.java
@@ -80,4 +80,26 @@ public class IdFieldTest extends ServerTestCase {
     assertEquals(1, hit.getFieldsOrThrow("id").getFieldValueCount());
     assertEquals("3", hit.getFieldsOrThrow("id").getFieldValue(0).getTextValue());
   }
+
+  @Test
+  public void testAlwaysSearchable() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(DEFAULT_TEST_INDEX)
+                    .setTopHits(3)
+                    .addRetrieveFields("id")
+                    .setQuery(
+                        Query.newBuilder()
+                            .setTermQuery(
+                                TermQuery.newBuilder().setField("id").setTextValue("2").build())
+                            .build())
+                    .build());
+    assertEquals(1, response.getHitsCount());
+    SearchResponse.Hit hit = response.getHits(0);
+    assertEquals(1, hit.getFieldsOrThrow("id").getFieldValueCount());
+    assertEquals("2", hit.getFieldsOrThrow("id").getFieldValue(0).getTextValue());
+  }
 }


### PR DESCRIPTION
The `_ID` field always indexes `DOCS`, regardless of the `search` parameter for the field. This branch overrides the `isSearchable()` method to reflect this condition. Otherwise, queries will fail during validation.