### PR TITLE
Make index autoStart default to true

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/IndexStartConfig.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/IndexStartConfig.java
@@ -43,7 +43,7 @@ public class IndexStartConfig {
    */
   public static IndexStartConfig fromConfig(YamlConfigReader configReader) {
     Objects.requireNonNull(configReader);
-    boolean autoStart = configReader.getBoolean(CONFIG_PREFIX + "autoStart", false);
+    boolean autoStart = configReader.getBoolean(CONFIG_PREFIX + "autoStart", true);
     Mode mode = Mode.valueOf(configReader.getString(CONFIG_PREFIX + "mode", "STANDALONE"));
     String discoveryHost =
         configReader.getString(CONFIG_PREFIX + PRIMARY_DISCOVERY_PREFIX + "host", "");

--- a/src/test/java/com/yelp/nrtsearch/server/config/IndexStartConfigTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/IndexStartConfigTest.java
@@ -16,7 +16,6 @@
 package com.yelp.nrtsearch.server.config;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -36,7 +35,7 @@ public class IndexStartConfigTest {
   public void testDefaultConfig() {
     String configFile = "nodeName: \"lucene_server_foo\"";
     IndexStartConfig startConfig = getConfig(configFile);
-    assertFalse(startConfig.getAutoStart());
+    assertTrue(startConfig.getAutoStart());
     assertEquals(Mode.STANDALONE, startConfig.getMode());
     assertEquals("", startConfig.getDiscoveryHost());
     assertEquals(Integer.valueOf(0), startConfig.getDiscoveryPort());


### PR DESCRIPTION
Make indices automatically start based on global state by default.