### PR TITLE
Refactor thread pool configuration

### DIFF
--- a/docker-compose-config/lucene_server_configuration_primary.yaml
+++ b/docker-compose-config/lucene_server_configuration_primary.yaml
@@ -5,8 +5,10 @@ replicationPort: "8001"
 stateDir: "/user/app/primary_state"
 indexDir: "/user/app/primary_index_base"
 threadPoolConfiguration:
-  maxSearchingThreads: 4
-  maxIndexingThreads: 18
+  search:
+    maxThreads: 4
+  index:
+    maxThreads: 18
 botoCfgPath: "/user/app/boto.cfg"
 bucketName: "nrtsearch-bucket"
 serviceName: "nrtsearch-service-test"

--- a/docker-compose-config/lucene_server_configuration_replica.yaml
+++ b/docker-compose-config/lucene_server_configuration_replica.yaml
@@ -5,8 +5,10 @@ replicationPort: "8003"
 stateDir: "/user/app/replica_state"
 indexDir: "/user/app/replica_index_base"
 threadPoolConfiguration:
-  maxSearchingThreads: 16
-  maxIndexingThreads: 4
+  search:
+    maxThreads: 16
+  index:
+    maxThreads: 4
 botoCfgPath: "/user/app/boto.cfg"
 bucketName: "nrtsearch-bucket"
 serviceName: "nrtsearch-service-test"

--- a/docs/server_configuration.rst
+++ b/docs/server_configuration.rst
@@ -221,17 +221,17 @@ Example server configuration
      - Name prefix for threads created by metrics threadpool executor
      - MetricsExecutor
 
-   * - vector_merge.maxThreads
+   * - vectormerge.maxThreads
      - int
      - Size of vector merge threadpool executor
      - numCPUs
 
-   * - vector_merge.maxBufferedItems
+   * - vectormerge.maxBufferedItems
      - int
      - Max tasks that can be queued by vector merge threadpool executor
      - max(100, 2 * numCPUs)
 
-   * - vector_merge.threadNamePrefix
+   * - vectormerge.threadNamePrefix
      - string
      - Name prefix for threads created by vector merge threadpool executor
      - VectorMergeExecutor

--- a/docs/server_configuration.rst
+++ b/docs/server_configuration.rst
@@ -19,8 +19,10 @@ Example server configuration
   stateDir: "/user/app/primary_state"
   indexDir: "/user/app/primary_index_base"
   threadPoolConfiguration:
-    maxSearchingThreads: 4
-    maxIndexingThreads: 18
+    search:
+      maxThreads: 4
+    index:
+      maxThreads: 18
   botoCfgPath: "/user/app/boto.cfg"
   bucketName: "nrtsearch-bucket"
   serviceName: "nrtsearch-service-test"
@@ -114,32 +116,127 @@ Example server configuration
      - Description
      - Default
 
-   * - maxSearchingThreads
+   * - search.maxThreads
      - int
      - Size of searcher threadpool executor
      - (numCPUs * 3) / 2 + 1
 
-   * - maxFetchThreads
+   * - search.maxBufferedItems
      - int
-     - Size of fetch threadpool executor
-     - 1
+     - Max tasks that can be queued by searcher threadpool executor
+     - max(1000, 2 * ((numCPUs * 3) / 2 + 1))
 
-   * - maxIndexingThreads
+   * - search.threadNamePrefix
+     - string
+     - Name prefix for threads created by searcher threadpool executor
+     - LuceneSearchExecutor
+
+   * - index.maxThreads
      - int
      - Size of indexing threadpool executor
      - numCPUs + 1
 
-   * - maxGrpcLuceneserverThreads
+   * - index.maxBufferedItems
+     - int
+     - Max tasks that can be queued by indexing threadpool executor
+     - max(200, 2 * (numCPUs + 1))
+
+   * - index.threadNamePrefix
+     - string
+     - Name prefix for threads created by indexing threadpool executor
+     - LuceneIndexingExecutor
+
+   * - luceneserver.maxThreads
      - int
      - Size of LuceneServer threadpool executor
      - numCPUs + 1
 
-   * - maxGrpcReplicationserverThreads
+   * - luceneserver.maxBufferedItems
+     - int
+     - Max tasks that can be queued by LuceneServer threadpool executor
+     - max(200, 2 * (numCPUs + 1))
+
+   * - luceneserver.threadNamePrefix
+     - string
+     - Name prefix for threads created by LuceneServer threadpool executor
+     - GrpcLuceneServerExecutor
+
+   * - replicationserver.maxThreads
      - int
      - Size of ReplicationServer threadpool executor
      - numCPUs + 1
 
