### PR TITLE
Rename some LuceneServer class in the server core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ dependencies {
 startScripts.enabled = false
 
 task luceneServer(type: CreateStartScripts) {
-    mainClass = 'com.yelp.nrtsearch.server.grpc.LuceneServer'
+    mainClass = 'com.yelp.nrtsearch.server.grpc.NrtsearchServer'
     applicationName = 'lucene-server'
     outputDir = new File(project.buildDir, 'tmp-app')
     classpath = startScripts.classpath
@@ -134,7 +134,7 @@ task luceneServer(type: CreateStartScripts) {
 }
 
 task luceneServerClient(type: CreateStartScripts) {
-    mainClass = 'com.yelp.nrtsearch.tools.cli.LuceneClientCommand'
+    mainClass = 'com.yelp.nrtsearch.tools.cli.NrtsearchClientCommand'
     applicationName = 'lucene-client'
     outputDir = new File(project.buildDir, 'tmp-app')
     classpath = startScripts.classpath

--- a/src/main/java/com/yelp/nrtsearch/server/analysis/AnalysisComponent.java
+++ b/src/main/java/com/yelp/nrtsearch/server/analysis/AnalysisComponent.java
@@ -15,13 +15,13 @@
  */
 package com.yelp.nrtsearch.server.analysis;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 
 /**
  * Interface to provide additional nrtsearch related information to components of {@link
  * org.apache.lucene.analysis.custom.CustomAnalyzer}s. The {@link
- * #initializeComponent(LuceneServerConfiguration)} method is called after the custom analyzer is
- * built, but before it is returned to the caller.
+ * #initializeComponent(NrtsearchConfig)} method is called after the custom analyzer is built, but
+ * before it is returned to the caller.
  *
  * <p>This is intended mainly to be used by custom implementations registered by plugins (currently
  * only token filters supported). This is needed because the custom analyzer building does not give
@@ -35,5 +35,5 @@ public interface AnalysisComponent {
    *
    * @param configuration nrtsearch config accessor
    */
-  void initializeComponent(LuceneServerConfiguration configuration);
+  void initializeComponent(NrtsearchConfig configuration);
 }

--- a/src/main/java/com/yelp/nrtsearch/server/analysis/AnalyzerCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/analysis/AnalyzerCreator.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.server.analysis;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.ConditionalTokenFilter;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.NameAndParams;
@@ -45,12 +45,12 @@ public class AnalyzerCreator {
 
   private static AnalyzerCreator instance;
 
-  private final LuceneServerConfiguration configuration;
+  private final NrtsearchConfig configuration;
   private final Map<String, AnalysisProvider<? extends Analyzer>> analyzerMap = new HashMap<>();
   private final Map<String, Class<? extends TokenFilterFactory>> tokenFilterMap = new HashMap<>();
   private final Map<String, Class<? extends CharFilterFactory>> charFilterMap = new HashMap<>();
 
-  public AnalyzerCreator(LuceneServerConfiguration configuration) {
+  public AnalyzerCreator(NrtsearchConfig configuration) {
     this.configuration = configuration;
     registerAnalyzer(STANDARD, name -> new StandardAnalyzer());
     registerAnalyzer(CLASSIC, name -> new ClassicAnalyzer());
@@ -131,7 +131,7 @@ public class AnalyzerCreator {
     charFilterMap.put(name, filterClass);
   }
 
-  public static void initialize(LuceneServerConfiguration configuration, Iterable<Plugin> plugins) {
+  public static void initialize(NrtsearchConfig configuration, Iterable<Plugin> plugins) {
     instance = new AnalyzerCreator(configuration);
     Set<String> builtInTokenFilters =
         TokenFilterFactory.availableTokenFilters().stream()

--- a/src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java
@@ -37,7 +37,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.lucene.search.suggest.document.CompletionPostingsFormat.FSTLoadMode;
 
-public class LuceneServerConfiguration {
+public class NrtsearchConfig {
   private static final Pattern ENV_VAR_PATTERN = Pattern.compile("\\$\\{([A-Za-z0-9_]+)}");
 
   private static final long AS_LARGE_AS_INFINITE = TimeUnit.DAYS.toSeconds(1000L);
@@ -110,7 +110,7 @@ public class LuceneServerConfiguration {
   private final boolean useKeepAliveForReplication;
 
   @Inject
-  public LuceneServerConfiguration(InputStream yamlStream) {
+  public NrtsearchConfig(InputStream yamlStream) {
     configReader = new YamlConfigReader(yamlStream);
 
     port = configReader.getInteger("port", DEFAULT_PORT);
@@ -148,7 +148,7 @@ public class LuceneServerConfiguration {
     pluginSearchPath =
         configReader.get(
             "pluginSearchPath",
-            LuceneServerConfiguration::getPluginSearchPath,
+            NrtsearchConfig::getPluginSearchPath,
             List.of(DEFAULT_PLUGIN_SEARCH_PATH.toString()));
     serviceName = configReader.getString("serviceName", DEFAULT_SERVICE_NAME);
     preloadConfig = IndexPreloadConfig.fromConfig(configReader);

--- a/src/main/java/com/yelp/nrtsearch/server/custom/request/CustomRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/custom/request/CustomRequestProcessor.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.server.custom.request;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.CustomRequest;
 import com.yelp.nrtsearch.server.grpc.CustomResponse;
 import com.yelp.nrtsearch.server.plugins.CustomRequestPlugin;
@@ -29,9 +29,9 @@ public class CustomRequestProcessor {
   private final Map<String, Map<String, CustomRequestPlugin.RequestProcessor>> routeMapping =
       new HashMap<>();
 
-  public CustomRequestProcessor(LuceneServerConfiguration configuration) {}
+  public CustomRequestProcessor(NrtsearchConfig configuration) {}
 
-  public static void initialize(LuceneServerConfiguration configuration, Iterable<Plugin> plugins) {
+  public static void initialize(NrtsearchConfig configuration, Iterable<Plugin> plugins) {
     instance = new CustomRequestProcessor(configuration);
     for (Plugin plugin : plugins) {
       if (plugin instanceof CustomRequestPlugin) {

--- a/src/main/java/com/yelp/nrtsearch/server/field/FieldDefCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/FieldDefCreator.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.server.field;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.FieldType;
 import com.yelp.nrtsearch.server.plugins.FieldTypePlugin;
@@ -34,7 +34,7 @@ public class FieldDefCreator {
 
   private final Map<String, FieldDefProvider<? extends FieldDef>> fieldDefMap = new HashMap<>();
 
-  public FieldDefCreator(LuceneServerConfiguration configuration) {
+  public FieldDefCreator(NrtsearchConfig configuration) {
     register("ATOM", AtomFieldDef::new);
     register("TEXT", TextFieldDef::new);
     register("BOOLEAN", BooleanFieldDef::new);
@@ -119,7 +119,7 @@ public class FieldDefCreator {
    * @param configuration service configuration
    * @param plugins list of loaded plugins
    */
-  public static void initialize(LuceneServerConfiguration configuration, Iterable<Plugin> plugins) {
+  public static void initialize(NrtsearchConfig configuration, Iterable<Plugin> plugins) {
     instance = new FieldDefCreator(configuration);
     for (Plugin plugin : plugins) {
       if (plugin instanceof FieldTypePlugin) {

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchClient.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchClient.java
@@ -35,9 +35,9 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** A simple client that requests a greeting from the {@link LuceneServer}. */
-public class LuceneServerClient implements Closeable {
-  private static final Logger logger = LoggerFactory.getLogger(LuceneServerClient.class.getName());
+/** A simple client that requests a greeting from the {@link NrtsearchServer}. */
+public class NrtsearchClient implements Closeable {
+  private static final Logger logger = LoggerFactory.getLogger(NrtsearchClient.class.getName());
 
   private final ManagedChannel channel;
 
@@ -53,7 +53,7 @@ public class LuceneServerClient implements Closeable {
   private final LuceneServerGrpc.LuceneServerStub asyncStub;
 
   /** Construct client connecting to LuceneServer server at {@code host:port}. */
-  public LuceneServerClient(String host, int port) {
+  public NrtsearchClient(String host, int port) {
     this(
         ManagedChannelBuilder.forAddress(host, port)
             // Channels are secure by default (via SSL/TLS). For the example we disable TLS to avoid
@@ -64,7 +64,7 @@ public class LuceneServerClient implements Closeable {
   }
 
   /** Construct client for accessing LuceneServer server using the existing channel. */
-  LuceneServerClient(ManagedChannel channel) {
+  NrtsearchClient(ManagedChannel channel) {
     this.channel = channel;
     blockingStub =
         LuceneServerGrpc.newBlockingStub(channel)
@@ -159,8 +159,7 @@ public class LuceneServerClient implements Closeable {
   public void settingsV2(String indexName, Path filePath) throws IOException {
     SettingsV2Request settingsRequest;
     if (filePath != null) {
-      settingsRequest =
-          new LuceneServerClientBuilder.SettingsV2ClientBuilder().buildRequest(filePath);
+      settingsRequest = new NrtsearchClientBuilder.SettingsV2ClientBuilder().buildRequest(filePath);
       settingsRequest = settingsRequest.toBuilder().setIndexName(indexName).build();
     } else {
       settingsRequest = SettingsV2Request.newBuilder().setIndexName(indexName).build();
@@ -181,7 +180,7 @@ public class LuceneServerClient implements Closeable {
 
   public void startIndex(Path filePath) throws IOException {
     StartIndexRequest startIndexRequest =
-        new LuceneServerClientBuilder.StartIndexClientBuilder().buildRequest(filePath);
+        new NrtsearchClientBuilder.StartIndexClientBuilder().buildRequest(filePath);
     StartIndexResponse response;
     try {
       response = blockingStub.startIndex(startIndexRequest);
@@ -321,7 +320,7 @@ public class LuceneServerClient implements Closeable {
 
   public void search(Path filePath) throws IOException {
     SearchRequest searchRequest =
-        new LuceneServerClientBuilder.SearchClientBuilder().buildRequest(filePath);
+        new NrtsearchClientBuilder.SearchClientBuilder().buildRequest(filePath);
     SearchResponse response;
     try {
       response = blockingStub.search(searchRequest);
@@ -334,7 +333,7 @@ public class LuceneServerClient implements Closeable {
 
   public void delete(Path filePath) throws IOException {
     AddDocumentRequest addDocumentRequest =
-        new LuceneServerClientBuilder.DeleteDocumentsBuilder().buildRequest(filePath);
+        new NrtsearchClientBuilder.DeleteDocumentsBuilder().buildRequest(filePath);
     AddDocumentResponse response;
     try {
       response = blockingStub.delete(addDocumentRequest);

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchClientBuilder.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchClientBuilder.java
@@ -31,11 +31,11 @@ import org.apache.commons.csv.CSVRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public interface LuceneServerClientBuilder<T> {
+public interface NrtsearchClientBuilder<T> {
 
   T buildRequest(Path filePath) throws IOException;
 
-  class SettingsClientBuilder implements LuceneServerClientBuilder<SettingsRequest> {
+  class SettingsClientBuilder implements NrtsearchClientBuilder<SettingsRequest> {
     private static final Logger logger =
         LoggerFactory.getLogger(SettingsClientBuilder.class.getName());
 
@@ -70,7 +70,7 @@ public interface LuceneServerClientBuilder<T> {
     }
   }
 
-  class SettingsV2ClientBuilder implements LuceneServerClientBuilder<SettingsV2Request> {
+  class SettingsV2ClientBuilder implements NrtsearchClientBuilder<SettingsV2Request> {
     private static final Logger logger =
         LoggerFactory.getLogger(SettingsClientBuilder.class.getName());
 
@@ -94,7 +94,7 @@ public interface LuceneServerClientBuilder<T> {
     }
   }
 
-  class StartIndexClientBuilder implements LuceneServerClientBuilder<StartIndexRequest> {
+  class StartIndexClientBuilder implements NrtsearchClientBuilder<StartIndexRequest> {
     private static final Logger logger =
         LoggerFactory.getLogger(StartIndexClientBuilder.class.getName());
 
@@ -116,7 +116,7 @@ public interface LuceneServerClientBuilder<T> {
     }
   }
 
-  class AddDocumentsClientBuilder implements LuceneServerClientBuilder<Stream<AddDocumentRequest>> {
+  class AddDocumentsClientBuilder implements NrtsearchClientBuilder<Stream<AddDocumentRequest>> {
     private static final Logger logger =
         LoggerFactory.getLogger(AddDocumentsClientBuilder.class.getName());
     private final String indexName;
@@ -153,7 +153,7 @@ public interface LuceneServerClientBuilder<T> {
   }
 
   class AddJsonDocumentsClientBuilder
-      implements LuceneServerClientBuilder<Stream<AddDocumentRequest>> {
+      implements NrtsearchClientBuilder<Stream<AddDocumentRequest>> {
     private static final Logger logger =
         LoggerFactory.getLogger(AddJsonDocumentsClientBuilder.class.getName());
     private final String indexName;
@@ -231,7 +231,7 @@ public interface LuceneServerClientBuilder<T> {
     }
   }
 
-  class SearchClientBuilder implements LuceneServerClientBuilder<SearchRequest> {
+  class SearchClientBuilder implements NrtsearchClientBuilder<SearchRequest> {
     private static final Logger logger =
         LoggerFactory.getLogger(SearchClientBuilder.class.getName());
 
@@ -253,7 +253,7 @@ public interface LuceneServerClientBuilder<T> {
     }
   }
 
-  class DeleteDocumentsBuilder implements LuceneServerClientBuilder<AddDocumentRequest> {
+  class DeleteDocumentsBuilder implements NrtsearchClientBuilder<AddDocumentRequest> {
     private static final Logger logger =
         LoggerFactory.getLogger(DeleteDocumentsBuilder.class.getName());
 

--- a/src/main/java/com/yelp/nrtsearch/server/handler/Handler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/Handler.java
@@ -18,6 +18,7 @@ package com.yelp.nrtsearch.server.handler;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.GeneratedMessageV3;
 import com.yelp.nrtsearch.server.grpc.LuceneServerStubBuilder;
+import com.yelp.nrtsearch.server.grpc.NrtsearchServer;
 import com.yelp.nrtsearch.server.grpc.ReplicationServerClient;
 import com.yelp.nrtsearch.server.state.GlobalState;
 import io.grpc.Status;
@@ -31,8 +32,8 @@ import org.slf4j.LoggerFactory;
  * streaming responses. For a gRPC method x, create a class xHandler that extends Handler. Override
  * the {@link #handle(StreamObserver)} method for streaming responses, or the {@link
  * #handle(GeneratedMessageV3, StreamObserver)} method for unary responses. Initialize the handler
- * in {@link com.yelp.nrtsearch.server.grpc.LuceneServer.LuceneServerImpl} and call the appropriate
- * method on the handler in the gRPC call.
+ * in {@link NrtsearchServer.LuceneServerImpl} and call the appropriate method on the handler in the
+ * gRPC call.
  *
  * @param <T> Request type
  * @param <S> Response type

--- a/src/main/java/com/yelp/nrtsearch/server/highlights/HighlighterService.java
+++ b/src/main/java/com/yelp/nrtsearch/server/highlights/HighlighterService.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.server.highlights;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.plugins.HighlighterPlugin;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import java.util.HashMap;
@@ -32,7 +32,7 @@ public class HighlighterService {
    *
    * @param configuration server configuration
    */
-  public HighlighterService(LuceneServerConfiguration configuration) {}
+  public HighlighterService(NrtsearchConfig configuration) {}
 
   private void register(Iterable<Highlighter> highlighters) {
     highlighters.forEach(highlighter -> register(highlighter.getName(), highlighter));
@@ -58,7 +58,7 @@ public class HighlighterService {
    * @param configuration service configuration
    * @param plugins list of loaded plugins
    */
-  public static void initialize(LuceneServerConfiguration configuration, Iterable<Plugin> plugins) {
+  public static void initialize(NrtsearchConfig configuration, Iterable<Plugin> plugins) {
     instance = new HighlighterService(configuration);
     initializeBuiltinHighlighters();
     for (Plugin plugin : plugins) {

--- a/src/main/java/com/yelp/nrtsearch/server/index/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/IndexState.java
@@ -17,7 +17,7 @@ package com.yelp.nrtsearch.server.index;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonObject;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.config.ThreadPoolConfiguration;
 import com.yelp.nrtsearch.server.doc.DocLookup;
 import com.yelp.nrtsearch.server.doc.SegmentDocLookup;
@@ -257,7 +257,7 @@ public abstract class IndexState implements Closeable {
   }
 
   public void initWarmer(RemoteBackend remoteBackend, String indexName) {
-    LuceneServerConfiguration configuration = globalState.getConfiguration();
+    NrtsearchConfig configuration = globalState.getConfiguration();
     WarmerConfig warmerConfig = configuration.getWarmerConfig();
     if (warmerConfig.isWarmOnStartup() || warmerConfig.getMaxWarmingQueries() > 0) {
       this.warmer =

--- a/src/main/java/com/yelp/nrtsearch/server/index/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/ShardState.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.server.index;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.field.FieldDef;
 import com.yelp.nrtsearch.server.field.IndexableFieldDef.FacetValueType;
 import com.yelp.nrtsearch.server.field.properties.GlobalOrdinalable;
@@ -940,7 +940,7 @@ public class ShardState implements Closeable {
       throw new IllegalStateException("index \"" + name + "\" was already started");
     }
     IndexState indexState = indexStateManager.getCurrent();
-    LuceneServerConfiguration configuration = indexState.getGlobalState().getConfiguration();
+    NrtsearchConfig configuration = indexState.getGlobalState().getConfiguration();
 
     // nocommit share code better w/ start and startPrimary!
     try {

--- a/src/main/java/com/yelp/nrtsearch/server/logging/HitsLoggerCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/logging/HitsLoggerCreator.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.server.logging;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.LoggingHits;
 import com.yelp.nrtsearch.server.plugins.HitsLoggerPlugin;
 import com.yelp.nrtsearch.server.plugins.Plugin;
@@ -33,7 +33,7 @@ public class HitsLoggerCreator {
    *
    * @param configuration server configuration
    */
-  public HitsLoggerCreator(LuceneServerConfiguration configuration) {}
+  public HitsLoggerCreator(NrtsearchConfig configuration) {}
 
   private void register(Map<String, HitsLoggerProvider<? extends HitsLogger>> hitsLoggers) {
     hitsLoggers.forEach(this::register);
@@ -53,7 +53,7 @@ public class HitsLoggerCreator {
    * @param configuration service configuration
    * @param plugins list of loaded plugins
    */
-  public static void initialize(LuceneServerConfiguration configuration, Iterable<Plugin> plugins) {
+  public static void initialize(NrtsearchConfig configuration, Iterable<Plugin> plugins) {
     instance = new HitsLoggerCreator(configuration);
     for (Plugin plugin : plugins) {
       if (plugin instanceof HitsLoggerPlugin loggerPlugin) {

--- a/src/main/java/com/yelp/nrtsearch/server/modules/BackendModule.java
+++ b/src/main/java/com/yelp/nrtsearch/server/modules/BackendModule.java
@@ -17,7 +17,7 @@ package com.yelp.nrtsearch.server.modules;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.google.inject.*;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.remote.RemoteBackend;
 import com.yelp.nrtsearch.server.remote.s3.S3Backend;
 
@@ -26,8 +26,7 @@ public class BackendModule extends AbstractModule {
   @Inject
   @Singleton
   @Provides
-  protected RemoteBackend providesRemoteBackend(
-      LuceneServerConfiguration configuration, AmazonS3 s3) {
+  protected RemoteBackend providesRemoteBackend(NrtsearchConfig configuration, AmazonS3 s3) {
     return new S3Backend(configuration, s3);
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/modules/NrtsearchModule.java
+++ b/src/main/java/com/yelp/nrtsearch/server/modules/NrtsearchModule.java
@@ -19,20 +19,20 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
-import com.yelp.nrtsearch.server.grpc.LuceneServer;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
+import com.yelp.nrtsearch.server.grpc.NrtsearchServer;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.util.Optional;
 
-public class LuceneServerModule extends AbstractModule {
+public class NrtsearchModule extends AbstractModule {
   private static final String DEFAULT_CONFIG_FILE_RESOURCE =
       "/lucene_server_default_configuration.yaml";
-  private final LuceneServer.LuceneServerCommand args;
+  private final NrtsearchServer.NrtsearchServerCommand args;
 
-  public LuceneServerModule(LuceneServer.LuceneServerCommand args) {
+  public NrtsearchModule(NrtsearchServer.NrtsearchServerCommand args) {
     this.args = args;
   }
 
@@ -52,17 +52,14 @@ public class LuceneServerModule extends AbstractModule {
   @Inject
   @Singleton
   @Provides
-  protected LuceneServerConfiguration providesLuceneServerConfiguration()
-      throws FileNotFoundException {
-    LuceneServerConfiguration luceneServerConfiguration;
+  protected NrtsearchConfig providesNrtsearchConfig() throws FileNotFoundException {
+    NrtsearchConfig luceneServerConfiguration;
     Optional<File> maybeConfigFile = args.maybeConfigFile();
     if (maybeConfigFile.isEmpty()) {
       luceneServerConfiguration =
-          new LuceneServerConfiguration(
-              getClass().getResourceAsStream(DEFAULT_CONFIG_FILE_RESOURCE));
+          new NrtsearchConfig(getClass().getResourceAsStream(DEFAULT_CONFIG_FILE_RESOURCE));
     } else {
-      luceneServerConfiguration =
-          new LuceneServerConfiguration(new FileInputStream(maybeConfigFile.get()));
+      luceneServerConfiguration = new NrtsearchConfig(new FileInputStream(maybeConfigFile.get()));
     }
     return luceneServerConfiguration;
   }

--- a/src/main/java/com/yelp/nrtsearch/server/modules/S3Module.java
+++ b/src/main/java/com/yelp/nrtsearch/server/modules/S3Module.java
@@ -20,14 +20,14 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.remote.s3.S3Util;
 
 public class S3Module extends AbstractModule {
   @Inject
   @Singleton
   @Provides
-  protected AmazonS3 providesAmazonS3(LuceneServerConfiguration luceneServerConfiguration) {
+  protected AmazonS3 providesAmazonS3(NrtsearchConfig luceneServerConfiguration) {
     return S3Util.buildS3Client(luceneServerConfiguration);
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/NrtsearchMonitoringServerInterceptor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/NrtsearchMonitoringServerInterceptor.java
@@ -23,17 +23,17 @@ import io.grpc.ServerInterceptor;
 import java.time.Clock;
 
 /** A {@link ServerInterceptor} which sends stats about incoming grpc calls to Prometheus. */
-public class LuceneServerMonitoringServerInterceptor implements ServerInterceptor {
+public class NrtsearchMonitoringServerInterceptor implements ServerInterceptor {
   private final Clock clock;
   private final Configuration configuration;
   private final ServerMetrics.Factory serverMetricsFactory;
 
-  public static LuceneServerMonitoringServerInterceptor create(Configuration configuration) {
-    return new LuceneServerMonitoringServerInterceptor(
+  public static NrtsearchMonitoringServerInterceptor create(Configuration configuration) {
+    return new NrtsearchMonitoringServerInterceptor(
         Clock.systemDefaultZone(), configuration, new ServerMetrics.Factory(configuration));
   }
 
-  private LuceneServerMonitoringServerInterceptor(
+  private NrtsearchMonitoringServerInterceptor(
       Clock clock, Configuration configuration, ServerMetrics.Factory serverMetricsFactory) {
     this.clock = clock;
     this.configuration = configuration;

--- a/src/main/java/com/yelp/nrtsearch/server/plugins/HighlighterPlugin.java
+++ b/src/main/java/com/yelp/nrtsearch/server/plugins/HighlighterPlugin.java
@@ -15,15 +15,16 @@
  */
 package com.yelp.nrtsearch.server.plugins;
 
+import com.yelp.nrtsearch.server.grpc.NrtsearchServer;
 import com.yelp.nrtsearch.server.highlights.Highlighter;
 import com.yelp.nrtsearch.server.highlights.HighlighterService;
 import java.util.Collections;
 
 /**
  * Plugin interface for providing custom highlighters. The plugins will be loaded at the startup
- * time of the {@link com.yelp.nrtsearch.server.grpc.LuceneServer}. The highlighter instances
- * provided from the getHighlighters will be responsible for handling the corresponding highlight
- * tasks (identified by name). Therefore, do not alter the instance object for any requests.
+ * time of the {@link NrtsearchServer}. The highlighter instances provided from the getHighlighters
+ * will be responsible for handling the corresponding highlight tasks (identified by name).
+ * Therefore, do not alter the instance object for any requests.
  */
 public interface HighlighterPlugin {
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/plugins/HitsLoggerPlugin.java
+++ b/src/main/java/com/yelp/nrtsearch/server/plugins/HitsLoggerPlugin.java
@@ -15,6 +15,7 @@
  */
 package com.yelp.nrtsearch.server.plugins;
 
+import com.yelp.nrtsearch.server.grpc.NrtsearchServer;
 import com.yelp.nrtsearch.server.logging.HitsLogger;
 import com.yelp.nrtsearch.server.logging.HitsLoggerProvider;
 import java.util.Collections;
@@ -22,9 +23,9 @@ import java.util.Map;
 
 /**
  * Plugin interface for providing custom logging. The plugins will be loaded at the startup time of
- * the {@link com.yelp.nrtsearch.server.grpc.LuceneServer}. The hits logger instances provided from
- * the getHitsLoggers() will be responsible for handling the corresponding hits logger task.
- * Therefore, do not alter the instance objects for any requests.
+ * the {@link NrtsearchServer}. The hits logger instances provided from the getHitsLoggers() will be
+ * responsible for handling the corresponding hits logger task. Therefore, do not alter the instance
+ * objects for any requests.
  */
 public interface HitsLoggerPlugin {
   default Map<String, HitsLoggerProvider<? extends HitsLogger>> getHitsLoggers() {

--- a/src/main/java/com/yelp/nrtsearch/server/plugins/PluginsService.java
+++ b/src/main/java/com/yelp/nrtsearch/server/plugins/PluginsService.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.server.plugins;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.remote.PluginDownloader;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.File;
@@ -33,23 +33,23 @@ import org.slf4j.LoggerFactory;
 /**
  * Class to handle the loading and registration of nrtsearch plugins.
  *
- * <p>Loads the plugins specified by the {@link LuceneServerConfiguration}. Plugins are located by
- * searching the config provided plugin search path for a folder matching the plugin name. A
- * classloader is created with the jars provided in the plugin directory. The plugin provides a
- * config file containing the {@link Plugin} classname that should be loaded. Reflection is used to
- * give the loaded plugin access to the lucene server config.
+ * <p>Loads the plugins specified by the {@link NrtsearchConfig}. Plugins are located by searching
+ * the config provided plugin search path for a folder matching the plugin name. A classloader is
+ * created with the jars provided in the plugin directory. The plugin provides a config file
+ * containing the {@link Plugin} classname that should be loaded. Reflection is used to give the
+ * loaded plugin access to the lucene server config.
  */
 public class PluginsService {
   private static final Logger logger = LoggerFactory.getLogger(PluginsService.class);
 
-  private final LuceneServerConfiguration config;
+  private final NrtsearchConfig config;
   private final PrometheusRegistry prometheusRegistry;
   private final List<PluginDescriptor> loadedPluginDescriptors = new ArrayList<>();
 
   private final PluginDownloader pluginDownloader;
 
   public PluginsService(
-      LuceneServerConfiguration config,
+      NrtsearchConfig config,
       PluginDownloader pluginDownloader,
       PrometheusRegistry prometheusRegistry) {
     this.config = config;
@@ -58,8 +58,8 @@ public class PluginsService {
   }
 
   /**
-   * Load the list of plugins specified in the {@link LuceneServerConfiguration}. This handles both
-   * the loading of the plugin class from provided jars and creation of a new instance.
+   * Load the list of plugins specified in the {@link NrtsearchConfig}. This handles both the
+   * loading of the plugin class from provided jars and creation of a new instance.
    *
    * @return list of loaded plugin instances
    */
@@ -190,7 +190,7 @@ public class PluginsService {
     try {
       Plugin plugin =
           pluginClass
-              .getDeclaredConstructor(new Class[] {LuceneServerConfiguration.class})
+              .getDeclaredConstructor(new Class[] {NrtsearchConfig.class})
               .newInstance(config);
       if (plugin instanceof MetricsPlugin) {
         ((MetricsPlugin) plugin).registerMetrics(prometheusRegistry);

--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
@@ -30,7 +30,7 @@ import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.google.common.annotations.VisibleForTesting;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.nrt.state.NrtFileMetaData;
 import com.yelp.nrtsearch.server.nrt.state.NrtPointState;
 import com.yelp.nrtsearch.server.remote.RemoteBackend;
@@ -95,7 +95,7 @@ public class S3Backend implements RemoteBackend {
    * @param configuration configuration
    * @param s3 s3 client
    */
-  public S3Backend(LuceneServerConfiguration configuration, AmazonS3 s3) {
+  public S3Backend(NrtsearchConfig configuration, AmazonS3 s3) {
     this(configuration.getBucketName(), configuration.getSavePluginBeforeUnzip(), s3);
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Util.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Util.java
@@ -31,7 +31,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.AmazonS3URI;
 import com.google.common.base.Strings;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.slf4j.Logger;
@@ -49,7 +49,7 @@ public class S3Util {
    * @param luceneServerConfiguration configuration
    * @return s3 client
    */
-  public static AmazonS3 buildS3Client(LuceneServerConfiguration luceneServerConfiguration) {
+  public static AmazonS3 buildS3Client(NrtsearchConfig luceneServerConfiguration) {
     AWSCredentialsProvider awsCredentialsProvider;
     if (luceneServerConfiguration.getBotoCfgPath() == null) {
       awsCredentialsProvider = new DefaultAWSCredentialsProviderChain();

--- a/src/main/java/com/yelp/nrtsearch/server/rescore/RescorerCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/rescore/RescorerCreator.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.server.rescore;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.PluginRescorer;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.plugins.RescorerPlugin;
@@ -34,7 +34,7 @@ public class RescorerCreator {
   private final Map<String, RescorerProvider<? extends RescoreOperation>> rescorersMap =
       new HashMap<>();
 
-  public RescorerCreator(LuceneServerConfiguration configuration) {}
+  public RescorerCreator(NrtsearchConfig configuration) {}
 
   /**
    * Get a {@link RescoreOperation} implementation by name, and with the given parameters. Valid
@@ -73,7 +73,7 @@ public class RescorerCreator {
    * @param configuration service configuration
    * @param plugins list of loaded plugins
    */
-  public static void initialize(LuceneServerConfiguration configuration, Iterable<Plugin> plugins) {
+  public static void initialize(NrtsearchConfig configuration, Iterable<Plugin> plugins) {
     instance = new RescorerCreator(configuration);
     for (Plugin plugin : plugins) {
       if (plugin instanceof RescorerPlugin) {

--- a/src/main/java/com/yelp/nrtsearch/server/script/ScriptService.java
+++ b/src/main/java/com/yelp/nrtsearch/server/script/ScriptService.java
@@ -19,7 +19,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.config.ScriptCacheConfig;
 import com.yelp.nrtsearch.server.grpc.Script;
 import com.yelp.nrtsearch.server.plugins.Plugin;
@@ -53,7 +53,7 @@ public class ScriptService {
   private final Map<String, ScriptEngine> scriptEngineMap = new HashMap<>();
   private final LoadingCache<ScriptCacheKey, Object> scriptCache;
 
-  private ScriptService(LuceneServerConfiguration configuration) {
+  private ScriptService(NrtsearchConfig configuration) {
     // add provided javascript engine
     scriptEngineMap.put("js", new JsScriptEngine());
 
@@ -118,7 +118,7 @@ public class ScriptService {
    * @param configuration server configuration
    * @param plugins loaded plugins
    */
-  public static void initialize(LuceneServerConfiguration configuration, Iterable<Plugin> plugins) {
+  public static void initialize(NrtsearchConfig configuration, Iterable<Plugin> plugins) {
     instance = new ScriptService(configuration);
     for (Plugin plugin : plugins) {
       if (plugin instanceof ScriptPlugin) {

--- a/src/main/java/com/yelp/nrtsearch/server/search/FetchTaskCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/FetchTaskCreator.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.server.search;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.FetchTask;
 import com.yelp.nrtsearch.server.plugins.FetchTaskPlugin;
 import com.yelp.nrtsearch.server.plugins.Plugin;
@@ -35,7 +35,7 @@ public class FetchTaskCreator {
    *
    * @param configuration server configuration
    */
-  public FetchTaskCreator(LuceneServerConfiguration configuration) {}
+  public FetchTaskCreator(NrtsearchConfig configuration) {}
 
   /**
    * Create a {@link FetchTasks.FetchTask} instance given the {@link FetchTask} message from the
@@ -70,7 +70,7 @@ public class FetchTaskCreator {
    * @param configuration service configuration
    * @param plugins list of loaded plugins
    */
-  public static void initialize(LuceneServerConfiguration configuration, Iterable<Plugin> plugins) {
+  public static void initialize(NrtsearchConfig configuration, Iterable<Plugin> plugins) {
     instance = new FetchTaskCreator(configuration);
     for (Plugin plugin : plugins) {
       if (plugin instanceof FetchTaskPlugin) {

--- a/src/main/java/com/yelp/nrtsearch/server/search/collectors/CollectorCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/collectors/CollectorCreator.java
@@ -16,7 +16,7 @@
 package com.yelp.nrtsearch.server.search.collectors;
 
 import com.yelp.nrtsearch.server.collectors.BucketOrder;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.Collector;
 import com.yelp.nrtsearch.server.grpc.CollectorResult;
 import com.yelp.nrtsearch.server.grpc.PluginCollector;
@@ -50,7 +50,7 @@ public class CollectorCreator {
                       ? extends org.apache.lucene.search.Collector, CollectorResult>>>
       collectorsMap = new HashMap<>();
 
-  private CollectorCreator(LuceneServerConfiguration configuration) {}
+  private CollectorCreator(NrtsearchConfig configuration) {}
 
   /**
    * Create {@link AdditionalCollectorManager} for the given {@link Collector} definition message.
@@ -157,7 +157,7 @@ public class CollectorCreator {
    * @param configuration service configuration
    * @param plugins list of loaded plugins
    */
-  public static void initialize(LuceneServerConfiguration configuration, Iterable<Plugin> plugins) {
+  public static void initialize(NrtsearchConfig configuration, Iterable<Plugin> plugins) {
     instance = new CollectorCreator(configuration);
     for (Plugin plugin : plugins) {
       if (plugin instanceof CollectorPlugin) {

--- a/src/main/java/com/yelp/nrtsearch/server/similarity/SimilarityCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/similarity/SimilarityCreator.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.server.similarity;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.plugins.SimilarityPlugin;
 import java.util.HashMap;
@@ -36,7 +36,7 @@ public class SimilarityCreator {
   private final Map<String, SimilarityProvider<? extends Similarity>> similarityMap =
       new HashMap<>();
 
-  public SimilarityCreator(LuceneServerConfiguration configuration) {
+  public SimilarityCreator(NrtsearchConfig configuration) {
     register("classic", params -> new ClassicSimilarity());
     register("BM25", params -> new BM25Similarity());
     register("boolean", params -> new BooleanSimilarity());
@@ -81,7 +81,7 @@ public class SimilarityCreator {
    * @param configuration service configuration
    * @param plugins list of loaded plugins
    */
-  public static void initialize(LuceneServerConfiguration configuration, Iterable<Plugin> plugins) {
+  public static void initialize(NrtsearchConfig configuration, Iterable<Plugin> plugins) {
     instance = new SimilarityCreator(configuration);
     for (Plugin plugin : plugins) {
       if (plugin instanceof SimilarityPlugin) {

--- a/src/main/java/com/yelp/nrtsearch/server/state/BackendGlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/state/BackendGlobalState.java
@@ -20,7 +20,7 @@ import static com.yelp.nrtsearch.server.utils.TimeStringUtils.generateTimeString
 import com.google.common.annotations.VisibleForTesting;
 import com.yelp.nrtsearch.server.config.IndexStartConfig;
 import com.yelp.nrtsearch.server.config.IndexStartConfig.IndexDataLocationType;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.CreateIndexRequest;
 import com.yelp.nrtsearch.server.grpc.DummyResponse;
 import com.yelp.nrtsearch.server.grpc.GlobalStateInfo;
@@ -103,8 +103,7 @@ public class BackendGlobalState extends GlobalState {
    * @param remoteBackend backend for persistent remote storage
    * @throws IOException on filesystem error
    */
-  public BackendGlobalState(
-      LuceneServerConfiguration luceneServerConfiguration, RemoteBackend remoteBackend)
+  public BackendGlobalState(NrtsearchConfig luceneServerConfiguration, RemoteBackend remoteBackend)
       throws IOException {
     super(luceneServerConfiguration, remoteBackend);
     stateBackend = createStateBackend();

--- a/src/main/java/com/yelp/nrtsearch/server/state/GlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/state/GlobalState.java
@@ -16,7 +16,7 @@
 package com.yelp.nrtsearch.server.state;
 
 import com.yelp.nrtsearch.server.concurrent.ThreadPoolExecutorFactory;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.config.ThreadPoolConfiguration;
 import com.yelp.nrtsearch.server.grpc.CreateIndexRequest;
 import com.yelp.nrtsearch.server.grpc.DummyResponse;
@@ -55,7 +55,7 @@ public abstract class GlobalState implements Closeable {
 
   private final String nodeName;
 
-  private final LuceneServerConfiguration configuration;
+  private final NrtsearchConfig configuration;
 
   /** Server shuts down once this latch is decremented. */
   private final CountDownLatch shutdownNow = new CountDownLatch(1);
@@ -68,8 +68,7 @@ public abstract class GlobalState implements Closeable {
   private final ThreadPoolExecutor searchThreadPoolExecutor;
 
   public static GlobalState createState(
-      LuceneServerConfiguration luceneServerConfiguration, RemoteBackend remoteBackend)
-      throws IOException {
+      NrtsearchConfig luceneServerConfiguration, RemoteBackend remoteBackend) throws IOException {
     return new BackendGlobalState(luceneServerConfiguration, remoteBackend);
   }
 
@@ -77,8 +76,7 @@ public abstract class GlobalState implements Closeable {
     return remoteBackend;
   }
 
-  protected GlobalState(
-      LuceneServerConfiguration luceneServerConfiguration, RemoteBackend remoteBackend)
+  protected GlobalState(NrtsearchConfig luceneServerConfiguration, RemoteBackend remoteBackend)
       throws IOException {
     this.remoteBackend = remoteBackend;
     this.nodeName = luceneServerConfiguration.getNodeName();
@@ -104,7 +102,7 @@ public abstract class GlobalState implements Closeable {
     this.configuration = luceneServerConfiguration;
   }
 
-  public LuceneServerConfiguration getConfiguration() {
+  public NrtsearchConfig getConfiguration() {
     return configuration;
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/state/backend/RemoteStateBackend.java
+++ b/src/main/java/com/yelp/nrtsearch/server/state/backend/RemoteStateBackend.java
@@ -16,7 +16,7 @@
 package com.yelp.nrtsearch.server.state.backend;
 
 import com.google.protobuf.util.JsonFormat;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.config.StateConfig;
 import com.yelp.nrtsearch.server.grpc.GlobalStateInfo;
 import com.yelp.nrtsearch.server.grpc.IndexStateInfo;
@@ -54,8 +54,7 @@ public class RemoteStateBackend implements StateBackend {
      * @param luceneServerConfiguration server configuration
      * @return config for remote backend
      */
-    public static RemoteBackendConfig fromConfig(
-        LuceneServerConfiguration luceneServerConfiguration) {
+    public static RemoteBackendConfig fromConfig(NrtsearchConfig luceneServerConfiguration) {
       boolean readOnly =
           luceneServerConfiguration.getConfigReader().getBoolean(CONFIG_PREFIX + "readOnly", true);
       return new RemoteBackendConfig(readOnly);

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/AddDocumentsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/AddDocumentsCommand.java
@@ -19,8 +19,8 @@ import static com.yelp.nrtsearch.tools.cli.AddDocumentsCommand.ADD_DOCUMENTS;
 
 import com.google.gson.Gson;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
-import com.yelp.nrtsearch.server.grpc.LuceneServerClientBuilder;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClientBuilder;
 import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -35,7 +35,7 @@ import picocli.CommandLine;
 public class AddDocumentsCommand implements Callable<Integer> {
   public static final String ADD_DOCUMENTS = "addDocuments";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-f", "--fileName"},
@@ -81,7 +81,7 @@ public class AddDocumentsCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       String indexName = getIndexName();
       String fileType = getFileType();
@@ -91,12 +91,12 @@ public class AddDocumentsCommand implements Callable<Integer> {
         Reader reader = Files.newBufferedReader(filePath);
         CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT.withFirstRecordAsHeader());
         addDocumentRequestStream =
-            new LuceneServerClientBuilder.AddDocumentsClientBuilder(indexName, csvParser)
+            new NrtsearchClientBuilder.AddDocumentsClientBuilder(indexName, csvParser)
                 .buildRequest(filePath);
         client.addDocuments(addDocumentRequestStream);
       } else if (fileType.equalsIgnoreCase("json")) {
-        LuceneServerClientBuilder.AddJsonDocumentsClientBuilder addJsonDocumentsClientBuilder =
-            new LuceneServerClientBuilder.AddJsonDocumentsClientBuilder(
+        NrtsearchClientBuilder.AddJsonDocumentsClientBuilder addJsonDocumentsClientBuilder =
+            new NrtsearchClientBuilder.AddJsonDocumentsClientBuilder(
                 indexName, new Gson(), filePath, getMaxBufferLen());
         while (!addJsonDocumentsClientBuilder.isFinished()) {
           addDocumentRequestStream = addJsonDocumentsClientBuilder.buildRequest(filePath);

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/BackupWarmingQueriesCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/BackupWarmingQueriesCommand.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.tools.cli;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
@@ -25,7 +25,7 @@ import picocli.CommandLine;
 public class BackupWarmingQueriesCommand implements Callable<Integer> {
   public static final String BACKUP_WARMING_QUERIES = "backupWarmingQueries";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-i", "--index"},
@@ -66,7 +66,7 @@ public class BackupWarmingQueriesCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       client.backupWarmingQueries(
           getIndex(), getServiceName(), getNumQueriesThreshold(), getUptimeMinutesThreshold());

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/CommitCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/CommitCommand.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.tools.cli;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
@@ -25,7 +25,7 @@ import picocli.CommandLine;
 public class CommitCommand implements Callable<Integer> {
   public static final String COMMIT = "commit";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-i", "--indexName"},
@@ -39,7 +39,7 @@ public class CommitCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       client.commit(getIndexName());
     } finally {

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/CreateIndexCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/CreateIndexCommand.java
@@ -18,7 +18,7 @@ package com.yelp.nrtsearch.tools.cli;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
 import com.yelp.nrtsearch.server.grpc.IndexLiveSettings;
 import com.yelp.nrtsearch.server.grpc.IndexSettings;
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
@@ -28,7 +28,7 @@ import picocli.CommandLine;
 public class CreateIndexCommand implements Callable<Integer> {
   public static final String CREATE_INDEX = "createIndex";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-i", "--indexName"},
@@ -72,7 +72,7 @@ public class CreateIndexCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       IndexSettings indexSettings = null;
       IndexLiveSettings indexLiveSettings = null;

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/DeleteAllDocumentsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/DeleteAllDocumentsCommand.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.tools.cli;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
@@ -25,7 +25,7 @@ import picocli.CommandLine;
 public class DeleteAllDocumentsCommand implements Callable<Integer> {
   public static final String DELETE_ALL_DOCS = "deleteAllDocs";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-i", "--indexName"},
@@ -39,7 +39,7 @@ public class DeleteAllDocumentsCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       client.deleteAllDocuments(getIndexName());
     } finally {

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/DeleteDocumentsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/DeleteDocumentsCommand.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.tools.cli;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.Callable;
@@ -27,7 +27,7 @@ import picocli.CommandLine;
 public class DeleteDocumentsCommand implements Callable<Integer> {
   public static final String DELETE_DOCS = "delete";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-i", "--indexName"},
@@ -51,7 +51,7 @@ public class DeleteDocumentsCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       Path filePath = Paths.get(getFileName());
       client.delete(filePath);

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/DeleteIndexCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/DeleteIndexCommand.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.tools.cli;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
@@ -23,7 +23,7 @@ import picocli.CommandLine;
 public class DeleteIndexCommand implements Callable<Integer> {
   public static final String DELETE_INDEX = "deleteIndex";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-i", "--indexName"},
@@ -37,7 +37,7 @@ public class DeleteIndexCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       client.deleteIndex(getIndexName());
     } finally {

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/ForceMergeCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/ForceMergeCommand.java
@@ -17,7 +17,7 @@ package com.yelp.nrtsearch.tools.cli;
 
 import com.yelp.nrtsearch.server.grpc.ForceMergeRequest;
 import com.yelp.nrtsearch.server.grpc.ForceMergeResponse;
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.util.concurrent.Callable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,7 +28,7 @@ public class ForceMergeCommand implements Callable<Integer> {
   private static final Logger logger = LoggerFactory.getLogger(ForceMergeCommand.class);
   public static final String FORCE_MERGE = "forceMerge";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-i", "--indexName"},
@@ -63,7 +63,7 @@ public class ForceMergeCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       ForceMergeResponse response =
           client

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/ForceMergeDeletesCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/ForceMergeDeletesCommand.java
@@ -17,7 +17,7 @@ package com.yelp.nrtsearch.tools.cli;
 
 import com.yelp.nrtsearch.server.grpc.ForceMergeDeletesRequest;
 import com.yelp.nrtsearch.server.grpc.ForceMergeDeletesResponse;
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.util.concurrent.Callable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,7 +30,7 @@ public class ForceMergeDeletesCommand implements Callable<Integer> {
   private static final Logger logger = LoggerFactory.getLogger(ForceMergeDeletesCommand.class);
   public static final String FORCE_MERGE_DELETES = "forceMergeDeletes";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-i", "--indexName"},
@@ -55,7 +55,7 @@ public class ForceMergeDeletesCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       ForceMergeDeletesResponse response =
           client

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/GetCurrentSearcherVersion.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/GetCurrentSearcherVersion.java
@@ -15,9 +15,9 @@
  */
 package com.yelp.nrtsearch.tools.cli;
 
-import static com.yelp.nrtsearch.tools.cli.LuceneClientCommand.logger;
+import static com.yelp.nrtsearch.tools.cli.NrtsearchClientCommand.logger;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import com.yelp.nrtsearch.server.grpc.ReplicationServerClient;
 import com.yelp.nrtsearch.server.grpc.SearcherVersion;
 import java.util.concurrent.Callable;
@@ -30,7 +30,7 @@ import picocli.CommandLine;
 public class GetCurrentSearcherVersion implements Callable<Integer> {
   public static final String CURRENT_SEARCHER_VERSION = "currSearcherVer";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-i", "--indexName"},
@@ -64,7 +64,7 @@ public class GetCurrentSearcherVersion implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       ReplicationServerClient replServerClient =
           new ReplicationServerClient(getHostName(), getPort());

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/IndicesCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/IndicesCommand.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.tools.cli;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.util.List;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
@@ -25,11 +25,11 @@ public class IndicesCommand implements Callable<Integer> {
 
   public static final String INDICES = "indices";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       List<String> indicesList = client.getIndices();
       System.out.println();

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/LiveSettingsV2Command.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/LiveSettingsV2Command.java
@@ -21,7 +21,7 @@ import com.google.protobuf.Int32Value;
 import com.google.protobuf.UInt64Value;
 import com.yelp.nrtsearch.server.grpc.IndexLiveSettings;
 import com.yelp.nrtsearch.server.grpc.LiveSettingsV2Request;
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
@@ -31,7 +31,7 @@ import picocli.CommandLine;
 public class LiveSettingsV2Command implements Callable<Integer> {
   public static final String LIVE_SETTINGS_V2 = "liveSettingsV2";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-i", "--indexName"},
@@ -136,7 +136,7 @@ public class LiveSettingsV2Command implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       LiveSettingsV2Request.Builder settingsRequestV2Builder = LiveSettingsV2Request.newBuilder();
       settingsRequestV2Builder.setIndexName(indexName);

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/NrtsearchClientCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/NrtsearchClientCommand.java
@@ -16,7 +16,7 @@
 package com.yelp.nrtsearch.tools.cli;
 
 import com.yelp.nrtsearch.server.Version;
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -52,8 +52,9 @@ import picocli.CommandLine;
       WriteNRTPointCommand.class,
       CommandLine.HelpCommand.class
     })
-public class LuceneClientCommand implements Runnable {
-  public static final Logger logger = LoggerFactory.getLogger(LuceneClientCommand.class.getName());
+public class NrtsearchClientCommand implements Runnable {
+  public static final Logger logger =
+      LoggerFactory.getLogger(NrtsearchClientCommand.class.getName());
 
   @CommandLine.Option(
       names = {"-p", "--port"},
@@ -80,12 +81,12 @@ public class LuceneClientCommand implements Runnable {
     return hostname;
   }
 
-  public LuceneServerClient getClient() {
-    return new LuceneServerClient(getHostname(), getPort());
+  public NrtsearchClient getClient() {
+    return new NrtsearchClient(getHostname(), getPort());
   }
 
   public static void main(String[] args) {
-    System.exit(new CommandLine(new LuceneClientCommand()).execute(args));
+    System.exit(new CommandLine(new NrtsearchClientCommand()).execute(args));
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/ReadyCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/ReadyCommand.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.tools.cli;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
@@ -25,7 +25,7 @@ import picocli.CommandLine;
 public class ReadyCommand implements Callable<Integer> {
   public static final String READY = "ready";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-i", "--indices"},
@@ -36,7 +36,7 @@ public class ReadyCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     boolean ready;
     try {
       ready = client.ready(indices);

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/RefreshCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/RefreshCommand.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.tools.cli;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
@@ -25,7 +25,7 @@ import picocli.CommandLine;
 public class RefreshCommand implements Callable<Integer> {
   public static final String REFRESH = "refresh";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-i", "--indexName"},
@@ -40,7 +40,7 @@ public class RefreshCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       client.refresh(getIndexName());
     } finally {

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/RegisterFieldsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/RegisterFieldsCommand.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.tools.cli;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.concurrent.Callable;
@@ -27,7 +27,7 @@ import picocli.CommandLine;
 public class RegisterFieldsCommand implements Callable<Integer> {
   public static final String REGISTER_FIELDS = "registerFields";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-f", "--fileName"},
@@ -41,7 +41,7 @@ public class RegisterFieldsCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       String jsonStr = Files.readString(Paths.get(getFileName()));
       client.registerFields(jsonStr);

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/ReloadStateCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/ReloadStateCommand.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.tools.cli;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
@@ -25,11 +25,11 @@ import picocli.CommandLine;
 public class ReloadStateCommand implements Callable<Integer> {
   public static final String RELOAD_STATE = "reloadState";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       client.reloadState();
     } finally {

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/SearchCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/SearchCommand.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.tools.cli;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.Callable;
@@ -25,7 +25,7 @@ import picocli.CommandLine;
 public class SearchCommand implements Callable<Integer> {
   public static final String SEARCH = "search";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-f", "--fileName"},
@@ -39,7 +39,7 @@ public class SearchCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       Path filePath = Paths.get(getFileName());
       client.search(filePath);

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/SettingsV2Command.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/SettingsV2Command.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.tools.cli;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.Callable;
@@ -28,7 +28,7 @@ import picocli.CommandLine;
 public class SettingsV2Command implements Callable<Integer> {
   public static final String SETTINGS_V2 = "settingsV2";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-i", "--indexName"},
@@ -51,7 +51,7 @@ public class SettingsV2Command implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       Path filePath = fileName == null ? null : Paths.get(getFileName());
       client.settingsV2(indexName, filePath);

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/StartIndexCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/StartIndexCommand.java
@@ -17,7 +17,7 @@ package com.yelp.nrtsearch.tools.cli;
 
 import static com.yelp.nrtsearch.tools.cli.StartIndexCommand.START_INDEX;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.Callable;
@@ -27,7 +27,7 @@ import picocli.CommandLine;
 public class StartIndexCommand implements Callable<Integer> {
   public static final String START_INDEX = "startIndex";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-f", "--fileName"},
@@ -41,7 +41,7 @@ public class StartIndexCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       Path filePath = Paths.get(getFileName());
       client.startIndex(filePath);

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/StartIndexV2Command.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/StartIndexV2Command.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.tools.cli;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
@@ -25,7 +25,7 @@ import picocli.CommandLine;
 public class StartIndexV2Command implements Callable<Integer> {
   public static final String START_INDEX_V2 = "startIndexV2";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-i", "--indexName"},
@@ -35,7 +35,7 @@ public class StartIndexV2Command implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       client.startIndexV2(indexName);
     } finally {

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/StatsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/StatsCommand.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.tools.cli;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
@@ -23,7 +23,7 @@ import picocli.CommandLine;
 public class StatsCommand implements Callable<Integer> {
   public static final String STATS = "stats";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-i", "--indexName"},
@@ -37,7 +37,7 @@ public class StatsCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       client.stats(getIndexName());
     } finally {

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/StatusCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/StatusCommand.java
@@ -17,7 +17,7 @@ package com.yelp.nrtsearch.tools.cli;
 
 import static com.yelp.nrtsearch.tools.cli.StatusCommand.STATUS;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
@@ -25,11 +25,11 @@ import picocli.CommandLine;
 public class StatusCommand implements Callable<Integer> {
   public static final String STATUS = "status";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       client.status();
     } finally {

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/StopIndexCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/StopIndexCommand.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.tools.cli;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
@@ -23,7 +23,7 @@ import picocli.CommandLine;
 public class StopIndexCommand implements Callable<Integer> {
   public static final String STOP_INDEX = "stopIndex";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-i", "--indexName"},
@@ -37,7 +37,7 @@ public class StopIndexCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       client.stopIndex(getIndexName());
     } finally {

--- a/src/main/java/com/yelp/nrtsearch/tools/cli/WriteNRTPointCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/cli/WriteNRTPointCommand.java
@@ -15,9 +15,9 @@
  */
 package com.yelp.nrtsearch.tools.cli;
 
-import static com.yelp.nrtsearch.tools.cli.LuceneClientCommand.logger;
+import static com.yelp.nrtsearch.tools.cli.NrtsearchClientCommand.logger;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import com.yelp.nrtsearch.server.grpc.ReplicationServerClient;
 import com.yelp.nrtsearch.server.grpc.SearcherVersion;
 import java.util.concurrent.Callable;
@@ -29,7 +29,7 @@ import picocli.CommandLine;
 public class WriteNRTPointCommand implements Callable<Integer> {
   public static final String WRITE_NRT_POINT = "writeNRT";
 
-  @CommandLine.ParentCommand private LuceneClientCommand baseCmd;
+  @CommandLine.ParentCommand private NrtsearchClientCommand baseCmd;
 
   @CommandLine.Option(
       names = {"-i", "--indexName"},
@@ -63,7 +63,7 @@ public class WriteNRTPointCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    LuceneServerClient client = baseCmd.getClient();
+    NrtsearchClient client = baseCmd.getClient();
     try {
       ReplicationServerClient replicationServerClient =
           new ReplicationServerClient(getHostName(), getPort());

--- a/src/test/java/com/yelp/nrtsearch/clientlib/NodeNameResolverAndLoadBalancingTests.java
+++ b/src/test/java/com/yelp/nrtsearch/clientlib/NodeNameResolverAndLoadBalancingTests.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.CommitRequest;
 import com.yelp.nrtsearch.server.grpc.CreateIndexRequest;
@@ -111,7 +111,7 @@ public class NodeNameResolverAndLoadBalancingTests {
   }
 
   private GrpcServer createGrpcServer() throws IOException {
-    LuceneServerConfiguration luceneServerConfiguration =
+    NrtsearchConfig luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     return new GrpcServer(
         grpcCleanup,

--- a/src/test/java/com/yelp/nrtsearch/module/TestNrtsearchModule.java
+++ b/src/test/java/com/yelp/nrtsearch/module/TestNrtsearchModule.java
@@ -20,21 +20,18 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
+import com.yelp.nrtsearch.server.grpc.NrtsearchServer;
 import com.yelp.nrtsearch.server.modules.BackendModule;
 
-/**
- * A Guice module to initialize {@link com.yelp.nrtsearch.server.grpc.LuceneServer} instance for
- * tests.
- */
-public class TestLuceneServerModule extends AbstractModule {
+/** A Guice module to initialize {@link NrtsearchServer} instance for tests. */
+public class TestNrtsearchModule extends AbstractModule {
 
-  private final LuceneServerConfiguration luceneServerConfiguration;
+  private final NrtsearchConfig nrtsearchConfig;
   private final AmazonS3 amazonS3;
 
-  public TestLuceneServerModule(
-      LuceneServerConfiguration luceneServerConfiguration, AmazonS3 amazonS3) {
-    this.luceneServerConfiguration = luceneServerConfiguration;
+  public TestNrtsearchModule(NrtsearchConfig nrtsearchConfig, AmazonS3 amazonS3) {
+    this.nrtsearchConfig = nrtsearchConfig;
     this.amazonS3 = amazonS3;
   }
 
@@ -45,8 +42,8 @@ public class TestLuceneServerModule extends AbstractModule {
   @Inject
   @Singleton
   @Provides
-  protected LuceneServerConfiguration providesLuceneServerConfiguration() {
-    return luceneServerConfiguration;
+  protected NrtsearchConfig providesNrtsearchConfig() {
+    return nrtsearchConfig;
   }
 
   @Inject

--- a/src/test/java/com/yelp/nrtsearch/server/ServerTestCase.java
+++ b/src/test/java/com/yelp/nrtsearch/server/ServerTestCase.java
@@ -20,16 +20,16 @@ import static com.yelp.nrtsearch.server.grpc.GrpcServer.rmDir;
 import com.google.gson.Gson;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.AddDocumentResponse;
 import com.yelp.nrtsearch.server.grpc.CreateIndexRequest;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
 import com.yelp.nrtsearch.server.grpc.GrpcServer;
 import com.yelp.nrtsearch.server.grpc.LiveSettingsRequest;
-import com.yelp.nrtsearch.server.grpc.LuceneServerClientBuilder;
 import com.yelp.nrtsearch.server.grpc.LuceneServerGrpc;
 import com.yelp.nrtsearch.server.grpc.Mode;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClientBuilder;
 import com.yelp.nrtsearch.server.grpc.RefreshRequest;
 import com.yelp.nrtsearch.server.grpc.SettingsRequest;
 import com.yelp.nrtsearch.server.grpc.StartIndexRequest;
@@ -171,7 +171,7 @@ public class ServerTestCase {
     Reader reader = Files.newBufferedReader(filePath);
     CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT.withFirstRecordAsHeader());
     Stream<AddDocumentRequest> requestStream =
-        new LuceneServerClientBuilder.AddDocumentsClientBuilder(index, csvParser)
+        new NrtsearchClientBuilder.AddDocumentsClientBuilder(index, csvParser)
             .buildRequest(filePath);
     addDocuments(requestStream);
   }
@@ -181,7 +181,7 @@ public class ServerTestCase {
     Path filePath = Paths.get(ServerTestCase.class.getResource(resourceFile).toURI());
     int maxBufferLen = 10;
     Stream<AddDocumentRequest> requestStream =
-        new LuceneServerClientBuilder.AddJsonDocumentsClientBuilder(
+        new NrtsearchClientBuilder.AddJsonDocumentsClientBuilder(
                 index, new Gson(), filePath, maxBufferLen)
             .buildRequest();
     addDocuments(requestStream);
@@ -217,7 +217,7 @@ public class ServerTestCase {
 
   private GrpcServer setUpGrpcServer(PrometheusRegistry prometheusRegistry) throws IOException {
     String testIndex = "test_index";
-    LuceneServerConfiguration luceneServerConfiguration =
+    NrtsearchConfig luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(
             Mode.STANDALONE, folder.getRoot(), getExtraConfig());
     GrpcServer server =
@@ -286,7 +286,7 @@ public class ServerTestCase {
 
   protected void initIndex(String name) throws Exception {}
 
-  protected List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
+  protected List<Plugin> getPlugins(NrtsearchConfig configuration) {
     return Collections.emptyList();
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/analysis/AnalyzerCreatorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/analysis/AnalyzerCreatorTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.fail;
 
 import com.carrotsearch.randomizedtesting.RandomizedRunner;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.IntObject;
 import com.yelp.nrtsearch.server.grpc.NameAndParams;
@@ -80,9 +80,9 @@ public class AnalyzerCreatorTest {
     AnalyzerCreator.initialize(getEmptyConfig(), plugins);
   }
 
-  private LuceneServerConfiguration getEmptyConfig() {
+  private NrtsearchConfig getEmptyConfig() {
     String config = "nodeName: \"lucene_server_foo\"";
-    return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
   }
 
   // Tests for predefined analyzers
@@ -576,14 +576,14 @@ public class AnalyzerCreatorTest {
 
   public static class TokenFilterAnalysisComponent extends LowerCaseFilterFactory
       implements AnalysisComponent {
-    LuceneServerConfiguration configuration;
+    NrtsearchConfig configuration;
 
     public TokenFilterAnalysisComponent(Map<String, String> args) {
       super(args);
     }
 
     @Override
-    public void initializeComponent(LuceneServerConfiguration configuration) {
+    public void initializeComponent(NrtsearchConfig configuration) {
       this.configuration = configuration;
     }
   }
@@ -780,14 +780,14 @@ public class AnalyzerCreatorTest {
 
   public static class CharFilterAnalysisComponent extends MappingCharFilterFactory
       implements AnalysisComponent {
-    LuceneServerConfiguration configuration;
+    NrtsearchConfig configuration;
 
     public CharFilterAnalysisComponent(Map<String, String> args) {
       super(args);
     }
 
     @Override
-    public void initializeComponent(LuceneServerConfiguration configuration) {
+    public void initializeComponent(NrtsearchConfig configuration) {
       this.configuration = configuration;
     }
   }

--- a/src/test/java/com/yelp/nrtsearch/server/analysis/SynonymV2GraphFilterFactoryITest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/analysis/SynonymV2GraphFilterFactoryITest.java
@@ -18,7 +18,7 @@ package com.yelp.nrtsearch.server.analysis;
 import static org.junit.Assert.assertEquals;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.*;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest.MultiValuedField;
 import com.yelp.nrtsearch.server.plugins.Plugin;
@@ -44,9 +44,9 @@ public class SynonymV2GraphFilterFactoryITest extends ServerTestCase {
     AnalyzerCreator.initialize(getEmptyConfig(), plugins);
   }
 
-  private LuceneServerConfiguration getEmptyConfig() {
+  private NrtsearchConfig getEmptyConfig() {
     String config = "nodeName: \"lucene_server_foo\"";
-    return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
   }
 
   protected List<String> getIndices() {

--- a/src/test/java/com/yelp/nrtsearch/server/analysis/SynonymV2GraphFilterFactoryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/analysis/SynonymV2GraphFilterFactoryTest.java
@@ -16,7 +16,7 @@
 package com.yelp.nrtsearch.server.analysis;
 
 import com.carrotsearch.randomizedtesting.RandomizedRunner;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -48,9 +48,9 @@ public class SynonymV2GraphFilterFactoryTest extends LuceneTestCase {
     AnalyzerCreator.initialize(getEmptyConfig(), plugins);
   }
 
-  private LuceneServerConfiguration getEmptyConfig() {
+  private NrtsearchConfig getEmptyConfig() {
     String config = "nodeName: \"lucene_server_foo\"";
-    return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
   }
 
   public void testNoSynonymMappings() throws IOException, ParseException {

--- a/src/test/java/com/yelp/nrtsearch/server/codec/ServerCodecTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/codec/ServerCodecTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.field.FieldDef;
 import com.yelp.nrtsearch.server.field.IndexableFieldDef;
 import com.yelp.nrtsearch.server.field.VectorFieldDef;
@@ -43,8 +43,7 @@ public class ServerCodecTest {
   @BeforeClass
   public static void beforeClass() {
     SimilarityCreator.initialize(
-        new LuceneServerConfiguration(new ByteArrayInputStream("name: node1".getBytes())),
-        List.of());
+        new NrtsearchConfig(new ByteArrayInputStream("name: node1".getBytes())), List.of());
   }
 
   private IndexStateManager getManager(FieldDef fieldDef) {

--- a/src/test/java/com/yelp/nrtsearch/server/concurrent/ThreadPoolExecutorFactoryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/concurrent/ThreadPoolExecutorFactoryTest.java
@@ -18,7 +18,7 @@ package com.yelp.nrtsearch.server.concurrent;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.config.ThreadPoolConfiguration;
 import java.io.ByteArrayInputStream;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -31,8 +31,8 @@ public class ThreadPoolExecutorFactoryTest {
   }
 
   private void init(String config) {
-    LuceneServerConfiguration luceneServerConfiguration =
-        new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+    NrtsearchConfig luceneServerConfiguration =
+        new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
     ThreadPoolExecutorFactory.init(luceneServerConfiguration.getThreadPoolConfiguration());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/config/NrtsearchConfigTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/NrtsearchConfigTest.java
@@ -25,16 +25,16 @@ import java.io.ByteArrayInputStream;
 import org.apache.lucene.search.suggest.document.CompletionPostingsFormat.FSTLoadMode;
 import org.junit.Test;
 
-public class LuceneServerConfigurationTest {
+public class NrtsearchConfigTest {
 
-  private LuceneServerConfiguration getForConfig(String config) {
-    return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+  private NrtsearchConfig getForConfig(String config) {
+    return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
   }
 
   @Test
   public void testGetsHostName() {
     String config = String.join("\n", "nodeName: \"lucene_server_foo\"", "hostName: my_host_name");
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals("my_host_name", luceneConfig.getHostName());
   }
 
@@ -42,7 +42,7 @@ public class LuceneServerConfigurationTest {
   public void testGetEnvHostName() {
     String config =
         String.join("\n", "nodeName: \"lucene_server_foo\"", "hostName: ${CUSTOM_HOST}");
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals("my_custom_host", luceneConfig.getHostName());
   }
 
@@ -51,7 +51,7 @@ public class LuceneServerConfigurationTest {
     String config =
         String.join(
             "\n", "nodeName: \"lucene_server_foo\"", "hostName: my_${VAR1}_${VAR2}_${VAR1}_host");
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals("my_v1_v2_v1_host", luceneConfig.getHostName());
   }
 
@@ -60,14 +60,14 @@ public class LuceneServerConfigurationTest {
     String config =
         String.join(
             "\n", "nodeName: \"lucene_server_foo\"", "hostName: my_${VAR4}_${VAR3}_${VAR4}_host");
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals("my__v3__host", luceneConfig.getHostName());
   }
 
   @Test
   public void testDefaultDiscoveryFileUpdateInterval() {
     String config = "nodeName: \"lucene_server_foo\"";
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals(
         ReplicationServerClient.FILE_UPDATE_INTERVAL_MS,
         luceneConfig.getDiscoveryFileUpdateIntervalMs());
@@ -77,76 +77,74 @@ public class LuceneServerConfigurationTest {
   public void testSetDiscoveryFileUpdateInterval() {
     String config =
         String.join("\n", "nodeName: \"lucene_server_foo\"", "discoveryFileUpdateIntervalMs: 100");
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals(100, luceneConfig.getDiscoveryFileUpdateIntervalMs());
   }
 
   @Test
   public void testDefaultCompletionCodecLoadMode() {
     String config = "nodeName: \"lucene_server_foo\"";
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals(FSTLoadMode.ON_HEAP, luceneConfig.getCompletionCodecLoadMode());
   }
 
   @Test
   public void testSetCompletionCodecLoadMode() {
     String config = "completionCodecLoadMode: OFF_HEAP";
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals(FSTLoadMode.OFF_HEAP, luceneConfig.getCompletionCodecLoadMode());
   }
 
   @Test
   public void testInitialSyncPrimaryWaitMs_default() {
     String config = "nodeName: \"lucene_server_foo\"";
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals(
-        LuceneServerConfiguration.DEFAULT_INITIAL_SYNC_PRIMARY_WAIT_MS,
+        NrtsearchConfig.DEFAULT_INITIAL_SYNC_PRIMARY_WAIT_MS,
         luceneConfig.getInitialSyncPrimaryWaitMs());
   }
 
   @Test
   public void testInitialSyncPrimaryWaitMs_set() {
     String config = "initialSyncPrimaryWaitMs: 100";
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals(100L, luceneConfig.getInitialSyncPrimaryWaitMs());
   }
 
   @Test
   public void testInitialSyncMaxTimeMs_default() {
     String config = "nodeName: \"lucene_server_foo\"";
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals(
-        LuceneServerConfiguration.DEFAULT_INITIAL_SYNC_MAX_TIME_MS,
-        luceneConfig.getInitialSyncMaxTimeMs());
+        NrtsearchConfig.DEFAULT_INITIAL_SYNC_MAX_TIME_MS, luceneConfig.getInitialSyncMaxTimeMs());
   }
 
   @Test
   public void testInitialSyncMaxTimeMs_set() {
     String config = "initialSyncMaxTimeMs: 100";
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals(100L, luceneConfig.getInitialSyncMaxTimeMs());
   }
 
   @Test
   public void testMaxS3ClientRetries_default() {
     String config = "nodeName: \"lucene_server_foo\"";
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals(
-        LuceneServerConfiguration.DEFAULT_MAX_S3_CLIENT_RETRIES,
-        luceneConfig.getMaxS3ClientRetries());
+        NrtsearchConfig.DEFAULT_MAX_S3_CLIENT_RETRIES, luceneConfig.getMaxS3ClientRetries());
   }
 
   @Test
   public void testMaxS3ClientRetries_set() {
     String config = "maxS3ClientRetries: 10";
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals(10, luceneConfig.getMaxS3ClientRetries());
   }
 
   @Test
   public void testLiveSettingsOverride_default() {
     String config = "nodeName: \"lucene_server_foo\"";
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals(
         IndexLiveSettings.newBuilder().build(), luceneConfig.getLiveSettingsOverride("test_index"));
   }
@@ -163,7 +161,7 @@ public class LuceneServerConfigurationTest {
             "  test_index_2:",
             "    defaultSearchTimeoutSec: 10.25",
             "    segmentsPerTier: 30");
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals(
         IndexLiveSettings.newBuilder()
             .setSliceMaxDocs(Int32Value.newBuilder().setValue(1).build())
@@ -184,28 +182,28 @@ public class LuceneServerConfigurationTest {
   @Test
   public void testLowPriorityCopyPercentage_default() {
     String config = "nodeName: \"lucene_server_foo\"";
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals(0, luceneConfig.getLowPriorityCopyPercentage());
   }
 
   @Test
   public void testLowPriorityCopyPercentage_set() {
     String config = "lowPriorityCopyPercentage: 10";
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals(10, luceneConfig.getLowPriorityCopyPercentage());
   }
 
   @Test
   public void testVerifyReplicationIndexId_default() {
     String config = "nodeName: \"lucene_server_foo\"";
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertTrue(luceneConfig.getVerifyReplicationIndexId());
   }
 
   @Test
   public void testVerifyReplicationIndexId_set() {
     String config = "verifyReplicationIndexId: false";
-    LuceneServerConfiguration luceneConfig = getForConfig(config);
+    NrtsearchConfig luceneConfig = getForConfig(config);
     assertFalse(luceneConfig.getVerifyReplicationIndexId());
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/config/ThreadPoolConfigurationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/ThreadPoolConfigurationTest.java
@@ -38,8 +38,7 @@ public class ThreadPoolConfigurationTest {
   public void testConfiguration() throws FileNotFoundException {
     String config =
         Paths.get("src", "test", "resources", "config.yaml").toAbsolutePath().toString();
-    LuceneServerConfiguration luceneServerConfiguration =
-        new LuceneServerConfiguration(new FileInputStream(config));
+    NrtsearchConfig luceneServerConfiguration = new NrtsearchConfig(new FileInputStream(config));
     assertEquals("lucene_server_foo", luceneServerConfiguration.getNodeName());
     assertEquals("foohost", luceneServerConfiguration.getHostName());
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =

--- a/src/test/java/com/yelp/nrtsearch/server/custom/request/CustomRpcTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/custom/request/CustomRpcTest.java
@@ -18,7 +18,7 @@ package com.yelp.nrtsearch.server.custom.request;
 import static org.junit.Assert.assertEquals;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.CustomRequest;
 import com.yelp.nrtsearch.server.grpc.CustomResponse;
 import com.yelp.nrtsearch.server.plugins.Plugin;
@@ -33,7 +33,7 @@ public class CustomRpcTest extends ServerTestCase {
   @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
   @Override
-  protected List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
+  protected List<Plugin> getPlugins(NrtsearchConfig configuration) {
     return List.of(new CustomRequestTestPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/doc/SharedDocContextTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/doc/SharedDocContextTest.java
@@ -18,7 +18,7 @@ package com.yelp.nrtsearch.server.doc;
 import static org.junit.Assert.assertEquals;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
 import com.yelp.nrtsearch.server.grpc.Query;
@@ -110,7 +110,7 @@ public class SharedDocContextTest extends ServerTestCase {
   }
 
   @Override
-  public List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
+  public List<Plugin> getPlugins(NrtsearchConfig configuration) {
     return Collections.singletonList(new TestSharedContextPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/facet/FacetScriptFacetsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/facet/FacetScriptFacetsTest.java
@@ -18,7 +18,7 @@ package com.yelp.nrtsearch.server.facet;
 import static org.junit.Assert.assertEquals;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.doc.DocLookup;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.Facet;
@@ -258,7 +258,7 @@ public class FacetScriptFacetsTest extends ServerTestCase {
   }
 
   @Override
-  protected List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
+  protected List<Plugin> getPlugins(NrtsearchConfig configuration) {
     return Collections.singletonList(new TestFacetScriptPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/facet/RuntimeScriptFacetsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/facet/RuntimeScriptFacetsTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.protobuf.Value;
 import com.yelp.nrtsearch.server.ServerTestCase;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.doc.DocLookup;
 import com.yelp.nrtsearch.server.doc.LoadedDocValues;
 import com.yelp.nrtsearch.server.grpc.*;
@@ -225,7 +225,7 @@ public class RuntimeScriptFacetsTest extends ServerTestCase {
   }
 
   @Override
-  protected List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
+  protected List<Plugin> getPlugins(NrtsearchConfig configuration) {
     return Collections.singletonList(new TestRuntimeScriptPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/field/AtomFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/AtomFieldDefTest.java
@@ -17,7 +17,7 @@ package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.assertEquals;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.TextDocValuesType;
 import com.yelp.nrtsearch.server.similarity.SimilarityCreator;
@@ -33,8 +33,8 @@ public class AtomFieldDefTest {
   @BeforeClass
   public static void init() {
     String configStr = "node: node1";
-    LuceneServerConfiguration configuration =
-        new LuceneServerConfiguration(new ByteArrayInputStream(configStr.getBytes()));
+    NrtsearchConfig configuration =
+        new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
     SimilarityCreator.initialize(configuration, Collections.emptyList());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/field/FieldDefCreatorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/FieldDefCreatorTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.FieldType;
 import com.yelp.nrtsearch.server.plugins.FieldTypePlugin;
@@ -43,9 +43,9 @@ public class FieldDefCreatorTest {
     FieldDefCreator.initialize(getEmptyConfig(), plugins);
   }
 
-  private LuceneServerConfiguration getEmptyConfig() {
+  private NrtsearchConfig getEmptyConfig() {
     String config = "nodeName: \"lucene_server_foo\"";
-    return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
   }
 
   static class TestFieldDef extends FieldDef {

--- a/src/test/java/com/yelp/nrtsearch/server/field/TestFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/TestFieldDefTest.java
@@ -17,7 +17,7 @@ package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.assertEquals;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.similarity.SimilarityCreator;
 import java.io.ByteArrayInputStream;
@@ -30,8 +30,8 @@ public class TestFieldDefTest {
   @BeforeClass
   public static void init() {
     String configStr = "node: node1";
-    LuceneServerConfiguration configuration =
-        new LuceneServerConfiguration(new ByteArrayInputStream(configStr.getBytes()));
+    NrtsearchConfig configuration =
+        new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
     SimilarityCreator.initialize(configuration, Collections.emptyList());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/field/TextFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/TextFieldDefTest.java
@@ -17,7 +17,7 @@ package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.*;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.TextDocValuesType;
 import com.yelp.nrtsearch.server.similarity.SimilarityCreator;
@@ -33,8 +33,8 @@ public class TextFieldDefTest {
   @BeforeClass
   public static void init() {
     String configStr = "node: node1";
-    LuceneServerConfiguration configuration =
-        new LuceneServerConfiguration(new ByteArrayInputStream(configStr.getBytes()));
+    NrtsearchConfig configuration =
+        new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
     SimilarityCreator.initialize(configuration, Collections.emptyList());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/AckedCopyTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/AckedCopyTest.java
@@ -19,7 +19,7 @@ import static com.yelp.nrtsearch.server.grpc.GrpcServer.rmDir;
 import static com.yelp.nrtsearch.server.grpc.ReplicationServerTest.validateSearchResults;
 
 import com.amazonaws.services.s3.AmazonS3;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.remote.RemoteBackend;
 import com.yelp.nrtsearch.server.remote.s3.S3Backend;
 import com.yelp.nrtsearch.server.utils.LuceneServerTestConfigurationFactory;
@@ -78,7 +78,7 @@ public class AckedCopyTest {
 
     // set up primary servers
     String testIndex = "test_index";
-    LuceneServerConfiguration luceneServerPrimaryConfiguration =
+    NrtsearchConfig luceneServerPrimaryConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.PRIMARY, folder.getRoot(), extraConfig);
     remoteBackend = new S3Backend(luceneServerPrimaryConfiguration, s3);
     luceneServerPrimary =
@@ -105,7 +105,7 @@ public class AckedCopyTest {
         .getGlobalState()
         .replicationStarted(luceneServerPrimaryConfiguration.getReplicationPort());
     // set up secondary servers
-    LuceneServerConfiguration luceneServerSecondaryConfiguration =
+    NrtsearchConfig luceneServerSecondaryConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.REPLICA, folder.getRoot(), extraConfig);
 
     luceneServerSecondary =
@@ -188,7 +188,7 @@ public class AckedCopyTest {
                     .setStartHit(0)
                     .setTopHits(10)
                     .setVersion(searcherVersionPrimary.getVersion())
-                    .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+                    .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
                     .build());
 
     // replica should too!
@@ -201,7 +201,7 @@ public class AckedCopyTest {
                     .setStartHit(0)
                     .setTopHits(10)
                     .setVersion(searcherVersionPrimary.getVersion())
-                    .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+                    .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
                     .build());
 
     validateSearchResults(searchResponsePrimary);

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/CopyFileTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/CopyFileTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.protobuf.ByteString;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.state.GlobalState;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
@@ -57,7 +57,7 @@ public class CopyFileTest {
     String serverName = InProcessServerBuilder.generateName();
 
     GlobalState mockGlobalState = mock(GlobalState.class);
-    LuceneServerConfiguration mockConfiguration = mock(LuceneServerConfiguration.class);
+    NrtsearchConfig mockConfiguration = mock(NrtsearchConfig.class);
     when(mockGlobalState.getConfiguration()).thenReturn(mockConfiguration);
     when(mockConfiguration.getUseKeepAliveForReplication()).thenReturn(true);
 
@@ -65,7 +65,7 @@ public class CopyFileTest {
     grpcCleanup.register(
         InProcessServerBuilder.forName(serverName)
             .directExecutor()
-            .addService(new LuceneServer.ReplicationServerImpl(mockGlobalState, false))
+            .addService(new NrtsearchServer.ReplicationServerImpl(mockGlobalState, false))
             .build()
             .start());
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/CustomFieldTypeTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/CustomFieldTypeTest.java
@@ -18,7 +18,7 @@ package com.yelp.nrtsearch.server.grpc;
 import static com.yelp.nrtsearch.server.grpc.GrpcServer.rmDir;
 import static org.junit.Assert.assertEquals;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.doc.LoadedDocValues;
 import com.yelp.nrtsearch.server.field.FieldDef;
 import com.yelp.nrtsearch.server.field.FieldDefProvider;
@@ -81,7 +81,7 @@ public class CustomFieldTypeTest {
 
   private GrpcServer setUpGrpcServer(PrometheusRegistry prometheusRegistry) throws IOException {
     String testIndex = "test_index";
-    LuceneServerConfiguration luceneServerConfiguration =
+    NrtsearchConfig luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     return new GrpcServer(
         prometheusRegistry,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/GrpcServer.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/GrpcServer.java
@@ -17,10 +17,10 @@ package com.yelp.nrtsearch.server.grpc;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
-import com.yelp.nrtsearch.server.grpc.LuceneServer.LuceneServerImpl;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
+import com.yelp.nrtsearch.server.grpc.NrtsearchServer.LuceneServerImpl;
 import com.yelp.nrtsearch.server.monitoring.Configuration;
-import com.yelp.nrtsearch.server.monitoring.LuceneServerMonitoringServerInterceptor;
+import com.yelp.nrtsearch.server.monitoring.NrtsearchMonitoringServerInterceptor;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.remote.RemoteBackend;
 import com.yelp.nrtsearch.server.state.GlobalState;
@@ -64,7 +64,7 @@ public class GrpcServer {
   private ReplicationServerGrpc.ReplicationServerStub replicationServerStub;
 
   private GlobalState globalState;
-  private LuceneServerConfiguration configuration;
+  private NrtsearchConfig configuration;
   private Server luceneServer;
   private ManagedChannel luceneServerManagedChannel;
   private Server replicationServer;
@@ -73,7 +73,7 @@ public class GrpcServer {
   public GrpcServer(
       PrometheusRegistry prometheusRegistry,
       GrpcCleanupRule grpcCleanup,
-      LuceneServerConfiguration configuration,
+      NrtsearchConfig configuration,
       TemporaryFolder temporaryFolder,
       GlobalState replicationGlobalState,
       String indexDir,
@@ -94,7 +94,7 @@ public class GrpcServer {
 
   public GrpcServer(
       GrpcCleanupRule grpcCleanup,
-      LuceneServerConfiguration configuration,
+      NrtsearchConfig configuration,
       TemporaryFolder temporaryFolder,
       GlobalState replicationGlobalState,
       String indexDir,
@@ -117,7 +117,7 @@ public class GrpcServer {
 
   public GrpcServer(
       GrpcCleanupRule grpcCleanup,
-      LuceneServerConfiguration configuration,
+      NrtsearchConfig configuration,
       TemporaryFolder temporaryFolder,
       GlobalState replicationGlobalState,
       String indexDir,
@@ -214,7 +214,7 @@ public class GrpcServer {
       Server server;
       if (prometheusRegistry == null) {
         LuceneServerImpl serverImpl =
-            new LuceneServer.LuceneServerImpl(
+            new NrtsearchServer.LuceneServerImpl(
                 configuration, remoteBackend, prometheusRegistry, plugins);
         globalState = serverImpl.getGlobalState();
         // Create a server, add service, start, and register for automatic graceful shutdown.
@@ -226,11 +226,11 @@ public class GrpcServer {
                 .build()
                 .start();
       } else {
-        LuceneServerMonitoringServerInterceptor monitoringInterceptor =
-            LuceneServerMonitoringServerInterceptor.create(
+        NrtsearchMonitoringServerInterceptor monitoringInterceptor =
+            NrtsearchMonitoringServerInterceptor.create(
                 Configuration.allMetrics().withPrometheusRegistry(prometheusRegistry));
         LuceneServerImpl serverImpl =
-            new LuceneServer.LuceneServerImpl(
+            new NrtsearchServer.LuceneServerImpl(
                 configuration, remoteBackend, prometheusRegistry, plugins);
         globalState = serverImpl.getGlobalState();
         // Create a server, add service, start, and register for automatic graceful shutdown.
@@ -261,7 +261,7 @@ public class GrpcServer {
       // Create a server, add service, start, and register for automatic graceful shutdown.
       Server server =
           ServerBuilder.forPort(port)
-              .addService(new LuceneServer.ReplicationServerImpl(globalState, false))
+              .addService(new NrtsearchServer.ReplicationServerImpl(globalState, false))
               .compressorRegistry(LuceneServerStubBuilder.COMPRESSOR_REGISTRY)
               .decompressorRegistry(LuceneServerStubBuilder.DECOMPRESSOR_REGISTRY)
               .build()
@@ -401,7 +401,7 @@ public class GrpcServer {
       Path filePath = Paths.get("src", "test", "resources", addDocsFile);
       Reader reader = Files.newBufferedReader(filePath);
       CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT.withFirstRecordAsHeader());
-      return new LuceneServerClientBuilder.AddDocumentsClientBuilder(
+      return new NrtsearchClientBuilder.AddDocumentsClientBuilder(
               grpcServer.getTestIndex(), csvParser)
           .buildRequest(filePath);
     }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/MergeBehaviorTests.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/MergeBehaviorTests.java
@@ -16,11 +16,11 @@
 package com.yelp.nrtsearch.server.grpc;
 
 import static com.yelp.nrtsearch.server.grpc.GrpcServer.rmDir;
-import static com.yelp.nrtsearch.server.grpc.LuceneServerTest.RETRIEVED_VALUES;
+import static com.yelp.nrtsearch.server.grpc.NrtsearchServerTest.RETRIEVED_VALUES;
 import static org.junit.Assert.*;
 
 import com.google.common.collect.Sets;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.state.BackendGlobalState;
 import com.yelp.nrtsearch.server.utils.LuceneServerTestConfigurationFactory;
 import io.grpc.testing.GrpcCleanupRule;
@@ -85,7 +85,7 @@ public class MergeBehaviorTests {
 
   private GrpcServer setUpGrpcServer(PrometheusRegistry prometheusRegistry) throws IOException {
     String testIndex = "test_index";
-    LuceneServerConfiguration luceneServerConfiguration =
+    NrtsearchConfig luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     return new GrpcServer(
         prometheusRegistry,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/MultiIndexAddDocumentsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/MultiIndexAddDocumentsTest.java
@@ -122,7 +122,7 @@ public class MultiIndexAddDocumentsTest extends ServerTestCase {
     Path filePath = Paths.get(ServerTestCase.class.getResource(docsResourceFile).toURI());
     Reader reader = Files.newBufferedReader(filePath);
     CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT.withFirstRecordAsHeader());
-    return new LuceneServerClientBuilder.AddDocumentsClientBuilder(index, csvParser)
+    return new NrtsearchClientBuilder.AddDocumentsClientBuilder(index, csvParser)
         .buildRequest(filePath);
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/NrtsearchClientBuilderTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/NrtsearchClientBuilderTest.java
@@ -26,14 +26,14 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.Test;
 
-public class LuceneServerClientBuilderTest {
+public class NrtsearchClientBuilderTest {
 
   @Test
   public void buildRequest() throws IOException {
     Path filePath = Paths.get("src", "test", "resources", "addDocs.txt");
     int maxBufferLen = 10;
-    LuceneServerClientBuilder.AddJsonDocumentsClientBuilder addJsonDocumentsClientBuilder =
-        new LuceneServerClientBuilder.AddJsonDocumentsClientBuilder(
+    NrtsearchClientBuilder.AddJsonDocumentsClientBuilder addJsonDocumentsClientBuilder =
+        new NrtsearchClientBuilder.AddJsonDocumentsClientBuilder(
             "test_index", new Gson(), filePath, maxBufferLen);
     Stream<AddDocumentRequest> addDocumentRequestStream =
         addJsonDocumentsClientBuilder.buildRequest(filePath);

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/NrtsearchServerIdFieldTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/NrtsearchServerIdFieldTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.utils.LuceneServerTestConfigurationFactory;
 import io.grpc.StatusRuntimeException;
 import io.grpc.testing.GrpcCleanupRule;
@@ -39,7 +39,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class LuceneServerIdFieldTest {
+public class NrtsearchServerIdFieldTest {
 
   /**
    * This rule manages automatic graceful shutdown for the registered servers and channels at the
@@ -75,7 +75,7 @@ public class LuceneServerIdFieldTest {
 
   private GrpcServer setUpGrpcServer(PrometheusRegistry prometheusRegistry) throws IOException {
     String testIndex = "test_index";
-    LuceneServerConfiguration luceneServerConfiguration =
+    NrtsearchConfig luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     return new GrpcServer(
         prometheusRegistry,

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/NrtsearchServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/NrtsearchServerTest.java
@@ -27,8 +27,8 @@ import static org.junit.Assert.fail;
 import com.amazonaws.services.s3.AmazonS3;
 import com.google.api.HttpBody;
 import com.google.protobuf.Empty;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
-import com.yelp.nrtsearch.server.grpc.LuceneServer.LuceneServerImpl;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
+import com.yelp.nrtsearch.server.grpc.NrtsearchServer.LuceneServerImpl;
 import com.yelp.nrtsearch.server.grpc.SearchResponse.Hit.CompositeFieldValue;
 import com.yelp.nrtsearch.server.remote.RemoteBackend;
 import com.yelp.nrtsearch.server.remote.s3.S3Backend;
@@ -72,7 +72,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class LuceneServerTest {
+public class NrtsearchServerTest {
   public static final List<String> RETRIEVED_VALUES =
       Arrays.asList(
           "doc_id",
@@ -141,7 +141,7 @@ public class LuceneServerTest {
 
   @Before
   public void setUp() throws IOException {
-    LuceneServerConfiguration luceneServerConfiguration =
+    NrtsearchConfig luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(
             Mode.STANDALONE, folder.getRoot(), "bucketName: " + bucketName);
 
@@ -152,8 +152,7 @@ public class LuceneServerTest {
     setUpWarmer();
   }
 
-  private RemoteBackend setUpRemoteBackend(LuceneServerConfiguration configuration)
-      throws IOException {
+  private RemoteBackend setUpRemoteBackend(NrtsearchConfig configuration) throws IOException {
     s3 = s3Provider.getAmazonS3();
     return new S3Backend(configuration, s3);
   }
@@ -179,7 +178,7 @@ public class LuceneServerTest {
   }
 
   private GrpcServer setUpGrpcServer(
-      LuceneServerConfiguration luceneServerConfiguration, PrometheusRegistry prometheusRegistry)
+      NrtsearchConfig luceneServerConfiguration, PrometheusRegistry prometheusRegistry)
       throws IOException {
     String testIndex = "test_index";
 
@@ -199,7 +198,7 @@ public class LuceneServerTest {
   private GrpcServer setUpReplicaGrpcServer(PrometheusRegistry prometheusRegistry)
       throws IOException {
     String testIndex = "test_index";
-    LuceneServerConfiguration luceneServerReplicaConfiguration =
+    NrtsearchConfig luceneServerReplicaConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(
             Mode.REPLICA, folder.getRoot(), getExtraConfig());
 
@@ -1237,13 +1236,13 @@ public class LuceneServerTest {
     assertTrue(queryCache instanceof NrtQueryCache);
 
     String configStr = String.join("\n", "queryCache:", "  enabled: false");
-    LuceneServerConfiguration configuration =
-        new LuceneServerConfiguration(new ByteArrayInputStream(configStr.getBytes()));
+    NrtsearchConfig configuration =
+        new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
     LuceneServerImpl.initQueryCache(configuration);
     assertNull(IndexSearcher.getDefaultQueryCache());
 
     configStr = String.join("\n", "queryCache:", "  enabled: true");
-    configuration = new LuceneServerConfiguration(new ByteArrayInputStream(configStr.getBytes()));
+    configuration = new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
     LuceneServerImpl.initQueryCache(configuration);
     queryCache = IndexSearcher.getDefaultQueryCache();
     assertTrue(queryCache instanceof NrtQueryCache);

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.utils.LuceneServerTestConfigurationFactory;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.IOException;
@@ -76,7 +76,7 @@ public class QueryTest {
 
   private GrpcServer setUpGrpcServer() throws IOException {
     String testIndex = "test_index";
-    LuceneServerConfiguration luceneServerConfiguration =
+    NrtsearchConfig luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     return new GrpcServer(
         grpcCleanup,
@@ -98,7 +98,7 @@ public class QueryTest {
                     .setIndexName(grpcServer.getTestIndex())
                     .setStartHit(0)
                     .setTopHits(10)
-                    .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+                    .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
                     .setQueryText("SECOND")
                     .build());
 
@@ -107,7 +107,7 @@ public class QueryTest {
     SearchResponse.Hit hit = searchResponse.getHits(0);
     String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
     assertEquals("2", docId);
-    LuceneServerTest.checkHits(hit);
+    NrtsearchServerTest.checkHits(hit);
   }
 
   @Test
@@ -120,7 +120,7 @@ public class QueryTest {
                     .setIndexName(grpcServer.getTestIndex())
                     .setStartHit(0)
                     .setTopHits(10)
-                    .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+                    .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
                     .setQueryText("SECOND")
                     .build());
     assertTrue(anyResponse.is(SearchResponse.class));
@@ -130,7 +130,7 @@ public class QueryTest {
     SearchResponse.Hit hit = searchResponse.getHits(0);
     String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
     assertEquals("2", docId);
-    LuceneServerTest.checkHits(hit);
+    NrtsearchServerTest.checkHits(hit);
   }
 
   @Test
@@ -146,7 +146,7 @@ public class QueryTest {
                       .setIndexName(grpcServer.getTestIndex())
                       .setStartHit(0)
                       .setTopHits(10)
-                      .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+                      .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
                       .setQueryText("SECOND")
                       .setResponseCompression(compressionType)
                       .build());
@@ -156,7 +156,7 @@ public class QueryTest {
       SearchResponse.Hit hit = searchResponse.getHits(0);
       String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
       assertEquals("2", docId);
-      LuceneServerTest.checkHits(hit);
+      NrtsearchServerTest.checkHits(hit);
     }
   }
 
@@ -173,7 +173,7 @@ public class QueryTest {
                       .setIndexName(grpcServer.getTestIndex())
                       .setStartHit(0)
                       .setTopHits(10)
-                      .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+                      .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
                       .setQueryText("SECOND")
                       .setResponseCompression(compressionType)
                       .build());
@@ -184,7 +184,7 @@ public class QueryTest {
       SearchResponse.Hit hit = searchResponse.getHits(0);
       String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
       assertEquals("2", docId);
-      LuceneServerTest.checkHits(hit);
+      NrtsearchServerTest.checkHits(hit);
     }
   }
 
@@ -218,7 +218,7 @@ public class QueryTest {
           SearchResponse.Hit hit = searchResponse.getHits(0);
           String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("1", docId);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
 
     testQuery(query, responseTester);
@@ -254,7 +254,7 @@ public class QueryTest {
           SearchResponse.Hit hit = searchResponse.getHits(0);
           String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("2", docId);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
 
     testQuery(query, responseTester);
@@ -280,7 +280,7 @@ public class QueryTest {
           SearchResponse.Hit hit = searchResponse.getHits(0);
           String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("2", docId);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
 
     testQuery(query, responseTester);
@@ -314,7 +314,7 @@ public class QueryTest {
           String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("2", docId);
           assertEquals(14.0, hit.getScore(), 0.0);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
 
     testQuery(query, responseTester);
@@ -340,14 +340,14 @@ public class QueryTest {
           String firstDocId = firstHit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("2", firstDocId);
           assertEquals(14.0, firstHit.getScore(), 0.0);
-          LuceneServerTest.checkHits(firstHit);
+          NrtsearchServerTest.checkHits(firstHit);
 
           SearchResponse.Hit secondHit = searchResponse.getHits(1);
           String secondDocId =
               secondHit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("1", secondDocId);
           assertEquals(6.0, secondHit.getScore(), 0.0);
-          LuceneServerTest.checkHits(secondHit);
+          NrtsearchServerTest.checkHits(secondHit);
         };
 
     testQuery(query, responseTester);
@@ -369,7 +369,7 @@ public class QueryTest {
           SearchResponse.Hit hit = searchResponse.getHits(0);
           String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("2", docId);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
 
     testQuery(query, responseTester);
@@ -435,7 +435,7 @@ public class QueryTest {
           // score should be equal 1.0 * firstPassScore + 4.0 * secondPassScore = 45
           // the scores are hardcoded in query. firstPass: 5, secondsPass: 10
           assertEquals(45, hit.getScore(), 0);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
 
     testQueryWithRescorers(firstPassQuery, List.of(queryRescorer), responseTester);
@@ -479,7 +479,7 @@ public class QueryTest {
           SearchResponse.Hit hit = searchResponse.getHits(0);
           String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("2", docId);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
 
     for (TermQuery termQuery :
@@ -525,9 +525,9 @@ public class QueryTest {
           assertEquals(2, searchResponse.getTotalHits().getValue());
           assertEquals(2, searchResponse.getHitsList().size());
           SearchResponse.Hit firstHit = searchResponse.getHits(0);
-          LuceneServerTest.checkHits(firstHit);
+          NrtsearchServerTest.checkHits(firstHit);
           SearchResponse.Hit secondHit = searchResponse.getHits(1);
-          LuceneServerTest.checkHits(secondHit);
+          NrtsearchServerTest.checkHits(secondHit);
         };
 
     for (TermInSetQuery termInSetQuery :
@@ -575,7 +575,7 @@ public class QueryTest {
           String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("2", docId);
           assertEquals(14.0, hit.getScore(), 0.0);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
 
     testQuery(query, responseTester);
@@ -599,7 +599,7 @@ public class QueryTest {
           SearchResponse.Hit hit = searchResponse.getHits(0);
           String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("2", docId);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
 
     testQuery(query, responseTester);
@@ -624,7 +624,7 @@ public class QueryTest {
           SearchResponse.Hit hit = searchResponse.getHits(0);
           String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("2", docId);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
 
     testQuery(query, responseTester);
@@ -652,7 +652,7 @@ public class QueryTest {
           SearchResponse.Hit hit = searchResponse.getHits(0);
           String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("2", docId);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
 
     testQuery(query, responseTester);
@@ -678,7 +678,7 @@ public class QueryTest {
           SearchResponse.Hit hit = searchResponse.getHits(0);
           String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("2", docId);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
 
     testQuery(query, responseTester);
@@ -728,7 +728,7 @@ public class QueryTest {
           SearchResponse.Hit hit = searchResponse.getHits(0);
           String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("2", docId);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
 
     testQuery(query, responseTester);
@@ -752,7 +752,7 @@ public class QueryTest {
           SearchResponse.Hit hit = searchResponse.getHits(0);
           String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("2", docId);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
 
     testQuery(query, responseTester);
@@ -795,7 +795,7 @@ public class QueryTest {
           SearchResponse.Hit hit = searchResponse.getHits(0);
           String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("2", docId);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
 
     testQuery(query, responseTester);
@@ -882,7 +882,7 @@ public class QueryTest {
           SearchResponse.Hit hit = searchResponse.getHits(0);
           String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("2", docId);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
 
     testQuery(query, responseTester);
@@ -920,7 +920,7 @@ public class QueryTest {
           SearchResponse.Hit hit = searchResponse.getHits(0);
           String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("2", docId);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
 
     testQuery(query, responseTester);
@@ -963,7 +963,7 @@ public class QueryTest {
           SearchResponse.Hit hit = searchResponse.getHits(0);
           String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("2", docId);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
 
     for (RangeQuery rangeQuery : List.of(intQuery, longQuery, floatQuery, doubleQuery, dateQuery)) {
@@ -991,7 +991,7 @@ public class QueryTest {
           SearchResponse.Hit hit = searchResponse.getHits(0);
           String docId = hit.getFieldsMap().get("doc_id").getFieldValue(0).getTextValue();
           assertEquals("2", docId);
-          LuceneServerTest.checkHits(hit);
+          NrtsearchServerTest.checkHits(hit);
         };
     SearchResponse searchResponse = grpcServer.getBlockingStub().search(buildSearchRequest(query));
     responseTester.accept(searchResponse);
@@ -1072,7 +1072,7 @@ public class QueryTest {
         .setIndexName(grpcServer.getTestIndex())
         .setStartHit(0)
         .setTopHits(10)
-        .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+        .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
         .setQuery(query)
         .build();
   }
@@ -1082,7 +1082,7 @@ public class QueryTest {
         .setIndexName(grpcServer.getTestIndex())
         .setStartHit(0)
         .setTopHits(10)
-        .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+        .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
         .setQuery(query)
         .setExplain(explain)
         .build();
@@ -1093,7 +1093,7 @@ public class QueryTest {
         .setIndexName(grpcServer.getTestIndex())
         .setStartHit(0)
         .setTopHits(10)
-        .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+        .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
         .setQuery(query)
         .addAllRescorers(rescorers)
         .build();

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClientTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClientTest.java
@@ -28,8 +28,8 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yelp.nrtsearch.clientlib.Node;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
-import com.yelp.nrtsearch.server.grpc.LuceneServer.ReplicationServerImpl;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
+import com.yelp.nrtsearch.server.grpc.NrtsearchServer.ReplicationServerImpl;
 import com.yelp.nrtsearch.server.grpc.ReplicationServerClient.DiscoveryFileAndPort;
 import com.yelp.nrtsearch.server.state.GlobalState;
 import io.grpc.ManagedChannelBuilder;
@@ -73,7 +73,7 @@ public class ReplicationServerClientTest {
     // we only need to test connectivity for now
     GlobalState mockGlobalState = mock(GlobalState.class);
     when(mockGlobalState.getIndex(any(String.class))).thenThrow(new RuntimeException("Expected"));
-    LuceneServerConfiguration mockConfiguration = mock(LuceneServerConfiguration.class);
+    NrtsearchConfig mockConfiguration = mock(NrtsearchConfig.class);
     when(mockGlobalState.getConfiguration()).thenReturn(mockConfiguration);
     when(mockConfiguration.getUseKeepAliveForReplication()).thenReturn(true);
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.amazonaws.services.s3.AmazonS3;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.remote.RemoteBackend;
 import com.yelp.nrtsearch.server.remote.s3.S3Backend;
 import com.yelp.nrtsearch.server.utils.LuceneServerTestConfigurationFactory;
@@ -188,7 +188,7 @@ public class ReplicationServerTest {
                     .setStartHit(0)
                     .setTopHits(10)
                     .setVersion(searcherVersionPrimary.getVersion())
-                    .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+                    .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
                     .build());
 
     // replica should too!
@@ -201,7 +201,7 @@ public class ReplicationServerTest {
                     .setStartHit(0)
                     .setTopHits(10)
                     .setVersion(searcherVersionPrimary.getVersion())
-                    .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+                    .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
                     .build());
 
     validateSearchResults(searchResponsePrimary);
@@ -246,7 +246,7 @@ public class ReplicationServerTest {
                     .setIndexName(luceneServerSecondary.getTestIndex())
                     .setStartHit(0)
                     .setTopHits(10)
-                    .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+                    .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
                     .build());
     assertEquals(0, searchResponseSecondary.getHitsCount());
 
@@ -271,7 +271,7 @@ public class ReplicationServerTest {
                     .setStartHit(0)
                     .setTopHits(10)
                     .setVersion(searcherVersionPrimary.getVersion())
-                    .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+                    .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
                     .build());
     validateSearchResults(searchResponseSecondary);
   }
@@ -303,7 +303,7 @@ public class ReplicationServerTest {
                     .setIndexName(luceneServerSecondary.getTestIndex())
                     .setStartHit(0)
                     .setTopHits(10)
-                    .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+                    .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
                     .build());
     assertEquals(0, searchResponseSecondary.getHitsCount());
 
@@ -324,7 +324,7 @@ public class ReplicationServerTest {
                     .setStartHit(0)
                     .setTopHits(10)
                     .setVersion(searcherVersionPrimary.getVersion())
-                    .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+                    .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
                     .build());
     validateSearchResults(searchResponseSecondary);
   }
@@ -356,7 +356,7 @@ public class ReplicationServerTest {
                     .setIndexName(luceneServerSecondary.getTestIndex())
                     .setStartHit(0)
                     .setTopHits(10)
-                    .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+                    .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
                     .build());
     assertEquals(0, searchResponseSecondary.getHitsCount());
 
@@ -376,7 +376,7 @@ public class ReplicationServerTest {
                     .setIndexName(luceneServerSecondary.getTestIndex())
                     .setStartHit(0)
                     .setTopHits(10)
-                    .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+                    .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
                     .build());
     assertEquals(0, searchResponseSecondary.getHitsCount());
   }
@@ -397,7 +397,7 @@ public class ReplicationServerTest {
                     .setIndexName(luceneServerSecondary.getTestIndex())
                     .setStartHit(0)
                     .setTopHits(10)
-                    .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+                    .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
                     .build());
     assertEquals(0, searchResponseSecondary.getHitsCount());
 
@@ -439,7 +439,7 @@ public class ReplicationServerTest {
                     .setIndexName(luceneServerSecondary.getTestIndex())
                     .setStartHit(0)
                     .setTopHits(10)
-                    .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+                    .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
                     .build());
     assertEquals(0, searchResponseSecondary.getHitsCount());
 
@@ -468,7 +468,7 @@ public class ReplicationServerTest {
                     .setStartHit(0)
                     .setTopHits(10)
                     .setVersion(searcherVersionPrimary.getVersion())
-                    .addAllRetrieveFields(LuceneServerTest.RETRIEVED_VALUES)
+                    .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
                     .build());
     validateSearchResults(searchResponseSecondary);
   }
@@ -477,9 +477,9 @@ public class ReplicationServerTest {
     assertEquals(4, searchResponse.getTotalHits().getValue());
     assertEquals(4, searchResponse.getHitsList().size());
     SearchResponse.Hit firstHit = searchResponse.getHits(0);
-    LuceneServerTest.checkHits(firstHit);
+    NrtsearchServerTest.checkHits(firstHit);
     SearchResponse.Hit secondHit = searchResponse.getHits(1);
-    LuceneServerTest.checkHits(secondHit);
+    NrtsearchServerTest.checkHits(secondHit);
   }
 
   @Test
@@ -517,7 +517,7 @@ public class ReplicationServerTest {
 
     // set up primary servers
     String testIndex = "test_index";
-    LuceneServerConfiguration luceneServerPrimaryConfiguration =
+    NrtsearchConfig luceneServerPrimaryConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.PRIMARY, folder.getRoot(), extraConfig);
     RemoteBackend remoteBackend = new S3Backend(luceneServerPrimaryConfiguration, s3);
     luceneServerPrimary =
@@ -544,7 +544,7 @@ public class ReplicationServerTest {
         .getGlobalState()
         .replicationStarted(luceneServerPrimaryConfiguration.getReplicationPort());
     // set up secondary servers
-    LuceneServerConfiguration luceneServerSecondaryConfiguration =
+    NrtsearchConfig luceneServerSecondaryConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.REPLICA, folder.getRoot(), extraConfig);
 
     luceneServerSecondary =

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/StateBackendServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/StateBackendServerTest.java
@@ -32,10 +32,10 @@ import com.google.protobuf.StringValue;
 import com.google.protobuf.UInt64Value;
 import com.google.protobuf.util.JsonFormat;
 import com.yelp.nrtsearch.clientlib.Node;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest.MultiValuedField;
-import com.yelp.nrtsearch.server.grpc.LuceneServer.LuceneServerImpl;
-import com.yelp.nrtsearch.server.grpc.LuceneServer.ReplicationServerImpl;
+import com.yelp.nrtsearch.server.grpc.NrtsearchServer.LuceneServerImpl;
+import com.yelp.nrtsearch.server.grpc.NrtsearchServer.ReplicationServerImpl;
 import com.yelp.nrtsearch.server.grpc.SearchResponse.Hit;
 import com.yelp.nrtsearch.server.index.ImmutableIndexState;
 import com.yelp.nrtsearch.server.remote.RemoteBackend;
@@ -77,11 +77,11 @@ public class StateBackendServerTest {
 
   private Server primaryServer;
   private Server primaryReplicationServer;
-  private LuceneServerClient primaryClient;
+  private NrtsearchClient primaryClient;
 
   private Server replicaServer;
   private Server replicaReplicationServer;
-  private LuceneServerClient replicaClient;
+  private NrtsearchClient replicaClient;
 
   private static final String TEST_BUCKET = "state-backend-server-test";
   private static final String TEST_SERVICE_NAME = "state-backend-test-service";
@@ -156,7 +156,7 @@ public class StateBackendServerTest {
     remoteBackendReplica = new S3Backend(TEST_BUCKET, false, s3);
   }
 
-  private LuceneServerConfiguration getPrimaryConfig() {
+  private NrtsearchConfig getPrimaryConfig() {
     String configStr =
         String.join(
             "\n",
@@ -166,10 +166,10 @@ public class StateBackendServerTest {
             "indexDir: " + getPrimaryIndexDir(),
             "stateConfig:",
             "  backendType: LOCAL");
-    return new LuceneServerConfiguration(new ByteArrayInputStream(configStr.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
   }
 
-  private LuceneServerConfiguration getPrimaryRemoteConfig() {
+  private NrtsearchConfig getPrimaryRemoteConfig() {
     String configStr =
         String.join(
             "\n",
@@ -184,10 +184,10 @@ public class StateBackendServerTest {
             "indexStartConfig:",
             "  mode: PRIMARY",
             "  dataLocationType: REMOTE");
-    return new LuceneServerConfiguration(new ByteArrayInputStream(configStr.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
   }
 
-  private LuceneServerConfiguration getReplicaConfig() {
+  private NrtsearchConfig getReplicaConfig() {
     String configStr =
         String.join(
             "\n",
@@ -198,10 +198,10 @@ public class StateBackendServerTest {
             "syncInitialNrtPoint: true",
             "stateConfig:",
             "  backendType: LOCAL");
-    return new LuceneServerConfiguration(new ByteArrayInputStream(configStr.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
   }
 
-  private LuceneServerConfiguration getReplicaRemoteConfig() {
+  private NrtsearchConfig getReplicaRemoteConfig() {
     String configStr =
         String.join(
             "\n",
@@ -216,7 +216,7 @@ public class StateBackendServerTest {
             "indexStartConfig:",
             "  mode: REPLICA",
             "  dataLocationType: REMOTE");
-    return new LuceneServerConfiguration(new ByteArrayInputStream(configStr.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
   }
 
   private void restartPrimary() throws IOException {
@@ -231,7 +231,7 @@ public class StateBackendServerTest {
             .build()
             .start();
     primaryServer = ServerBuilder.forPort(0).addService(serverImpl).build().start();
-    primaryClient = new LuceneServerClient("localhost", primaryServer.getPort());
+    primaryClient = new NrtsearchClient("localhost", primaryServer.getPort());
   }
 
   private void restartPrimaryWithRemote() throws IOException {
@@ -249,7 +249,7 @@ public class StateBackendServerTest {
             .build()
             .start();
     primaryServer = ServerBuilder.forPort(0).addService(serverImpl).build().start();
-    primaryClient = new LuceneServerClient("localhost", primaryServer.getPort());
+    primaryClient = new NrtsearchClient("localhost", primaryServer.getPort());
   }
 
   private void restartReplica() throws IOException {
@@ -264,7 +264,7 @@ public class StateBackendServerTest {
             .build()
             .start();
     replicaServer = ServerBuilder.forPort(0).addService(serverImpl).build().start();
-    replicaClient = new LuceneServerClient("localhost", replicaServer.getPort());
+    replicaClient = new NrtsearchClient("localhost", replicaServer.getPort());
   }
 
   private void restartReplicaWithRemote() throws IOException {
@@ -282,7 +282,7 @@ public class StateBackendServerTest {
             .build()
             .start();
     replicaServer = ServerBuilder.forPort(0).addService(serverImpl).build().start();
-    replicaClient = new LuceneServerClient("localhost", replicaServer.getPort());
+    replicaClient = new NrtsearchClient("localhost", replicaServer.getPort());
   }
 
   private Path getStateDir() {
@@ -349,7 +349,7 @@ public class StateBackendServerTest {
             FieldDefRequest.newBuilder().setIndexName("test_index").addAllField(fields2).build());
   }
 
-  private IndexStateInfo getIndexState(String indexName, LuceneServerClient client)
+  private IndexStateInfo getIndexState(String indexName, NrtsearchClient client)
       throws IOException {
     StateResponse response =
         client.getBlockingStub().state(StateRequest.newBuilder().setIndexName(indexName).build());
@@ -441,7 +441,7 @@ public class StateBackendServerTest {
   private final List<String> fieldList = List.of("id", "field1", "field2", "field3", "field4");
   private final List<String> subFieldList = List.of("id", "field1", "field2");
 
-  private void verifyDocs(int expectedCount, LuceneServerClient client) {
+  private void verifyDocs(int expectedCount, NrtsearchClient client) {
     SearchResponse response =
         client
             .getBlockingStub()
@@ -484,7 +484,7 @@ public class StateBackendServerTest {
     }
   }
 
-  private void verifySubFieldDocs(int expectedCount, LuceneServerClient client) {
+  private void verifySubFieldDocs(int expectedCount, NrtsearchClient client) {
     SearchResponse response =
         client
             .getBlockingStub()
@@ -564,11 +564,11 @@ public class StateBackendServerTest {
     return response.get();
   }
 
-  private StartIndexResponse startIndex(LuceneServerClient client, Mode mode) {
+  private StartIndexResponse startIndex(NrtsearchClient client, Mode mode) {
     return startIndex(client, mode, 0);
   }
 
-  private StartIndexResponse startIndex(LuceneServerClient client, Mode mode, long primaryGen) {
+  private StartIndexResponse startIndex(NrtsearchClient client, Mode mode, long primaryGen) {
     if (mode.equals(Mode.REPLICA)) {
       return client
           .getBlockingStub()
@@ -589,7 +589,7 @@ public class StateBackendServerTest {
   }
 
   private StartIndexResponse startIndexWithRestore(
-      LuceneServerClient client, Mode mode, boolean deleteExistingData) {
+      NrtsearchClient client, Mode mode, boolean deleteExistingData) {
     if (mode.equals(Mode.REPLICA)) {
       return client
           .getBlockingStub()
@@ -623,7 +623,7 @@ public class StateBackendServerTest {
     }
   }
 
-  private DummyResponse stopIndex(LuceneServerClient client) {
+  private DummyResponse stopIndex(NrtsearchClient client) {
     DummyResponse response =
         client
             .getBlockingStub()
@@ -632,13 +632,13 @@ public class StateBackendServerTest {
     return response;
   }
 
-  private CommitResponse commitIndex(LuceneServerClient client) {
+  private CommitResponse commitIndex(NrtsearchClient client) {
     return client
         .getBlockingStub()
         .commit(CommitRequest.newBuilder().setIndexName("test_index").build());
   }
 
-  private RefreshResponse refreshIndex(LuceneServerClient client) {
+  private RefreshResponse refreshIndex(NrtsearchClient client) {
     return client
         .getBlockingStub()
         .refresh(RefreshRequest.newBuilder().setIndexName("test_index").build());

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/TestServer.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/TestServer.java
@@ -28,11 +28,11 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.yelp.nrtsearch.clientlib.Node;
 import com.yelp.nrtsearch.server.config.IndexStartConfig.IndexDataLocationType;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.config.StateConfig.StateBackendType;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest.MultiValuedField;
-import com.yelp.nrtsearch.server.grpc.LuceneServer.LuceneServerImpl;
-import com.yelp.nrtsearch.server.grpc.LuceneServer.ReplicationServerImpl;
+import com.yelp.nrtsearch.server.grpc.NrtsearchServer.LuceneServerImpl;
+import com.yelp.nrtsearch.server.grpc.NrtsearchServer.ReplicationServerImpl;
 import com.yelp.nrtsearch.server.grpc.SearchResponse.Hit;
 import com.yelp.nrtsearch.server.index.IndexState;
 import com.yelp.nrtsearch.server.index.IndexStateManager;
@@ -98,12 +98,12 @@ public class TestServer {
 
   private static S3Mock api;
 
-  private final LuceneServerConfiguration configuration;
+  private final NrtsearchConfig configuration;
   private final boolean writeDiscoveryFile;
   private final Path discoveryFilePath;
   private Server server;
   private Server replicationServer;
-  private LuceneServerClient client;
+  private NrtsearchClient client;
   private ReplicationServerClient replicationClient;
   private LuceneServerImpl serverImpl;
   private RemoteBackend remoteBackend;
@@ -126,7 +126,7 @@ public class TestServer {
   }
 
   public TestServer(
-      LuceneServerConfiguration configuration, boolean writeDiscoveryFile, Path discoveryFilePath)
+      NrtsearchConfig configuration, boolean writeDiscoveryFile, Path discoveryFilePath)
       throws IOException {
     this.configuration = configuration;
     this.writeDiscoveryFile = writeDiscoveryFile;
@@ -167,7 +167,7 @@ public class TestServer {
     }
 
     server = ServerBuilder.forPort(0).addService(serverImpl).build().start();
-    client = new LuceneServerClient("localhost", server.getPort());
+    client = new NrtsearchClient("localhost", server.getPort());
     replicationClient = new ReplicationServerClient("localhost", replicationServer.getPort());
   }
 
@@ -203,7 +203,7 @@ public class TestServer {
     return serverImpl.getGlobalState();
   }
 
-  public LuceneServerClient getClient() {
+  public NrtsearchClient getClient() {
     return client;
   }
 
@@ -687,7 +687,7 @@ public class TestServer {
               "syncInitialNrtPoint: " + syncInitialNrtPoint,
               additionalConfig);
       return new TestServer(
-          new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes())),
+          new NrtsearchConfig(new ByteArrayInputStream(configFile.getBytes())),
           writeDiscoveryFile,
           Paths.get(folder.getRoot().toString(), DISCOVERY_FILE));
     }

--- a/src/test/java/com/yelp/nrtsearch/server/index/BackendStateManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/index/BackendStateManagerTest.java
@@ -30,7 +30,7 @@ import com.google.protobuf.BoolValue;
 import com.google.protobuf.DoubleValue;
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.StringValue;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.field.FieldDefCreator;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.FieldType;
@@ -68,8 +68,8 @@ public class BackendStateManagerTest {
   @BeforeClass
   public static void setup() {
     String configFile = "nodeName: \"lucene_server_foo\"";
-    LuceneServerConfiguration dummyConfig =
-        new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+    NrtsearchConfig dummyConfig =
+        new NrtsearchConfig(new ByteArrayInputStream(configFile.getBytes()));
     List<Plugin> dummyPlugins = Collections.emptyList();
     // these must be initialized to create an IndexState
     FieldDefCreator.initialize(dummyConfig, dummyPlugins);

--- a/src/test/java/com/yelp/nrtsearch/server/index/FieldUpdateUtilsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/index/FieldUpdateUtilsTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.field.AtomFieldDef;
 import com.yelp.nrtsearch.server.field.BooleanFieldDef;
 import com.yelp.nrtsearch.server.field.DoubleFieldDef;
@@ -85,8 +85,8 @@ public class FieldUpdateUtilsTest {
   @BeforeClass
   public static void setup() {
     String configFile = "nodeName: \"lucene_server_foo\"";
-    LuceneServerConfiguration dummyConfig =
-        new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+    NrtsearchConfig dummyConfig =
+        new NrtsearchConfig(new ByteArrayInputStream(configFile.getBytes()));
     List<Plugin> dummyPlugins = Collections.emptyList();
     // these must be initialized to create an IndexState
     FieldDefCreator.initialize(dummyConfig, dummyPlugins);

--- a/src/test/java/com/yelp/nrtsearch/server/index/ImmutableIndexStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/index/ImmutableIndexStateTest.java
@@ -37,7 +37,7 @@ import com.google.protobuf.Int32Value;
 import com.google.protobuf.StringValue;
 import com.google.protobuf.UInt64Value;
 import com.yelp.nrtsearch.server.config.IndexPreloadConfig;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.field.AtomFieldDef;
 import com.yelp.nrtsearch.server.field.FieldDef;
 import com.yelp.nrtsearch.server.field.FieldDefCreator;
@@ -88,8 +88,8 @@ public class ImmutableIndexStateTest {
   @BeforeClass
   public static void setup() {
     String configFile = "nodeName: \"lucene_server_foo\"";
-    LuceneServerConfiguration dummyConfig =
-        new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+    NrtsearchConfig dummyConfig =
+        new NrtsearchConfig(new ByteArrayInputStream(configFile.getBytes()));
     List<Plugin> dummyPlugins = Collections.emptyList();
     // these must be initialized to create an IndexState
     FieldDefCreator.initialize(dummyConfig, dummyPlugins);
@@ -130,8 +130,8 @@ public class ImmutableIndexStateTest {
     GlobalState mockGlobalState = mock(GlobalState.class);
 
     String configFile = "nodeName: \"lucene_server_foo\"";
-    LuceneServerConfiguration dummyConfig =
-        new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+    NrtsearchConfig dummyConfig =
+        new NrtsearchConfig(new ByteArrayInputStream(configFile.getBytes()));
 
     when(mockGlobalState.getIndexDirBase()).thenReturn(folder.getRoot().toPath());
     when(mockGlobalState.getConfiguration()).thenReturn(dummyConfig);
@@ -623,8 +623,8 @@ public class ImmutableIndexStateTest {
     GlobalState mockGlobalState = mock(GlobalState.class);
 
     String configFile = "virtualSharding: " + (enabled ? "true" : "false");
-    LuceneServerConfiguration dummyConfig =
-        new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+    NrtsearchConfig dummyConfig =
+        new NrtsearchConfig(new ByteArrayInputStream(configFile.getBytes()));
 
     when(mockGlobalState.getIndexDirBase()).thenReturn(folder.getRoot().toPath());
     when(mockGlobalState.getConfiguration()).thenReturn(dummyConfig);
@@ -873,8 +873,7 @@ public class ImmutableIndexStateTest {
     GlobalState mockGlobalState = mock(GlobalState.class);
 
     String configFile = "threadPoolConfiguration:\n  fetch:\n    maxThreads: 10";
-    LuceneServerConfiguration config =
-        new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+    NrtsearchConfig config = new NrtsearchConfig(new ByteArrayInputStream(configFile.getBytes()));
 
     when(mockGlobalState.getIndexDirBase()).thenReturn(folder.getRoot().toPath());
     when(mockGlobalState.getConfiguration()).thenReturn(config);
@@ -949,8 +948,8 @@ public class ImmutableIndexStateTest {
     GlobalState mockGlobalState = mock(GlobalState.class);
 
     String configFile = "nodeName: \"lucene_server_foo\"";
-    LuceneServerConfiguration dummyConfig =
-        new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+    NrtsearchConfig dummyConfig =
+        new NrtsearchConfig(new ByteArrayInputStream(configFile.getBytes()));
 
     when(mockGlobalState.getIndexDirBase()).thenReturn(folder.getRoot().toPath());
     when(mockGlobalState.getConfiguration()).thenReturn(dummyConfig);

--- a/src/test/java/com/yelp/nrtsearch/server/logging/HitsLoggerCreatorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/logging/HitsLoggerCreatorTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.LoggingHits;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import com.yelp.nrtsearch.server.plugins.HitsLoggerPlugin;
@@ -44,9 +44,9 @@ public class HitsLoggerCreatorTest {
     HitsLoggerCreator.initialize(getEmptyConfig(), plugins);
   }
 
-  private LuceneServerConfiguration getEmptyConfig() {
+  private NrtsearchConfig getEmptyConfig() {
     String config = "nodeName: \"lucene_server_foo\"";
-    return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
   }
 
   public static class TestHitsLoggerPlugin extends Plugin implements HitsLoggerPlugin {

--- a/src/test/java/com/yelp/nrtsearch/server/logging/HitsLoggerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/logging/HitsLoggerTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import com.yelp.nrtsearch.server.ServerTestCase;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
 import com.yelp.nrtsearch.server.grpc.LoggingHits;
@@ -47,7 +47,7 @@ public class HitsLoggerTest extends ServerTestCase {
   @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
   @Override
-  protected List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
+  protected List<Plugin> getPlugins(NrtsearchConfig configuration) {
     return Collections.singletonList(new HitsLoggerTest.TestHitsLoggerPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/plugins/PluginsServiceTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/plugins/PluginsServiceTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -36,22 +36,22 @@ public class PluginsServiceTest {
 
   @Rule public TemporaryFolder folder = new TemporaryFolder();
 
-  private LuceneServerConfiguration getEmptyConfig() {
+  private NrtsearchConfig getEmptyConfig() {
     String config = "nodeName: \"lucene_server_foo\"";
-    return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
   }
 
-  private LuceneServerConfiguration getConfigWithSearchPath(String path) {
+  private NrtsearchConfig getConfigWithSearchPath(String path) {
     String config = "pluginSearchPath: \"" + path + "\"";
-    return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
   }
 
-  private LuceneServerConfiguration getConfigWithSearchPaths(String... paths) {
+  private NrtsearchConfig getConfigWithSearchPaths(String... paths) {
     StringBuilder config = new StringBuilder("pluginSearchPath:").append("\n");
     for (String path : paths) {
       config.append("  - ").append(path).append("\n");
     }
-    return new LuceneServerConfiguration(new ByteArrayInputStream(config.toString().getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(config.toString().getBytes()));
   }
 
   private PrometheusRegistry getPrometheusRegistry() {
@@ -60,7 +60,7 @@ public class PluginsServiceTest {
 
   @Test
   public void testGetSinglePluginSearchPath() {
-    LuceneServerConfiguration config = getConfigWithSearchPath("some/plugin/path");
+    NrtsearchConfig config = getConfigWithSearchPath("some/plugin/path");
     PluginsService pluginsService = new PluginsService(config, null, getPrometheusRegistry());
     List<File> expectedPaths = new ArrayList<>();
     expectedPaths.add(new File("some/plugin/path"));
@@ -69,7 +69,7 @@ public class PluginsServiceTest {
 
   @Test
   public void testGetMultiPluginSearchPath() {
-    LuceneServerConfiguration config =
+    NrtsearchConfig config =
         getConfigWithSearchPaths(
             "some1/plugin1/path1", "some2/plugin2/path2", "some3/plugin3/path3");
     PluginsService pluginsService = new PluginsService(config, null, getPrometheusRegistry());
@@ -141,10 +141,10 @@ public class PluginsServiceTest {
   }
 
   public static class LoadTestPlugin extends Plugin {
-    public LuceneServerConfiguration config;
+    public NrtsearchConfig config;
     public PrometheusRegistry prometheusRegistry;
 
-    public LoadTestPlugin(LuceneServerConfiguration config) {
+    public LoadTestPlugin(NrtsearchConfig config) {
       this.config = config;
     }
 
@@ -159,10 +159,10 @@ public class PluginsServiceTest {
   }
 
   public static class LoadTestPluginWithMetrics extends Plugin implements MetricsPlugin {
-    public LuceneServerConfiguration config;
+    public NrtsearchConfig config;
     public PrometheusRegistry prometheusRegistry;
 
-    public LoadTestPluginWithMetrics(LuceneServerConfiguration config) {
+    public LoadTestPluginWithMetrics(NrtsearchConfig config) {
       this.config = config;
     }
 
@@ -217,7 +217,7 @@ public class PluginsServiceTest {
 
   @Test
   public void testGetPluginInstanceHasConfig() {
-    LuceneServerConfiguration config = getEmptyConfig();
+    NrtsearchConfig config = getEmptyConfig();
     PluginsService pluginsService = new PluginsService(config, null, getPrometheusRegistry());
     Plugin loadedPlugin = pluginsService.getPluginInstance(LoadTestPlugin.class);
     LoadTestPlugin loadTestPlugin = (LoadTestPlugin) loadedPlugin;

--- a/src/test/java/com/yelp/nrtsearch/server/query/QueryNodeMapperTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/query/QueryNodeMapperTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.doc.DocLookup;
 import com.yelp.nrtsearch.server.grpc.*;
 import com.yelp.nrtsearch.server.grpc.SearchResponse.Diagnostics;
@@ -58,9 +58,9 @@ public class QueryNodeMapperTest extends ServerTestCase {
     ScriptService.initialize(getEmptyConfig(), plugins);
   }
 
-  private LuceneServerConfiguration getEmptyConfig() {
+  private NrtsearchConfig getEmptyConfig() {
     String config = "nodeName: \"lucene_server_foo\"";
-    return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
   }
 
   @Override

--- a/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendTest.java
@@ -27,7 +27,7 @@ import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
 import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.nrt.state.NrtFileMetaData;
 import com.yelp.nrtsearch.server.nrt.state.NrtPointState;
 import com.yelp.nrtsearch.server.remote.RemoteBackend;
@@ -72,8 +72,7 @@ public class S3BackendTest {
   @BeforeClass
   public static void setup() throws IOException {
     String configStr = "bucketName: " + BUCKET_NAME;
-    LuceneServerConfiguration config =
-        new LuceneServerConfiguration(new ByteArrayInputStream(configStr.getBytes()));
+    NrtsearchConfig config = new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
     s3 = S3_PROVIDER.getAmazonS3();
     s3Backend = new S3Backend(config, s3);
     s3.putObject(BUCKET_NAME, KEY, CONTENT);

--- a/src/test/java/com/yelp/nrtsearch/server/rescore/RescorerCreatorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/rescore/RescorerCreatorTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.PluginRescorer;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.plugins.RescorerPlugin;
@@ -45,9 +45,9 @@ public class RescorerCreatorTest {
     RescorerCreator.initialize(getEmptyConfig(), plugins);
   }
 
-  private LuceneServerConfiguration getEmptyConfig() {
+  private NrtsearchConfig getEmptyConfig() {
     String config = "nodeName: \"lucene_server_foo\"";
-    return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
   }
 
   public static class TestRescorerPlugin extends Plugin implements RescorerPlugin {

--- a/src/test/java/com/yelp/nrtsearch/server/rescore/RescorerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/rescore/RescorerTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.doc.LoadedDocValues;
 import com.yelp.nrtsearch.server.field.IndexableFieldDef;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
@@ -172,7 +172,7 @@ public class RescorerTest extends ServerTestCase {
   }
 
   @Override
-  protected List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
+  protected List<Plugin> getPlugins(NrtsearchConfig configuration) {
     return Collections.singletonList(new TestRescorerPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/script/ScoreScriptTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/script/ScoreScriptTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.common.primitives.Floats;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.doc.DocLookup;
 import com.yelp.nrtsearch.server.doc.LoadedDocValues;
 import com.yelp.nrtsearch.server.doc.LoadedDocValues.SingleVector;
@@ -98,7 +98,7 @@ public class ScoreScriptTest {
 
   private GrpcServer setUpGrpcServer(PrometheusRegistry prometheusRegistry) throws IOException {
     String testIndex = "test_index";
-    LuceneServerConfiguration luceneServerConfiguration =
+    NrtsearchConfig luceneServerConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
     return new GrpcServer(
         prometheusRegistry,

--- a/src/test/java/com/yelp/nrtsearch/server/script/ScriptServiceTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/script/ScriptServiceTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.Script;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.plugins.ScriptPlugin;
@@ -44,9 +44,9 @@ public class ScriptServiceTest {
     ScriptService.initialize(getEmptyConfig(), plugins);
   }
 
-  private LuceneServerConfiguration getEmptyConfig() {
+  private NrtsearchConfig getEmptyConfig() {
     String config = "nodeName: \"lucene_server_foo\"";
-    return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
   }
 
   static class TestScriptPlugin extends Plugin implements ScriptPlugin {

--- a/src/test/java/com/yelp/nrtsearch/server/search/FetchTaskCreatorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/FetchTaskCreatorTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.FetchTask;
 import com.yelp.nrtsearch.server.plugins.FetchTaskPlugin;
 import com.yelp.nrtsearch.server.plugins.Plugin;
@@ -42,9 +42,9 @@ public class FetchTaskCreatorTest {
     FetchTaskCreator.initialize(getEmptyConfig(), plugins);
   }
 
-  private LuceneServerConfiguration getEmptyConfig() {
+  private NrtsearchConfig getEmptyConfig() {
     String config = "nodeName: \"lucene_server_foo\"";
-    return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
   }
 
   public static class TestFetchTaskPlugin extends Plugin implements FetchTaskPlugin {

--- a/src/test/java/com/yelp/nrtsearch/server/search/FetchTasksTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/FetchTasksTest.java
@@ -18,7 +18,7 @@ package com.yelp.nrtsearch.server.search;
 import static org.junit.Assert.assertEquals;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.doc.LoadedDocValues;
 import com.yelp.nrtsearch.server.field.FieldDef;
 import com.yelp.nrtsearch.server.field.IndexableFieldDef;
@@ -83,7 +83,7 @@ public class FetchTasksTest extends ServerTestCase {
   }
 
   @Override
-  public List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
+  public List<Plugin> getPlugins(NrtsearchConfig configuration) {
     return Collections.singletonList(new TestFetchTaskPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/search/collectors/CollectorCreatorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/collectors/CollectorCreatorTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.Collector;
 import com.yelp.nrtsearch.server.grpc.CollectorResult;
 import com.yelp.nrtsearch.server.grpc.PluginCollector;
@@ -57,9 +57,9 @@ public class CollectorCreatorTest {
     CollectorCreator.initialize(getEmptyConfig(), plugins);
   }
 
-  private LuceneServerConfiguration getEmptyConfig() {
+  private NrtsearchConfig getEmptyConfig() {
     String config = "nodeName: \"lucene_server_foo\"";
-    return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
   }
 
   public static class TestCollectorPlugin extends Plugin implements CollectorPlugin {

--- a/src/test/java/com/yelp/nrtsearch/server/search/collectors/CollectorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/collectors/CollectorTest.java
@@ -24,7 +24,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import com.yelp.nrtsearch.server.ServerTestCase;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.doc.LoadedDocValues;
 import com.yelp.nrtsearch.server.field.IndexableFieldDef;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
@@ -313,7 +313,7 @@ public class CollectorTest extends ServerTestCase {
   }
 
   @Override
-  protected List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
+  protected List<Plugin> getPlugins(NrtsearchConfig configuration) {
     return Collections.singletonList(new TestCollectorPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/CollectorStatsWrapperTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/CollectorStatsWrapperTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.doc.DocLookup;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.Collector;
@@ -112,7 +112,7 @@ public class CollectorStatsWrapperTest extends ServerTestCase {
   }
 
   @Override
-  public List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
+  public List<Plugin> getPlugins(NrtsearchConfig configuration) {
     return Collections.singletonList(new TestScriptPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/ScriptTermsCollectorManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/ScriptTermsCollectorManagerTest.java
@@ -18,7 +18,7 @@ package com.yelp.nrtsearch.server.search.collectors.additional;
 import static com.yelp.nrtsearch.server.collectors.BucketOrder.COUNT;
 import static org.junit.Assert.assertEquals;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.doc.DocLookup;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.BucketOrder;
@@ -230,7 +230,7 @@ public class ScriptTermsCollectorManagerTest extends TermsCollectorManagerTestsB
   }
 
   @Override
-  protected List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
+  protected List<Plugin> getPlugins(NrtsearchConfig configuration) {
     return Collections.singletonList(new TestTermsScriptPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/similarity/SimilarityCreatorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/similarity/SimilarityCreatorTest.java
@@ -18,7 +18,7 @@ package com.yelp.nrtsearch.server.similarity;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.plugins.SimilarityPlugin;
 import java.io.ByteArrayInputStream;
@@ -47,9 +47,9 @@ public class SimilarityCreatorTest {
     SimilarityCreator.initialize(getEmptyConfig(), plugins);
   }
 
-  private LuceneServerConfiguration getEmptyConfig() {
+  private NrtsearchConfig getEmptyConfig() {
     String config = "nodeName: \"lucene_server_foo\"";
-    return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
   }
 
   public static class TestSimilarityPlugin extends Plugin implements SimilarityPlugin {

--- a/src/test/java/com/yelp/nrtsearch/server/similarity/SimilarityTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/similarity/SimilarityTest.java
@@ -18,7 +18,7 @@ package com.yelp.nrtsearch.server.similarity;
 import static org.junit.Assert.assertEquals;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest.MultiValuedField;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
@@ -107,7 +107,7 @@ public class SimilarityTest extends ServerTestCase {
   }
 
   @Override
-  protected List<Plugin> getPlugins(LuceneServerConfiguration configuration) {
+  protected List<Plugin> getPlugins(NrtsearchConfig configuration) {
     return Collections.singletonList(new TestSimilarityPlugin());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/state/BackendGlobalStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/state/BackendGlobalStateTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.protobuf.Int32Value;
 import com.yelp.nrtsearch.server.concurrent.ThreadPoolExecutorFactory;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.field.FieldDefCreator;
 import com.yelp.nrtsearch.server.grpc.GlobalStateInfo;
 import com.yelp.nrtsearch.server.grpc.IndexGlobalState;
@@ -84,8 +84,8 @@ public class BackendGlobalStateTest {
   @BeforeClass
   public static void setup() {
     String configFile = "nodeName: \"lucene_server_foo\"";
-    LuceneServerConfiguration dummyConfig =
-        new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+    NrtsearchConfig dummyConfig =
+        new NrtsearchConfig(new ByteArrayInputStream(configFile.getBytes()));
     List<Plugin> dummyPlugins = Collections.emptyList();
     // these must be initialized to create an IndexState
     FieldDefCreator.initialize(dummyConfig, dummyPlugins);
@@ -111,8 +111,7 @@ public class BackendGlobalStateTest {
      * @param luceneServerConfiguration server config
      * @throws IOException on filesystem error
      */
-    public MockBackendGlobalState(LuceneServerConfiguration luceneServerConfiguration)
-        throws IOException {
+    public MockBackendGlobalState(NrtsearchConfig luceneServerConfiguration) throws IOException {
       super(luceneServerConfiguration, null);
     }
 
@@ -138,7 +137,7 @@ public class BackendGlobalStateTest {
     }
   }
 
-  private LuceneServerConfiguration getConfig() throws IOException {
+  private NrtsearchConfig getConfig() throws IOException {
     String configFile =
         String.join(
             "\n",
@@ -146,10 +145,10 @@ public class BackendGlobalStateTest {
             "  backendType: LOCAL",
             "stateDir: " + folder.newFolder("state").getAbsolutePath(),
             "indexDir: " + folder.newFolder("index").getAbsolutePath());
-    return new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(configFile.getBytes()));
   }
 
-  private LuceneServerConfiguration getConfigWithLiveSettingsOverrides() throws IOException {
+  private NrtsearchConfig getConfigWithLiveSettingsOverrides() throws IOException {
     String configFile =
         String.join(
             "\n",
@@ -161,7 +160,7 @@ public class BackendGlobalStateTest {
             "  test_index:",
             "    sliceMaxDocs: 1",
             "    virtualShards: 100");
-    return new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(configFile.getBytes()));
   }
 
   @Test
@@ -730,8 +729,7 @@ public class BackendGlobalStateTest {
             "  backendType: LOCAL",
             "stateDir: " + folder.newFolder("state").getAbsolutePath(),
             "indexDir: " + folder.newFolder("index").getAbsolutePath());
-    LuceneServerConfiguration config =
-        new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+    NrtsearchConfig config = new NrtsearchConfig(new ByteArrayInputStream(configFile.getBytes()));
     BackendGlobalState backendGlobalState = new BackendGlobalState(config, null);
     assertTrue(backendGlobalState.getStateBackend() instanceof LocalStateBackend);
   }
@@ -747,8 +745,7 @@ public class BackendGlobalStateTest {
             "    readOnly: false",
             "stateDir: " + folder.newFolder("state").getAbsolutePath(),
             "indexDir: " + folder.newFolder("index").getAbsolutePath());
-    LuceneServerConfiguration config =
-        new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+    NrtsearchConfig config = new NrtsearchConfig(new ByteArrayInputStream(configFile.getBytes()));
 
     Path tmpStateFolder =
         Paths.get(folder.getRoot().getAbsolutePath(), StateUtils.GLOBAL_STATE_FOLDER);

--- a/src/test/java/com/yelp/nrtsearch/server/state/GlobalStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/state/GlobalStateTest.java
@@ -18,7 +18,7 @@ package com.yelp.nrtsearch.server.state;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import org.junit.Rule;
@@ -29,8 +29,8 @@ public class GlobalStateTest {
 
   @Rule public final TemporaryFolder folder = new TemporaryFolder();
 
-  private LuceneServerConfiguration getConfig(String config) {
-    return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+  private NrtsearchConfig getConfig(String config) {
+    return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
   }
 
   @Test
@@ -41,7 +41,7 @@ public class GlobalStateTest {
             "stateConfig:",
             "  backendType: LOCAL",
             "stateDir: " + folder.getRoot().getAbsolutePath());
-    LuceneServerConfiguration configuration = getConfig(configFile);
+    NrtsearchConfig configuration = getConfig(configFile);
     GlobalState globalState = GlobalState.createState(configuration, null);
     assertTrue(globalState instanceof BackendGlobalState);
   }
@@ -49,7 +49,7 @@ public class GlobalStateTest {
   @Test
   public void testGetGeneration() throws IOException {
     String configFile = String.join("\n", "stateConfig:", "  backendType: LOCAL");
-    LuceneServerConfiguration configuration = getConfig(configFile);
+    NrtsearchConfig configuration = getConfig(configFile);
     GlobalState globalState = GlobalState.createState(configuration, null);
     long gen = globalState.getGeneration();
     assertTrue(gen > 0);

--- a/src/test/java/com/yelp/nrtsearch/server/state/backend/LocalStateBackendTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/state/backend/LocalStateBackendTest.java
@@ -28,7 +28,7 @@ import com.google.protobuf.BoolValue;
 import com.google.protobuf.DoubleValue;
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.StringValue;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.GlobalStateInfo;
 import com.yelp.nrtsearch.server.grpc.IndexGlobalState;
 import com.yelp.nrtsearch.server.grpc.IndexLiveSettings;
@@ -52,19 +52,19 @@ public class LocalStateBackendTest {
 
   @Rule public final TemporaryFolder folder = new TemporaryFolder();
 
-  private LuceneServerConfiguration getConfig() throws IOException {
+  private NrtsearchConfig getConfig() throws IOException {
     String configFile =
         String.join(
             "\n",
             "stateConfig:",
             "  backendType: LOCAL",
             "stateDir: " + folder.getRoot().getAbsolutePath());
-    return new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(configFile.getBytes()));
   }
 
   private GlobalState getMockGlobalState() throws IOException {
     GlobalState mockState = mock(GlobalState.class);
-    LuceneServerConfiguration serverConfiguration = getConfig();
+    NrtsearchConfig serverConfiguration = getConfig();
     when(mockState.getConfiguration()).thenReturn(serverConfiguration);
     when(mockState.getStateDir()).thenReturn(Paths.get(serverConfiguration.getStateDir()));
     return mockState;

--- a/src/test/java/com/yelp/nrtsearch/server/state/backend/RemoteStateBackendTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/state/backend/RemoteStateBackendTest.java
@@ -29,7 +29,7 @@ import com.google.protobuf.BoolValue;
 import com.google.protobuf.DoubleValue;
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.StringValue;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.GlobalStateInfo;
 import com.yelp.nrtsearch.server.grpc.IndexGlobalState;
 import com.yelp.nrtsearch.server.grpc.IndexLiveSettings;
@@ -67,7 +67,7 @@ public class RemoteStateBackendTest {
     remoteBackend = new S3Backend(TEST_BUCKET, false, s3Provider.getAmazonS3());
   }
 
-  private LuceneServerConfiguration getConfig(boolean readOnly) throws IOException {
+  private NrtsearchConfig getConfig(boolean readOnly) throws IOException {
     String configFile =
         String.join(
             "\n",
@@ -77,12 +77,12 @@ public class RemoteStateBackendTest {
             "    readOnly: " + readOnly,
             "stateDir: " + folder.getRoot().getAbsolutePath(),
             "serviceName: " + TEST_SERVICE_NAME);
-    return new LuceneServerConfiguration(new ByteArrayInputStream(configFile.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(configFile.getBytes()));
   }
 
   private GlobalState getMockGlobalState(boolean readOnly) throws IOException {
     GlobalState mockState = mock(GlobalState.class);
-    LuceneServerConfiguration serverConfiguration = getConfig(readOnly);
+    NrtsearchConfig serverConfiguration = getConfig(readOnly);
     when(mockState.getConfiguration()).thenReturn(serverConfiguration);
     when(mockState.getStateDir()).thenReturn(Paths.get(serverConfiguration.getStateDir()));
     when(mockState.getRemoteBackend()).thenReturn(remoteBackend);

--- a/src/test/java/com/yelp/nrtsearch/server/utils/LuceneServerTestConfigurationFactory.java
+++ b/src/test/java/com/yelp/nrtsearch/server/utils/LuceneServerTestConfigurationFactory.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.server.utils;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.Mode;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -25,12 +25,11 @@ import java.util.concurrent.atomic.AtomicLong;
 public class LuceneServerTestConfigurationFactory {
   static AtomicLong atomicLong = new AtomicLong();
 
-  public static LuceneServerConfiguration getConfig(Mode mode, File dataRootDir) {
+  public static NrtsearchConfig getConfig(Mode mode, File dataRootDir) {
     return getConfig(mode, dataRootDir, "");
   }
 
-  public static LuceneServerConfiguration getConfig(
-      Mode mode, File dataRootDir, String extraConfig) {
+  public static NrtsearchConfig getConfig(Mode mode, File dataRootDir, String extraConfig) {
     String dirNum = String.valueOf(atomicLong.addAndGet(1));
     if (mode.equals(Mode.STANDALONE)) {
       String stateDir =
@@ -46,7 +45,7 @@ public class LuceneServerTestConfigurationFactory {
               "port: " + (9700 + atomicLong.intValue()),
               "replicationPort: " + (17000 + atomicLong.intValue()),
               extraConfig);
-      return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+      return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
     } else if (mode.equals(Mode.PRIMARY)) {
       String stateDir =
           Paths.get(dataRootDir.getAbsolutePath(), "primary", dirNum, "state").toString();
@@ -61,7 +60,7 @@ public class LuceneServerTestConfigurationFactory {
               "port: " + 9900,
               "replicationPort: " + 9001,
               extraConfig);
-      return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+      return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
     } else if (mode.equals(Mode.REPLICA)) {
       String stateDir =
           Paths.get(dataRootDir.getAbsolutePath(), "replica", dirNum, "state").toString();
@@ -76,7 +75,7 @@ public class LuceneServerTestConfigurationFactory {
               "port: " + 9902,
               "replicationPort: " + 9003,
               extraConfig);
-      return new LuceneServerConfiguration(new ByteArrayInputStream(config.getBytes()));
+      return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
     }
     throw new RuntimeException("Invalid mode %s, cannot build config" + mode);
   }

--- a/src/test/java/com/yelp/nrtsearch/server/warming/WarmerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/warming/WarmerTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.amazonaws.services.s3.AmazonS3;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.Query;
 import com.yelp.nrtsearch.server.grpc.SearchRequest;
 import com.yelp.nrtsearch.server.grpc.TermQuery;
@@ -61,8 +61,7 @@ public class WarmerTest {
   @Before
   public void setup() throws IOException {
     String configStr = "bucketName: " + bucketName;
-    LuceneServerConfiguration config =
-        new LuceneServerConfiguration(new ByteArrayInputStream(configStr.getBytes()));
+    NrtsearchConfig config = new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
     s3 = s3Provider.getAmazonS3();
     remoteBackend = new S3Backend(config, s3);
     warmer = new Warmer(remoteBackend, service, index, 2);

--- a/src/test/java/com/yelp/nrtsearch/test_utils/NrtsearchTest.java
+++ b/src/test/java/com/yelp/nrtsearch/test_utils/NrtsearchTest.java
@@ -20,9 +20,11 @@ import static com.yelp.nrtsearch.test_utils.DefaultTestProperties.REPLICATION_PO
 import static com.yelp.nrtsearch.test_utils.DefaultTestProperties.S3_BUCKET_NAME;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.yelp.nrtsearch.module.TestNrtsearchModule;
 import com.yelp.nrtsearch.server.ServerTestCase;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchServer;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -38,10 +40,9 @@ import org.yaml.snakeyaml.Yaml;
 /**
  * Base class for tests which need to initialize an Nrtsearch instance. Unlike {@link
  * ServerTestCase} which directly creates a gRPC server using {@link
- * com.yelp.nrtsearch.server.grpc.LuceneServer.LuceneServerImpl}, this class creates and starts
- * {@link com.yelp.nrtsearch.server.grpc.LuceneServer} using a custom guice module ({@link
- * com.yelp.nrtsearch.module.TestLuceneServerModule}. This class is useful for tests which require
- * testing the initialization path of {@link com.yelp.nrtsearch.server.grpc.LuceneServer}.
+ * NrtsearchServer.LuceneServerImpl}, this class creates and starts {@link NrtsearchServer} using a
+ * custom guice module ({@link TestNrtsearchModule}. This class is useful for tests which require
+ * testing the initialization path of {@link NrtsearchServer}.
  */
 public class NrtsearchTest {
 
@@ -82,11 +83,11 @@ public class NrtsearchTest {
 
   /**
    * Override this method to add any additional configuration which will be used to build {@link
-   * LuceneServerConfiguration} for the test Nrtsearch instance. When overriding this method
-   * remember to call {@code super.addNrtsearchConfigs(config)} so that the default configs get
-   * added as well, unless you don't need the defaults.
+   * NrtsearchConfig} for the test Nrtsearch instance. When overriding this method remember to call
+   * {@code super.addNrtsearchConfigs(config)} so that the default configs get added as well, unless
+   * you don't need the defaults.
    *
-   * @param config A {@link Map} which will be used to built {@link LuceneServerConfiguration}
+   * @param config A {@link Map} which will be used to built {@link NrtsearchConfig}
    */
   protected void addNrtsearchConfigs(Map<String, Object> config) {
     config.put("port", PORT);
@@ -102,7 +103,7 @@ public class NrtsearchTest {
     }
   }
 
-  private LuceneServerConfiguration getConfig() {
+  private NrtsearchConfig getConfig() {
     Map<String, Object> config = new HashMap<>();
     addNrtsearchConfigs(config);
 
@@ -111,15 +112,15 @@ public class NrtsearchTest {
     options.setPrettyFlow(false);
 
     String yamlConfig = yaml.dump(config);
-    return new LuceneServerConfiguration(new ByteArrayInputStream(yamlConfig.getBytes()));
+    return new NrtsearchConfig(new ByteArrayInputStream(yamlConfig.getBytes()));
   }
 
   /**
-   * Get the {@link LuceneServerClient} for the test Nrtsearch instance
+   * Get the {@link NrtsearchClient} for the test Nrtsearch instance
    *
-   * @return {@link LuceneServerClient}
+   * @return {@link NrtsearchClient}
    */
-  protected LuceneServerClient getClient() {
+  protected NrtsearchClient getClient() {
     return testLuceneServer.getClient();
   }
 

--- a/src/test/java/com/yelp/nrtsearch/test_utils/TestLuceneServer.java
+++ b/src/test/java/com/yelp/nrtsearch/test_utils/TestLuceneServer.java
@@ -18,25 +18,25 @@ package com.yelp.nrtsearch.test_utils;
 import com.amazonaws.services.s3.AmazonS3;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import com.yelp.nrtsearch.module.TestLuceneServerModule;
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
-import com.yelp.nrtsearch.server.grpc.LuceneServer;
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.module.TestNrtsearchModule;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchServer;
 import java.io.IOException;
 import org.junit.rules.ExternalResource;
 
 /**
- * A JUnit {@link org.junit.Rule} that creates a {@link LuceneServer} instance and starts the grpc
- * server from it. After the test it will delete the index data and stop the server.
+ * A JUnit {@link org.junit.Rule} that creates a {@link NrtsearchServer} instance and starts the
+ * grpc server from it. After the test it will delete the index data and stop the server.
  */
 public class TestLuceneServer extends ExternalResource {
 
-  private final LuceneServerConfiguration luceneServerConfiguration;
+  private final NrtsearchConfig luceneServerConfiguration;
   private final AmazonS3 amazonS3;
-  private LuceneServer luceneServer;
-  private LuceneServerClient client;
+  private NrtsearchServer luceneServer;
+  private NrtsearchClient client;
 
-  public TestLuceneServer(LuceneServerConfiguration luceneServerConfiguration, AmazonS3 amazonS3) {
+  public TestLuceneServer(NrtsearchConfig luceneServerConfiguration, AmazonS3 amazonS3) {
     this.luceneServerConfiguration = luceneServerConfiguration;
     this.amazonS3 = amazonS3;
   }
@@ -44,7 +44,7 @@ public class TestLuceneServer extends ExternalResource {
   @Override
   protected void before() throws Throwable {
     this.luceneServer = createTestServer();
-    this.client = new LuceneServerClient("localhost", luceneServerConfiguration.getPort());
+    this.client = new NrtsearchClient("localhost", luceneServerConfiguration.getPort());
   }
 
   @Override
@@ -54,14 +54,14 @@ public class TestLuceneServer extends ExternalResource {
     luceneServer.stop();
   }
 
-  protected LuceneServerClient getClient() {
+  protected NrtsearchClient getClient() {
     return client;
   }
 
-  private LuceneServer createTestServer() throws IOException {
+  private NrtsearchServer createTestServer() throws IOException {
     Injector injector =
-        Guice.createInjector(new TestLuceneServerModule(luceneServerConfiguration, amazonS3));
-    LuceneServer luceneServer = injector.getInstance(LuceneServer.class);
+        Guice.createInjector(new TestNrtsearchModule(luceneServerConfiguration, amazonS3));
+    NrtsearchServer luceneServer = injector.getInstance(NrtsearchServer.class);
     luceneServer.start();
     return luceneServer;
   }

--- a/src/test/java/com/yelp/nrtsearch/tools/cli/CreateIndexCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/cli/CreateIndexCommandTest.java
@@ -56,7 +56,7 @@ public class CreateIndexCommandTest {
   public void testCreateIndex() throws IOException {
     TestServer server = getTestServer();
 
-    CommandLine cmd = new CommandLine(new LuceneClientCommand());
+    CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
         cmd.execute(
             "--hostname=localhost",
@@ -76,7 +76,7 @@ public class CreateIndexCommandTest {
   public void testCreateIndexWithSettings() throws IOException {
     TestServer server = getTestServer();
 
-    CommandLine cmd = new CommandLine(new LuceneClientCommand());
+    CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
         cmd.execute(
             "--hostname=localhost",
@@ -99,7 +99,7 @@ public class CreateIndexCommandTest {
   public void testCreateIndexWithLiveSettings() throws IOException {
     TestServer server = getTestServer();
 
-    CommandLine cmd = new CommandLine(new LuceneClientCommand());
+    CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
         cmd.execute(
             "--hostname=localhost",
@@ -122,7 +122,7 @@ public class CreateIndexCommandTest {
   public void testCreateIndexWithFields() throws IOException {
     TestServer server = getTestServer();
 
-    CommandLine cmd = new CommandLine(new LuceneClientCommand());
+    CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
         cmd.execute(
             "--hostname=localhost",
@@ -154,7 +154,7 @@ public class CreateIndexCommandTest {
   public void testCreateIndexWithAll() throws IOException {
     TestServer server = getTestServer();
 
-    CommandLine cmd = new CommandLine(new LuceneClientCommand());
+    CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
         cmd.execute(
             "--hostname=localhost",
@@ -191,7 +191,7 @@ public class CreateIndexCommandTest {
   public void testCreateAndStartIndex() throws IOException {
     TestServer server = getTestServer();
 
-    CommandLine cmd = new CommandLine(new LuceneClientCommand());
+    CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
         cmd.execute(
             "--hostname=localhost",

--- a/src/test/java/com/yelp/nrtsearch/tools/cli/IndicesCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/cli/IndicesCommandTest.java
@@ -80,7 +80,7 @@ public class IndicesCommandTest extends ServerTestCase {
   }
 
   private int runIndicesCommand() {
-    CommandLine cmd = new CommandLine(new LuceneClientCommand());
+    CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     return cmd.execute(
         "--hostname=localhost", "--port=" + getGrpcServer().getGlobalState().getPort(), "indices");
   }

--- a/src/test/java/com/yelp/nrtsearch/tools/cli/LiveSettingsV2CommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/cli/LiveSettingsV2CommandTest.java
@@ -53,7 +53,7 @@ public class LiveSettingsV2CommandTest {
 
     assertFalse(server.getGlobalState().getIndex("test_index").getVerboseMetrics());
 
-    CommandLine cmd = new CommandLine(new LuceneClientCommand());
+    CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
         cmd.execute(
             "--hostname=localhost",
@@ -99,7 +99,7 @@ public class LiveSettingsV2CommandTest {
     server.createSimpleIndex("test_index");
     server.startIndexV2(StartIndexV2Request.newBuilder().setIndexName("test_index").build());
 
-    CommandLine cmd = new CommandLine(new LuceneClientCommand());
+    CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
         cmd.execute(
             "--hostname=localhost",
@@ -119,7 +119,7 @@ public class LiveSettingsV2CommandTest {
     assertEquals(
         0.0, server.getGlobalState().getIndex("test_index").getDefaultSearchTimeoutSec(), 0);
 
-    CommandLine cmd = new CommandLine(new LuceneClientCommand());
+    CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
         cmd.execute(
             "--hostname=localhost",
@@ -146,7 +146,7 @@ public class LiveSettingsV2CommandTest {
     assertEquals(
         0.0, server.getGlobalState().getIndex("test_index").getDefaultSearchTimeoutSec(), 0);
 
-    CommandLine cmd = new CommandLine(new LuceneClientCommand());
+    CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
         cmd.execute(
             "--hostname=localhost",

--- a/src/test/java/com/yelp/nrtsearch/tools/cli/ReadyCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/cli/ReadyCommandTest.java
@@ -17,7 +17,7 @@ package com.yelp.nrtsearch.tools.cli;
 
 import static org.junit.Assert.assertEquals;
 
-import com.yelp.nrtsearch.server.config.LuceneServerConfiguration;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.CreateIndexRequest;
 import com.yelp.nrtsearch.server.grpc.GrpcServer;
 import com.yelp.nrtsearch.server.grpc.Mode;
@@ -48,7 +48,7 @@ public class ReadyCommandTest {
   private GrpcServer server;
 
   private void startServer() throws IOException {
-    LuceneServerConfiguration luceneServerPrimaryConfiguration =
+    NrtsearchConfig luceneServerPrimaryConfiguration =
         LuceneServerTestConfigurationFactory.getConfig(Mode.PRIMARY, folder.getRoot());
     server =
         new GrpcServer(
@@ -77,7 +77,7 @@ public class ReadyCommandTest {
 
   @Test
   public void testNoServer() {
-    CommandLine cmd = new CommandLine(new LuceneClientCommand());
+    CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode = cmd.execute("--hostname=localhost", "--port=12345", "ready");
     assertEquals(1, exitCode);
   }
@@ -85,7 +85,7 @@ public class ReadyCommandTest {
   @Test
   public void testNoIndices() throws IOException {
     startServer();
-    CommandLine cmd = new CommandLine(new LuceneClientCommand());
+    CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
         cmd.execute("--hostname=localhost", "--port=" + server.getGlobalState().getPort(), "ready");
     assertEquals(0, exitCode);
@@ -124,7 +124,7 @@ public class ReadyCommandTest {
     verifyIndicesReady("test_index,test_index_2", 0);
     verifyIndicesReady("test_index,test_index_3", 1);
 
-    CommandLine cmd = new CommandLine(new LuceneClientCommand());
+    CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
         cmd.execute("--hostname=localhost", "--port=" + server.getGlobalState().getPort(), "ready");
     assertEquals(0, exitCode);
@@ -144,14 +144,14 @@ public class ReadyCommandTest {
     verifyIndicesReady("test_index,test_index_2", 1);
     verifyIndicesReady("test_index,test_index_3", 0);
 
-    CommandLine cmd = new CommandLine(new LuceneClientCommand());
+    CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
         cmd.execute("--hostname=localhost", "--port=" + server.getGlobalState().getPort(), "ready");
     assertEquals(0, exitCode);
   }
 
   private void verifyIndicesReady(String indices, int expectedExitCode) {
-    CommandLine cmd = new CommandLine(new LuceneClientCommand());
+    CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
         cmd.execute(
             "--hostname=localhost",

--- a/src/test/java/com/yelp/nrtsearch/tools/cli/StartIndexV2CommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/cli/StartIndexV2CommandTest.java
@@ -52,7 +52,7 @@ public class StartIndexV2CommandTest {
     assertTrue(server.indices().contains("test_index"));
     assertFalse(server.isStarted("test_index"));
 
-    CommandLine cmd = new CommandLine(new LuceneClientCommand());
+    CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
         cmd.execute(
             "--hostname=localhost",

--- a/src/test/java/com/yelp/nrtsearch/yelp_reviews/utils/DocumentGeneratorAndIndexer.java
+++ b/src/test/java/com/yelp/nrtsearch/yelp_reviews/utils/DocumentGeneratorAndIndexer.java
@@ -17,7 +17,7 @@ package com.yelp.nrtsearch.yelp_reviews.utils;
 
 import com.google.gson.Gson;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.util.concurrent.Callable;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -27,13 +27,13 @@ import org.slf4j.LoggerFactory;
 public class DocumentGeneratorAndIndexer implements Callable<Long> {
   private final Stream<String> lines;
   private final Gson gson = new Gson();
-  final LuceneServerClient luceneServerClient;
+  final NrtsearchClient luceneServerClient;
   private static final Logger logger =
       LoggerFactory.getLogger(DocumentGeneratorAndIndexer.class.getName());
   private final OneDocBuilder oneDocBuilder;
 
   public DocumentGeneratorAndIndexer(
-      OneDocBuilder oneDocBuilder, Stream<String> lines, LuceneServerClient luceneServerClient) {
+      OneDocBuilder oneDocBuilder, Stream<String> lines, NrtsearchClient luceneServerClient) {
     this.lines = lines;
     this.luceneServerClient = luceneServerClient;
     this.oneDocBuilder = oneDocBuilder;

--- a/src/test/java/com/yelp/nrtsearch/yelp_reviews/utils/IndexerTask.java
+++ b/src/test/java/com/yelp/nrtsearch/yelp_reviews/utils/IndexerTask.java
@@ -17,7 +17,7 @@ package com.yelp.nrtsearch.yelp_reviews.utils;
 
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.AddDocumentResponse;
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import io.grpc.stub.StreamObserver;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -30,7 +30,7 @@ public class IndexerTask {
   private String genId;
 
   public Long index(
-      LuceneServerClient luceneServerClient, Stream<AddDocumentRequest> addDocumentRequestStream)
+      NrtsearchClient luceneServerClient, Stream<AddDocumentRequest> addDocumentRequestStream)
       throws Exception {
     String threadId = Thread.currentThread().getName() + Thread.currentThread().getId();
 

--- a/src/test/java/com/yelp/nrtsearch/yelp_reviews/utils/ParallelDocumentIndexer.java
+++ b/src/test/java/com/yelp/nrtsearch/yelp_reviews/utils/ParallelDocumentIndexer.java
@@ -15,7 +15,7 @@
  */
 package com.yelp.nrtsearch.yelp_reviews.utils;
 
-import com.yelp.nrtsearch.server.grpc.LuceneServerClient;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
@@ -37,7 +37,7 @@ public class ParallelDocumentIndexer {
       OneDocBuilder oneDocBuilder,
       Path path,
       ExecutorService executorService,
-      LuceneServerClient luceneServerClient)
+      NrtsearchClient luceneServerClient)
       throws IOException, InterruptedException {
     try (BufferedReader br = new BufferedReader(new FileReader(path.toFile()))) {
       String line;
@@ -71,7 +71,7 @@ public class ParallelDocumentIndexer {
   private static Future<Long> submitTask(
       OneDocBuilder oneDocBuilder,
       ExecutorService executorService,
-      LuceneServerClient luceneServerClient,
+      NrtsearchClient luceneServerClient,
       List<String> rawLines)
       throws InterruptedException {
     Future<Long> genIdFuture;


### PR DESCRIPTION
Rename
- `LuceneServerConfiguration` -> `NrtsearchConfig`
- `LuceneServer` -> `NrtsearchServer`
- `LuceneServerClient` -> `NrtsearchClient`
- `LuceneServerClientBuilder` -> `NrtsearchClientBuilder`
- `LuceneServerModule` -> `NrtsearchModule`
- `LuceneClientCommand` -> `NrtsearchClientCommand`
- `LuceneServerMonitoringServerInterceptor` -> `NrtsearchMonitoringServerInterceptor`

A similar renaming was done for test classes.

I am sure there is still a bunch of variable name/comment cleanup that needs to be done, but this should unblock releasing a new version.