### PR TITLE
Remove IndexState from DocLookup

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/IndexState.java
@@ -44,7 +44,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.regex.Pattern;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.AnalyzerWrapper;
-import org.apache.lucene.expressions.Bindings;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.search.similarities.PerFieldSimilarityWrapper;
@@ -95,7 +94,7 @@ public abstract class IndexState implements Closeable {
    * Index level doc values lookup. Generates {@link
    * com.yelp.nrtsearch.server.luceneserver.doc.SegmentDocLookup} for a given lucene segment.
    */
-  public final DocLookup docLookup = new DocLookup(this, this::getField);
+  public final DocLookup docLookup = new DocLookup(this::getField);
 
   /** Search-time analyzer. */
   public final Analyzer searchAnalyzer =
@@ -361,9 +360,6 @@ public abstract class IndexState implements Closeable {
 
   /** Get fields with doc values that do eager global ordinal building. */
   public abstract Map<String, GlobalOrdinalable> getEagerFieldGlobalOrdinalFields();
-
-  /** Get field bindings to use for javascript expressions. */
-  public abstract Bindings getExpressionBindings();
 
   /** Verifies if it has nested child object fields. */
   public abstract boolean hasNestedChildFields();

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/doc/DocLookup.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/doc/DocLookup.java
@@ -15,7 +15,6 @@
  */
 package com.yelp.nrtsearch.server.luceneserver.doc;
 
-import com.yelp.nrtsearch.server.luceneserver.IndexState;
 import com.yelp.nrtsearch.server.luceneserver.field.FieldDef;
 import java.util.function.Function;
 import org.apache.lucene.index.LeafReaderContext;
@@ -25,11 +24,9 @@ import org.apache.lucene.index.LeafReaderContext;
  * SegmentDocLookup} bound to single lucene segment.
  */
 public class DocLookup {
-  private final IndexState indexState;
   private final Function<String, FieldDef> fieldDefLookup;
 
-  public DocLookup(IndexState indexState, Function<String, FieldDef> fieldDefLookup) {
-    this.indexState = indexState;
+  public DocLookup(Function<String, FieldDef> fieldDefLookup) {
     this.fieldDefLookup = fieldDefLookup;
   }
 
@@ -41,15 +38,6 @@ public class DocLookup {
    */
   public SegmentDocLookup getSegmentLookup(LeafReaderContext context) {
     return new SegmentDocLookup(fieldDefLookup, context);
-  }
-
-  /**
-   * Get the state information associated with this index.
-   *
-   * @return index state
-   */
-  public IndexState getIndexState() {
-    return indexState;
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/FieldDefBindings.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/field/FieldDefBindings.java
@@ -16,7 +16,7 @@
 package com.yelp.nrtsearch.server.luceneserver.field;
 
 import com.yelp.nrtsearch.server.luceneserver.field.properties.Bindable;
-import java.util.Map;
+import java.util.function.Function;
 import org.apache.lucene.expressions.Bindings;
 import org.apache.lucene.expressions.js.VariableContext;
 import org.apache.lucene.expressions.js.VariableContext.Type;
@@ -25,11 +25,11 @@ import org.apache.lucene.search.DoubleValuesSource;
 /** Implements {@link Bindings} on top of the registered fields. */
 public final class FieldDefBindings extends Bindings {
 
-  private final Map<String, FieldDef> fields;
+  private final Function<String, FieldDef> fieldDefLookup;
 
   /** Sole constructor. */
-  public FieldDefBindings(Map<String, FieldDef> fields) {
-    this.fields = fields;
+  public FieldDefBindings(Function<String, FieldDef> fieldDefLookup) {
+    this.fieldDefLookup = fieldDefLookup;
   }
 
   /**
@@ -55,7 +55,7 @@ public final class FieldDefBindings extends Bindings {
     if (name.equals("_score")) {
       return DoubleValuesSource.SCORES;
     }
-    FieldDef fd = fields.get(name);
+    FieldDef fd = fieldDefLookup.apply(name);
     String property = Bindable.VALUE_PROPERTY;
     String fieldName = name;
     if (fd == null) {
@@ -72,7 +72,7 @@ public final class FieldDefBindings extends Bindings {
             "Invalid field binding format: " + name + ", expected: doc['field_name'].property");
       }
       fieldName = parsed[1].text;
-      fd = fields.get(fieldName);
+      fd = fieldDefLookup.apply(fieldName);
       if (fd == null) {
         throw new IllegalArgumentException("Unknown field to bind: " + fieldName);
       }

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/FieldAndFacetState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/FieldAndFacetState.java
@@ -17,7 +17,6 @@ package com.yelp.nrtsearch.server.luceneserver.index;
 
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.luceneserver.field.FieldDef;
-import com.yelp.nrtsearch.server.luceneserver.field.FieldDefBindings;
 import com.yelp.nrtsearch.server.luceneserver.field.IdFieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.IndexableFieldDef;
 import com.yelp.nrtsearch.server.luceneserver.field.ObjectFieldDef;
@@ -31,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.lucene.expressions.Bindings;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.FacetsConfig.DimConfig;
 
@@ -48,7 +46,6 @@ public class FieldAndFacetState {
   private final List<String> indexedAnalyzedFields;
   private final Map<String, FieldDef> eagerGlobalOrdinalFields;
   private final Map<String, GlobalOrdinalable> eagerFieldGlobalOrdinalFields;
-  private final Bindings exprBindings;
 
   // facet
   private final FacetsConfig facetsConfig;
@@ -62,7 +59,6 @@ public class FieldAndFacetState {
     indexedAnalyzedFields = Collections.emptyList();
     eagerGlobalOrdinalFields = Collections.emptyMap();
     eagerFieldGlobalOrdinalFields = Collections.emptyMap();
-    exprBindings = new FieldDefBindings(fields);
 
     facetsConfig = new FacetsConfig();
     internalFacetFieldNames = Collections.emptySet();
@@ -81,7 +77,6 @@ public class FieldAndFacetState {
     eagerGlobalOrdinalFields = Collections.unmodifiableMap(builder.eagerGlobalOrdinalFields);
     eagerFieldGlobalOrdinalFields =
         Collections.unmodifiableMap(builder.eagerFieldGlobalOrdinalFields);
-    exprBindings = builder.exprBindings;
 
     facetsConfig = builder.facetsConfig;
     internalFacetFieldNames = Collections.unmodifiableSet(builder.internalFacetFieldNames);
@@ -117,11 +112,6 @@ public class FieldAndFacetState {
     return eagerFieldGlobalOrdinalFields;
   }
 
-  /** Get field expression {@link Bindings} used for js scripting language. */
-  public Bindings getExprBindings() {
-    return exprBindings;
-  }
-
   /** Get facet config. */
   public FacetsConfig getFacetsConfig() {
     return facetsConfig;
@@ -145,7 +135,6 @@ public class FieldAndFacetState {
     private final List<String> indexedAnalyzedFields;
     private final Map<String, FieldDef> eagerGlobalOrdinalFields;
     private final Map<String, GlobalOrdinalable> eagerFieldGlobalOrdinalFields;
-    private final Bindings exprBindings;
 
     // facet
     private final FacetsConfig facetsConfig;
@@ -158,7 +147,6 @@ public class FieldAndFacetState {
       this.indexedAnalyzedFields = new ArrayList<>(initial.indexedAnalyzedFields);
       this.eagerGlobalOrdinalFields = new HashMap<>(initial.eagerGlobalOrdinalFields);
       this.eagerFieldGlobalOrdinalFields = new HashMap<>(initial.eagerFieldGlobalOrdinalFields);
-      this.exprBindings = new FieldDefBindings(this.fields);
 
       this.facetsConfig = new FacetsConfig();
       this.internalFacetFieldNames = new HashSet<>();
@@ -174,8 +162,13 @@ public class FieldAndFacetState {
       }
     }
 
-    public Bindings getBindings() {
-      return exprBindings;
+    /**
+     * Get fields currently registered with the builder.
+     *
+     * @return map of registered fields
+     */
+    public Map<String, FieldDef> getFields() {
+      return fields;
     }
 
     /**

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/ImmutableIndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/index/ImmutableIndexState.java
@@ -54,7 +54,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.lucene.expressions.Bindings;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.index.ConcurrentMergeScheduler;
 import org.apache.lucene.index.IndexWriterConfig;
@@ -467,11 +466,6 @@ public class ImmutableIndexState extends IndexState {
   @Override
   public Map<String, GlobalOrdinalable> getEagerFieldGlobalOrdinalFields() {
     return fieldAndFacetState.getFieldEagerGlobalOrdinalFields();
-  }
-
-  @Override
-  public Bindings getExpressionBindings() {
-    return fieldAndFacetState.getExprBindings();
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/luceneserver/search/SearchRequestProcessor.java
@@ -68,7 +68,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.lucene.facet.DrillDownQuery;
 import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager;
@@ -143,8 +142,7 @@ public class SearchRequestProcessor {
         getRetrieveFields(searchRequest.getRetrieveFieldsList(), queryFields);
     contextBuilder.setRetrieveFields(Collections.unmodifiableMap(retrieveFields));
 
-    Function<String, FieldDef> fieldDefLookup = (String s) -> queryFields.get(s);
-    DocLookup docLookup = new DocLookup(indexState, fieldDefLookup);
+    DocLookup docLookup = new DocLookup(queryFields::get);
     contextBuilder.setDocLookup(docLookup);
 
     String rootQueryNestedPath =
@@ -418,8 +416,8 @@ public class SearchRequestProcessor {
   /**
    * Add index fields to given query fields map.
    *
-   * @param indexState state for query index
    * @param queryFields mutable current map of query fields
+   * @param otherFields fields to add to query fields
    * @throws IllegalArgumentException if any index field already exists
    */
   private static void addToQueryFields(

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/index/ImmutableIndexStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/index/ImmutableIndexStateTest.java
@@ -72,7 +72,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import org.apache.lucene.expressions.Bindings;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.index.ConcurrentMergeScheduler;
 import org.apache.lucene.index.IndexWriterConfig;
@@ -1027,17 +1026,6 @@ public class ImmutableIndexStateTest {
     ImmutableIndexState indexState = getIndexState(getEmptyState(), mockFieldState);
     assertSame(eagerOrdinalFields, indexState.getEagerGlobalOrdinalFields());
     verify(mockFieldState, times(1)).getEagerGlobalOrdinalFields();
-    verifyNoMoreInteractions(mockFieldState);
-  }
-
-  @Test
-  public void testGetExpressionBindings() throws IOException {
-    FieldAndFacetState mockFieldState = mock(FieldAndFacetState.class);
-    Bindings mockBindings = mock(Bindings.class);
-    when(mockFieldState.getExprBindings()).thenReturn(mockBindings);
-    ImmutableIndexState indexState = getIndexState(getEmptyState(), mockFieldState);
-    assertSame(mockBindings, indexState.getExpressionBindings());
-    verify(mockFieldState, times(1)).getExprBindings();
     verifyNoMoreInteractions(mockFieldState);
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/index/handlers/FieldUpdateHandlerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/index/handlers/FieldUpdateHandlerTest.java
@@ -17,7 +17,6 @@ package com.yelp.nrtsearch.server.luceneserver.index.handlers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -116,7 +115,6 @@ public class FieldUpdateHandlerTest {
     assertTrue(fieldAndFacetState.getIdFieldDef().isEmpty());
     assertTrue(fieldAndFacetState.getIndexedAnalyzedFields().isEmpty());
     assertTrue(fieldAndFacetState.getEagerGlobalOrdinalFields().isEmpty());
-    assertNotNull(fieldAndFacetState.getExprBindings());
     assertTrue(fieldAndFacetState.getFacetsConfig().getDimConfigs().isEmpty());
     assertTrue(fieldAndFacetState.getInternalFacetFieldNames().isEmpty());
     return updatedFieldInfo;
@@ -168,7 +166,6 @@ public class FieldUpdateHandlerTest {
     assertTrue(fieldAndFacetState.getIdFieldDef().isEmpty());
     assertTrue(fieldAndFacetState.getIndexedAnalyzedFields().isEmpty());
     assertTrue(fieldAndFacetState.getEagerGlobalOrdinalFields().isEmpty());
-    assertNotNull(fieldAndFacetState.getExprBindings());
     assertTrue(fieldAndFacetState.getFacetsConfig().getDimConfigs().isEmpty());
     assertTrue(fieldAndFacetState.getInternalFacetFieldNames().isEmpty());
   }
@@ -215,7 +212,6 @@ public class FieldUpdateHandlerTest {
         fieldAndFacetState.getFields().get("field4"), fieldAndFacetState.getIdFieldDef().get());
     assertTrue(fieldAndFacetState.getIndexedAnalyzedFields().isEmpty());
     assertTrue(fieldAndFacetState.getEagerGlobalOrdinalFields().isEmpty());
-    assertNotNull(fieldAndFacetState.getExprBindings());
     assertTrue(fieldAndFacetState.getFacetsConfig().getDimConfigs().isEmpty());
     assertTrue(fieldAndFacetState.getInternalFacetFieldNames().isEmpty());
   }
@@ -303,7 +299,6 @@ public class FieldUpdateHandlerTest {
     assertEquals(
         Set.of("field3", "field4"), Sets.newHashSet(fieldAndFacetState.getIndexedAnalyzedFields()));
     assertTrue(fieldAndFacetState.getEagerGlobalOrdinalFields().isEmpty());
-    assertNotNull(fieldAndFacetState.getExprBindings());
     assertTrue(fieldAndFacetState.getFacetsConfig().getDimConfigs().isEmpty());
     assertTrue(fieldAndFacetState.getInternalFacetFieldNames().isEmpty());
   }
@@ -339,7 +334,6 @@ public class FieldUpdateHandlerTest {
     assertTrue(fieldAndFacetState.getIdFieldDef().isEmpty());
     assertTrue(fieldAndFacetState.getIndexedAnalyzedFields().isEmpty());
     assertTrue(fieldAndFacetState.getEagerGlobalOrdinalFields().isEmpty());
-    assertNotNull(fieldAndFacetState.getExprBindings());
     assertTrue(fieldAndFacetState.getFacetsConfig().getDimConfigs().isEmpty());
     assertTrue(fieldAndFacetState.getInternalFacetFieldNames().isEmpty());
   }
@@ -385,7 +379,6 @@ public class FieldUpdateHandlerTest {
     assertTrue(fieldAndFacetState.getIdFieldDef().isEmpty());
     assertTrue(fieldAndFacetState.getIndexedAnalyzedFields().isEmpty());
     assertTrue(fieldAndFacetState.getEagerGlobalOrdinalFields().isEmpty());
-    assertNotNull(fieldAndFacetState.getExprBindings());
     assertTrue(fieldAndFacetState.getFacetsConfig().getDimConfigs().isEmpty());
     assertTrue(fieldAndFacetState.getInternalFacetFieldNames().isEmpty());
   }
@@ -455,7 +448,6 @@ public class FieldUpdateHandlerTest {
         Set.of("field3.child1", "field3.child3.grandchild1"),
         Sets.newHashSet(fieldAndFacetState.getIndexedAnalyzedFields()));
     assertTrue(fieldAndFacetState.getEagerGlobalOrdinalFields().isEmpty());
-    assertNotNull(fieldAndFacetState.getExprBindings());
     assertTrue(fieldAndFacetState.getFacetsConfig().getDimConfigs().isEmpty());
     assertTrue(fieldAndFacetState.getInternalFacetFieldNames().isEmpty());
   }
@@ -526,7 +518,6 @@ public class FieldUpdateHandlerTest {
         Set.of("field3.child1", "field3.child3.grandchild1"),
         Sets.newHashSet(fieldAndFacetState.getIndexedAnalyzedFields()));
     assertTrue(fieldAndFacetState.getEagerGlobalOrdinalFields().isEmpty());
-    assertNotNull(fieldAndFacetState.getExprBindings());
     assertTrue(fieldAndFacetState.getFacetsConfig().getDimConfigs().isEmpty());
     assertTrue(fieldAndFacetState.getInternalFacetFieldNames().isEmpty());
   }
@@ -578,7 +569,6 @@ public class FieldUpdateHandlerTest {
     assertEquals(List.of("field3"), fieldAndFacetState.getIndexedAnalyzedFields());
     assertEquals(1, fieldAndFacetState.getEagerGlobalOrdinalFields().size());
     assertTrue(fieldAndFacetState.getEagerGlobalOrdinalFields().containsKey("field3"));
-    assertNotNull(fieldAndFacetState.getExprBindings());
     assertEquals(1, fieldAndFacetState.getFacetsConfig().getDimConfigs().size());
     DimConfig dimConfig = fieldAndFacetState.getFacetsConfig().getDimConfig("field3");
     assertTrue(dimConfig.multiValued);
@@ -619,7 +609,6 @@ public class FieldUpdateHandlerTest {
     assertEquals(Set.of("field3"), Sets.newHashSet(fieldAndFacetState.getIndexedAnalyzedFields()));
     assertEquals(1, fieldAndFacetState.getEagerGlobalOrdinalFields().size());
     assertTrue(fieldAndFacetState.getEagerGlobalOrdinalFields().containsKey("field3"));
-    assertNotNull(fieldAndFacetState.getExprBindings());
     assertEquals(2, fieldAndFacetState.getFacetsConfig().getDimConfigs().size());
     dimConfig = fieldAndFacetState.getFacetsConfig().getDimConfig("field3");
     assertTrue(dimConfig.multiValued);

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/ScoreScriptTest.java
@@ -60,7 +60,6 @@ import org.apache.lucene.search.DoubleValues;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -713,7 +712,6 @@ public class ScoreScriptTest {
     testQueryFieldScript("verify_doc_values", "registerFieldsBasic.json", "addDocs.csv", 1.5);
   }
 
-  @Ignore("Only js scripting language is supported in index fields now, enable after fix")
   @Test
   public void testScriptDocValuesIndexField() throws Exception {
     GrpcServer.TestServer testAddDocs =
@@ -841,7 +839,6 @@ public class ScoreScriptTest {
         Math.ulp(2.0));
   }
 
-  @Ignore("Only js scripting language is supported in index fields now, enable after fix")
   @Test
   public void testScriptUsingScoreInIndexField() throws Exception {
     GrpcServer.TestServer testAddDocs =

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/js/JsScriptBindingsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/script/js/JsScriptBindingsTest.java
@@ -79,7 +79,7 @@ public class JsScriptBindingsTest {
 
   @Test(expected = NullPointerException.class)
   public void testNullParams() {
-    new JsScriptBindings(new FieldDefBindings(Collections.emptyMap()), null);
+    new JsScriptBindings(new FieldDefBindings(name -> null), null);
   }
 
   @Test
@@ -88,8 +88,7 @@ public class JsScriptBindingsTest {
     params.put("param1", 100);
     params.put("param2", 1.11);
 
-    JsScriptBindings bindings =
-        new JsScriptBindings(new FieldDefBindings(Collections.emptyMap()), params);
+    JsScriptBindings bindings = new JsScriptBindings(new FieldDefBindings(name -> null), params);
     DoubleValuesSource p1Source = bindings.getDoubleValuesSource("param1");
     assertEquals(100D, p1Source.getValues(null, null).doubleValue(), 0.001);
     DoubleValuesSource p2Source = bindings.getDoubleValuesSource("param2");
@@ -108,7 +107,8 @@ public class JsScriptBindingsTest {
     fieldDefMap.put("field1", new VirtualFieldDef("field1", field1Source));
     fieldDefMap.put("field2", new VirtualFieldDef("field2", field2Source));
 
-    JsScriptBindings bindings = new JsScriptBindings(new FieldDefBindings(fieldDefMap), params);
+    JsScriptBindings bindings =
+        new JsScriptBindings(new FieldDefBindings(fieldDefMap::get), params);
     DoubleValuesSource f1Source = bindings.getDoubleValuesSource("field1");
     DoubleValuesSource f2Source = bindings.getDoubleValuesSource("field2");
     assertNotSame(f1Source, f2Source);
@@ -128,7 +128,8 @@ public class JsScriptBindingsTest {
     fieldDefMap.put("field1", new VirtualFieldDef("field1", field1Source));
     fieldDefMap.put("field2", new VirtualFieldDef("field2", field2Source));
 
-    JsScriptBindings bindings = new JsScriptBindings(new FieldDefBindings(fieldDefMap), params);
+    JsScriptBindings bindings =
+        new JsScriptBindings(new FieldDefBindings(fieldDefMap::get), params);
     bindings.getDoubleValuesSource("invalid");
   }
 
@@ -144,7 +145,8 @@ public class JsScriptBindingsTest {
     fieldDefMap.put("field1", new VirtualFieldDef("field1", field1Source));
     fieldDefMap.put("field2", new VirtualFieldDef("field2", field2Source));
 
-    JsScriptBindings bindings = new JsScriptBindings(new FieldDefBindings(fieldDefMap), params);
+    JsScriptBindings bindings =
+        new JsScriptBindings(new FieldDefBindings(fieldDefMap::get), params);
     bindings.getDoubleValuesSource("doc['invalid'].value");
   }
 
@@ -160,7 +162,8 @@ public class JsScriptBindingsTest {
     fieldDefMap.put("field1", new VirtualFieldDef("field1", field1Source));
     fieldDefMap.put("field2", new VirtualFieldDef("field2", field2Source));
 
-    JsScriptBindings bindings = new JsScriptBindings(new FieldDefBindings(fieldDefMap), params);
+    JsScriptBindings bindings =
+        new JsScriptBindings(new FieldDefBindings(fieldDefMap::get), params);
     bindings.getDoubleValuesSource("doc[1].value");
   }
 
@@ -176,7 +179,8 @@ public class JsScriptBindingsTest {
     fieldDefMap.put("field1", new VirtualFieldDef("field1", field1Source));
     fieldDefMap.put("field2", new VirtualFieldDef("field2", field2Source));
 
-    JsScriptBindings bindings = new JsScriptBindings(new FieldDefBindings(fieldDefMap), params);
+    JsScriptBindings bindings =
+        new JsScriptBindings(new FieldDefBindings(fieldDefMap::get), params);
     bindings.getDoubleValuesSource("not_doc['field1'].value");
   }
 
@@ -192,7 +196,8 @@ public class JsScriptBindingsTest {
     fieldDefMap.put("field1", new VirtualFieldDef("field1", field1Source));
     fieldDefMap.put("field2", new VirtualFieldDef("field2", field2Source));
 
-    JsScriptBindings bindings = new JsScriptBindings(new FieldDefBindings(fieldDefMap), params);
+    JsScriptBindings bindings =
+        new JsScriptBindings(new FieldDefBindings(fieldDefMap::get), params);
     bindings.getDoubleValuesSource("doc['field1']");
   }
 
@@ -202,8 +207,7 @@ public class JsScriptBindingsTest {
     params.put("param1", 100);
     params.put("param2", 1.11);
 
-    JsScriptBindings bindings =
-        new JsScriptBindings(new FieldDefBindings(Collections.emptyMap()), params);
+    JsScriptBindings bindings = new JsScriptBindings(new FieldDefBindings(name -> null), params);
     DoubleValuesSource p1Source = bindings.getDoubleValuesSource("param1");
     DoubleValuesSource p2Source = bindings.getDoubleValuesSource("param2");
     DoubleValuesSource p1SourceNext = bindings.getDoubleValuesSource("param1");

--- a/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/SearchContextTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/luceneserver/search/SearchContextTest.java
@@ -88,7 +88,7 @@ public class SearchContextTest extends ServerTestCase {
         .setCollector(new DummyCollector())
         .setFetchTasks(new FetchTasks(Collections.emptyList()))
         .setRescorers(Collections.emptyList())
-        .setDocLookup(new DocLookup(getGlobalState().getIndex(DEFAULT_TEST_INDEX), null))
+        .setDocLookup(new DocLookup(getGlobalState().getIndex(DEFAULT_TEST_INDEX)::getField))
         .setSharedDocContext(new DefaultSharedDocContext());
   }
 


### PR DESCRIPTION
Remove usage of `IndexState` from `DocLookup`. This class already has access to a `fieldDefLookup` function to get the `FieldDefs`.

This change allows us to simplify the expression binding handling used for the javascript script engine. It also remove the special case handling for javascript compilation, and restores the functionality of storing non-javascript script types as index virtual fields.