-.. list-table:: `Alternative Max Threads Config <https://github.com/Yelp/nrtsearch/blob/master/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java>`_ (``threadPoolConfiguration.max*Threads.*``)
+   * - replicationserver.maxBufferedItems
+     - int
+     - Max tasks that can be queued by ReplicationServer threadpool executor
+     - max(200, 2 * (numCPUs + 1))
+
+   * - replicationserver.threadNamePrefix
+     - string
+     - Name prefix for threads created by ReplicationServer threadpool executor
+     - GrpcReplicationServerExecutor
+
+   * - fetch.maxThreads
+     - int
+     - Size of fetch threadpool executor
+     - 1
+
+   * - fetch.maxBufferedItems
+     - int
+     - Max tasks that can be queued by fetch threadpool executor
+     - max(1000, 2 * ((numCPUs * 3) / 2 + 1))
+
+   * - fetch.threadNamePrefix
+     - string
+     - Name prefix for threads created by fetch threadpool executor
+     - LuceneFetchExecutor
+
+   * - grpc.maxThreads
+     - int
+     - Size of gRPC threadpool executor
+     - 2 * numCPUs
+
+   * - grpc.maxBufferedItems
+     - int
+     - Max tasks that can be queued by gRPC threadpool executor
+     - 8
+
+   * - grpc.threadNamePrefix
+     - string
+     - Name prefix for threads created by gRPC threadpool executor
+     - GrpcExecutor
+
+   * - metrics.maxThreads
+     - int
+     - Size of metrics threadpool executor
+     - numCPUs
+
+   * - metrics.maxBufferedItems
+     - int
+     - Max tasks that can be queued by metrics threadpool executor
+     - 8
+
+   * - metrics.threadNamePrefix
+     - string
+     - Name prefix for threads created by metrics threadpool executor
+     - MetricsExecutor
+
+   * - vector_merge.maxThreads
+     - int
+     - Size of vector merge threadpool executor
+     - numCPUs
+
+   * - vector_merge.maxBufferedItems
+     - int
+     - Max tasks that can be queued by vector merge threadpool executor
+     - max(100, 2 * numCPUs)
+
+   * - vector_merge.threadNamePrefix
+     - string
+     - Name prefix for threads created by vector merge threadpool executor
+     - VectorMergeExecutor
+
+.. list-table:: `Alternative Max Threads Config <https://github.com/Yelp/nrtsearch/blob/master/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java>`_ (``threadPoolConfiguration.*.maxThreads.*``)
    :widths: 25 10 50 25
    :header-rows: 1
 

