### PR TITLE
Add explicit throw methods for getting index state and fields

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/codec/ServerCodec.java
+++ b/src/main/java/com/yelp/nrtsearch/server/codec/ServerCodec.java
@@ -41,7 +41,7 @@ public class ServerCodec extends Lucene912Codec {
   public PostingsFormat getPostingsFormatForField(String field) {
     IndexState state = stateManager.getCurrent();
     try {
-      FieldDef fd = state.getField(field);
+      FieldDef fd = state.getFieldOrThrow(field);
       if (fd instanceof IndexableFieldDef indexableFieldDef) {
         PostingsFormat postingsFormat = indexableFieldDef.getPostingsFormat();
         if (postingsFormat != null) {
@@ -64,7 +64,7 @@ public class ServerCodec extends Lucene912Codec {
   public DocValuesFormat getDocValuesFormatForField(String field) {
     IndexState state = stateManager.getCurrent();
     try {
-      FieldDef fd = state.getField(field);
+      FieldDef fd = state.getFieldOrThrow(field);
       if (fd instanceof IndexableFieldDef indexableFieldDef) {
         DocValuesFormat docValuesFormat = indexableFieldDef.getDocValuesFormat();
         if (docValuesFormat != null) {
@@ -85,7 +85,7 @@ public class ServerCodec extends Lucene912Codec {
   public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
     IndexState state = stateManager.getCurrent();
     try {
-      FieldDef fd = state.getField(field);
+      FieldDef fd = state.getFieldOrThrow(field);
       if (fd instanceof VectorFieldDef vectorFieldDef) {
         KnnVectorsFormat vectorsFormat = vectorFieldDef.getVectorsFormat();
         if (vectorsFormat != null) {

--- a/src/main/java/com/yelp/nrtsearch/server/facet/FacetTopDocs.java
+++ b/src/main/java/com/yelp/nrtsearch/server/facet/FacetTopDocs.java
@@ -82,7 +82,7 @@ public class FacetTopDocs {
   private static FacetResult facetFromTopDocs(
       TopDocs topDocs, Facet facet, IndexState indexState, IndexSearcher searcher)
       throws IOException {
-    FieldDef fieldDef = indexState.getField(facet.getDim());
+    FieldDef fieldDef = indexState.getFieldOrThrow(facet.getDim());
     if (!(fieldDef instanceof IndexableFieldDef)) {
       throw new IllegalArgumentException(
           "Sampling facet field must be indexable: " + facet.getDim());

--- a/src/main/java/com/yelp/nrtsearch/server/handler/AddDocumentHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/AddDocumentHandler.java
@@ -70,7 +70,7 @@ public class AddDocumentHandler extends Handler<AddDocumentRequest, AddDocumentR
 
       private int getAddDocumentsMaxBufferLen(String indexName) {
         try {
-          return getGlobalState().getIndex(indexName).getAddDocumentsMaxBufferLen();
+          return getGlobalState().getIndexOrThrow(indexName).getAddDocumentsMaxBufferLen();
         } catch (Exception e) {
           String error =
               String.format("Index %s does not exist, unable to add documents", indexName);
@@ -327,7 +327,7 @@ public class AddDocumentHandler extends Handler<AddDocumentRequest, AddDocumentR
         DocumentsContext documentsContext,
         IndexState indexState)
         throws AddDocumentHandlerException {
-      parseMultiValueField(indexState.getField(fieldName), value, documentsContext);
+      parseMultiValueField(indexState.getFieldOrThrow(fieldName), value, documentsContext);
     }
 
     /** Parse MultiValuedField for a single field, which is always a List<String>. */
@@ -401,7 +401,7 @@ public class AddDocumentHandler extends Handler<AddDocumentRequest, AddDocumentR
       IdFieldDef idFieldDef;
 
       try {
-        indexState = globalState.getIndex(this.indexName);
+        indexState = globalState.getIndexOrThrow(this.indexName);
         shardState = indexState.getShard(0);
         idFieldDef = indexState.getIdFieldDef().orElse(null);
         for (AddDocumentRequest addDocumentRequest : addDocumentRequestList) {

--- a/src/main/java/com/yelp/nrtsearch/server/handler/AddReplicaHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/AddReplicaHandler.java
@@ -46,7 +46,7 @@ public class AddReplicaHandler extends Handler<AddReplicaRequest, AddReplicaResp
       AddReplicaRequest addReplicaRequest, StreamObserver<AddReplicaResponse> responseObserver) {
     try {
       IndexStateManager indexStateManager =
-          getGlobalState().getIndexStateManager(addReplicaRequest.getIndexName());
+          getGlobalState().getIndexStateManagerOrThrow(addReplicaRequest.getIndexName());
       checkIndexId(addReplicaRequest.getIndexId(), indexStateManager.getIndexId(), verifyIndexId);
 
       IndexState indexState = indexStateManager.getCurrent();

--- a/src/main/java/com/yelp/nrtsearch/server/handler/BackupWarmingQueriesHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/BackupWarmingQueriesHandler.java
@@ -42,7 +42,7 @@ public class BackupWarmingQueriesHandler
     logger.info("Received backup warming queries request: {}", request);
     String index = request.getIndex();
     try {
-      IndexState indexState = getGlobalState().getIndex(index);
+      IndexState indexState = getGlobalState().getIndexOrThrow(index);
       Warmer warmer = indexState.getWarmer();
       if (warmer == null) {
         logger.warn("Unable to backup warming queries as warmer not found for index: {}", index);

--- a/src/main/java/com/yelp/nrtsearch/server/handler/CommitHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/CommitHandler.java
@@ -45,7 +45,7 @@ public class CommitHandler extends Handler<CommitRequest, CommitResponse> {
                       () -> {
                         try {
                           IndexState indexState =
-                              getGlobalState().getIndex(commitRequest.getIndexName());
+                              getGlobalState().getIndexOrThrow(commitRequest.getIndexName());
                           long gen = indexState.commit();
                           CommitResponse reply =
                               CommitResponse.newBuilder()

--- a/src/main/java/com/yelp/nrtsearch/server/handler/CopyFilesHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/CopyFilesHandler.java
@@ -50,7 +50,7 @@ public class CopyFilesHandler extends Handler<CopyFiles, TransferStatus> {
   public void handle(CopyFiles request, StreamObserver<TransferStatus> responseObserver) {
     try {
       IndexStateManager indexStateManager =
-          getGlobalState().getIndexStateManager(request.getIndexName());
+          getGlobalState().getIndexStateManagerOrThrow(request.getIndexName());
       checkIndexId(request.getIndexId(), indexStateManager.getIndexId(), verifyIndexId);
 
       IndexState indexState = indexStateManager.getCurrent();

--- a/src/main/java/com/yelp/nrtsearch/server/handler/CreateSnapshotHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/CreateSnapshotHandler.java
@@ -46,7 +46,8 @@ public class CreateSnapshotHandler extends Handler<CreateSnapshotRequest, Create
       CreateSnapshotRequest createSnapshotRequest,
       StreamObserver<CreateSnapshotResponse> responseObserver) {
     try {
-      IndexState indexState = getGlobalState().getIndex(createSnapshotRequest.getIndexName());
+      IndexState indexState =
+          getGlobalState().getIndexOrThrow(createSnapshotRequest.getIndexName());
       CreateSnapshotResponse reply = createSnapshot(indexState, createSnapshotRequest);
       logger.info(String.format("CreateSnapshotHandler returned results %s", reply.toString()));
       responseObserver.onNext(reply);

--- a/src/main/java/com/yelp/nrtsearch/server/handler/DeleteAllDocumentsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/DeleteAllDocumentsHandler.java
@@ -40,7 +40,8 @@ public class DeleteAllDocumentsHandler
       StreamObserver<DeleteAllDocumentsResponse> responseObserver) {
     logger.info("Received delete all documents request: {}", deleteAllDocumentsRequest);
     try {
-      IndexState indexState = getGlobalState().getIndex(deleteAllDocumentsRequest.getIndexName());
+      IndexState indexState =
+          getGlobalState().getIndexOrThrow(deleteAllDocumentsRequest.getIndexName());
       DeleteAllDocumentsResponse reply = handle(indexState);
       logger.info("DeleteAllDocumentsHandler returned " + reply);
       responseObserver.onNext(reply);

--- a/src/main/java/com/yelp/nrtsearch/server/handler/DeleteByQueryHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/DeleteByQueryHandler.java
@@ -43,7 +43,7 @@ public class DeleteByQueryHandler extends Handler<DeleteByQueryRequest, AddDocum
       DeleteByQueryRequest deleteByQueryRequest,
       StreamObserver<AddDocumentResponse> responseObserver) {
     try {
-      IndexState indexState = getGlobalState().getIndex(deleteByQueryRequest.getIndexName());
+      IndexState indexState = getGlobalState().getIndexOrThrow(deleteByQueryRequest.getIndexName());
       AddDocumentResponse reply = handle(indexState, deleteByQueryRequest);
       logger.debug("DeleteDocumentsHandler returned " + reply.toString());
       responseObserver.onNext(reply);

--- a/src/main/java/com/yelp/nrtsearch/server/handler/DeleteDocumentsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/DeleteDocumentsHandler.java
@@ -43,7 +43,7 @@ public class DeleteDocumentsHandler extends Handler<AddDocumentRequest, AddDocum
   public void handle(
       AddDocumentRequest addDocumentRequest, StreamObserver<AddDocumentResponse> responseObserver) {
     try {
-      IndexState indexState = getGlobalState().getIndex(addDocumentRequest.getIndexName());
+      IndexState indexState = getGlobalState().getIndexOrThrow(addDocumentRequest.getIndexName());
       AddDocumentResponse reply = handleInternal(indexState, addDocumentRequest);
       logger.debug("DeleteDocumentsHandler returned {}", reply);
       responseObserver.onNext(reply);

--- a/src/main/java/com/yelp/nrtsearch/server/handler/DeleteIndexHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/DeleteIndexHandler.java
@@ -37,7 +37,7 @@ public class DeleteIndexHandler extends Handler<DeleteIndexRequest, DeleteIndexR
       DeleteIndexRequest deleteIndexRequest, StreamObserver<DeleteIndexResponse> responseObserver) {
     logger.info("Received delete index request: {}", deleteIndexRequest);
     try {
-      IndexState indexState = getGlobalState().getIndex(deleteIndexRequest.getIndexName());
+      IndexState indexState = getGlobalState().getIndexOrThrow(deleteIndexRequest.getIndexName());
       DeleteIndexResponse reply = handle(indexState);
       logger.info("DeleteIndexHandler returned " + reply);
       responseObserver.onNext(reply);

--- a/src/main/java/com/yelp/nrtsearch/server/handler/ForceMergeDeletesHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/ForceMergeDeletesHandler.java
@@ -45,7 +45,7 @@ public class ForceMergeDeletesHandler
     }
 
     try {
-      IndexState indexState = getGlobalState().getIndex(forceMergeRequest.getIndexName());
+      IndexState indexState = getGlobalState().getIndexOrThrow(forceMergeRequest.getIndexName());
       ShardState shardState = indexState.getShards().get(0);
       logger.info("Beginning force merge deletes for index: {}", forceMergeRequest.getIndexName());
       shardState.writer.forceMergeDeletes(forceMergeRequest.getDoWait());

--- a/src/main/java/com/yelp/nrtsearch/server/handler/ForceMergeHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/ForceMergeHandler.java
@@ -48,7 +48,7 @@ public class ForceMergeHandler extends Handler<ForceMergeRequest, ForceMergeResp
     }
 
     try {
-      IndexState indexState = getGlobalState().getIndex(forceMergeRequest.getIndexName());
+      IndexState indexState = getGlobalState().getIndexOrThrow(forceMergeRequest.getIndexName());
       ShardState shardState = indexState.getShards().get(0);
       logger.info("Beginning force merge for index: {}", forceMergeRequest.getIndexName());
       shardState.writer.forceMerge(

--- a/src/main/java/com/yelp/nrtsearch/server/handler/GetAllSnapshotIndexGenHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/GetAllSnapshotIndexGenHandler.java
@@ -39,7 +39,7 @@ public class GetAllSnapshotIndexGenHandler
     try {
       Set<Long> snapshotGens =
           getGlobalState()
-              .getIndex(request.getIndexName())
+              .getIndexOrThrow(request.getIndexName())
               .getShard(0)
               .snapshotGenToVersion
               .keySet();

--- a/src/main/java/com/yelp/nrtsearch/server/handler/GetNodesInfoHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/GetNodesInfoHandler.java
@@ -40,7 +40,7 @@ public class GetNodesInfoHandler extends Handler<GetNodesRequest, GetNodesRespon
   public void handle(
       GetNodesRequest getNodesRequest, StreamObserver<GetNodesResponse> responseObserver) {
     try {
-      IndexState indexState = getGlobalState().getIndex(getNodesRequest.getIndexName());
+      IndexState indexState = getGlobalState().getIndexOrThrow(getNodesRequest.getIndexName());
       GetNodesResponse reply = handle(indexState);
       logger.debug("GetNodesInfoHandler returned GetNodeResponse of size " + reply.getNodesCount());
       responseObserver.onNext(reply);

--- a/src/main/java/com/yelp/nrtsearch/server/handler/GetStateHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/GetStateHandler.java
@@ -37,7 +37,7 @@ public class GetStateHandler extends Handler<StateRequest, StateResponse> {
   @Override
   public void handle(StateRequest request, StreamObserver<StateResponse> responseObserver) {
     try {
-      IndexState indexState = getGlobalState().getIndex(request.getIndexName());
+      IndexState indexState = getGlobalState().getIndexOrThrow(request.getIndexName());
       StateResponse reply = handle(indexState);
       logger.debug("GetStateHandler returned " + reply);
       responseObserver.onNext(reply);

--- a/src/main/java/com/yelp/nrtsearch/server/handler/IndicesHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/IndicesHandler.java
@@ -57,7 +57,7 @@ public class IndicesHandler extends Handler<IndicesRequest, IndicesResponse> {
     Set<String> indexNames = globalState.getIndexNames();
     IndicesResponse.Builder builder = IndicesResponse.newBuilder();
     for (String indexName : indexNames) {
-      IndexState indexState = globalState.getIndex(indexName);
+      IndexState indexState = globalState.getIndexOrThrow(indexName);
       if (indexState.isStarted()) {
         StatsResponse statsResponse = StatsHandler.process(indexState);
         builder.addIndicesResponse(

--- a/src/main/java/com/yelp/nrtsearch/server/handler/LiveSettingsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/LiveSettingsHandler.java
@@ -42,7 +42,7 @@ public class LiveSettingsHandler extends Handler<LiveSettingsRequest, LiveSettin
       LiveSettingsRequest req, StreamObserver<LiveSettingsResponse> responseObserver) {
     logger.info("Received live settings request: {}", req);
     try {
-      IndexState indexState = getGlobalState().getIndex(req.getIndexName());
+      IndexState indexState = getGlobalState().getIndexOrThrow(req.getIndexName());
       LiveSettingsResponse reply = handle(indexState, req);
       logger.info("LiveSettingsHandler returned {}", reply.toString());
       responseObserver.onNext(reply);
@@ -80,7 +80,7 @@ public class LiveSettingsHandler extends Handler<LiveSettingsRequest, LiveSettin
     IndexStateManager indexStateManager;
     try {
       indexStateManager =
-          indexStateIn.getGlobalState().getIndexStateManager(indexStateIn.getName());
+          indexStateIn.getGlobalState().getIndexStateManagerOrThrow(indexStateIn.getName());
     } catch (IOException e) {
       throw new RuntimeException("Unable to get index state manager", e);
     }

--- a/src/main/java/com/yelp/nrtsearch/server/handler/LiveSettingsV2Handler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/LiveSettingsV2Handler.java
@@ -41,7 +41,7 @@ public class LiveSettingsV2Handler extends Handler<LiveSettingsV2Request, LiveSe
     logger.info("Received live settings V2 request: {}", req);
     try {
       IndexStateManager indexStateManager =
-          getGlobalState().getIndexStateManager(req.getIndexName());
+          getGlobalState().getIndexStateManagerOrThrow(req.getIndexName());
       LiveSettingsV2Response reply = handle(indexStateManager, req);
       logger.info("LiveSettingsV2Handler returned " + JsonFormat.printer().print(reply));
       responseObserver.onNext(reply);

--- a/src/main/java/com/yelp/nrtsearch/server/handler/NewNRTPointHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/NewNRTPointHandler.java
@@ -42,7 +42,7 @@ public class NewNRTPointHandler extends Handler<NewNRTPoint, TransferStatus> {
   public void handle(NewNRTPoint request, StreamObserver<TransferStatus> responseObserver) {
     try {
       IndexStateManager indexStateManager =
-          getGlobalState().getIndexStateManager(request.getIndexName());
+          getGlobalState().getIndexStateManagerOrThrow(request.getIndexName());
       checkIndexId(request.getIndexId(), indexStateManager.getIndexId(), verifyIndexId);
 
       IndexState indexState = indexStateManager.getCurrent();

--- a/src/main/java/com/yelp/nrtsearch/server/handler/ReadyHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/ReadyHandler.java
@@ -70,8 +70,7 @@ public class ReadyHandler extends Handler<ReadyCheckRequest, HealthCheckResponse
     try {
       List<String> indicesNotStarted = new ArrayList<>();
       for (String indexName : indexNames) {
-        // The ready endpoint should skip loading index state
-        IndexState indexState = getGlobalState().getIndex(indexName, true);
+        IndexState indexState = getGlobalState().getIndexOrThrow(indexName);
         if (!indexState.isStarted()) {
           indicesNotStarted.add(indexName);
         }

--- a/src/main/java/com/yelp/nrtsearch/server/handler/RecvCopyStateHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/RecvCopyStateHandler.java
@@ -48,7 +48,7 @@ public class RecvCopyStateHandler extends Handler<CopyStateRequest, CopyState> {
   public void handle(CopyStateRequest request, StreamObserver<CopyState> responseObserver) {
     try {
       IndexStateManager indexStateManager =
-          getGlobalState().getIndexStateManager(request.getIndexName());
+          getGlobalState().getIndexStateManagerOrThrow(request.getIndexName());
       checkIndexId(request.getIndexId(), indexStateManager.getIndexId(), verifyIndexId);
 
       IndexState indexState = indexStateManager.getCurrent();

--- a/src/main/java/com/yelp/nrtsearch/server/handler/RecvRawFileHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/RecvRawFileHandler.java
@@ -43,7 +43,7 @@ public class RecvRawFileHandler extends Handler<FileInfo, RawFileChunk> {
   public void handle(FileInfo fileInfoRequest, StreamObserver<RawFileChunk> responseObserver) {
     try {
       IndexStateManager indexStateManager =
-          getGlobalState().getIndexStateManager(fileInfoRequest.getIndexName());
+          getGlobalState().getIndexStateManagerOrThrow(fileInfoRequest.getIndexName());
       checkIndexId(fileInfoRequest.getIndexId(), indexStateManager.getIndexId(), verifyIndexId);
 
       IndexState indexState = indexStateManager.getCurrent();

--- a/src/main/java/com/yelp/nrtsearch/server/handler/RecvRawFileV2Handler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/RecvRawFileV2Handler.java
@@ -59,7 +59,7 @@ public class RecvRawFileV2Handler extends Handler<FileInfo, RawFileChunk> {
           if (indexState == null) {
             // Start transfer
             IndexStateManager indexStateManager =
-                getGlobalState().getIndexStateManager(fileInfoRequest.getIndexName());
+                getGlobalState().getIndexStateManagerOrThrow(fileInfoRequest.getIndexName());
             checkIndexId(
                 fileInfoRequest.getIndexId(), indexStateManager.getIndexId(), verifyIndexId);
 

--- a/src/main/java/com/yelp/nrtsearch/server/handler/RefreshHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/RefreshHandler.java
@@ -37,7 +37,7 @@ public class RefreshHandler extends Handler<RefreshRequest, RefreshResponse> {
   public void handle(
       RefreshRequest refreshRequest, StreamObserver<RefreshResponse> responseObserver) {
     try {
-      IndexState indexState = getGlobalState().getIndex(refreshRequest.getIndexName());
+      IndexState indexState = getGlobalState().getIndexOrThrow(refreshRequest.getIndexName());
       final ShardState shardState = indexState.getShard(0);
       long t0 = System.nanoTime();
       shardState.maybeRefreshBlocking();

--- a/src/main/java/com/yelp/nrtsearch/server/handler/RegisterFieldsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/RegisterFieldsHandler.java
@@ -38,7 +38,7 @@ public class RegisterFieldsHandler extends Handler<FieldDefRequest, FieldDefResp
     logger.info("Received register fields request: {}", fieldDefRequest);
     try {
       IndexStateManager indexStateManager =
-          getGlobalState().getIndexStateManager(fieldDefRequest.getIndexName());
+          getGlobalState().getIndexStateManagerOrThrow(fieldDefRequest.getIndexName());
       String updatedFields = indexStateManager.updateFields(fieldDefRequest.getFieldList());
       FieldDefResponse reply = FieldDefResponse.newBuilder().setResponse(updatedFields).build();
       logger.info("RegisterFieldsHandler registered fields " + reply);

--- a/src/main/java/com/yelp/nrtsearch/server/handler/ReleaseSnapshotHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/ReleaseSnapshotHandler.java
@@ -39,7 +39,8 @@ public class ReleaseSnapshotHandler
       ReleaseSnapshotRequest releaseSnapshotRequest,
       StreamObserver<ReleaseSnapshotResponse> responseObserver) {
     try {
-      IndexState indexState = getGlobalState().getIndex(releaseSnapshotRequest.getIndexName());
+      IndexState indexState =
+          getGlobalState().getIndexOrThrow(releaseSnapshotRequest.getIndexName());
       ReleaseSnapshotResponse reply = handle(indexState, releaseSnapshotRequest);
       logger.info(String.format("CreateSnapshotHandler returned results %s", reply.toString()));
       responseObserver.onNext(reply);

--- a/src/main/java/com/yelp/nrtsearch/server/handler/ReplicaCurrentSearchingVersionHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/ReplicaCurrentSearchingVersionHandler.java
@@ -37,7 +37,7 @@ public class ReplicaCurrentSearchingVersionHandler extends Handler<IndexName, Se
   @Override
   public void handle(IndexName indexNameRequest, StreamObserver<SearcherVersion> responseObserver) {
     try {
-      IndexState indexState = getGlobalState().getIndex(indexNameRequest.getIndexName());
+      IndexState indexState = getGlobalState().getIndexOrThrow(indexNameRequest.getIndexName());
       SearcherVersion reply = handle(indexState, indexNameRequest);
       logger.info("ReplicaCurrentSearchingVersionHandler returned version " + reply.getVersion());
       responseObserver.onNext(reply);

--- a/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
@@ -151,7 +151,7 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
 
   public SearchResponse getSearchResponse(SearchRequest searchRequest)
       throws IOException, SearchHandlerException {
-    IndexState indexState = getGlobalState().getIndex(searchRequest.getIndexName());
+    IndexState indexState = getGlobalState().getIndexOrThrow(searchRequest.getIndexName());
     return handle(indexState, searchRequest);
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/handler/SettingsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SettingsHandler.java
@@ -44,7 +44,7 @@ public class SettingsHandler extends Handler<SettingsRequest, SettingsResponse> 
       SettingsRequest settingsRequest, StreamObserver<SettingsResponse> responseObserver) {
     logger.info("Received settings request: {}", settingsRequest);
     try {
-      IndexState indexState = getGlobalState().getIndex(settingsRequest.getIndexName());
+      IndexState indexState = getGlobalState().getIndexOrThrow(settingsRequest.getIndexName());
       SettingsResponse reply = handle(indexState, settingsRequest);
       logger.info("SettingsHandler returned " + reply);
       responseObserver.onNext(reply);
@@ -85,7 +85,8 @@ public class SettingsHandler extends Handler<SettingsRequest, SettingsResponse> 
       IndexState indexState, SettingsRequest settingsRequest) throws SettingsHandlerException {
     IndexStateManager indexStateManager;
     try {
-      indexStateManager = indexState.getGlobalState().getIndexStateManager(indexState.getName());
+      indexStateManager =
+          indexState.getGlobalState().getIndexStateManagerOrThrow(indexState.getName());
     } catch (IOException e) {
       throw new SettingsHandlerException("Unable to get index state manager", e);
     }

--- a/src/main/java/com/yelp/nrtsearch/server/handler/SettingsV2Handler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SettingsV2Handler.java
@@ -41,7 +41,7 @@ public class SettingsV2Handler extends Handler<SettingsV2Request, SettingsV2Resp
     logger.info("Received settings V2 request: {}", settingsRequest);
     try {
       IndexStateManager indexStateManager =
-          getGlobalState().getIndexStateManager(settingsRequest.getIndexName());
+          getGlobalState().getIndexStateManagerOrThrow(settingsRequest.getIndexName());
       SettingsV2Response reply = handle(indexStateManager, settingsRequest);
       logger.info("SettingsV2Handler returned: " + JsonFormat.printer().print(reply));
       responseObserver.onNext(reply);

--- a/src/main/java/com/yelp/nrtsearch/server/handler/StatsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/StatsHandler.java
@@ -48,7 +48,7 @@ public class StatsHandler extends Handler<StatsRequest, StatsResponse> {
   @Override
   public void handle(StatsRequest statsRequest, StreamObserver<StatsResponse> responseObserver) {
     try {
-      IndexState indexState = getGlobalState().getIndex(statsRequest.getIndexName());
+      IndexState indexState = getGlobalState().getIndexOrThrow(statsRequest.getIndexName());
       indexState.verifyStarted();
       StatsResponse reply = process(indexState);
       logger.debug("StatsHandler retrieved stats for index: {} ", reply);

--- a/src/main/java/com/yelp/nrtsearch/server/handler/UpdateFieldsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/UpdateFieldsHandler.java
@@ -38,7 +38,7 @@ public class UpdateFieldsHandler extends Handler<FieldDefRequest, FieldDefRespon
     logger.info("Received update fields request: {}", fieldDefRequest);
     try {
       IndexStateManager indexStateManager =
-          getGlobalState().getIndexStateManager(fieldDefRequest.getIndexName());
+          getGlobalState().getIndexStateManagerOrThrow(fieldDefRequest.getIndexName());
       String updatedFields = indexStateManager.updateFields(fieldDefRequest.getFieldList());
       FieldDefResponse reply = FieldDefResponse.newBuilder().setResponse(updatedFields).build();
       logger.info("UpdateFieldsHandler registered fields " + reply);

--- a/src/main/java/com/yelp/nrtsearch/server/handler/WriteNRTPointHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/WriteNRTPointHandler.java
@@ -45,7 +45,7 @@ public class WriteNRTPointHandler extends Handler<IndexName, SearcherVersion> {
   public void handle(IndexName indexNameRequest, StreamObserver<SearcherVersion> responseObserver) {
     try {
       IndexStateManager indexStateManager =
-          getGlobalState().getIndexStateManager(indexNameRequest.getIndexName());
+          getGlobalState().getIndexStateManagerOrThrow(indexNameRequest.getIndexName());
       String indexId = indexStateManager.getIndexId();
       IndexState indexState = indexStateManager.getCurrent();
       SearcherVersion reply = handle(indexState, indexId);

--- a/src/main/java/com/yelp/nrtsearch/server/highlights/HighlightFetchTask.java
+++ b/src/main/java/com/yelp/nrtsearch/server/highlights/HighlightFetchTask.java
@@ -73,7 +73,7 @@ public class HighlightFetchTask implements FetchTask {
     for (Entry<String, HighlightSettings> fieldSetting : fieldSettings.entrySet()) {
       String fieldName = fieldSetting.getKey();
       Highlighter highlighter = fieldSetting.getValue().getHighlighter();
-      FieldDef fieldDef = indexState.getField(fieldName);
+      FieldDef fieldDef = indexState.getFieldOrThrow(fieldName);
       TextBaseFieldDef textBaseFieldDef =
           (TextBaseFieldDef) fieldDef; // This is safe as we verified earlier
       String[] highlights =
@@ -112,7 +112,7 @@ public class HighlightFetchTask implements FetchTask {
     for (Entry<String, HighlightSettings> entry : fieldSettings.entrySet()) {
       String fieldName = entry.getKey();
       Highlighter highlighter = entry.getValue().getHighlighter();
-      FieldDef field = indexState.getField(fieldName);
+      FieldDef field = indexState.getFieldOrThrow(fieldName);
       if (!(field instanceof TextBaseFieldDef)) {
         throw new IllegalArgumentException(
             String.format(

--- a/src/main/java/com/yelp/nrtsearch/server/index/ImmutableIndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/ImmutableIndexState.java
@@ -435,13 +435,7 @@ public class ImmutableIndexState extends IndexState {
     if (fd != null) {
       return fd;
     }
-    fd = fieldAndFacetState.getFields().get(fieldName);
-    if (fd == null) {
-      String message =
-          "field \"" + fieldName + "\" is unknown: it was not registered with registerField";
-      throw new IllegalArgumentException(message);
-    }
-    return fd;
+    return fieldAndFacetState.getFields().get(fieldName);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/index/IndexAnalyzer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/IndexAnalyzer.java
@@ -38,7 +38,7 @@ public class IndexAnalyzer extends AnalyzerWrapper {
 
   @Override
   protected Analyzer getWrappedAnalyzer(String name) {
-    FieldDef fd = stateManager.getCurrent().getField(name);
+    FieldDef fd = stateManager.getCurrent().getFieldOrThrow(name);
     if (fd instanceof TextBaseFieldDef || fd instanceof ContextSuggestFieldDef) {
       Optional<Analyzer> maybeAnalyzer;
       if (fd instanceof TextBaseFieldDef) {

--- a/src/main/java/com/yelp/nrtsearch/server/index/IndexSimilarity.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/IndexSimilarity.java
@@ -50,7 +50,7 @@ public class IndexSimilarity extends PerFieldSimilarityWrapper {
    */
   public static Similarity getFromState(String name, IndexState indexState) {
     try {
-      FieldDef fd = indexState.getField(name);
+      FieldDef fd = indexState.getFieldOrThrow(name);
       if (fd instanceof IndexableFieldDef) {
         return ((IndexableFieldDef) fd).getSimilarity();
       }

--- a/src/main/java/com/yelp/nrtsearch/server/index/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/IndexState.java
@@ -114,7 +114,7 @@ public abstract class IndexState implements Closeable {
       new AnalyzerWrapper(Analyzer.PER_FIELD_REUSE_STRATEGY) {
         @Override
         public Analyzer getWrappedAnalyzer(String name) {
-          FieldDef fd = getField(name);
+          FieldDef fd = getFieldOrThrow(name);
           if (fd instanceof TextBaseFieldDef) {
             Optional<Analyzer> maybeAnalyzer = ((TextBaseFieldDef) fd).getSearchAnalyzer();
             if (maybeAnalyzer.isEmpty()) {
@@ -317,7 +317,7 @@ public abstract class IndexState implements Closeable {
     if (path == null || path.length() == 0 || path.equals(IndexState.ROOT)) {
       return IndexState.ROOT;
     }
-    FieldDef fieldDef = getField(path);
+    FieldDef fieldDef = getFieldOrThrow(path);
     if ((fieldDef instanceof ObjectFieldDef) && ((ObjectFieldDef) fieldDef).isNestedDoc()) {
       return path;
     }
@@ -344,11 +344,27 @@ public abstract class IndexState implements Closeable {
       throws IOException;
 
   /**
-   * Retrieve the field's type.
+   * Retrieve definition of field by name.
    *
-   * @throws IllegalArgumentException if the field was not registered.
+   * @param fieldName name of the field
+   * @return field definition or null if the field does not exist
    */
   public abstract FieldDef getField(String fieldName);
+
+  /**
+   * Retrieve definition of field by name. Throws an exception if the field does not exist.
+   *
+   * @param fieldName name of the field
+   * @return field definition
+   * @throws IllegalArgumentException if the field does not exist.
+   */
+  public FieldDef getFieldOrThrow(String fieldName) {
+    FieldDef fieldDef = getField(fieldName);
+    if (fieldDef == null) {
+      throw new IllegalArgumentException("field \"" + fieldName + "\" is unknown");
+    }
+    return fieldDef;
+  }
 
   /** Get all registered fields. */
   public abstract Map<String, FieldDef> getAllFields();

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/MergeSchedulerCollector.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/MergeSchedulerCollector.java
@@ -71,7 +71,7 @@ public class MergeSchedulerCollector implements MultiCollector {
     try {
       Set<String> indexNames = globalState.getIndexNames();
       for (String indexName : indexNames) {
-        IndexWriter writer = globalState.getIndex(indexName).getShard(0).getWriter();
+        IndexWriter writer = globalState.getIndexOrThrow(indexName).getShard(0).getWriter();
         if (writer != null) {
           MergeScheduler mergeScheduler = writer.getConfig().getMergeScheduler();
           if (mergeScheduler instanceof ConcurrentMergeScheduler concurrentMergeScheduler) {

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/SearchResponseCollector.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/SearchResponseCollector.java
@@ -143,7 +143,7 @@ public class SearchResponseCollector implements MultiCollector {
       boolean publishVerboseMetrics = false;
       Set<String> indexNames = globalState.getIndexNames();
       for (String indexName : indexNames) {
-        if (globalState.getIndex(indexName).getVerboseMetrics()) {
+        if (globalState.getIndexOrThrow(indexName).getVerboseMetrics()) {
           publishVerboseMetrics = true;
           break;
         }

--- a/src/main/java/com/yelp/nrtsearch/server/query/MatchPhrasePrefixQuery.java
+++ b/src/main/java/com/yelp/nrtsearch/server/query/MatchPhrasePrefixQuery.java
@@ -79,7 +79,7 @@ public class MatchPhrasePrefixQuery extends Query {
   public static Query build(
       com.yelp.nrtsearch.server.grpc.MatchPhrasePrefixQuery matchPhrasePrefixQueryGrpc,
       IndexState indexState) {
-    FieldDef fieldDef = indexState.getField(matchPhrasePrefixQueryGrpc.getField());
+    FieldDef fieldDef = indexState.getFieldOrThrow(matchPhrasePrefixQueryGrpc.getField());
     if (!(fieldDef instanceof IndexableFieldDef)) {
       throw new IllegalArgumentException("MatchPhrasePrefixQuery requires an indexable field");
     }

--- a/src/main/java/com/yelp/nrtsearch/server/query/QueryNodeMapper.java
+++ b/src/main/java/com/yelp/nrtsearch/server/query/QueryNodeMapper.java
@@ -320,7 +320,7 @@ public class QueryNodeMapper {
 
   private Query getTermQuery(com.yelp.nrtsearch.server.grpc.TermQuery termQuery, IndexState state) {
     String fieldName = termQuery.getField();
-    FieldDef fieldDef = state.getField(fieldName);
+    FieldDef fieldDef = state.getFieldOrThrow(fieldName);
 
     if (fieldDef instanceof TermQueryable) {
       validateTermQueryIsSearchable(fieldDef);
@@ -344,7 +344,7 @@ public class QueryNodeMapper {
   private Query getTermInSetQuery(
       com.yelp.nrtsearch.server.grpc.TermInSetQuery termInSetQuery, IndexState state) {
     String fieldName = termInSetQuery.getField();
-    FieldDef fieldDef = state.getField(fieldName);
+    FieldDef fieldDef = state.getFieldOrThrow(fieldName);
 
     if (fieldDef instanceof TermQueryable) {
       validateTermQueryIsSearchable(fieldDef);
@@ -510,7 +510,7 @@ public class QueryNodeMapper {
       Collection<String> fields, MultiMatchQuery multiMatchQuery, IndexState state) {
     Analyzer analyzer = null;
     for (String field : fields) {
-      FieldDef fieldDef = state.getField(field);
+      FieldDef fieldDef = state.getFieldOrThrow(field);
       if (!(fieldDef instanceof TextBaseFieldDef)) {
         throw new IllegalArgumentException("Field must be analyzable: " + field);
       }
@@ -540,7 +540,7 @@ public class QueryNodeMapper {
 
   private Query getRangeQuery(RangeQuery rangeQuery, IndexState state) {
     String fieldName = rangeQuery.getField();
-    FieldDef field = state.getField(fieldName);
+    FieldDef field = state.getFieldOrThrow(fieldName);
 
     if (!(field instanceof RangeQueryable)) {
       throw new IllegalArgumentException("Field: " + fieldName + " does not support RangeQuery");
@@ -551,7 +551,7 @@ public class QueryNodeMapper {
 
   private Query getGeoBoundingBoxQuery(GeoBoundingBoxQuery geoBoundingBoxQuery, IndexState state) {
     String fieldName = geoBoundingBoxQuery.getField();
-    FieldDef field = state.getField(fieldName);
+    FieldDef field = state.getFieldOrThrow(fieldName);
 
     if (!(field instanceof GeoQueryable)) {
       throw new IllegalArgumentException(
@@ -563,7 +563,7 @@ public class QueryNodeMapper {
 
   private Query getGeoRadiusQuery(GeoRadiusQuery geoRadiusQuery, IndexState state) {
     String fieldName = geoRadiusQuery.getField();
-    FieldDef field = state.getField(fieldName);
+    FieldDef field = state.getFieldOrThrow(fieldName);
     if (!(field instanceof GeoQueryable)) {
       throw new IllegalArgumentException(
           "Field: " + fieldName + " does not support GeoRadiusQuery");
@@ -573,7 +573,7 @@ public class QueryNodeMapper {
 
   private Query getGeoPointQuery(GeoPointQuery geoPolygonQuery, IndexState state) {
     String fieldName = geoPolygonQuery.getField();
-    FieldDef field = state.getField(fieldName);
+    FieldDef field = state.getFieldOrThrow(fieldName);
 
     if (!(field instanceof PolygonQueryable)) {
       throw new IllegalArgumentException("Field " + fieldName + "does not support GeoPolygonQuery");
@@ -583,7 +583,7 @@ public class QueryNodeMapper {
 
   private Query getGeoPolygonQuery(GeoPolygonQuery geoPolygonQuery, IndexState state) {
     String fieldName = geoPolygonQuery.getField();
-    FieldDef field = state.getField(fieldName);
+    FieldDef field = state.getFieldOrThrow(fieldName);
 
     if (!(field instanceof GeoQueryable)) {
       throw new IllegalArgumentException(
@@ -608,7 +608,7 @@ public class QueryNodeMapper {
   }
 
   private static Query getPrefixQuery(PrefixQuery prefixQuery, IndexState state) {
-    FieldDef fieldDef = state.getField(prefixQuery.getField());
+    FieldDef fieldDef = state.getFieldOrThrow(prefixQuery.getField());
     if (!(fieldDef instanceof IndexableFieldDef)) {
       throw new IllegalArgumentException(
           "Field \"" + prefixQuery.getPrefix() + "\" is not indexable");

--- a/src/main/java/com/yelp/nrtsearch/server/query/multifunction/GeoPointDecayFilterFunction.java
+++ b/src/main/java/com/yelp/nrtsearch/server/query/multifunction/GeoPointDecayFilterFunction.java
@@ -69,7 +69,7 @@ public class GeoPointDecayFilterFunction extends DecayFilterFunction {
             ? GeoUtils.getDistance(decayFunction.getOffset())
             : 0.0;
     this.indexState = indexState;
-    validateLatLonField(indexState.getField(fieldName));
+    validateLatLonField(indexState.getFieldOrThrow(fieldName));
   }
 
   public void validateLatLonField(FieldDef fieldDef) {

--- a/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
@@ -265,7 +265,7 @@ public class SearchRequestProcessor {
    */
   private static Query buildKnnQuery(KnnQuery knnQuery, IndexState indexState) {
     String field = knnQuery.getField();
-    FieldDef fieldDef = indexState.getField(field);
+    FieldDef fieldDef = indexState.getFieldOrThrow(field);
     if (!(fieldDef instanceof VectorQueryable vectorQueryable)) {
       throw new IllegalArgumentException("Field does not support vector search: " + field);
     }

--- a/src/main/java/com/yelp/nrtsearch/server/state/GlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/state/GlobalState.java
@@ -193,10 +193,30 @@ public abstract class GlobalState implements Closeable {
   /** Create a new index based on the given create request. */
   public abstract IndexState createIndex(CreateIndexRequest createIndexRequest) throws IOException;
 
-  public abstract IndexState getIndex(String name, boolean hasRestore) throws IOException;
-
-  /** Get the {@link IndexState} by index name. */
+  /**
+   * Get the {@link IndexState} by index name.
+   *
+   * @param name index name
+   * @return index state, or null if index does not exist
+   * @throws IOException on error reading index data
+   */
   public abstract IndexState getIndex(String name) throws IOException;
+
+  /**
+   * Get the {@link IndexState} by index name. Throws an exception if the index does not exist.
+   *
+   * @param name index name
+   * @return index state
+   * @throws IllegalArgumentException if the index does not exist
+   * @throws IOException on error reading index data
+   */
+  public IndexState getIndexOrThrow(String name) throws IOException {
+    IndexState indexState = getIndex(name);
+    if (indexState == null) {
+      throw new IllegalArgumentException("index \"" + name + "\" not found");
+    }
+    return indexState;
+  }
 
   /**
    * Get the state manager for a given index.
@@ -206,6 +226,22 @@ public abstract class GlobalState implements Closeable {
    * @throws IOException on error reading index data
    */
   public abstract IndexStateManager getIndexStateManager(String name) throws IOException;
+
+  /**
+   * Get the state manager for a given index. Throws an exception if the index does not exist.
+   *
+   * @param name index name
+   * @return state manager
+   * @throws IllegalArgumentException if the index does not exist
+   * @throws IOException on error reading index data
+   */
+  public IndexStateManager getIndexStateManagerOrThrow(String name) throws IOException {
+    IndexStateManager indexStateManager = getIndexStateManager(name);
+    if (indexStateManager == null) {
+      throw new IllegalArgumentException("index \"" + name + "\" not found");
+    }
+    return indexStateManager;
+  }
 
   /**
    * Reload state from backend

--- a/src/test/java/com/yelp/nrtsearch/server/codec/ServerCodecTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/codec/ServerCodecTest.java
@@ -50,7 +50,7 @@ public class ServerCodecTest {
     IndexStateManager mockStateManager = mock(IndexStateManager.class);
     IndexState mockIndexState = mock(IndexState.class);
     when(mockStateManager.getCurrent()).thenReturn(mockIndexState);
-    when(mockIndexState.getField("field")).thenReturn(fieldDef);
+    when(mockIndexState.getFieldOrThrow("field")).thenReturn(fieldDef);
     when(mockIndexState.getInternalFacetFieldNames()).thenReturn(Set.of("internal_field"));
     return mockStateManager;
   }

--- a/src/test/java/com/yelp/nrtsearch/server/doc/SharedDocContextTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/doc/SharedDocContextTest.java
@@ -67,7 +67,7 @@ public class SharedDocContextTest extends ServerTestCase {
 
   @Override
   public void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 

--- a/src/test/java/com/yelp/nrtsearch/server/facet/DocValuesFacetsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/facet/DocValuesFacetsTest.java
@@ -56,7 +56,7 @@ public class DocValuesFacetsTest extends ServerTestCase {
   }
 
   protected void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 

--- a/src/test/java/com/yelp/nrtsearch/server/facet/EagerGlobalOrdinalsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/facet/EagerGlobalOrdinalsTest.java
@@ -80,9 +80,10 @@ public class EagerGlobalOrdinalsTest extends ServerTestCase {
   @Test
   public void testEagerOrdinals() throws Exception {
     SearcherTaxonomyManager.SearcherAndTaxonomy s = null;
-    ShardState shardState = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0);
+    ShardState shardState = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0);
     try {
-      FieldDef fieldDef = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getField(EAGER_FIELD);
+      FieldDef fieldDef =
+          getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getFieldOrThrow(EAGER_FIELD);
       addDocAndRefresh();
       s = shardState.acquire();
       assertGlobalOrdinals(s.searcher.getIndexReader(), fieldDef);
@@ -105,9 +106,10 @@ public class EagerGlobalOrdinalsTest extends ServerTestCase {
   @Test
   public void testWithoutEagerOrdinals() throws Exception {
     SearcherTaxonomyManager.SearcherAndTaxonomy s = null;
-    ShardState shardState = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0);
+    ShardState shardState = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0);
     try {
-      FieldDef fieldDef = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getField(NOT_EAGER_FIELD);
+      FieldDef fieldDef =
+          getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getFieldOrThrow(NOT_EAGER_FIELD);
       addDocAndRefresh();
       s = shardState.acquire();
       assertNoGlobalOrdinals(s.searcher.getIndexReader(), fieldDef);
@@ -132,7 +134,7 @@ public class EagerGlobalOrdinalsTest extends ServerTestCase {
   private void assertNoGlobalOrdinals(IndexReader reader, FieldDef fieldDef) throws IOException {
     Map<String, SortedSetDocValuesReaderState> readerSSDVStates =
         getGlobalState()
-            .getIndex(DEFAULT_TEST_INDEX)
+            .getIndexOrThrow(DEFAULT_TEST_INDEX)
             .getShard(0)
             .ssdvStates
             .get(reader.getReaderCacheHelper().getKey());
@@ -140,7 +142,7 @@ public class EagerGlobalOrdinalsTest extends ServerTestCase {
     if (readerSSDVStates != null) {
       FacetsConfig.DimConfig dimConfig =
           getGlobalState()
-              .getIndex(DEFAULT_TEST_INDEX)
+              .getIndexOrThrow(DEFAULT_TEST_INDEX)
               .getFacetsConfig()
               .getDimConfig(fieldDef.getName());
       SortedSetDocValuesReaderState ssdvState = readerSSDVStates.get(dimConfig.indexFieldName);
@@ -151,7 +153,7 @@ public class EagerGlobalOrdinalsTest extends ServerTestCase {
   private void assertGlobalOrdinals(IndexReader reader, FieldDef fieldDef) throws IOException {
     Map<String, SortedSetDocValuesReaderState> readerSSDVStates =
         getGlobalState()
-            .getIndex(DEFAULT_TEST_INDEX)
+            .getIndexOrThrow(DEFAULT_TEST_INDEX)
             .getShard(0)
             .ssdvStates
             .get(reader.getReaderCacheHelper().getKey());
@@ -159,7 +161,7 @@ public class EagerGlobalOrdinalsTest extends ServerTestCase {
 
     FacetsConfig.DimConfig dimConfig =
         getGlobalState()
-            .getIndex(DEFAULT_TEST_INDEX)
+            .getIndexOrThrow(DEFAULT_TEST_INDEX)
             .getFacetsConfig()
             .getDimConfig(fieldDef.getName());
     SortedSetDocValuesReaderState ssdvState = readerSSDVStates.get(dimConfig.indexFieldName);

--- a/src/test/java/com/yelp/nrtsearch/server/facet/FacetScriptFacetsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/facet/FacetScriptFacetsTest.java
@@ -217,7 +217,7 @@ public class FacetScriptFacetsTest extends ServerTestCase {
   }
 
   protected void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 

--- a/src/test/java/com/yelp/nrtsearch/server/facet/FacetTopHitsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/facet/FacetTopHitsTest.java
@@ -62,7 +62,7 @@ public class FacetTopHitsTest extends ServerTestCase {
   }
 
   protected void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 

--- a/src/test/java/com/yelp/nrtsearch/server/facet/FilteredSSDVFacetCountsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/facet/FilteredSSDVFacetCountsTest.java
@@ -57,7 +57,7 @@ public class FilteredSSDVFacetCountsTest extends ServerTestCase {
 
   @Override
   public void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 

--- a/src/test/java/com/yelp/nrtsearch/server/facet/RuntimeScriptFacetsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/facet/RuntimeScriptFacetsTest.java
@@ -184,7 +184,7 @@ public class RuntimeScriptFacetsTest extends ServerTestCase {
   }
 
   protected void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 

--- a/src/test/java/com/yelp/nrtsearch/server/field/ContextSuggestFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/ContextSuggestFieldDefTest.java
@@ -46,7 +46,7 @@ public class ContextSuggestFieldDefTest extends ServerTestCase {
   private static final String FIELD_TYPE = "CONTEXT_SUGGEST";
 
   public FieldDef getFieldDef(String testIndex, String fieldName) throws IOException {
-    return getGrpcServer().getGlobalState().getIndex(testIndex).getField(fieldName);
+    return getGrpcServer().getGlobalState().getIndexOrThrow(testIndex).getFieldOrThrow(fieldName);
   }
 
   @Override

--- a/src/test/java/com/yelp/nrtsearch/server/field/EagerFieldOrdinalTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/EagerFieldOrdinalTest.java
@@ -122,10 +122,11 @@ public class EagerFieldOrdinalTest extends ServerTestCase {
   @Test
   public void testEagerOrdinals() throws Exception {
     SearcherTaxonomyManager.SearcherAndTaxonomy s = null;
-    ShardState shardState = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0);
+    ShardState shardState = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0);
     try {
       for (String field : EAGER_FIELDS) {
-        FieldDef fieldDef = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getField(field);
+        FieldDef fieldDef =
+            getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getFieldOrThrow(field);
         addDocAndRefresh();
         s = shardState.acquire();
         assertGlobalOrdinals(s.searcher.getIndexReader(), fieldDef);
@@ -149,10 +150,11 @@ public class EagerFieldOrdinalTest extends ServerTestCase {
   @Test
   public void testWithoutEagerOrdinals() throws Exception {
     SearcherTaxonomyManager.SearcherAndTaxonomy s = null;
-    ShardState shardState = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0);
+    ShardState shardState = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0);
     try {
       for (String field : NOT_EAGER_FIELDS) {
-        FieldDef fieldDef = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getField(field);
+        FieldDef fieldDef =
+            getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getFieldOrThrow(field);
         addDocAndRefresh();
         s = shardState.acquire();
         assertNoGlobalOrdinals(s.searcher.getIndexReader(), fieldDef);

--- a/src/test/java/com/yelp/nrtsearch/server/field/MultivaluedObjectTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/MultivaluedObjectTest.java
@@ -302,7 +302,7 @@ public class MultivaluedObjectTest extends ServerTestCase {
         exception
             .getMessage()
             .contains(
-                "field \"multivalued_object.inner_object1.inner_object2.object\" is unknown: it was not registered with registerField"));
+                "field \"multivalued_object.inner_object1.inner_object2.object\" is unknown"));
 
     exception = null;
     try {

--- a/src/test/java/com/yelp/nrtsearch/server/field/VectorFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/VectorFieldDefTest.java
@@ -84,11 +84,12 @@ public class VectorFieldDefTest extends ServerTestCase {
   }
 
   private void indexVectorSearchDocs() throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(VECTOR_SEARCH_INDEX_NAME).getShard(0).writer;
+    IndexWriter writer =
+        getGlobalState().getIndexOrThrow(VECTOR_SEARCH_INDEX_NAME).getShard(0).writer;
     // don't want any merges for these tests to verify parallel search
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
     getGlobalState()
-        .getIndexStateManager(DEFAULT_TEST_INDEX)
+        .getIndexStateManagerOrThrow(DEFAULT_TEST_INDEX)
         .updateLiveSettings(
             IndexLiveSettings.newBuilder().setSliceMaxSegments(Int32Value.of(1)).build(), false);
 
@@ -216,7 +217,7 @@ public class VectorFieldDefTest extends ServerTestCase {
   }
 
   public FieldDef getFieldDef(String testIndex, String fieldName) throws IOException {
-    return getGrpcServer().getGlobalState().getIndex(testIndex).getField(fieldName);
+    return getGrpcServer().getGlobalState().getIndexOrThrow(testIndex).getFieldOrThrow(fieldName);
   }
 
   @Test
@@ -1049,45 +1050,48 @@ public class VectorFieldDefTest extends ServerTestCase {
     return (VectorFieldDef.FloatVectorFieldDef)
         getGrpcServer()
             .getGlobalState()
-            .getIndex(VECTOR_SEARCH_INDEX_NAME)
-            .getField("vector_cosine");
+            .getIndexOrThrow(VECTOR_SEARCH_INDEX_NAME)
+            .getFieldOrThrow("vector_cosine");
   }
 
   private VectorFieldDef.FloatVectorFieldDef getL2Field() throws IOException {
     return (VectorFieldDef.FloatVectorFieldDef)
         getGrpcServer()
             .getGlobalState()
-            .getIndex(VECTOR_SEARCH_INDEX_NAME)
-            .getField("vector_l2_norm");
+            .getIndexOrThrow(VECTOR_SEARCH_INDEX_NAME)
+            .getFieldOrThrow("vector_l2_norm");
   }
 
   private VectorFieldDef.FloatVectorFieldDef getDotField() throws IOException {
     return (VectorFieldDef.FloatVectorFieldDef)
-        getGrpcServer().getGlobalState().getIndex(VECTOR_SEARCH_INDEX_NAME).getField("vector_dot");
+        getGrpcServer()
+            .getGlobalState()
+            .getIndexOrThrow(VECTOR_SEARCH_INDEX_NAME)
+            .getFieldOrThrow("vector_dot");
   }
 
   private VectorFieldDef.ByteVectorFieldDef getCosineByteField() throws IOException {
     return (VectorFieldDef.ByteVectorFieldDef)
         getGrpcServer()
             .getGlobalState()
-            .getIndex(VECTOR_SEARCH_INDEX_NAME)
-            .getField("byte_vector_cosine");
+            .getIndexOrThrow(VECTOR_SEARCH_INDEX_NAME)
+            .getFieldOrThrow("byte_vector_cosine");
   }
 
   private VectorFieldDef.ByteVectorFieldDef getL2ByteField() throws IOException {
     return (VectorFieldDef.ByteVectorFieldDef)
         getGrpcServer()
             .getGlobalState()
-            .getIndex(VECTOR_SEARCH_INDEX_NAME)
-            .getField("byte_vector_l2_norm");
+            .getIndexOrThrow(VECTOR_SEARCH_INDEX_NAME)
+            .getFieldOrThrow("byte_vector_l2_norm");
   }
 
   private VectorFieldDef.FloatVectorFieldDef getQuantizedField() throws IOException {
     return (VectorFieldDef.FloatVectorFieldDef)
         getGrpcServer()
             .getGlobalState()
-            .getIndex(VECTOR_SEARCH_INDEX_NAME)
-            .getField("quantized_vector_7");
+            .getIndexOrThrow(VECTOR_SEARCH_INDEX_NAME)
+            .getFieldOrThrow("quantized_vector_7");
   }
 
   @Test
@@ -1110,10 +1114,7 @@ public class VectorFieldDefTest extends ServerTestCase {
                   .build());
       fail();
     } catch (StatusRuntimeException e) {
-      assertTrue(
-          e.getMessage()
-              .contains(
-                  "field \"non_existent_field\" is unknown: it was not registered with registerField"));
+      assertTrue(e.getMessage().contains("field \"non_existent_field\" is unknown"));
     }
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/AddFieldsSimilarityTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/AddFieldsSimilarityTest.java
@@ -68,7 +68,7 @@ public class AddFieldsSimilarityTest {
     Similarity writerSim =
         server
             .getGlobalState()
-            .getIndex("test_index")
+            .getIndexOrThrow("test_index")
             .getShard(0)
             .writer
             .getConfig()

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/GlobalStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/GlobalStateTest.java
@@ -45,7 +45,7 @@ public class GlobalStateTest {
     TestServer server = TestServer.builder(folder).build();
     server.createSimpleIndex("test_index");
     server.startPrimaryIndex("test_index", -1, null);
-    String indexId = server.getGlobalState().getIndexStateManager("test_index").getIndexId();
+    String indexId = server.getGlobalState().getIndexStateManagerOrThrow("test_index").getIndexId();
     GlobalStateResponse response =
         server.getClient().getBlockingStub().globalState(GlobalStateRequest.newBuilder().build());
     GlobalStateInfo expected =

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/IndexStartTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/IndexStartTest.java
@@ -211,7 +211,7 @@ public class IndexStartTest {
     ReplicaDeleterManager rdm =
         replicaServer
             .getGlobalState()
-            .getIndex("test_index")
+            .getIndexOrThrow("test_index")
             .getShard(0)
             .nrtReplicaNode
             .getReplicaDeleterManager();
@@ -588,7 +588,7 @@ public class IndexStartTest {
     ReplicationServerClient replicationClient =
         replicaServer
             .getGlobalState()
-            .getIndex("test_index")
+            .getIndexOrThrow("test_index")
             .getShard(0)
             .nrtReplicaNode
             .getPrimaryAddress();
@@ -606,7 +606,7 @@ public class IndexStartTest {
     replicationClient =
         replicaServer2
             .getGlobalState()
-            .getIndex("test_index")
+            .getIndexOrThrow("test_index")
             .getShard(0)
             .nrtReplicaNode
             .getPrimaryAddress();
@@ -687,7 +687,7 @@ public class IndexStartTest {
 
     assertTrue(server.indices().contains("test_index"));
     assertTrue(server.isStarted("test_index"));
-    assertTrue(server.getGlobalState().getIndex("test_index").getShard(0).isPrimary());
+    assertTrue(server.getGlobalState().getIndexOrThrow("test_index").getShard(0).isPrimary());
 
     verifyCreateProperties(server);
   }
@@ -710,12 +710,12 @@ public class IndexStartTest {
 
     assertTrue(server.indices().contains("test_index"));
     assertTrue(server.isStarted("test_index"));
-    assertTrue(server.getGlobalState().getIndex("test_index").getShard(0).isPrimary());
+    assertTrue(server.getGlobalState().getIndexOrThrow("test_index").getShard(0).isPrimary());
 
     server.restart();
     assertTrue(server.indices().contains("test_index"));
     assertTrue(server.isStarted("test_index"));
-    assertTrue(server.getGlobalState().getIndex("test_index").getShard(0).isPrimary());
+    assertTrue(server.getGlobalState().getIndexOrThrow("test_index").getShard(0).isPrimary());
 
     verifyCreateProperties(server);
   }
@@ -748,7 +748,7 @@ public class IndexStartTest {
 
     assertTrue(replica.indices().contains("test_index"));
     assertTrue(replica.isStarted("test_index"));
-    assertTrue(replica.getGlobalState().getIndex("test_index").getShard(0).isReplica());
+    assertTrue(replica.getGlobalState().getIndexOrThrow("test_index").getShard(0).isReplica());
   }
 
   private CreateIndexRequest getCreateWithPropertiesRequest() {
@@ -772,7 +772,7 @@ public class IndexStartTest {
     assertTrue(
         server
             .getGlobalState()
-            .getIndexStateManager("test_index")
+            .getIndexStateManagerOrThrow("test_index")
             .getSettings()
             .getIndexMergeSchedulerAutoThrottle()
             .getValue());
@@ -780,13 +780,13 @@ public class IndexStartTest {
         1000,
         server
             .getGlobalState()
-            .getIndexStateManager("test_index")
+            .getIndexStateManagerOrThrow("test_index")
             .getLiveSettings(false)
             .getAddDocumentsMaxBufferLen()
             .getValue());
     assertEquals(
         new HashSet<>(TestServer.simpleFieldNames),
-        server.getGlobalState().getIndex("test_index").getAllFields().keySet());
+        server.getGlobalState().getIndexOrThrow("test_index").getAllFields().keySet());
   }
 
   @Test
@@ -816,7 +816,7 @@ public class IndexStartTest {
     assertTrue(replicaServer.isStarted("test_index"));
     replicaServer.verifySimpleDocs("test_index", 3);
     NRTReplicaNode nrtReplicaNode =
-        replicaServer.getGlobalState().getIndex("test_index").getShard(0).nrtReplicaNode;
+        replicaServer.getGlobalState().getIndexOrThrow("test_index").getShard(0).nrtReplicaNode;
     ReplicaDeleterManager rdm = nrtReplicaNode.getReplicaDeleterManager();
 
     assertFalse(rdm == null);
@@ -845,7 +845,7 @@ public class IndexStartTest {
     assertFalse(
         server
             .getGlobalState()
-            .getIndex("test_index")
+            .getIndexOrThrow("test_index")
             .getShard(0)
             .nrtPrimaryNode
             .getNrtDataManager()
@@ -863,7 +863,7 @@ public class IndexStartTest {
     assertTrue(
         server
             .getGlobalState()
-            .getIndex("test_index")
+            .getIndexOrThrow("test_index")
             .getShard(0)
             .nrtPrimaryNode
             .getNrtDataManager()

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/MergeBehaviorTests.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/MergeBehaviorTests.java
@@ -387,7 +387,7 @@ public class MergeBehaviorTests {
             grpcServer.getTestIndex(),
             grpcServer
                 .getGlobalState()
-                .getIndexStateManager(grpcServer.getTestIndex())
+                .getIndexStateManagerOrThrow(grpcServer.getTestIndex())
                 .getIndexId()),
         "shard0",
         "index");

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/MultiSegmentTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/MultiSegmentTest.java
@@ -49,7 +49,7 @@ public class MultiSegmentTest extends ServerTestCase {
 
   @Override
   public void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 
@@ -96,14 +96,14 @@ public class MultiSegmentTest extends ServerTestCase {
   public void testNumSegments() throws Exception {
     SearcherTaxonomyManager.SearcherAndTaxonomy s = null;
     try {
-      s = getGlobalState().getIndex(TEST_INDEX).getShard(0).acquire();
+      s = getGlobalState().getIndexOrThrow(TEST_INDEX).getShard(0).acquire();
       assertEquals(NUM_DOCS / SEGMENT_CHUNK, s.searcher.getIndexReader().leaves().size());
       for (LeafReaderContext context : s.searcher.getIndexReader().leaves()) {
         assertEquals(SEGMENT_CHUNK, context.reader().maxDoc());
       }
     } finally {
       if (s != null) {
-        getGlobalState().getIndex(TEST_INDEX).getShard(0).release(s);
+        getGlobalState().getIndexOrThrow(TEST_INDEX).getShard(0).release(s);
       }
     }
   }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/NestedFieldTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/NestedFieldTest.java
@@ -49,7 +49,7 @@ public class NestedFieldTest {
     primaryServer.refresh("test_index");
 
     primaryServer.verifySimpleDocs("test_index", 3);
-    IndexState indexState = primaryServer.getGlobalState().getIndex("test_index");
+    IndexState indexState = primaryServer.getGlobalState().getIndexOrThrow("test_index");
     assertFalse(indexState.hasNestedChildFields());
 
     String nestedFieldJson =
@@ -74,7 +74,7 @@ public class NestedFieldTest {
     primaryServer
         .getClient()
         .registerFields("{\"indexName\": \"test_index\", \"field\": [" + nestedFieldJson + "]}");
-    indexState = primaryServer.getGlobalState().getIndex("test_index");
+    indexState = primaryServer.getGlobalState().getIndexOrThrow("test_index");
     assertTrue(indexState.hasNestedChildFields());
 
     // add more documents

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/NrtsearchServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/NrtsearchServerTest.java
@@ -944,10 +944,13 @@ public class NrtsearchServerTest {
         new GrpcServer.TestServer(replicaGrpcServer, true, Mode.REPLICA);
     replicaGrpcServer
         .getGlobalState()
-        .getIndex(replicaGrpcServer.getTestIndex())
+        .getIndexOrThrow(replicaGrpcServer.getTestIndex())
         .initWarmer(remoteBackend);
     assertNotNull(
-        replicaGrpcServer.getGlobalState().getIndex(replicaGrpcServer.getTestIndex()).getWarmer());
+        replicaGrpcServer
+            .getGlobalState()
+            .getIndexOrThrow(replicaGrpcServer.getTestIndex())
+            .getWarmer());
     // Average case should pass
     replicaGrpcServer
         .getBlockingStub()
@@ -1189,7 +1192,7 @@ public class NrtsearchServerTest {
       assertEquals(0, startIndexResponse.getNumDocs());
     }
 
-    grpcServer.getGlobalState().getIndex(index3).getShard(0).writer.close();
+    grpcServer.getGlobalState().getIndexOrThrow(index3).getShard(0).writer.close();
 
     try {
       blockingStub.ready(ReadyCheckRequest.newBuilder().setIndexNames("").build());

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/PrimaryRestartTests.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/PrimaryRestartTests.java
@@ -348,7 +348,12 @@ public class PrimaryRestartTests {
         currentLeaves2, Set.of("_0", "_1", "_2", "_3", "_4"), Collections.emptySet());
 
     Thread.sleep(3000);
-    replicaServer.getGlobalState().getIndex("test_index").getShard(0).slm.prune(new PruneByAge(1));
+    replicaServer
+        .getGlobalState()
+        .getIndexOrThrow("test_index")
+        .getShard(0)
+        .slm
+        .prune(new PruneByAge(1));
 
     verifySegmentReaderStatus(previousLeaves1, Set.of("_0"), Set.of("_1"));
     verifySegmentReaderStatus(previousLeaves2, Set.of("_0"), Set.of("_1", "_2"));
@@ -361,9 +366,9 @@ public class PrimaryRestartTests {
   private List<LeafReaderContext> getVersionLeaves(TestServer server, long version)
       throws IOException {
     IndexSearcher searcher =
-        server.getGlobalState().getIndex("test_index").getShard(0).slm.acquire(version);
+        server.getGlobalState().getIndexOrThrow("test_index").getShard(0).slm.acquire(version);
     List<LeafReaderContext> leaves = searcher.getIndexReader().leaves();
-    server.getGlobalState().getIndex("test_index").getShard(0).slm.release(searcher);
+    server.getGlobalState().getIndexOrThrow("test_index").getShard(0).slm.release(searcher);
     return leaves;
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClientTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClientTest.java
@@ -72,7 +72,8 @@ public class ReplicationServerClientTest {
   private Server getBasicReplicationServer() throws IOException {
     // we only need to test connectivity for now
     GlobalState mockGlobalState = mock(GlobalState.class);
-    when(mockGlobalState.getIndex(any(String.class))).thenThrow(new RuntimeException("Expected"));
+    when(mockGlobalState.getIndexOrThrow(any(String.class)))
+        .thenThrow(new RuntimeException("Expected"));
     NrtsearchConfig mockConfiguration = mock(NrtsearchConfig.class);
     when(mockGlobalState.getConfiguration()).thenReturn(mockConfiguration);
     when(mockConfiguration.getUseKeepAliveForReplication()).thenReturn(true);

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerTest.java
@@ -309,7 +309,7 @@ public class ReplicationServerTest {
 
     luceneServerSecondary
         .getGlobalState()
-        .getIndex("test_index")
+        .getIndexOrThrow("test_index")
         .getShard(0)
         .nrtReplicaNode
         .syncFromCurrentPrimary(120000, 300000);
@@ -362,7 +362,7 @@ public class ReplicationServerTest {
 
     luceneServerSecondary
         .getGlobalState()
-        .getIndex("test_index")
+        .getIndexOrThrow("test_index")
         .getShard(0)
         .nrtReplicaNode
         .syncFromCurrentPrimary(120000, 0);
@@ -404,7 +404,7 @@ public class ReplicationServerTest {
     long startTime = System.currentTimeMillis();
     luceneServerSecondary
         .getGlobalState()
-        .getIndex("test_index")
+        .getIndexOrThrow("test_index")
         .getShard(0)
         .nrtReplicaNode
         .syncFromCurrentPrimary(2000, 30000);
@@ -445,7 +445,7 @@ public class ReplicationServerTest {
 
     luceneServerSecondary
         .getGlobalState()
-        .getIndex("test_index")
+        .getIndexOrThrow("test_index")
         .getShard(0)
         .nrtReplicaNode
         .syncFromCurrentPrimary(120000, 300000);
@@ -453,7 +453,7 @@ public class ReplicationServerTest {
     // sync again after we already have the current version
     luceneServerSecondary
         .getGlobalState()
-        .getIndex("test_index")
+        .getIndexOrThrow("test_index")
         .getShard(0)
         .nrtReplicaNode
         .syncFromCurrentPrimary(120000, 300000);

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/SortFieldTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/SortFieldTest.java
@@ -52,7 +52,7 @@ public class SortFieldTest extends ServerTestCase {
 
   @Override
   protected void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/TestServer.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/TestServer.java
@@ -224,7 +224,7 @@ public class TestServer {
       GlobalState globalState = serverImpl.getGlobalState();
       for (String indexName : globalState.getIndexNames()) {
         try {
-          IndexState indexState = globalState.getIndex(indexName);
+          IndexState indexState = globalState.getIndexOrThrow(indexName);
           if (indexState.isStarted()) {
             indexState.close();
           }
@@ -526,7 +526,7 @@ public class TestServer {
   }
 
   public void waitForReplication(String indexName, long timeoutMs) throws IOException {
-    ShardState shardState = getGlobalState().getIndex(indexName).getShard(0);
+    ShardState shardState = getGlobalState().getIndexOrThrow(indexName).getShard(0);
     if (!shardState.isReplica()) {
       throw new IllegalStateException("Must be called on replica index");
     }
@@ -549,7 +549,7 @@ public class TestServer {
   }
 
   public void registerWithPrimary(String indexName, long timeoutMs) throws IOException {
-    IndexStateManager indexStateManager = getGlobalState().getIndexStateManager(indexName);
+    IndexStateManager indexStateManager = getGlobalState().getIndexStateManagerOrThrow(indexName);
     ShardState shardState = indexStateManager.getCurrent().getShard(0);
     if (!shardState.isReplica()) {
       throw new IllegalStateException("Must be called on replica index");

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/TimeoutTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/TimeoutTest.java
@@ -88,7 +88,7 @@ public class TimeoutTest extends ServerTestCase {
 
   @Override
   public void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 
@@ -152,14 +152,14 @@ public class TimeoutTest extends ServerTestCase {
   public void testNumSegments() throws Exception {
     SearcherTaxonomyManager.SearcherAndTaxonomy s = null;
     try {
-      s = getGlobalState().getIndex(TEST_INDEX).getShard(0).acquire();
+      s = getGlobalState().getIndexOrThrow(TEST_INDEX).getShard(0).acquire();
       assertEquals(NUM_DOCS / SEGMENT_CHUNK, s.searcher.getIndexReader().leaves().size());
       for (LeafReaderContext context : s.searcher.getIndexReader().leaves()) {
         assertEquals(SEGMENT_CHUNK, context.reader().maxDoc());
       }
     } finally {
       if (s != null) {
-        getGlobalState().getIndex(TEST_INDEX).getShard(0).release(s);
+        getGlobalState().getIndexOrThrow(TEST_INDEX).getShard(0).release(s);
       }
     }
   }
@@ -458,7 +458,7 @@ public class TimeoutTest extends ServerTestCase {
   private TopDocs queryWithFunction(SearchRequest request, Function<SearchContext, TopDocs> func)
       throws Exception {
     SearcherTaxonomyManager.SearcherAndTaxonomy s = null;
-    IndexState indexState = getGlobalState().getIndex(TEST_INDEX);
+    IndexState indexState = getGlobalState().getIndexOrThrow(TEST_INDEX);
     ShardState shardState = indexState.getShard(0);
     try {
       s = shardState.acquire();

--- a/src/test/java/com/yelp/nrtsearch/server/index/BucketedTieredMergePolicyTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/index/BucketedTieredMergePolicyTest.java
@@ -72,7 +72,7 @@ public class BucketedTieredMergePolicyTest extends ServerTestCase {
 
   @Before
   public void clearIndex() throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0).writer;
     writer.deleteAll();
   }
 
@@ -81,7 +81,7 @@ public class BucketedTieredMergePolicyTest extends ServerTestCase {
     setLiveSettings(5, 10000, 100);
     addData(500);
 
-    ShardState shardState = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0);
+    ShardState shardState = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0);
     MergePolicy policy = shardState.writer.getConfig().getMergePolicy();
     assertTrue(policy instanceof BucketedTieredMergePolicy);
 
@@ -90,7 +90,7 @@ public class BucketedTieredMergePolicyTest extends ServerTestCase {
 
     SearcherAndTaxonomy s = null;
     try {
-      s = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).acquire();
+      s = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0).acquire();
       assertEquals(5, s.searcher.getSlices().length);
       for (LeafSlice slice : s.searcher.getSlices()) {
         assertTrue(slice.leaves.length < 100);
@@ -113,14 +113,14 @@ public class BucketedTieredMergePolicyTest extends ServerTestCase {
     setLiveSettings(10, 10000, 100);
     addData(600);
 
-    ShardState shardState = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0);
+    ShardState shardState = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0);
     shardState.writer.forceMerge(1, true);
     waitForMerges(shardState);
     shardState.maybeRefreshBlocking();
 
     SearcherAndTaxonomy s = null;
     try {
-      s = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).acquire();
+      s = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0).acquire();
       assertEquals(10, s.searcher.getSlices().length);
       for (LeafSlice slice : s.searcher.getSlices()) {
         assertEquals(1, slice.leaves.length);
@@ -145,7 +145,7 @@ public class BucketedTieredMergePolicyTest extends ServerTestCase {
 
     s = null;
     try {
-      s = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).acquire();
+      s = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0).acquire();
       assertEquals(5, s.searcher.getSlices().length);
       for (LeafSlice slice : s.searcher.getSlices()) {
         assertEquals(1, slice.leaves.length);
@@ -184,7 +184,7 @@ public class BucketedTieredMergePolicyTest extends ServerTestCase {
 
   private void setLiveSettings(int virtualShards, int maxDocs, int maxSegments) throws IOException {
     getGlobalState()
-        .getIndexStateManager(DEFAULT_TEST_INDEX)
+        .getIndexStateManagerOrThrow(DEFAULT_TEST_INDEX)
         .updateLiveSettings(
             IndexLiveSettings.newBuilder()
                 .setVirtualShards(Int32Value.newBuilder().setValue(virtualShards).build())
@@ -195,7 +195,7 @@ public class BucketedTieredMergePolicyTest extends ServerTestCase {
   }
 
   private void addData(int count) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0).writer;
 
     for (int i = 0; i < count; ++i) {
       AddDocumentRequest request =
@@ -220,7 +220,7 @@ public class BucketedTieredMergePolicyTest extends ServerTestCase {
       addDocuments(Stream.of(request));
       writer.flush();
     }
-    getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).maybeRefreshBlocking();
+    getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0).maybeRefreshBlocking();
   }
 
   private void verifyData(int docs) {

--- a/src/test/java/com/yelp/nrtsearch/server/innerhit/innerHitTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/innerhit/innerHitTest.java
@@ -561,8 +561,7 @@ public class innerHitTest extends ServerTestCase {
                                     .build())
                             .build()))
         .isInstanceOf(StatusRuntimeException.class)
-        .hasMessageContaining(
-            "field \"abcdefg\" is unknown: it was not registered with registerField");
+        .hasMessageContaining("field \"abcdefg\" is unknown");
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/monitoring/MergeSchedulerCollectorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/monitoring/MergeSchedulerCollectorTest.java
@@ -66,7 +66,7 @@ public class MergeSchedulerCollectorTest {
     when(mockShardState.getWriter()).thenReturn(mockIndexWriter);
     when(mockIndexState.getShard(0)).thenReturn(mockShardState);
     when(mockGlobalState.getIndexNames()).thenReturn(Collections.singleton("test_index"));
-    when(mockGlobalState.getIndex("test_index")).thenReturn(mockIndexState);
+    when(mockGlobalState.getIndexOrThrow("test_index")).thenReturn(mockIndexState);
 
     MergeSchedulerCollector collector = new MergeSchedulerCollector(mockGlobalState);
     MetricSnapshots metrics = collector.collect();

--- a/src/test/java/com/yelp/nrtsearch/server/monitoring/SearchResponseCollectorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/monitoring/SearchResponseCollectorTest.java
@@ -70,7 +70,7 @@ public class SearchResponseCollectorTest {
 
     when(mockIndexState.getVerboseMetrics()).thenReturn(false);
     when(mockGlobalState.getIndexNames()).thenReturn(Collections.singleton("test_index"));
-    when(mockGlobalState.getIndex("test_index")).thenReturn(mockIndexState);
+    when(mockGlobalState.getIndexOrThrow("test_index")).thenReturn(mockIndexState);
 
     SearchResponseCollector collector = new SearchResponseCollector(mockGlobalState);
     MetricSnapshots metrics = collector.collect();
@@ -92,7 +92,7 @@ public class SearchResponseCollectorTest {
 
     when(mockIndexState.getVerboseMetrics()).thenReturn(true);
     when(mockGlobalState.getIndexNames()).thenReturn(Collections.singleton("test_index"));
-    when(mockGlobalState.getIndex("test_index")).thenReturn(mockIndexState);
+    when(mockGlobalState.getIndexOrThrow("test_index")).thenReturn(mockIndexState);
 
     SearchResponseCollector collector = new SearchResponseCollector(mockGlobalState);
     MetricSnapshots metrics = collector.collect();

--- a/src/test/java/com/yelp/nrtsearch/server/query/MatchCrossFieldsQueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/query/MatchCrossFieldsQueryTest.java
@@ -323,9 +323,7 @@ public class MatchCrossFieldsQueryTest extends ServerTestCase {
               .build());
       fail();
     } catch (StatusRuntimeException e) {
-      assertTrue(
-          e.getMessage()
-              .contains("field \"unknown\" is unknown: it was not registered with registerField"));
+      assertTrue(e.getMessage().contains("field \"unknown\" is unknown"));
     }
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/query/PrefixQueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/query/PrefixQueryTest.java
@@ -112,9 +112,7 @@ public class PrefixQueryTest extends ServerTestCase {
       doQuery("invalid", "prefix");
       fail();
     } catch (StatusRuntimeException e) {
-      assertTrue(
-          e.getMessage()
-              .contains("field \"invalid\" is unknown: it was not registered with registerField"));
+      assertTrue(e.getMessage().contains("field \"invalid\" is unknown"));
     }
   }
 
@@ -193,7 +191,7 @@ public class PrefixQueryTest extends ServerTestCase {
   private RewriteMethod getRewriteMethodOfBuiltQuery(
       com.yelp.nrtsearch.server.grpc.RewriteMethod rewriteMethodGrpc, int topTermsSize)
       throws IOException {
-    IndexState state = getGlobalState().getIndex(DEFAULT_TEST_INDEX);
+    IndexState state = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX);
     org.apache.lucene.search.Query query =
         QueryNodeMapper.getInstance()
             .getQuery(

--- a/src/test/java/com/yelp/nrtsearch/server/query/QueryNodeMapperTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/query/QueryNodeMapperTest.java
@@ -75,7 +75,7 @@ public class QueryNodeMapperTest extends ServerTestCase {
 
   @Override
   public void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 
@@ -188,7 +188,7 @@ public class QueryNodeMapperTest extends ServerTestCase {
             .addAllVirtualFields(getVirtualFields())
             .setQuery(getQuery())
             .build();
-    IndexState indexState = getGlobalState().getIndex(TEST_INDEX);
+    IndexState indexState = getGlobalState().getIndexOrThrow(TEST_INDEX);
     ShardState shardState = indexState.getShard(0);
     SearcherTaxonomyManager.SearcherAndTaxonomy s = null;
 

--- a/src/test/java/com/yelp/nrtsearch/server/rescore/RescorerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/rescore/RescorerTest.java
@@ -72,7 +72,7 @@ public class RescorerTest extends ServerTestCase {
 
   @Override
   public void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 
@@ -143,7 +143,7 @@ public class RescorerTest extends ServerTestCase {
           LoadedDocValues<Integer> docValues =
               ((LoadedDocValues<Integer>)
                   ((IndexableFieldDef)
-                          context.getSearchContext().getIndexState().getField("int_score"))
+                          context.getSearchContext().getIndexState().getFieldOrThrow("int_score"))
                       .getDocValues(leaf));
           docValues.setDocId(doc.doc - leaf.docBase);
           int score = docValues.get(0);

--- a/src/test/java/com/yelp/nrtsearch/server/search/GlobalOrdinalLookupTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/GlobalOrdinalLookupTest.java
@@ -53,26 +53,26 @@ public class GlobalOrdinalLookupTest extends ServerTestCase {
   }
 
   protected void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
   }
 
   @Before
   public void clearIndex() throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0).writer;
     writer.deleteAll();
   }
 
   @Test
   public void testEmptyIndex() throws IOException {
     SearcherTaxonomyManager.SearcherAndTaxonomy s = null;
-    IndexState indexState = getGlobalState().getIndex(DEFAULT_TEST_INDEX);
+    IndexState indexState = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX);
     ShardState shardState = indexState.getShard(0);
     try {
       s = shardState.acquire();
-      assertEmptyLookup(indexState.getField(VALUE_FIELD), s.searcher.getIndexReader());
-      assertEmptyLookup(indexState.getField(VALUE_MULTI_FIELD), s.searcher.getIndexReader());
+      assertEmptyLookup(indexState.getFieldOrThrow(VALUE_FIELD), s.searcher.getIndexReader());
+      assertEmptyLookup(indexState.getFieldOrThrow(VALUE_MULTI_FIELD), s.searcher.getIndexReader());
     } finally {
       if (s != null) {
         shardState.release(s);
@@ -99,12 +99,13 @@ public class GlobalOrdinalLookupTest extends ServerTestCase {
     addData("1");
 
     SearcherTaxonomyManager.SearcherAndTaxonomy s = null;
-    IndexState indexState = getGlobalState().getIndex(DEFAULT_TEST_INDEX);
+    IndexState indexState = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX);
     ShardState shardState = indexState.getShard(0);
     try {
       s = shardState.acquire();
-      assertSingleLookup(indexState.getField(VALUE_FIELD), s.searcher.getIndexReader());
-      assertSingleLookup(indexState.getField(VALUE_MULTI_FIELD), s.searcher.getIndexReader());
+      assertSingleLookup(indexState.getFieldOrThrow(VALUE_FIELD), s.searcher.getIndexReader());
+      assertSingleLookup(
+          indexState.getFieldOrThrow(VALUE_MULTI_FIELD), s.searcher.getIndexReader());
     } finally {
       if (s != null) {
         shardState.release(s);
@@ -127,12 +128,12 @@ public class GlobalOrdinalLookupTest extends ServerTestCase {
     addData("3");
 
     SearcherTaxonomyManager.SearcherAndTaxonomy s = null;
-    IndexState indexState = getGlobalState().getIndex(DEFAULT_TEST_INDEX);
+    IndexState indexState = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX);
     ShardState shardState = indexState.getShard(0);
     try {
       s = shardState.acquire();
-      assertMultiLookup(indexState.getField(VALUE_FIELD), s.searcher.getIndexReader());
-      assertMultiLookup(indexState.getField(VALUE_MULTI_FIELD), s.searcher.getIndexReader());
+      assertMultiLookup(indexState.getFieldOrThrow(VALUE_FIELD), s.searcher.getIndexReader());
+      assertMultiLookup(indexState.getFieldOrThrow(VALUE_MULTI_FIELD), s.searcher.getIndexReader());
     } finally {
       if (s != null) {
         shardState.release(s);
@@ -156,7 +157,7 @@ public class GlobalOrdinalLookupTest extends ServerTestCase {
   }
 
   private void addData(String value) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0).writer;
 
     AddDocumentRequest request =
         AddDocumentRequest.newBuilder()
@@ -170,6 +171,6 @@ public class GlobalOrdinalLookupTest extends ServerTestCase {
             .build();
     addDocuments(Stream.of(request));
     writer.flush();
-    getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).maybeRefreshBlocking();
+    getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0).maybeRefreshBlocking();
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/search/MyIndexSearcherTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/MyIndexSearcherTest.java
@@ -64,7 +64,7 @@ public class MyIndexSearcherTest extends ServerTestCase {
 
   @Override
   public void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 
@@ -132,7 +132,7 @@ public class MyIndexSearcherTest extends ServerTestCase {
 
   private void assertSliceParams(String index, int maxDocs, int maxSegments) throws IOException {
     SearcherAndTaxonomy s = null;
-    IndexState indexState = getGlobalState().getIndex(index);
+    IndexState indexState = getGlobalState().getIndexOrThrow(index);
     ShardState shardState = indexState.getShard(0);
     try {
       s = shardState.acquire();
@@ -154,7 +154,7 @@ public class MyIndexSearcherTest extends ServerTestCase {
   @Test
   public void testSliceDocsLimit() throws IOException {
     SearcherAndTaxonomy s = null;
-    ShardState shardState = getGlobalState().getIndex(DOCS_INDEX).getShard(0);
+    ShardState shardState = getGlobalState().getIndexOrThrow(DOCS_INDEX).getShard(0);
     try {
       s = shardState.acquire();
       LeafSlice[] slices = s.searcher.getSlices();
@@ -173,7 +173,7 @@ public class MyIndexSearcherTest extends ServerTestCase {
   @Test
   public void testSliceSegmentsLimit() throws IOException {
     SearcherAndTaxonomy s = null;
-    ShardState shardState = getGlobalState().getIndex(SEGMENTS_INDEX).getShard(0);
+    ShardState shardState = getGlobalState().getIndexOrThrow(SEGMENTS_INDEX).getShard(0);
     try {
       s = shardState.acquire();
       LeafSlice[] slices = s.searcher.getSlices();

--- a/src/test/java/com/yelp/nrtsearch/server/search/MyIndexSearcherVirtualShardsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/MyIndexSearcherVirtualShardsTest.java
@@ -49,7 +49,7 @@ public class MyIndexSearcherVirtualShardsTest extends ServerTestCase {
 
   @Override
   public void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
   }
@@ -61,7 +61,7 @@ public class MyIndexSearcherVirtualShardsTest extends ServerTestCase {
 
   @Before
   public void clearIndex() throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0).writer;
     writer.deleteAll();
   }
 
@@ -112,7 +112,7 @@ public class MyIndexSearcherVirtualShardsTest extends ServerTestCase {
     setLiveSettings(111, 10000, 2);
     addSegments(Collections.emptyList());
     SearcherAndTaxonomy s = null;
-    ShardState shardState = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0);
+    ShardState shardState = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0);
     try {
       s = shardState.acquire();
       assertTrue(s.searcher instanceof MyIndexSearcher);
@@ -130,7 +130,7 @@ public class MyIndexSearcherVirtualShardsTest extends ServerTestCase {
 
   private void setLiveSettings(int virtualShards, int maxDocs, int maxSegments) throws IOException {
     getGlobalState()
-        .getIndexStateManager(DEFAULT_TEST_INDEX)
+        .getIndexStateManagerOrThrow(DEFAULT_TEST_INDEX)
         .updateLiveSettings(
             IndexLiveSettings.newBuilder()
                 .setVirtualShards(Int32Value.newBuilder().setValue(virtualShards).build())
@@ -141,7 +141,7 @@ public class MyIndexSearcherVirtualShardsTest extends ServerTestCase {
   }
 
   private void addSegments(Iterable<Integer> sizes) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0).writer;
 
     int currentVal = 0;
     for (Integer size : sizes) {
@@ -171,7 +171,7 @@ public class MyIndexSearcherVirtualShardsTest extends ServerTestCase {
       addDocuments(requestChunk.stream());
       writer.commit();
     }
-    getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0).maybeRefreshBlocking();
+    getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0).maybeRefreshBlocking();
   }
 
   private void assertSlices(List<Integer> docCounts, List<Integer> segmentCounts)
@@ -179,7 +179,7 @@ public class MyIndexSearcherVirtualShardsTest extends ServerTestCase {
     assertEquals(docCounts.size(), segmentCounts.size());
 
     SearcherAndTaxonomy s = null;
-    ShardState shardState = getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0);
+    ShardState shardState = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0);
     try {
       s = shardState.acquire();
       LeafSlice[] slices = s.searcher.getSlices();

--- a/src/test/java/com/yelp/nrtsearch/server/search/SearchContextTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/SearchContextTest.java
@@ -75,8 +75,8 @@ public class SearchContextTest extends ServerTestCase {
 
   private SearchContext.Builder getCompleteBuilder() throws IOException {
     return SearchContext.newBuilder()
-        .setIndexState(getGlobalState().getIndex(DEFAULT_TEST_INDEX))
-        .setShardState(getGlobalState().getIndex(DEFAULT_TEST_INDEX).getShard(0))
+        .setIndexState(getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX))
+        .setShardState(getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0))
         .setSearcherAndTaxonomy(new SearcherAndTaxonomy(null, null))
         .setResponseBuilder(SearchResponse.newBuilder())
         .setTimestampSec(1)
@@ -88,7 +88,8 @@ public class SearchContextTest extends ServerTestCase {
         .setCollector(new DummyCollector())
         .setFetchTasks(new FetchTasks(Collections.emptyList()))
         .setRescorers(Collections.emptyList())
-        .setDocLookup(new DocLookup(getGlobalState().getIndex(DEFAULT_TEST_INDEX)::getField))
+        .setDocLookup(
+            new DocLookup(getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX)::getFieldOrThrow))
         .setSharedDocContext(new DefaultSharedDocContext());
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/search/SearchStatsWrapperTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/SearchStatsWrapperTest.java
@@ -66,7 +66,7 @@ public class SearchStatsWrapperTest extends ServerTestCase {
 
   @Override
   public void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 

--- a/src/test/java/com/yelp/nrtsearch/server/search/TerminateAfterWrapperTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/TerminateAfterWrapperTest.java
@@ -56,7 +56,7 @@ public class TerminateAfterWrapperTest extends ServerTestCase {
 
   @Override
   public void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 
@@ -124,7 +124,7 @@ public class TerminateAfterWrapperTest extends ServerTestCase {
 
   @Test
   public void testDefaultTerminateAfter() throws IOException {
-    IndexState indexState = getGlobalState().getIndex(DEFAULT_TEST_INDEX);
+    IndexState indexState = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX);
     try {
       setDefaultTerminateAfter(15);
       SearchResponse response = doQuery(0, 0, 0.0, false);
@@ -138,7 +138,7 @@ public class TerminateAfterWrapperTest extends ServerTestCase {
 
   @Test
   public void testOverrideDefaultTerminateAfter() throws IOException {
-    IndexState indexState = getGlobalState().getIndex(DEFAULT_TEST_INDEX);
+    IndexState indexState = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX);
     try {
       setDefaultTerminateAfter(15);
       SearchResponse response = doQuery(5, 0, 0.0, false);
@@ -184,7 +184,7 @@ public class TerminateAfterWrapperTest extends ServerTestCase {
 
   private void setDefaultTerminateAfter(int defaultTerminateAfter) throws IOException {
     getGlobalState()
-        .getIndexStateManager(DEFAULT_TEST_INDEX)
+        .getIndexStateManagerOrThrow(DEFAULT_TEST_INDEX)
         .updateLiveSettings(
             IndexLiveSettings.newBuilder()
                 .setDefaultTerminateAfter(

--- a/src/test/java/com/yelp/nrtsearch/server/search/collectors/CollectorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/collectors/CollectorTest.java
@@ -86,7 +86,7 @@ public class CollectorTest extends ServerTestCase {
 
   @Override
   public void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 
@@ -175,7 +175,8 @@ public class CollectorTest extends ServerTestCase {
         this.context = context;
         // The maximum number of top matching reviews to return per business.
         this.size = ((Number) params.get("size")).intValue();
-        this.businessIdField = (IndexableFieldDef) context.getIndexState().getField("business_id");
+        this.businessIdField =
+            (IndexableFieldDef) context.getIndexState().getFieldOrThrow("business_id");
       }
 
       @Override

--- a/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/CollectorStatsWrapperTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/CollectorStatsWrapperTest.java
@@ -69,7 +69,7 @@ public class CollectorStatsWrapperTest extends ServerTestCase {
 
   @Override
   public void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 

--- a/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/FilterCollectorManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/FilterCollectorManagerTest.java
@@ -81,11 +81,11 @@ public class FilterCollectorManagerTest extends ServerTestCase {
   }
 
   protected void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
     getGlobalState()
-        .getIndexStateManager(DEFAULT_TEST_INDEX)
+        .getIndexStateManagerOrThrow(DEFAULT_TEST_INDEX)
         .updateLiveSettings(
             IndexLiveSettings.newBuilder().setSliceMaxSegments(Int32Value.of(1)).build(), false);
 

--- a/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/NestedCollectionTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/NestedCollectionTest.java
@@ -68,7 +68,7 @@ public class NestedCollectionTest extends ServerTestCase {
 
   @Override
   public void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 

--- a/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/NestedCollectorOrderTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/NestedCollectorOrderTest.java
@@ -59,11 +59,11 @@ public class NestedCollectorOrderTest extends ServerTestCase {
   }
 
   protected void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests to ensure we have multiple index slices
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
     getGlobalState()
-        .getIndexStateManager(DEFAULT_TEST_INDEX)
+        .getIndexStateManagerOrThrow(DEFAULT_TEST_INDEX)
         .updateLiveSettings(
             IndexLiveSettings.newBuilder().setSliceMaxSegments(Int32Value.of(1)).build(), false);
 

--- a/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/TermsCollectorManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/TermsCollectorManagerTest.java
@@ -43,7 +43,7 @@ public class TermsCollectorManagerTest extends ServerTestCase {
   @Test
   public void testFieldNotExist() throws IOException {
     SearcherTaxonomyManager.SearcherAndTaxonomy s = null;
-    IndexState indexState = getGlobalState().getIndex(DEFAULT_TEST_INDEX);
+    IndexState indexState = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX);
     ShardState shardState = indexState.getShard(0);
     try {
       s = shardState.acquire();
@@ -77,7 +77,7 @@ public class TermsCollectorManagerTest extends ServerTestCase {
   @Test
   public void testNoDocValues() throws IOException {
     SearcherTaxonomyManager.SearcherAndTaxonomy s = null;
-    IndexState indexState = getGlobalState().getIndex(DEFAULT_TEST_INDEX);
+    IndexState indexState = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX);
     ShardState shardState = indexState.getShard(0);
     try {
       s = shardState.acquire();

--- a/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/TermsCollectorManagerTestsBase.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/TermsCollectorManagerTestsBase.java
@@ -60,7 +60,7 @@ public abstract class TermsCollectorManagerTestsBase extends ServerTestCase {
   }
 
   protected void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 

--- a/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/TopHitsCollectorManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/TopHitsCollectorManagerTest.java
@@ -66,7 +66,7 @@ public class TopHitsCollectorManagerTest extends ServerTestCase {
 
   @Override
   public void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
 

--- a/src/test/java/com/yelp/nrtsearch/server/utils/MinMaxUtilTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/utils/MinMaxUtilTest.java
@@ -70,11 +70,11 @@ public class MinMaxUtilTest extends ServerTestCase {
   }
 
   protected void initIndex(String name) throws Exception {
-    IndexWriter writer = getGlobalState().getIndex(name).getShard(0).writer;
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
     // don't want any merges for these tests
     writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
     getGlobalState()
-        .getIndexStateManager(DEFAULT_TEST_INDEX)
+        .getIndexStateManagerOrThrow(DEFAULT_TEST_INDEX)
         .updateLiveSettings(
             IndexLiveSettings.newBuilder().setSliceMaxSegments(Int32Value.of(1)).build(), false);
 

--- a/src/test/java/com/yelp/nrtsearch/tools/cli/CreateIndexCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/cli/CreateIndexCommandTest.java
@@ -212,14 +212,14 @@ public class CreateIndexCommandTest {
   }
 
   private IndexSettings getIndexSettings(TestServer server) throws IOException {
-    return server.getGlobalState().getIndexStateManager("test_index").getSettings();
+    return server.getGlobalState().getIndexStateManagerOrThrow("test_index").getSettings();
   }
 
   private IndexLiveSettings getIndexLiveSettings(TestServer server) throws IOException {
-    return server.getGlobalState().getIndexStateManager("test_index").getLiveSettings(false);
+    return server.getGlobalState().getIndexStateManagerOrThrow("test_index").getLiveSettings(false);
   }
 
   private Map<String, FieldDef> getIndexFields(TestServer server) throws IOException {
-    return server.getGlobalState().getIndex("test_index").getAllFields();
+    return server.getGlobalState().getIndexOrThrow("test_index").getAllFields();
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/tools/cli/LiveSettingsV2CommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/cli/LiveSettingsV2CommandTest.java
@@ -51,7 +51,7 @@ public class LiveSettingsV2CommandTest {
     server.createSimpleIndex("test_index");
     server.startIndexV2(StartIndexV2Request.newBuilder().setIndexName("test_index").build());
 
-    assertFalse(server.getGlobalState().getIndex("test_index").getVerboseMetrics());
+    assertFalse(server.getGlobalState().getIndexOrThrow("test_index").getVerboseMetrics());
 
     CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
@@ -61,7 +61,7 @@ public class LiveSettingsV2CommandTest {
             "liveSettingsV2",
             "--indexName=test_index");
     assertEquals(0, exitCode);
-    assertFalse(server.getGlobalState().getIndex("test_index").getVerboseMetrics());
+    assertFalse(server.getGlobalState().getIndexOrThrow("test_index").getVerboseMetrics());
 
     exitCode =
         cmd.execute(
@@ -71,7 +71,7 @@ public class LiveSettingsV2CommandTest {
             "--indexName=test_index",
             "--verboseMetrics=true");
     assertEquals(0, exitCode);
-    assertTrue(server.getGlobalState().getIndex("test_index").getVerboseMetrics());
+    assertTrue(server.getGlobalState().getIndexOrThrow("test_index").getVerboseMetrics());
 
     exitCode =
         cmd.execute(
@@ -80,7 +80,7 @@ public class LiveSettingsV2CommandTest {
             "liveSettingsV2",
             "--indexName=test_index");
     assertEquals(0, exitCode);
-    assertTrue(server.getGlobalState().getIndex("test_index").getVerboseMetrics());
+    assertTrue(server.getGlobalState().getIndexOrThrow("test_index").getVerboseMetrics());
 
     exitCode =
         cmd.execute(
@@ -90,7 +90,7 @@ public class LiveSettingsV2CommandTest {
             "--indexName=test_index",
             "--verboseMetrics=false");
     assertEquals(0, exitCode);
-    assertFalse(server.getGlobalState().getIndex("test_index").getVerboseMetrics());
+    assertFalse(server.getGlobalState().getIndexOrThrow("test_index").getVerboseMetrics());
   }
 
   @Test
@@ -117,7 +117,7 @@ public class LiveSettingsV2CommandTest {
     server.startIndexV2(StartIndexV2Request.newBuilder().setIndexName("test_index").build());
 
     assertEquals(
-        0.0, server.getGlobalState().getIndex("test_index").getDefaultSearchTimeoutSec(), 0);
+        0.0, server.getGlobalState().getIndexOrThrow("test_index").getDefaultSearchTimeoutSec(), 0);
 
     CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
@@ -129,12 +129,12 @@ public class LiveSettingsV2CommandTest {
             "--defaultSearchTimeoutSec=1.0");
     assertEquals(0, exitCode);
     assertEquals(
-        1.0, server.getGlobalState().getIndex("test_index").getDefaultSearchTimeoutSec(), 0);
+        1.0, server.getGlobalState().getIndexOrThrow("test_index").getDefaultSearchTimeoutSec(), 0);
 
     server.restart();
 
     assertEquals(
-        1.0, server.getGlobalState().getIndex("test_index").getDefaultSearchTimeoutSec(), 0);
+        1.0, server.getGlobalState().getIndexOrThrow("test_index").getDefaultSearchTimeoutSec(), 0);
   }
 
   @Test
@@ -144,7 +144,7 @@ public class LiveSettingsV2CommandTest {
     server.startIndexV2(StartIndexV2Request.newBuilder().setIndexName("test_index").build());
 
     assertEquals(
-        0.0, server.getGlobalState().getIndex("test_index").getDefaultSearchTimeoutSec(), 0);
+        0.0, server.getGlobalState().getIndexOrThrow("test_index").getDefaultSearchTimeoutSec(), 0);
 
     CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
@@ -157,11 +157,11 @@ public class LiveSettingsV2CommandTest {
             "--local");
     assertEquals(0, exitCode);
     assertEquals(
-        1.0, server.getGlobalState().getIndex("test_index").getDefaultSearchTimeoutSec(), 0);
+        1.0, server.getGlobalState().getIndexOrThrow("test_index").getDefaultSearchTimeoutSec(), 0);
 
     server.restart();
 
     assertEquals(
-        0.0, server.getGlobalState().getIndex("test_index").getDefaultSearchTimeoutSec(), 0);
+        0.0, server.getGlobalState().getIndexOrThrow("test_index").getDefaultSearchTimeoutSec(), 0);
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetRemoteStateCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetRemoteStateCommandTest.java
@@ -153,7 +153,7 @@ public class GetRemoteStateCommandTest {
     JsonFormat.parser().merge(contents, builder);
     IndexStateInfo stateInfo = builder.build();
     IndexStateInfo expected =
-        ((ImmutableIndexState) server.getGlobalState().getIndex("test_index"))
+        ((ImmutableIndexState) server.getGlobalState().getIndexOrThrow("test_index"))
             .getCurrentStateInfo();
     assertEquals(expected, stateInfo);
   }
@@ -179,7 +179,7 @@ public class GetRemoteStateCommandTest {
     JsonFormat.parser().merge(contents, builder);
     IndexStateInfo stateInfo = builder.build();
     IndexStateInfo expected =
-        ((ImmutableIndexState) server.getGlobalState().getIndex("test_index"))
+        ((ImmutableIndexState) server.getGlobalState().getIndexOrThrow("test_index"))
             .getCurrentStateInfo();
     assertEquals(expected, stateInfo);
   }

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetResourceVersionCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetResourceVersionCommandTest.java
@@ -238,7 +238,7 @@ public class GetResourceVersionCommandTest {
     TestServer server = getTestServer();
     server.startPrimaryIndex("test_index", -1, null);
     S3Backend backend = new S3Backend(TEST_BUCKET, false, getS3());
-    String indexId = server.getGlobalState().getIndexStateManager("test_index").getIndexId();
+    String indexId = server.getGlobalState().getIndexStateManagerOrThrow("test_index").getIndexId();
     String prefix =
         S3Backend.getIndexResourcePrefix(
             SERVICE_NAME,

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/ListResourceVersionsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/ListResourceVersionsTest.java
@@ -203,7 +203,7 @@ public class ListResourceVersionsTest {
     TestServer server = getTestServer();
     server.startPrimaryIndex("test_index", -1, null);
     S3Backend backend = new S3Backend(TEST_BUCKET, false, getS3());
-    String indexId = server.getGlobalState().getIndexStateManager("test_index").getIndexId();
+    String indexId = server.getGlobalState().getIndexStateManagerOrThrow("test_index").getIndexId();
     String prefix =
         S3Backend.getIndexResourcePrefix(
             SERVICE_NAME,

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/PutRemoteStateCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/PutRemoteStateCommandTest.java
@@ -117,7 +117,7 @@ public class PutRemoteStateCommandTest {
   public void testPutIndexState() throws IOException {
     TestServer server = getTestServer();
     IndexStateInfo currentState =
-        ((ImmutableIndexState) server.getGlobalState().getIndex("test_index"))
+        ((ImmutableIndexState) server.getGlobalState().getIndexOrThrow("test_index"))
             .getCurrentStateInfo();
     IndexStateInfo updatedState =
         currentState.toBuilder()
@@ -141,7 +141,7 @@ public class PutRemoteStateCommandTest {
 
     server.restart();
     IndexStateInfo newCurrentState =
-        ((ImmutableIndexState) server.getGlobalState().getIndex("test_index"))
+        ((ImmutableIndexState) server.getGlobalState().getIndexOrThrow("test_index"))
             .getCurrentStateInfo();
     assertEquals(updatedState, newCurrentState);
     assertNotEquals(currentState, newCurrentState);
@@ -151,7 +151,7 @@ public class PutRemoteStateCommandTest {
   public void testPutIndexStateExact() throws IOException {
     TestServer server = getTestServer();
     IndexStateInfo currentState =
-        ((ImmutableIndexState) server.getGlobalState().getIndex("test_index"))
+        ((ImmutableIndexState) server.getGlobalState().getIndexOrThrow("test_index"))
             .getCurrentStateInfo();
     IndexStateInfo updatedState =
         currentState.toBuilder()
@@ -176,7 +176,7 @@ public class PutRemoteStateCommandTest {
 
     server.restart();
     IndexStateInfo newCurrentState =
-        ((ImmutableIndexState) server.getGlobalState().getIndex("test_index"))
+        ((ImmutableIndexState) server.getGlobalState().getIndexOrThrow("test_index"))
             .getCurrentStateInfo();
     assertEquals(updatedState, newCurrentState);
     assertNotEquals(currentState, newCurrentState);

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/SetResourceVersionCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/SetResourceVersionCommandTest.java
@@ -299,7 +299,7 @@ public class SetResourceVersionCommandTest {
     TestServer server = getTestServer();
     server.startPrimaryIndex("test_index", -1, null);
     S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, getS3());
-    String indexId = server.getGlobalState().getIndexStateManager("test_index").getIndexId();
+    String indexId = server.getGlobalState().getIndexStateManagerOrThrow("test_index").getIndexId();
     String prefix =
         S3Backend.getIndexResourcePrefix(
             SERVICE_NAME,

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/StateCommandUtilsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/StateCommandUtilsTest.java
@@ -144,7 +144,7 @@ public class StateCommandUtilsTest {
     JsonFormat.parser().merge(contents, builder);
     IndexStateInfo stateInfo = builder.build();
     IndexStateInfo expected =
-        ((ImmutableIndexState) server.getGlobalState().getIndex("test_index"))
+        ((ImmutableIndexState) server.getGlobalState().getIndexOrThrow("test_index"))
             .getCurrentStateInfo();
     assertEquals(expected, stateInfo);
   }
@@ -185,7 +185,7 @@ public class StateCommandUtilsTest {
   public void testWriteIndexStateDataToBackend() throws IOException {
     TestServer server = getTestServer();
     IndexStateInfo currentState =
-        ((ImmutableIndexState) server.getGlobalState().getIndex("test_index"))
+        ((ImmutableIndexState) server.getGlobalState().getIndexOrThrow("test_index"))
             .getCurrentStateInfo();
     IndexStateInfo updatedState =
         currentState.toBuilder()
@@ -203,7 +203,7 @@ public class StateCommandUtilsTest {
 
     server.restart();
     IndexStateInfo newCurrentState =
-        ((ImmutableIndexState) server.getGlobalState().getIndex("test_index"))
+        ((ImmutableIndexState) server.getGlobalState().getIndexOrThrow("test_index"))
             .getCurrentStateInfo();
     assertEquals(updatedState, newCurrentState);
     assertNotEquals(currentState, newCurrentState);

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/UpdateGlobalIndexStateCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/UpdateGlobalIndexStateCommandTest.java
@@ -105,7 +105,8 @@ public class UpdateGlobalIndexStateCommandTest {
     server.commit("test_index");
     server.verifySimpleDocs("test_index", 3);
 
-    String firstIndexId = server.getGlobalState().getIndexStateManager("test_index").getIndexId();
+    String firstIndexId =
+        server.getGlobalState().getIndexStateManagerOrThrow("test_index").getIndexId();
     server.deleteIndex("test_index");
 
     server.createSimpleIndex("test_index");
@@ -114,7 +115,8 @@ public class UpdateGlobalIndexStateCommandTest {
     server.refresh("test_index");
     server.commit("test_index");
     server.verifySimpleDocs("test_index", 5);
-    String secondIndexId = server.getGlobalState().getIndexStateManager("test_index").getIndexId();
+    String secondIndexId =
+        server.getGlobalState().getIndexStateManagerOrThrow("test_index").getIndexId();
     assertNotEquals(firstIndexId, secondIndexId);
 
     CommandLine cmd = getInjectedCommand();
@@ -128,7 +130,8 @@ public class UpdateGlobalIndexStateCommandTest {
     server.restart();
     assertTrue(server.isStarted("test_index"));
 
-    String thirdIndexId = server.getGlobalState().getIndexStateManager("test_index").getIndexId();
+    String thirdIndexId =
+        server.getGlobalState().getIndexStateManagerOrThrow("test_index").getIndexId();
     assertEquals(firstIndexId, thirdIndexId);
     server.verifySimpleDocs("test_index", 3);
   }
@@ -138,8 +141,9 @@ public class UpdateGlobalIndexStateCommandTest {
     TestServer server = getTestServer();
     server.startPrimaryIndex("test_index", -1, null);
     server.createSimpleIndex("test_index_2");
-    String indexId = server.getGlobalState().getIndexStateManager("test_index").getIndexId();
-    String index2Id = server.getGlobalState().getIndexStateManager("test_index_2").getIndexId();
+    String indexId = server.getGlobalState().getIndexStateManagerOrThrow("test_index").getIndexId();
+    String index2Id =
+        server.getGlobalState().getIndexStateManagerOrThrow("test_index_2").getIndexId();
 
     CommandLine cmd = getInjectedCommand();
     int exitCode =
@@ -159,9 +163,10 @@ public class UpdateGlobalIndexStateCommandTest {
     server.restart();
     assertTrue(server.isStarted("test_index"));
     assertFalse(server.isStarted("test_index_2"));
-    assertEquals(indexId, server.getGlobalState().getIndexStateManager("test_index").getIndexId());
     assertEquals(
-        index2Id, server.getGlobalState().getIndexStateManager("test_index_2").getIndexId());
+        indexId, server.getGlobalState().getIndexStateManagerOrThrow("test_index").getIndexId());
+    assertEquals(
+        index2Id, server.getGlobalState().getIndexStateManagerOrThrow("test_index_2").getIndexId());
   }
 
   @Test
@@ -194,7 +199,7 @@ public class UpdateGlobalIndexStateCommandTest {
   public void testIndexIDNotInBackend() throws IOException {
     TestServer server = getTestServer();
     server.startPrimaryIndex("test_index", -1, null);
-    String indexId = server.getGlobalState().getIndexStateManager("test_index").getIndexId();
+    String indexId = server.getGlobalState().getIndexStateManagerOrThrow("test_index").getIndexId();
 
     CommandLine cmd = getInjectedCommand();
     int exitCode =
@@ -207,7 +212,8 @@ public class UpdateGlobalIndexStateCommandTest {
     server.restart();
 
     assertTrue(server.isStarted("test_index"));
-    assertEquals(indexId, server.getGlobalState().getIndexStateManager("test_index").getIndexId());
+    assertEquals(
+        indexId, server.getGlobalState().getIndexStateManagerOrThrow("test_index").getIndexId());
   }
 
   @Test


### PR DESCRIPTION
`IndexState.getField(name)`, `GlobalState.getIndex(name)`, and `GlobalState.getIndexStateManager(name)` all throw an `IllegalArgumentException` if the index/field does not exist. This makes it harder to handles cases where something not existing is acceptable.

I modified these methods to return `null` instead of throwing an exception. Separate methods have been added (`*OrThrow()`) that preserve the status quo behavior. Almost all existing usage of these methods has been change to use the throwing version. The `DocLookup` in the `IndexState` uses the non-throwing version, as this provides consistent behavior with the lookup created during search request processing.

None of the currently ported plugins use this api, so they should still be compatible.

The example-plugin test is expected to fail until it gets updated for the alpha.2 release.