--- a/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java
@@ -100,7 +100,7 @@ public class ThreadPoolConfiguration {
               ThreadPoolExecutorFactory.ExecutorType.METRICS,
               new ThreadPoolSettings(
                   DEFAULT_METRICS_THREADS, DEFAULT_METRICS_BUFFERED_ITEMS, "MetricsExecutor"),
-              ThreadPoolExecutorFactory.ExecutorType.VECTOR_MERGE,
+              ThreadPoolExecutorFactory.ExecutorType.VECTORMERGE,
               new ThreadPoolSettings(
                   DEFAULT_VECTOR_MERGE_THREADS,
                   DEFAULT_VECTOR_MERGE_BUFFERED_ITEMS,

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/SearchHandler.java
@@ -46,6 +46,7 @@ import com.yelp.nrtsearch.server.luceneserver.search.SearchRequestProcessor;
 import com.yelp.nrtsearch.server.luceneserver.search.SearcherResult;
 import com.yelp.nrtsearch.server.monitoring.SearchResponseCollector;
 import com.yelp.nrtsearch.server.utils.ObjectToCompositeFieldTransformer;
+import com.yelp.nrtsearch.server.utils.ThreadPoolExecutorFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -323,7 +324,11 @@ public class SearchHandler implements Handler<SearchRequest, SearchResponse> {
     hitBuilders.sort(Comparator.comparing(Hit.Builder::getLuceneDocId));
 
     IndexState indexState = searchContext.getIndexState();
-    int fetch_thread_pool_size = indexState.getThreadPoolConfiguration().getMaxFetchThreads();
+    int fetch_thread_pool_size =
+        indexState
+            .getThreadPoolConfiguration()
+            .getThreadPoolSettings(ThreadPoolExecutorFactory.ExecutorType.FETCH)
+            .maxThreads();
     int min_parallel_fetch_num_fields =
         indexState.getThreadPoolConfiguration().getMinParallelFetchNumFields();
     int min_parallel_fetch_num_hits =

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/VectorFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/VectorFieldDef.java
@@ -112,7 +112,7 @@ public class VectorFieldDef extends IndexableFieldDef implements VectorQueryable
     ExecutorService executorService =
         mergeWorkers > 1
             ? ThreadPoolExecutorFactory.getInstance()
-                .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.VECTOR_MERGE)
+                .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.VECTORMERGE)
             : null;
     KnnVectorsFormat vectorsFormat =
         switch (vectorSearchType) {

--- a/src/main/java/com/yelp/nrtsearch/server/utils/ThreadPoolExecutorFactory.java
+++ b/src/main/java/com/yelp/nrtsearch/server/utils/ThreadPoolExecutorFactory.java
@@ -39,7 +39,6 @@ public class ThreadPoolExecutorFactory {
   }
 
   private static final Logger logger = LoggerFactory.getLogger(ThreadPoolExecutorFactory.class);
-  private static final int DEFAULT_QUEUE_SIZE = 8;
 
   private static ThreadPoolExecutorFactory instance;
 
@@ -89,121 +88,22 @@ public class ThreadPoolExecutorFactory {
   }
 
   private ThreadPoolExecutor createThreadPoolExecutor(ExecutorType executorType) {
-    ThreadPoolExecutor threadPoolExecutor;
-    if (executorType.equals(ExecutorType.SEARCH)) {
-      logger.info(
-          "Creating LuceneSearchExecutor of size "
-              + threadPoolConfiguration.getMaxSearchingThreads());
-      BlockingQueue<Runnable> docsToIndex =
-          new LinkedBlockingQueue<Runnable>(threadPoolConfiguration.getMaxSearchBufferedItems());
-      // same as Executors.newFixedThreadPool except we want a NamedThreadFactory instead of
-      // defaultFactory
-      threadPoolExecutor =
-          new ThreadPoolExecutor(
-              threadPoolConfiguration.getMaxSearchingThreads(),
-              threadPoolConfiguration.getMaxSearchingThreads(),
-              0,
-              TimeUnit.SECONDS,
-              docsToIndex,
-              new NamedThreadFactory("LuceneSearchExecutor"));
-
-    } else if (executorType.equals(ExecutorType.INDEX)) {
-      logger.info(
-          "Creating LuceneIndexingExecutor of size "
-              + threadPoolConfiguration.getMaxIndexingThreads());
-      BlockingQueue<Runnable> docsToIndex =
-          new LinkedBlockingQueue<Runnable>(threadPoolConfiguration.getMaxIndexingBufferedItems());
-      threadPoolExecutor =
-          new ThreadPoolExecutor(
-              threadPoolConfiguration.getMaxIndexingThreads(),
-              threadPoolConfiguration.getMaxIndexingThreads(),
-              0,
-              TimeUnit.SECONDS,
-              docsToIndex,
-              new NamedThreadFactory("LuceneIndexingExecutor"));
-    } else if (executorType.equals(ExecutorType.LUCENESERVER)) {
-      logger.info(
-          "Creating GrpcLuceneServerExecutor of size "
-              + threadPoolConfiguration.getMaxGrpcLuceneserverThreads());
-      BlockingQueue<Runnable> docsToIndex =
-          new LinkedBlockingQueue<Runnable>(
-              threadPoolConfiguration.getMaxGrpcLuceneserverBufferedItems());
-      threadPoolExecutor =
-          new ThreadPoolExecutor(
-              threadPoolConfiguration.getMaxGrpcLuceneserverThreads(),
-              threadPoolConfiguration.getMaxGrpcLuceneserverThreads(),
-              0,
-              TimeUnit.SECONDS,
-              docsToIndex,
-              new NamedThreadFactory("GrpcLuceneServerExecutor"));
-    } else if (executorType.equals(ExecutorType.REPLICATIONSERVER)) {
-      logger.info(
-          "Creating GrpcReplicationServerExecutor of size "
-              + threadPoolConfiguration.getMaxGrpcReplicationserverThreads());
-      BlockingQueue<Runnable> docsToIndex =
-          new LinkedBlockingQueue<Runnable>(
-              threadPoolConfiguration.getMaxGrpcReplicationserverBufferedItems());
-      threadPoolExecutor =
-          new ThreadPoolExecutor(
-              threadPoolConfiguration.getMaxGrpcReplicationserverThreads(),
-              threadPoolConfiguration.getMaxGrpcReplicationserverThreads(),
-              0,
-              TimeUnit.SECONDS,
-              docsToIndex,
-              new NamedThreadFactory("GrpcReplicationServerExecutor"));
-    } else if (executorType.equals(ExecutorType.FETCH)) {
-      logger.info(
-          "Creating LuceneFetchExecutor of size " + threadPoolConfiguration.getMaxFetchThreads());
-      BlockingQueue<Runnable> docsToIndex =
-          new LinkedBlockingQueue<Runnable>(threadPoolConfiguration.getMaxSearchBufferedItems());
-      threadPoolExecutor =
-          new ThreadPoolExecutor(
-              threadPoolConfiguration.getMaxFetchThreads(),
-              threadPoolConfiguration.getMaxFetchThreads(),
-              0,
-              TimeUnit.SECONDS,
-              docsToIndex,
-              new NamedThreadFactory("LuceneFetchExecutor"));
-    } else if (executorType == ExecutorType.GRPC) {
-      logger.info(
-          "Creating default gRPC executor of size {}",
-          threadPoolConfiguration.getGrpcExecutorThreads());
-      threadPoolExecutor =
-          new ThreadPoolExecutor(
-              threadPoolConfiguration.getGrpcExecutorThreads(),
-              threadPoolConfiguration.getGrpcExecutorThreads(),
-              0L,
-              TimeUnit.SECONDS,
-              new LinkedBlockingQueue<>(DEFAULT_QUEUE_SIZE),
-              new NamedThreadFactory("GrpcExecutor"));
-    } else if (executorType == ExecutorType.METRICS) {
-      logger.info(
-          "Creating MetricsExecutor of size {}",
-          threadPoolConfiguration.getMetricsExecutorThreads());
-      threadPoolExecutor =
-          new ThreadPoolExecutor(
-              threadPoolConfiguration.getMetricsExecutorThreads(),
-              threadPoolConfiguration.getMetricsExecutorThreads(),
-              0L,
-              TimeUnit.SECONDS,
-              new LinkedBlockingQueue<>(DEFAULT_QUEUE_SIZE),
-              new NamedThreadFactory("MetricsExecutor"));
-    } else if (executorType == ExecutorType.VECTOR_MERGE) {
-      logger.info(
-          "Creating VectorMergeExecutor of size {}",
-          threadPoolConfiguration.getVectorMergeExecutorThreads());
-      threadPoolExecutor =
-          new ThreadPoolExecutor(
-              threadPoolConfiguration.getVectorMergeExecutorThreads(),
-              threadPoolConfiguration.getVectorMergeExecutorThreads(),
-              0L,
-              TimeUnit.SECONDS,
-              new LinkedBlockingQueue<>(
-                  threadPoolConfiguration.getVectorMergeExecutorBufferedItems()),
-              new NamedThreadFactory("VectorMergeExecutor"));
-    } else {
-      throw new RuntimeException("Invalid executor type provided " + executorType);
-    }
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(executorType);
+    logger.info(
+        "Creating {} of size {}",
+        threadPoolSettings.threadNamePrefix(),
+        threadPoolSettings.maxThreads());
+    BlockingQueue<Runnable> queue =
+        new LinkedBlockingQueue<>(threadPoolSettings.maxBufferedItems());
+    ThreadPoolExecutor threadPoolExecutor =
+        new ThreadPoolExecutor(
+            threadPoolSettings.maxThreads(),
+            threadPoolSettings.maxThreads(),
+            0L,
+            TimeUnit.SECONDS,
+            queue,
+            new NamedThreadFactory(threadPoolSettings.threadNamePrefix()));
     ThreadPoolCollector.addPool(executorType.name(), threadPoolExecutor);
     return threadPoolExecutor;
   }

--- a/src/main/java/com/yelp/nrtsearch/server/utils/ThreadPoolExecutorFactory.java
+++ b/src/main/java/com/yelp/nrtsearch/server/utils/ThreadPoolExecutorFactory.java
@@ -35,7 +35,7 @@ public class ThreadPoolExecutorFactory {
     FETCH,
     GRPC,
     METRICS,
-    VECTOR_MERGE
+    VECTORMERGE
   }
 
   private static final Logger logger = LoggerFactory.getLogger(ThreadPoolExecutorFactory.class);

--- a/src/test/java/com/yelp/nrtsearch/server/config/ThreadPoolConfigurationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/ThreadPoolConfigurationTest.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.server.config;
 
 import static org.junit.Assert.*;
 
+import com.yelp.nrtsearch.server.utils.ThreadPoolExecutorFactory;
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -41,10 +42,319 @@ public class ThreadPoolConfigurationTest {
         new LuceneServerConfiguration(new FileInputStream(config));
     assertEquals("lucene_server_foo", luceneServerConfiguration.getNodeName());
     assertEquals("foohost", luceneServerConfiguration.getHostName());
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        luceneServerConfiguration
+            .getThreadPoolConfiguration()
+            .getThreadPoolSettings(ThreadPoolExecutorFactory.ExecutorType.SEARCH);
+    assertEquals(threadPoolSettings.maxThreads(), 16);
+    assertEquals(threadPoolSettings.maxBufferedItems(), 100);
+  }
+
+  @Test
+  public void testSearchThreadPool_default() {
+    String config = "nodeName: node1";
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(
+            ThreadPoolExecutorFactory.ExecutorType.SEARCH);
     assertEquals(
-        luceneServerConfiguration.getThreadPoolConfiguration().getMaxSearchingThreads(), 16);
+        threadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_SEARCHING_THREADS);
     assertEquals(
-        luceneServerConfiguration.getThreadPoolConfiguration().getMaxSearchBufferedItems(), 100);
+        threadPoolSettings.maxBufferedItems(),
+        ThreadPoolConfiguration.DEFAULT_SEARCH_BUFFERED_ITEMS);
+    assertEquals("LuceneSearchExecutor", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
+  public void testSearchThreadPool_set() {
+    String config =
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  search:",
+            "    maxThreads: 5",
+            "    maxBufferedItems: 10",
+            "    threadNamePrefix: customName");
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(
+            ThreadPoolExecutorFactory.ExecutorType.SEARCH);
+    assertEquals(threadPoolSettings.maxThreads(), 5);
+    assertEquals(threadPoolSettings.maxBufferedItems(), 10);
+    assertEquals("customName", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
+  public void testIndexThreadPool_default() {
+    String config = "nodeName: node1";
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(ThreadPoolExecutorFactory.ExecutorType.INDEX);
+    assertEquals(threadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_INDEXING_THREADS);
+    assertEquals(
+        threadPoolSettings.maxBufferedItems(),
+        ThreadPoolConfiguration.DEFAULT_INDEXING_BUFFERED_ITEMS);
+    assertEquals("LuceneIndexingExecutor", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
+  public void testIndexThreadPool_set() {
+    String config =
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  index:",
+            "    maxThreads: 5",
+            "    maxBufferedItems: 10",
+            "    threadNamePrefix: customName");
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(ThreadPoolExecutorFactory.ExecutorType.INDEX);
+    assertEquals(threadPoolSettings.maxThreads(), 5);
+    assertEquals(threadPoolSettings.maxBufferedItems(), 10);
+    assertEquals("customName", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
+  public void testLuceneServerThreadPool_default() {
+    String config = "nodeName: node1";
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(
+            ThreadPoolExecutorFactory.ExecutorType.LUCENESERVER);
+    assertEquals(
+        threadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_GRPC_LUCENESERVER_THREADS);
+    assertEquals(
+        threadPoolSettings.maxBufferedItems(),
+        ThreadPoolConfiguration.DEFAULT_GRPC_LUCENESERVER_BUFFERED_ITEMS);
+    assertEquals("GrpcLuceneServerExecutor", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
+  public void testLuceneServerThreadPool_set() {
+    String config =
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  luceneserver:",
+            "    maxThreads: 5",
+            "    maxBufferedItems: 10",
+            "    threadNamePrefix: customName");
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(
+            ThreadPoolExecutorFactory.ExecutorType.LUCENESERVER);
+    assertEquals(threadPoolSettings.maxThreads(), 5);
+    assertEquals(threadPoolSettings.maxBufferedItems(), 10);
+    assertEquals("customName", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
+  public void testReplicationServerThreadPool_default() {
+    String config = "nodeName: node1";
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(
+            ThreadPoolExecutorFactory.ExecutorType.REPLICATIONSERVER);
+    assertEquals(
+        threadPoolSettings.maxThreads(),
+        ThreadPoolConfiguration.DEFAULT_GRPC_REPLICATIONSERVER_THREADS);
+    assertEquals(
+        threadPoolSettings.maxBufferedItems(),
+        ThreadPoolConfiguration.DEFAULT_GRPC_REPLICATIONSERVER_BUFFERED_ITEMS);
+    assertEquals("GrpcReplicationServerExecutor", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
+  public void testReplicationServerThreadPool_set() {
+    String config =
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  replicationserver:",
+            "    maxThreads: 5",
+            "    maxBufferedItems: 10",
+            "    threadNamePrefix: customName");
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(
+            ThreadPoolExecutorFactory.ExecutorType.REPLICATIONSERVER);
+    assertEquals(threadPoolSettings.maxThreads(), 5);
+    assertEquals(threadPoolSettings.maxBufferedItems(), 10);
+    assertEquals("customName", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
+  public void testFetchThreadPool_default() {
+    String config = "nodeName: node1";
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(ThreadPoolExecutorFactory.ExecutorType.FETCH);
+    assertEquals(threadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_FETCH_THREADS);
+    assertEquals(
+        threadPoolSettings.maxBufferedItems(),
+        ThreadPoolConfiguration.DEFAULT_FETCH_BUFFERED_ITEMS);
+    assertEquals("LuceneFetchExecutor", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
+  public void testFetchThreadPool_set() {
+    String config =
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  fetch:",
+            "    maxThreads: 5",
+            "    maxBufferedItems: 10",
+            "    threadNamePrefix: customName");
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(ThreadPoolExecutorFactory.ExecutorType.FETCH);
+    assertEquals(threadPoolSettings.maxThreads(), 5);
+    assertEquals(threadPoolSettings.maxBufferedItems(), 10);
+    assertEquals("customName", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
+  public void testGrpcThreadPool_default() {
+    String config = "nodeName: node1";
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(ThreadPoolExecutorFactory.ExecutorType.GRPC);
+    assertEquals(threadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_GRPC_THREADS);
+    assertEquals(
+        threadPoolSettings.maxBufferedItems(), ThreadPoolConfiguration.DEFAULT_GRPC_BUFFERED_ITEMS);
+    assertEquals("GrpcExecutor", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
+  public void testGrpcThreadPool_set() {
+    String config =
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  grpc:",
+            "    maxThreads: 5",
+            "    maxBufferedItems: 10",
+            "    threadNamePrefix: customName");
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(ThreadPoolExecutorFactory.ExecutorType.GRPC);
+    assertEquals(threadPoolSettings.maxThreads(), 5);
+    assertEquals(threadPoolSettings.maxBufferedItems(), 10);
+    assertEquals("customName", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
+  public void testMetricsThreadPool_default() {
+    String config = "nodeName: node1";
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(
+            ThreadPoolExecutorFactory.ExecutorType.METRICS);
+    assertEquals(threadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_METRICS_THREADS);
+    assertEquals(
+        threadPoolSettings.maxBufferedItems(),
+        ThreadPoolConfiguration.DEFAULT_METRICS_BUFFERED_ITEMS);
+    assertEquals("MetricsExecutor", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
+  public void testMetricsThreadPool_set() {
+    String config =
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  metrics:",
+            "    maxThreads: 5",
+            "    maxBufferedItems: 10",
+            "    threadNamePrefix: customName");
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(
+            ThreadPoolExecutorFactory.ExecutorType.METRICS);
+    assertEquals(threadPoolSettings.maxThreads(), 5);
+    assertEquals(threadPoolSettings.maxBufferedItems(), 10);
+    assertEquals("customName", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
+  public void testVectorMergeThreadPool_default() {
+    String config = "nodeName: node1";
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(
+            ThreadPoolExecutorFactory.ExecutorType.VECTOR_MERGE);
+    assertEquals(
+        threadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_VECTOR_MERGE_THREADS);
+    assertEquals(
+        threadPoolSettings.maxBufferedItems(),
+        ThreadPoolConfiguration.DEFAULT_VECTOR_MERGE_BUFFERED_ITEMS);
+    assertEquals("VectorMergeExecutor", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
+  public void testVectorMergeThreadPool_set() {
+    String config =
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  vector_merge:",
+            "    maxThreads: 5",
+            "    maxBufferedItems: 10",
+            "    threadNamePrefix: customName");
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(
+            ThreadPoolExecutorFactory.ExecutorType.VECTOR_MERGE);
+    assertEquals(threadPoolSettings.maxThreads(), 5);
+    assertEquals(threadPoolSettings.maxBufferedItems(), 10);
+    assertEquals("customName", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
+  public void partialOverride() {
+    String config =
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  search:",
+            "    maxThreads: 5",
+            "    threadNamePrefix: customName",
+            "  index:",
+            "    maxBufferedItems: 14");
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings searchThreadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(
+            ThreadPoolExecutorFactory.ExecutorType.SEARCH);
+    assertEquals(searchThreadPoolSettings.maxThreads(), 5);
+    assertEquals(
+        searchThreadPoolSettings.maxBufferedItems(),
+        ThreadPoolConfiguration.DEFAULT_SEARCH_BUFFERED_ITEMS);
+    assertEquals("customName", searchThreadPoolSettings.threadNamePrefix());
+    ThreadPoolConfiguration.ThreadPoolSettings indexThreadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(ThreadPoolExecutorFactory.ExecutorType.INDEX);
+    assertEquals(
+        indexThreadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_INDEXING_THREADS);
+    assertEquals(indexThreadPoolSettings.maxBufferedItems(), 14);
+    assertEquals("LuceneIndexingExecutor", indexThreadPoolSettings.threadNamePrefix());
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/config/ThreadPoolConfigurationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/ThreadPoolConfigurationTest.java
@@ -299,7 +299,7 @@ public class ThreadPoolConfigurationTest {
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
         threadPoolConfiguration.getThreadPoolSettings(
-            ThreadPoolExecutorFactory.ExecutorType.VECTOR_MERGE);
+            ThreadPoolExecutorFactory.ExecutorType.VECTORMERGE);
     assertEquals(
         threadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_VECTOR_MERGE_THREADS);
     assertEquals(
@@ -314,7 +314,7 @@ public class ThreadPoolConfigurationTest {
         String.join(
             "\n",
             "threadPoolConfiguration:",
-            "  vector_merge:",
+            "  vectormerge:",
             "    maxThreads: 5",
             "    maxBufferedItems: 10",
             "    threadNamePrefix: customName");
@@ -322,7 +322,7 @@ public class ThreadPoolConfigurationTest {
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
         threadPoolConfiguration.getThreadPoolSettings(
-            ThreadPoolExecutorFactory.ExecutorType.VECTOR_MERGE);
+            ThreadPoolExecutorFactory.ExecutorType.VECTORMERGE);
     assertEquals(threadPoolSettings.maxThreads(), 5);
     assertEquals(threadPoolSettings.maxBufferedItems(), 10);
     assertEquals("customName", threadPoolSettings.threadNamePrefix());

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/GrpcServerExecutorSupplierTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/GrpcServerExecutorSupplierTest.java
@@ -40,7 +40,7 @@ public class GrpcServerExecutorSupplierTest {
         new ThreadPoolConfiguration(
             new YamlConfigReader(
                 new ByteArrayInputStream(
-                    "threadPoolConfiguration:\n  maxSearchingThreads: 1".getBytes())));
+                    "threadPoolConfiguration:\n  search:\n    maxThreads: 1".getBytes())));
     ThreadPoolExecutorFactory.init(threadPoolConfiguration);
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/MultiSegmentParallelDocsFetchTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/MultiSegmentParallelDocsFetchTest.java
@@ -26,7 +26,8 @@ public class MultiSegmentParallelDocsFetchTest extends MultiSegmentTest {
     return String.join(
         "\n",
         "threadPoolConfiguration:",
-        "  maxFetchThreads: 8",
+        "  fetch:",
+        "    maxThreads: 8",
         "  minParallelFetchNumFields: 1",
         "  minParallelFetchNumHits: 1",
         "  parallelFetchByField: false");

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/MultiSegmentParallelFieldsFetchTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/MultiSegmentParallelFieldsFetchTest.java
@@ -26,7 +26,8 @@ public class MultiSegmentParallelFieldsFetchTest extends MultiSegmentTest {
     return String.join(
         "\n",
         "threadPoolConfiguration:",
-        "  maxFetchThreads: 8",
+        "  fetch:",
+        "    maxThreads: 8",
         "  minParallelFetchNumFields: 1",
         "  minParallelFetchNumHits: 1",
         "  parallelFetchByField: true");

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/TimeoutTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/TimeoutTest.java
@@ -83,7 +83,7 @@ public class TimeoutTest extends ServerTestCase {
 
   @Override
   public String getExtraConfig() {
-    return String.join("\n", "threadPoolConfiguration:", "  maxSearchingThreads: 1");
+    return String.join("\n", "threadPoolConfiguration:", "  search:", "    maxThreads: 1");
   }
 
   @Override

--- a/src/test/java/com/yelp/nrtsearch/server/utils/ThreadPoolExecutorFactoryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/utils/ThreadPoolExecutorFactoryTest.java
@@ -251,7 +251,7 @@ public class ThreadPoolExecutorFactoryTest {
     init();
     ThreadPoolExecutor executor =
         ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.VECTOR_MERGE);
+            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.VECTORMERGE);
     assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_VECTOR_MERGE_THREADS);
     assertEquals(
         executor.getQueue().remainingCapacity(),
@@ -264,12 +264,12 @@ public class ThreadPoolExecutorFactoryTest {
         String.join(
             "\n",
             "threadPoolConfiguration:",
-            "  vector_merge:",
+            "  vectormerge:",
             "    maxThreads: 5",
             "    maxBufferedItems: 10"));
     ThreadPoolExecutor executor =
         ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.VECTOR_MERGE);
+            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.VECTORMERGE);
     assertEquals(executor.getCorePoolSize(), 5);
     assertEquals(executor.getQueue().remainingCapacity(), 10);
   }

--- a/src/test/java/com/yelp/nrtsearch/server/utils/ThreadPoolExecutorFactoryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/utils/ThreadPoolExecutorFactoryTest.java
@@ -49,14 +49,213 @@ public class ThreadPoolExecutorFactoryTest {
   }
 
   @Test
+  public void testSearchThreadPool_default() {
+    init();
+    ThreadPoolExecutor executor =
+        ThreadPoolExecutorFactory.getInstance()
+            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.SEARCH);
+    assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_SEARCHING_THREADS);
+    assertEquals(
+        executor.getQueue().remainingCapacity(),
+        ThreadPoolConfiguration.DEFAULT_SEARCH_BUFFERED_ITEMS);
+  }
+
+  @Test
+  public void testSearchThreadPool_set() {
+    init(
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  search:",
+            "    maxThreads: 5",
+            "    maxBufferedItems: 10"));
+    ThreadPoolExecutor executor =
+        ThreadPoolExecutorFactory.getInstance()
+            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.SEARCH);
+    assertEquals(executor.getCorePoolSize(), 5);
+    assertEquals(executor.getQueue().remainingCapacity(), 10);
+  }
+
+  @Test
+  public void testIndexThreadPool_default() {
+    init();
+    ThreadPoolExecutor executor =
+        ThreadPoolExecutorFactory.getInstance()
+            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.INDEX);
+    assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_INDEXING_THREADS);
+    assertEquals(
+        executor.getQueue().remainingCapacity(),
+        ThreadPoolConfiguration.DEFAULT_INDEXING_BUFFERED_ITEMS);
+  }
+
+  @Test
+  public void testIndexThreadPool_set() {
+    init(
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  index:",
+            "    maxThreads: 5",
+            "    maxBufferedItems: 10"));
+    ThreadPoolExecutor executor =
+        ThreadPoolExecutorFactory.getInstance()
+            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.INDEX);
+    assertEquals(executor.getCorePoolSize(), 5);
+    assertEquals(executor.getQueue().remainingCapacity(), 10);
+  }
+
+  @Test
+  public void testLuceneServerThreadPool_default() {
+    init();
+    ThreadPoolExecutor executor =
+        ThreadPoolExecutorFactory.getInstance()
+            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.LUCENESERVER);
+    assertEquals(
+        executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_GRPC_LUCENESERVER_THREADS);
+    assertEquals(
+        executor.getQueue().remainingCapacity(),
+        ThreadPoolConfiguration.DEFAULT_GRPC_LUCENESERVER_BUFFERED_ITEMS);
+  }
+
+  @Test
+  public void testLuceneServerThreadPool_set() {
+    init(
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  luceneserver:",
+            "    maxThreads: 5",
+            "    maxBufferedItems: 10"));
+    ThreadPoolExecutor executor =
+        ThreadPoolExecutorFactory.getInstance()
+            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.LUCENESERVER);
+    assertEquals(executor.getCorePoolSize(), 5);
+    assertEquals(executor.getQueue().remainingCapacity(), 10);
+  }
+
+  @Test
+  public void testReplicationServerThreadPool_default() {
+    init();
+    ThreadPoolExecutor executor =
+        ThreadPoolExecutorFactory.getInstance()
+            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.REPLICATIONSERVER);
+    assertEquals(
+        executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_GRPC_REPLICATIONSERVER_THREADS);
+    assertEquals(
+        executor.getQueue().remainingCapacity(),
+        ThreadPoolConfiguration.DEFAULT_GRPC_REPLICATIONSERVER_BUFFERED_ITEMS);
+  }
+
+  @Test
+  public void testReplicationServerThreadPool_set() {
+    init(
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  replicationserver:",
+            "    maxThreads: 5",
+            "    maxBufferedItems: 10"));
+    ThreadPoolExecutor executor =
+        ThreadPoolExecutorFactory.getInstance()
+            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.REPLICATIONSERVER);
+    assertEquals(executor.getCorePoolSize(), 5);
+    assertEquals(executor.getQueue().remainingCapacity(), 10);
+  }
+
+  @Test
+  public void testFetchThreadPool_default() {
+    init();
+    ThreadPoolExecutor executor =
+        ThreadPoolExecutorFactory.getInstance()
+            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.FETCH);
+    assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_FETCH_THREADS);
+    assertEquals(
+        executor.getQueue().remainingCapacity(),
+        ThreadPoolConfiguration.DEFAULT_FETCH_BUFFERED_ITEMS);
+  }
+
+  @Test
+  public void testFetchThreadPool_set() {
+    init(
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  fetch:",
+            "    maxThreads: 5",
+            "    maxBufferedItems: 10"));
+    ThreadPoolExecutor executor =
+        ThreadPoolExecutorFactory.getInstance()
+            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.FETCH);
+    assertEquals(executor.getCorePoolSize(), 5);
+    assertEquals(executor.getQueue().remainingCapacity(), 10);
+  }
+
+  @Test
+  public void testGrpcThreadPool_default() {
+    init();
+    ThreadPoolExecutor executor =
+        ThreadPoolExecutorFactory.getInstance()
+            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.GRPC);
+    assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_GRPC_THREADS);
+    assertEquals(
+        executor.getQueue().remainingCapacity(),
+        ThreadPoolConfiguration.DEFAULT_GRPC_BUFFERED_ITEMS);
+  }
+
+  @Test
+  public void testGrpcThreadPool_set() {
+    init(
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  grpc:",
+            "    maxThreads: 5",
+            "    maxBufferedItems: 10"));
+    ThreadPoolExecutor executor =
+        ThreadPoolExecutorFactory.getInstance()
+            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.GRPC);
+    assertEquals(executor.getCorePoolSize(), 5);
+    assertEquals(executor.getQueue().remainingCapacity(), 10);
+  }
+
+  @Test
+  public void testMetricsThreadPool_default() {
+    init();
+    ThreadPoolExecutor executor =
+        ThreadPoolExecutorFactory.getInstance()
+            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.METRICS);
+    assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_METRICS_THREADS);
+    assertEquals(
+        executor.getQueue().remainingCapacity(),
+        ThreadPoolConfiguration.DEFAULT_METRICS_BUFFERED_ITEMS);
+  }
+
+  @Test
+  public void testMetricsThreadPool_set() {
+    init(
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  metrics:",
+            "    maxThreads: 5",
+            "    maxBufferedItems: 10"));
+    ThreadPoolExecutor executor =
+        ThreadPoolExecutorFactory.getInstance()
+            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.METRICS);
+    assertEquals(executor.getCorePoolSize(), 5);
+    assertEquals(executor.getQueue().remainingCapacity(), 10);
+  }
+
+  @Test
   public void testVectorMergeThreadPool_default() {
     init();
     ThreadPoolExecutor executor =
         ThreadPoolExecutorFactory.getInstance()
             .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.VECTOR_MERGE);
+    assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_VECTOR_MERGE_THREADS);
     assertEquals(
-        executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_VECTOR_MERGE_EXECUTOR_THREADS);
-    assertEquals(executor.getQueue().remainingCapacity(), 100);
+        executor.getQueue().remainingCapacity(),
+        ThreadPoolConfiguration.DEFAULT_VECTOR_MERGE_BUFFERED_ITEMS);
   }
 
   @Test
@@ -65,8 +264,9 @@ public class ThreadPoolExecutorFactoryTest {
         String.join(
             "\n",
             "threadPoolConfiguration:",
-            "  vectorMergeThreads: 5",
-            "  vectorMergeBufferedItems: 10"));
+            "  vector_merge:",
+            "    maxThreads: 5",
+            "    maxBufferedItems: 10"));
     ThreadPoolExecutor executor =
         ThreadPoolExecutorFactory.getInstance()
             .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.VECTOR_MERGE);

--- a/src/test/resources/config.yaml
+++ b/src/test/resources/config.yaml
@@ -5,9 +5,12 @@ replicationPort: "9999"
 stateDir: "state_dir"
 indexDir: "index_dir"
 threadPoolConfiguration:
-  maxSearchingThreads: 16
-  maxIndexingThreads: 4
-  maxSearchBufferedItems: 100
-  maxFetchThreads: 8
+  search:
+    maxThreads: 16
+    maxBufferedItems: 100
+  index:
+    maxThreads: 4
+  fetch:
+    maxThreads: 8
   minParallelFetchNumFields: 1
   minParallelFetchNumHits: 1

--- a/src/test/resources/yelp_reviews/primary/lucene_server_configuration.yaml
+++ b/src/test/resources/yelp_reviews/primary/lucene_server_configuration.yaml
@@ -5,6 +5,8 @@ replicationPort: "8001"
 stateDir: "primary_state"
 indexDir: "primary_index_base"
 threadPoolConfiguration:
-  maxSearchingThreads: 4
-  maxIndexingThreads: 18
+  search:
+    maxThreads: 4
+  index:
+    maxThreads: 18
 verifyReplicationIndexId: false

--- a/src/test/resources/yelp_reviews/replica/lucene_server_configuration.yaml
+++ b/src/test/resources/yelp_reviews/replica/lucene_server_configuration.yaml
@@ -5,6 +5,8 @@ replicationPort: "8003"
 stateDir: "replica_state"
 indexDir: "replica_index_base"
 threadPoolConfiguration:
-  maxSearchingThreads: 16
-  maxIndexingThreads: 4
+  search:
+    maxThreads: 16
+  index:
+    maxThreads: 4
 verifyReplicationIndexId: false


### PR DESCRIPTION
Change the thread pool settings to have a standardized structure. This should make it more straightforward to add new pools or settings.

Thread pool settings are now grouped by type:
```
threadPoolConfiguration:
  <pool_name>:
    maxThreads: 16
    maxBufferedItems: 250
```
When `<pool_name>` is one of: search, index, luceneserver, replicationserver, fetch, grpc, metrics, vector_merge.

Settings:
- `maxThreads` - max threads for the thread pool
- `maxBufferedItems` - max tasks to queue
- `threadNamePrefix` - prefix to add to thread names