### PR TITLE
Change api from ThreadPoolExecutor to ExecutorService

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java
@@ -16,7 +16,7 @@
 package com.yelp.nrtsearch.server.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.yelp.nrtsearch.server.concurrent.ThreadPoolExecutorFactory;
+import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
 import com.yelp.nrtsearch.server.utils.JsonUtils;
 import java.util.HashMap;
 import java.util.Map;
@@ -56,7 +56,7 @@ public class ThreadPoolConfiguration {
       Math.max(100, 2 * DEFAULT_VECTOR_MERGE_THREADS);
 
   /**
-   * Settings for a {@link ThreadPoolExecutorFactory.ExecutorType}.
+   * Settings for a {@link ExecutorFactory.ExecutorType}.
    *
    * @param maxThreads max number of threads
    * @param maxBufferedItems max number of buffered items
@@ -64,48 +64,47 @@ public class ThreadPoolConfiguration {
    */
   public record ThreadPoolSettings(int maxThreads, int maxBufferedItems, String threadNamePrefix) {}
 
-  private static final Map<ThreadPoolExecutorFactory.ExecutorType, ThreadPoolSettings>
+  private static final Map<ExecutorFactory.ExecutorType, ThreadPoolSettings>
       defaultThreadPoolSettings =
           Map.of(
-              ThreadPoolExecutorFactory.ExecutorType.SEARCH,
+              ExecutorFactory.ExecutorType.SEARCH,
               new ThreadPoolSettings(
                   DEFAULT_SEARCHING_THREADS, DEFAULT_SEARCH_BUFFERED_ITEMS, "LuceneSearchExecutor"),
-              ThreadPoolExecutorFactory.ExecutorType.INDEX,
+              ExecutorFactory.ExecutorType.INDEX,
               new ThreadPoolSettings(
                   DEFAULT_INDEXING_THREADS,
                   DEFAULT_INDEXING_BUFFERED_ITEMS,
                   "LuceneIndexingExecutor"),
-              ThreadPoolExecutorFactory.ExecutorType.LUCENESERVER,
+              ExecutorFactory.ExecutorType.LUCENESERVER,
               new ThreadPoolSettings(
                   DEFAULT_GRPC_LUCENESERVER_THREADS,
                   DEFAULT_GRPC_LUCENESERVER_BUFFERED_ITEMS,
                   "GrpcLuceneServerExecutor"),
-              ThreadPoolExecutorFactory.ExecutorType.REPLICATIONSERVER,
+              ExecutorFactory.ExecutorType.REPLICATIONSERVER,
               new ThreadPoolSettings(
                   DEFAULT_GRPC_REPLICATIONSERVER_THREADS,
                   DEFAULT_GRPC_REPLICATIONSERVER_BUFFERED_ITEMS,
                   "GrpcReplicationServerExecutor"),
-              ThreadPoolExecutorFactory.ExecutorType.FETCH,
+              ExecutorFactory.ExecutorType.FETCH,
               new ThreadPoolSettings(
                   DEFAULT_FETCH_THREADS, DEFAULT_FETCH_BUFFERED_ITEMS, "LuceneFetchExecutor"),
-              ThreadPoolExecutorFactory.ExecutorType.GRPC,
+              ExecutorFactory.ExecutorType.GRPC,
               new ThreadPoolSettings(
                   DEFAULT_GRPC_THREADS, DEFAULT_GRPC_BUFFERED_ITEMS, "GrpcExecutor"),
-              ThreadPoolExecutorFactory.ExecutorType.METRICS,
+              ExecutorFactory.ExecutorType.METRICS,
               new ThreadPoolSettings(
                   DEFAULT_METRICS_THREADS, DEFAULT_METRICS_BUFFERED_ITEMS, "MetricsExecutor"),
-              ThreadPoolExecutorFactory.ExecutorType.VECTORMERGE,
+              ExecutorFactory.ExecutorType.VECTORMERGE,
               new ThreadPoolSettings(
                   DEFAULT_VECTOR_MERGE_THREADS,
                   DEFAULT_VECTOR_MERGE_BUFFERED_ITEMS,
                   "VectorMergeExecutor"));
 
-  private final Map<ThreadPoolExecutorFactory.ExecutorType, ThreadPoolSettings> threadPoolSettings;
+  private final Map<ExecutorFactory.ExecutorType, ThreadPoolSettings> threadPoolSettings;
 
   public ThreadPoolConfiguration(YamlConfigReader configReader) {
     threadPoolSettings = new HashMap<>();
-    for (ThreadPoolExecutorFactory.ExecutorType executorType :
-        ThreadPoolExecutorFactory.ExecutorType.values()) {
+    for (ExecutorFactory.ExecutorType executorType : ExecutorFactory.ExecutorType.values()) {
       ThreadPoolSettings defaultSettings = defaultThreadPoolSettings.get(executorType);
       String poolConfigPrefix = CONFIG_PREFIX + executorType.name().toLowerCase() + ".";
       int maxThreads =
@@ -175,8 +174,7 @@ public class ThreadPoolConfiguration {
         defaultValue);
   }
 
-  public ThreadPoolSettings getThreadPoolSettings(
-      ThreadPoolExecutorFactory.ExecutorType executorType) {
+  public ThreadPoolSettings getThreadPoolSettings(ExecutorFactory.ExecutorType executorType) {
     return threadPoolSettings.get(executorType);
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/field/VectorFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/VectorFieldDef.java
@@ -17,7 +17,7 @@ package com.yelp.nrtsearch.server.field;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.yelp.nrtsearch.server.concurrent.ThreadPoolExecutorFactory;
+import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
 import com.yelp.nrtsearch.server.doc.LoadedDocValues;
 import com.yelp.nrtsearch.server.doc.LoadedDocValues.SingleSearchVector;
 import com.yelp.nrtsearch.server.doc.LoadedDocValues.SingleVector;
@@ -143,8 +143,7 @@ public abstract class VectorFieldDef<T> extends IndexableFieldDef<T> implements 
         vectorIndexingOptions.hasMergeWorkers() ? vectorIndexingOptions.getMergeWorkers() : 1;
     ExecutorService executorService =
         mergeWorkers > 1
-            ? ThreadPoolExecutorFactory.getInstance()
-                .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.VECTORMERGE)
+            ? ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.VECTORMERGE)
             : null;
     KnnVectorsFormat vectorsFormat =
         switch (vectorSearchType) {

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
@@ -26,7 +26,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.Empty;
 import com.google.protobuf.util.JsonFormat;
 import com.yelp.nrtsearch.server.analysis.AnalyzerCreator;
-import com.yelp.nrtsearch.server.concurrent.ThreadPoolExecutorFactory;
+import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.config.QueryCacheConfig;
 import com.yelp.nrtsearch.server.custom.request.CustomRequestProcessor;
@@ -162,9 +162,8 @@ public class NrtsearchServer {
                   new ReplicationServerImpl(
                       globalState, luceneServerConfiguration.getVerifyReplicationIndexId()))
               .executor(
-                  ThreadPoolExecutorFactory.getInstance()
-                      .getThreadPoolExecutor(
-                          ThreadPoolExecutorFactory.ExecutorType.REPLICATIONSERVER))
+                  ExecutorFactory.getInstance()
+                      .getExecutor(ExecutorFactory.ExecutorType.REPLICATIONSERVER))
               .maxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
               .maxConcurrentCallsPerConnection(
                   luceneServerConfiguration.getMaxConcurrentCallsPerConnectionForReplication())
@@ -182,9 +181,8 @@ public class NrtsearchServer {
                   new ReplicationServerImpl(
                       globalState, luceneServerConfiguration.getVerifyReplicationIndexId()))
               .executor(
-                  ThreadPoolExecutorFactory.getInstance()
-                      .getThreadPoolExecutor(
-                          ThreadPoolExecutorFactory.ExecutorType.REPLICATIONSERVER))
+                  ExecutorFactory.getInstance()
+                      .getExecutor(ExecutorFactory.ExecutorType.REPLICATIONSERVER))
               .maxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
               .build()
               .start();
@@ -212,7 +210,7 @@ public class NrtsearchServer {
             .callExecutor(executorSupplier)
             // We still need this executor to run tasks before the point when executorSupplier can
             // be called (https://github.com/grpc/grpc-java/issues/8274)
-            .executor(executorSupplier.getGrpcThreadPoolExecutor())
+            .executor(executorSupplier.getGrpcExecutor())
             .maxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
             .compressorRegistry(LuceneServerStubBuilder.COMPRESSOR_REGISTRY)
             .decompressorRegistry(LuceneServerStubBuilder.DECOMPRESSOR_REGISTRY)
@@ -374,7 +372,7 @@ public class NrtsearchServer {
       DeadlineUtils.setCancellationEnabled(configuration.getDeadlineCancellation());
       CompletionPostingsFormatUtil.setCompletionCodecLoadMode(
           configuration.getCompletionCodecLoadMode());
-      ThreadPoolExecutorFactory.init(configuration.getThreadPoolConfiguration());
+      ExecutorFactory.init(configuration.getThreadPoolConfiguration());
 
       initQueryCache(configuration);
       initExtendableComponents(configuration, plugins);

--- a/src/main/java/com/yelp/nrtsearch/server/index/ImmutableIndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/ImmutableIndexState.java
@@ -29,7 +29,7 @@ import com.google.protobuf.UInt64Value;
 import com.google.protobuf.util.FieldMaskUtil;
 import com.google.protobuf.util.JsonFormat;
 import com.yelp.nrtsearch.server.codec.ServerCodec;
-import com.yelp.nrtsearch.server.concurrent.ThreadPoolExecutorFactory;
+import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
 import com.yelp.nrtsearch.server.field.FieldDef;
 import com.yelp.nrtsearch.server.field.IdFieldDef;
 import com.yelp.nrtsearch.server.field.properties.GlobalOrdinalable;
@@ -267,7 +267,7 @@ public class ImmutableIndexState extends IndexState {
     int maxParallelism =
         globalState
             .getThreadPoolConfiguration()
-            .getThreadPoolSettings(ThreadPoolExecutorFactory.ExecutorType.FETCH)
+            .getThreadPoolSettings(ExecutorFactory.ExecutorType.FETCH)
             .maxThreads();
     boolean parallelFetchByField = mergedLiveSettingsWithLocal.getParallelFetchByField().getValue();
     int parallelFetchChunkSize = mergedLiveSettingsWithLocal.getParallelFetchChunkSize().getValue();
@@ -276,7 +276,7 @@ public class ImmutableIndexState extends IndexState {
             maxParallelism,
             parallelFetchByField,
             parallelFetchChunkSize,
-            globalState.getFetchService());
+            globalState.getFetchExecutor());
 
     // If there is previous shard state, use it. Otherwise, initialize the shard.
     if (previousShardState != null) {
@@ -292,7 +292,7 @@ public class ImmutableIndexState extends IndexState {
                       indexStateManager,
                       getName(),
                       getRootDir(),
-                      getSearchThreadPoolExecutor(),
+                      getSearchExecutor(),
                       0,
                       !currentStateInfo.getCommitted()))
               .build();

--- a/src/main/java/com/yelp/nrtsearch/server/index/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/IndexState.java
@@ -41,7 +41,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.regex.Pattern;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.AnalyzerWrapper;
@@ -84,7 +83,7 @@ public abstract class IndexState implements Closeable {
   private final Path rootDir;
 
   private static final Pattern reSimpleName = Pattern.compile("^[a-zA-Z_][a-zA-Z_0-9]*$");
-  private final ThreadPoolExecutor searchThreadPoolExecutor;
+  private final ExecutorService searchExecutor;
   private Warmer warmer = null;
 
   /** The meta field definitions */
@@ -234,7 +233,7 @@ public abstract class IndexState implements Closeable {
       Files.createDirectories(rootDir);
     }
 
-    searchThreadPoolExecutor = globalState.getSearchThreadPoolExecutor();
+    searchExecutor = globalState.getSearchExecutor();
   }
 
   /** Get index name. */
@@ -280,9 +279,9 @@ public abstract class IndexState implements Closeable {
     }
   }
 
-  /** Get thread pool to use for search operations. */
-  public ThreadPoolExecutor getSearchThreadPoolExecutor() {
-    return searchThreadPoolExecutor;
+  /** Get executor to use for search operations. */
+  public ExecutorService getSearchExecutor() {
+    return searchExecutor;
   }
 
   public ThreadPoolConfiguration getThreadPoolConfiguration() {

--- a/src/main/java/com/yelp/nrtsearch/server/index/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/ShardState.java
@@ -85,7 +85,7 @@ public class ShardState implements Closeable {
   public static final int REPLICA_ID = 0;
   public static final String INDEX_DATA_DIR_NAME = "index";
   public static final String TAXONOMY_DATA_DIR_NAME = "taxonomy";
-  final ThreadPoolExecutor searchExecutor;
+  final ExecutorService searchExecutor;
 
   /** {@link IndexStateManager} for the index this shard belongs to */
   private final IndexStateManager indexStateManager;
@@ -283,7 +283,7 @@ public class ShardState implements Closeable {
    * @param indexStateManager state manager for index
    * @param indexName index name
    * @param rootDir this index data root directory
-   * @param searchExecutor search thread pool
+   * @param searchExecutor search executor
    * @param shardOrd shard number
    * @param doCreate if index should be created when started
    */
@@ -291,7 +291,7 @@ public class ShardState implements Closeable {
       IndexStateManager indexStateManager,
       String indexName,
       Path rootDir,
-      ThreadPoolExecutor searchExecutor,
+      ExecutorService searchExecutor,
       int shardOrd,
       boolean doCreate)
       throws IOException {

--- a/src/main/java/com/yelp/nrtsearch/server/warming/Warmer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/warming/Warmer.java
@@ -105,8 +105,7 @@ public class Warmer {
   public void warmFromS3(IndexState indexState, int parallelism)
       throws IOException, SearchHandler.SearchHandlerException, InterruptedException {
     SearchHandler searchHandler =
-        new SearchHandler(
-            indexState.getGlobalState(), indexState.getSearchThreadPoolExecutor(), true);
+        new SearchHandler(indexState.getGlobalState(), indexState.getSearchExecutor(), true);
     warmFromS3(indexState, parallelism, searchHandler);
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/concurrent/ExecutorFactoryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/concurrent/ExecutorFactoryTest.java
@@ -21,10 +21,11 @@ import static org.junit.Assert.assertSame;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.config.ThreadPoolConfiguration;
 import java.io.ByteArrayInputStream;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import org.junit.Test;
 
-public class ThreadPoolExecutorFactoryTest {
+public class ExecutorFactoryTest {
 
   private void init() {
     init("nodeName: node1");
@@ -33,18 +34,16 @@ public class ThreadPoolExecutorFactoryTest {
   private void init(String config) {
     NrtsearchConfig luceneServerConfiguration =
         new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
-    ThreadPoolExecutorFactory.init(luceneServerConfiguration.getThreadPoolConfiguration());
+    ExecutorFactory.init(luceneServerConfiguration.getThreadPoolConfiguration());
   }
 
   @Test
   public void testCachesThreadPoolExecutor() {
     init();
-    ThreadPoolExecutor executor1 =
-        ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.SEARCH);
-    ThreadPoolExecutor executor2 =
-        ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.SEARCH);
+    ExecutorService executor1 =
+        ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.SEARCH);
+    ExecutorService executor2 =
+        ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.SEARCH);
     assertSame(executor1, executor2);
   }
 
@@ -52,8 +51,8 @@ public class ThreadPoolExecutorFactoryTest {
   public void testSearchThreadPool_default() {
     init();
     ThreadPoolExecutor executor =
-        ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.SEARCH);
+        (ThreadPoolExecutor)
+            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.SEARCH);
     assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_SEARCHING_THREADS);
     assertEquals(
         executor.getQueue().remainingCapacity(),
@@ -70,8 +69,8 @@ public class ThreadPoolExecutorFactoryTest {
             "    maxThreads: 5",
             "    maxBufferedItems: 10"));
     ThreadPoolExecutor executor =
-        ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.SEARCH);
+        (ThreadPoolExecutor)
+            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.SEARCH);
     assertEquals(executor.getCorePoolSize(), 5);
     assertEquals(executor.getQueue().remainingCapacity(), 10);
   }
@@ -80,8 +79,8 @@ public class ThreadPoolExecutorFactoryTest {
   public void testIndexThreadPool_default() {
     init();
     ThreadPoolExecutor executor =
-        ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.INDEX);
+        (ThreadPoolExecutor)
+            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.INDEX);
     assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_INDEXING_THREADS);
     assertEquals(
         executor.getQueue().remainingCapacity(),
@@ -98,8 +97,8 @@ public class ThreadPoolExecutorFactoryTest {
             "    maxThreads: 5",
             "    maxBufferedItems: 10"));
     ThreadPoolExecutor executor =
-        ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.INDEX);
+        (ThreadPoolExecutor)
+            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.INDEX);
     assertEquals(executor.getCorePoolSize(), 5);
     assertEquals(executor.getQueue().remainingCapacity(), 10);
   }
@@ -108,8 +107,8 @@ public class ThreadPoolExecutorFactoryTest {
   public void testLuceneServerThreadPool_default() {
     init();
     ThreadPoolExecutor executor =
-        ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.LUCENESERVER);
+        (ThreadPoolExecutor)
+            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.LUCENESERVER);
     assertEquals(
         executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_GRPC_LUCENESERVER_THREADS);
     assertEquals(
@@ -127,8 +126,8 @@ public class ThreadPoolExecutorFactoryTest {
             "    maxThreads: 5",
             "    maxBufferedItems: 10"));
     ThreadPoolExecutor executor =
-        ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.LUCENESERVER);
+        (ThreadPoolExecutor)
+            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.LUCENESERVER);
     assertEquals(executor.getCorePoolSize(), 5);
     assertEquals(executor.getQueue().remainingCapacity(), 10);
   }
@@ -137,8 +136,9 @@ public class ThreadPoolExecutorFactoryTest {
   public void testReplicationServerThreadPool_default() {
     init();
     ThreadPoolExecutor executor =
-        ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.REPLICATIONSERVER);
+        (ThreadPoolExecutor)
+            ExecutorFactory.getInstance()
+                .getExecutor(ExecutorFactory.ExecutorType.REPLICATIONSERVER);
     assertEquals(
         executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_GRPC_REPLICATIONSERVER_THREADS);
     assertEquals(
@@ -156,8 +156,9 @@ public class ThreadPoolExecutorFactoryTest {
             "    maxThreads: 5",
             "    maxBufferedItems: 10"));
     ThreadPoolExecutor executor =
-        ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.REPLICATIONSERVER);
+        (ThreadPoolExecutor)
+            ExecutorFactory.getInstance()
+                .getExecutor(ExecutorFactory.ExecutorType.REPLICATIONSERVER);
     assertEquals(executor.getCorePoolSize(), 5);
     assertEquals(executor.getQueue().remainingCapacity(), 10);
   }
@@ -166,8 +167,8 @@ public class ThreadPoolExecutorFactoryTest {
   public void testFetchThreadPool_default() {
     init();
     ThreadPoolExecutor executor =
-        ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.FETCH);
+        (ThreadPoolExecutor)
+            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.FETCH);
     assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_FETCH_THREADS);
     assertEquals(
         executor.getQueue().remainingCapacity(),
@@ -184,8 +185,8 @@ public class ThreadPoolExecutorFactoryTest {
             "    maxThreads: 5",
             "    maxBufferedItems: 10"));
     ThreadPoolExecutor executor =
-        ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.FETCH);
+        (ThreadPoolExecutor)
+            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.FETCH);
     assertEquals(executor.getCorePoolSize(), 5);
     assertEquals(executor.getQueue().remainingCapacity(), 10);
   }
@@ -194,8 +195,8 @@ public class ThreadPoolExecutorFactoryTest {
   public void testGrpcThreadPool_default() {
     init();
     ThreadPoolExecutor executor =
-        ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.GRPC);
+        (ThreadPoolExecutor)
+            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.GRPC);
     assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_GRPC_THREADS);
     assertEquals(
         executor.getQueue().remainingCapacity(),
@@ -212,8 +213,8 @@ public class ThreadPoolExecutorFactoryTest {
             "    maxThreads: 5",
             "    maxBufferedItems: 10"));
     ThreadPoolExecutor executor =
-        ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.GRPC);
+        (ThreadPoolExecutor)
+            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.GRPC);
     assertEquals(executor.getCorePoolSize(), 5);
     assertEquals(executor.getQueue().remainingCapacity(), 10);
   }
@@ -222,8 +223,8 @@ public class ThreadPoolExecutorFactoryTest {
   public void testMetricsThreadPool_default() {
     init();
     ThreadPoolExecutor executor =
-        ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.METRICS);
+        (ThreadPoolExecutor)
+            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.METRICS);
     assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_METRICS_THREADS);
     assertEquals(
         executor.getQueue().remainingCapacity(),
@@ -240,8 +241,8 @@ public class ThreadPoolExecutorFactoryTest {
             "    maxThreads: 5",
             "    maxBufferedItems: 10"));
     ThreadPoolExecutor executor =
-        ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.METRICS);
+        (ThreadPoolExecutor)
+            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.METRICS);
     assertEquals(executor.getCorePoolSize(), 5);
     assertEquals(executor.getQueue().remainingCapacity(), 10);
   }
@@ -250,8 +251,8 @@ public class ThreadPoolExecutorFactoryTest {
   public void testVectorMergeThreadPool_default() {
     init();
     ThreadPoolExecutor executor =
-        ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.VECTORMERGE);
+        (ThreadPoolExecutor)
+            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.VECTORMERGE);
     assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_VECTOR_MERGE_THREADS);
     assertEquals(
         executor.getQueue().remainingCapacity(),
@@ -268,8 +269,8 @@ public class ThreadPoolExecutorFactoryTest {
             "    maxThreads: 5",
             "    maxBufferedItems: 10"));
     ThreadPoolExecutor executor =
-        ThreadPoolExecutorFactory.getInstance()
-            .getThreadPoolExecutor(ThreadPoolExecutorFactory.ExecutorType.VECTORMERGE);
+        (ThreadPoolExecutor)
+            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.VECTORMERGE);
     assertEquals(executor.getCorePoolSize(), 5);
     assertEquals(executor.getQueue().remainingCapacity(), 10);
   }

--- a/src/test/java/com/yelp/nrtsearch/server/config/ThreadPoolConfigurationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/ThreadPoolConfigurationTest.java
@@ -17,7 +17,7 @@ package com.yelp.nrtsearch.server.config;
 
 import static org.junit.Assert.*;
 
-import com.yelp.nrtsearch.server.concurrent.ThreadPoolExecutorFactory;
+import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -44,7 +44,7 @@ public class ThreadPoolConfigurationTest {
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
         luceneServerConfiguration
             .getThreadPoolConfiguration()
-            .getThreadPoolSettings(ThreadPoolExecutorFactory.ExecutorType.SEARCH);
+            .getThreadPoolSettings(ExecutorFactory.ExecutorType.SEARCH);
     assertEquals(threadPoolSettings.maxThreads(), 16);
     assertEquals(threadPoolSettings.maxBufferedItems(), 100);
   }
@@ -55,8 +55,7 @@ public class ThreadPoolConfigurationTest {
     ThreadPoolConfiguration threadPoolConfiguration =
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
-        threadPoolConfiguration.getThreadPoolSettings(
-            ThreadPoolExecutorFactory.ExecutorType.SEARCH);
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.SEARCH);
     assertEquals(
         threadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_SEARCHING_THREADS);
     assertEquals(
@@ -78,8 +77,7 @@ public class ThreadPoolConfigurationTest {
     ThreadPoolConfiguration threadPoolConfiguration =
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
-        threadPoolConfiguration.getThreadPoolSettings(
-            ThreadPoolExecutorFactory.ExecutorType.SEARCH);
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.SEARCH);
     assertEquals(threadPoolSettings.maxThreads(), 5);
     assertEquals(threadPoolSettings.maxBufferedItems(), 10);
     assertEquals("customName", threadPoolSettings.threadNamePrefix());
@@ -91,7 +89,7 @@ public class ThreadPoolConfigurationTest {
     ThreadPoolConfiguration threadPoolConfiguration =
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
-        threadPoolConfiguration.getThreadPoolSettings(ThreadPoolExecutorFactory.ExecutorType.INDEX);
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.INDEX);
     assertEquals(threadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_INDEXING_THREADS);
     assertEquals(
         threadPoolSettings.maxBufferedItems(),
@@ -112,7 +110,7 @@ public class ThreadPoolConfigurationTest {
     ThreadPoolConfiguration threadPoolConfiguration =
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
-        threadPoolConfiguration.getThreadPoolSettings(ThreadPoolExecutorFactory.ExecutorType.INDEX);
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.INDEX);
     assertEquals(threadPoolSettings.maxThreads(), 5);
     assertEquals(threadPoolSettings.maxBufferedItems(), 10);
     assertEquals("customName", threadPoolSettings.threadNamePrefix());
@@ -124,8 +122,7 @@ public class ThreadPoolConfigurationTest {
     ThreadPoolConfiguration threadPoolConfiguration =
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
-        threadPoolConfiguration.getThreadPoolSettings(
-            ThreadPoolExecutorFactory.ExecutorType.LUCENESERVER);
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.LUCENESERVER);
     assertEquals(
         threadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_GRPC_LUCENESERVER_THREADS);
     assertEquals(
@@ -147,8 +144,7 @@ public class ThreadPoolConfigurationTest {
     ThreadPoolConfiguration threadPoolConfiguration =
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
-        threadPoolConfiguration.getThreadPoolSettings(
-            ThreadPoolExecutorFactory.ExecutorType.LUCENESERVER);
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.LUCENESERVER);
     assertEquals(threadPoolSettings.maxThreads(), 5);
     assertEquals(threadPoolSettings.maxBufferedItems(), 10);
     assertEquals("customName", threadPoolSettings.threadNamePrefix());
@@ -161,7 +157,7 @@ public class ThreadPoolConfigurationTest {
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
         threadPoolConfiguration.getThreadPoolSettings(
-            ThreadPoolExecutorFactory.ExecutorType.REPLICATIONSERVER);
+            ExecutorFactory.ExecutorType.REPLICATIONSERVER);
     assertEquals(
         threadPoolSettings.maxThreads(),
         ThreadPoolConfiguration.DEFAULT_GRPC_REPLICATIONSERVER_THREADS);
@@ -185,7 +181,7 @@ public class ThreadPoolConfigurationTest {
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
         threadPoolConfiguration.getThreadPoolSettings(
-            ThreadPoolExecutorFactory.ExecutorType.REPLICATIONSERVER);
+            ExecutorFactory.ExecutorType.REPLICATIONSERVER);
     assertEquals(threadPoolSettings.maxThreads(), 5);
     assertEquals(threadPoolSettings.maxBufferedItems(), 10);
     assertEquals("customName", threadPoolSettings.threadNamePrefix());
@@ -197,7 +193,7 @@ public class ThreadPoolConfigurationTest {
     ThreadPoolConfiguration threadPoolConfiguration =
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
-        threadPoolConfiguration.getThreadPoolSettings(ThreadPoolExecutorFactory.ExecutorType.FETCH);
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.FETCH);
     assertEquals(threadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_FETCH_THREADS);
     assertEquals(
         threadPoolSettings.maxBufferedItems(),
@@ -218,7 +214,7 @@ public class ThreadPoolConfigurationTest {
     ThreadPoolConfiguration threadPoolConfiguration =
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
-        threadPoolConfiguration.getThreadPoolSettings(ThreadPoolExecutorFactory.ExecutorType.FETCH);
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.FETCH);
     assertEquals(threadPoolSettings.maxThreads(), 5);
     assertEquals(threadPoolSettings.maxBufferedItems(), 10);
     assertEquals("customName", threadPoolSettings.threadNamePrefix());
@@ -230,7 +226,7 @@ public class ThreadPoolConfigurationTest {
     ThreadPoolConfiguration threadPoolConfiguration =
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
-        threadPoolConfiguration.getThreadPoolSettings(ThreadPoolExecutorFactory.ExecutorType.GRPC);
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.GRPC);
     assertEquals(threadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_GRPC_THREADS);
     assertEquals(
         threadPoolSettings.maxBufferedItems(), ThreadPoolConfiguration.DEFAULT_GRPC_BUFFERED_ITEMS);
@@ -250,7 +246,7 @@ public class ThreadPoolConfigurationTest {
     ThreadPoolConfiguration threadPoolConfiguration =
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
-        threadPoolConfiguration.getThreadPoolSettings(ThreadPoolExecutorFactory.ExecutorType.GRPC);
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.GRPC);
     assertEquals(threadPoolSettings.maxThreads(), 5);
     assertEquals(threadPoolSettings.maxBufferedItems(), 10);
     assertEquals("customName", threadPoolSettings.threadNamePrefix());
@@ -262,8 +258,7 @@ public class ThreadPoolConfigurationTest {
     ThreadPoolConfiguration threadPoolConfiguration =
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
-        threadPoolConfiguration.getThreadPoolSettings(
-            ThreadPoolExecutorFactory.ExecutorType.METRICS);
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.METRICS);
     assertEquals(threadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_METRICS_THREADS);
     assertEquals(
         threadPoolSettings.maxBufferedItems(),
@@ -284,8 +279,7 @@ public class ThreadPoolConfigurationTest {
     ThreadPoolConfiguration threadPoolConfiguration =
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
-        threadPoolConfiguration.getThreadPoolSettings(
-            ThreadPoolExecutorFactory.ExecutorType.METRICS);
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.METRICS);
     assertEquals(threadPoolSettings.maxThreads(), 5);
     assertEquals(threadPoolSettings.maxBufferedItems(), 10);
     assertEquals("customName", threadPoolSettings.threadNamePrefix());
@@ -297,8 +291,7 @@ public class ThreadPoolConfigurationTest {
     ThreadPoolConfiguration threadPoolConfiguration =
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
-        threadPoolConfiguration.getThreadPoolSettings(
-            ThreadPoolExecutorFactory.ExecutorType.VECTORMERGE);
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.VECTORMERGE);
     assertEquals(
         threadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_VECTOR_MERGE_THREADS);
     assertEquals(
@@ -320,8 +313,7 @@ public class ThreadPoolConfigurationTest {
     ThreadPoolConfiguration threadPoolConfiguration =
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
-        threadPoolConfiguration.getThreadPoolSettings(
-            ThreadPoolExecutorFactory.ExecutorType.VECTORMERGE);
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.VECTORMERGE);
     assertEquals(threadPoolSettings.maxThreads(), 5);
     assertEquals(threadPoolSettings.maxBufferedItems(), 10);
     assertEquals("customName", threadPoolSettings.threadNamePrefix());
@@ -341,15 +333,14 @@ public class ThreadPoolConfigurationTest {
     ThreadPoolConfiguration threadPoolConfiguration =
         new ThreadPoolConfiguration(getReaderForConfig(config));
     ThreadPoolConfiguration.ThreadPoolSettings searchThreadPoolSettings =
-        threadPoolConfiguration.getThreadPoolSettings(
-            ThreadPoolExecutorFactory.ExecutorType.SEARCH);
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.SEARCH);
     assertEquals(searchThreadPoolSettings.maxThreads(), 5);
     assertEquals(
         searchThreadPoolSettings.maxBufferedItems(),
         ThreadPoolConfiguration.DEFAULT_SEARCH_BUFFERED_ITEMS);
     assertEquals("customName", searchThreadPoolSettings.threadNamePrefix());
     ThreadPoolConfiguration.ThreadPoolSettings indexThreadPoolSettings =
-        threadPoolConfiguration.getThreadPoolSettings(ThreadPoolExecutorFactory.ExecutorType.INDEX);
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.INDEX);
     assertEquals(
         indexThreadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_INDEXING_THREADS);
     assertEquals(indexThreadPoolSettings.maxBufferedItems(), 14);

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/GrpcServerExecutorSupplierTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/GrpcServerExecutorSupplierTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.yelp.nrtsearch.server.concurrent.ThreadPoolExecutorFactory;
+import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
 import com.yelp.nrtsearch.server.config.ThreadPoolConfiguration;
 import com.yelp.nrtsearch.server.config.YamlConfigReader;
 import io.grpc.Metadata;
@@ -41,7 +41,7 @@ public class GrpcServerExecutorSupplierTest {
             new YamlConfigReader(
                 new ByteArrayInputStream(
                     "threadPoolConfiguration:\n  search:\n    maxThreads: 1".getBytes())));
-    ThreadPoolExecutorFactory.init(threadPoolConfiguration);
+    ExecutorFactory.init(threadPoolConfiguration);
   }
 
   @Test
@@ -54,10 +54,10 @@ public class GrpcServerExecutorSupplierTest {
     Metadata mockMetadata = mock(Metadata.class);
 
     assertEquals(
-        grpcServerExecutorSupplier.getMetricsThreadPoolExecutor(),
+        grpcServerExecutorSupplier.getMetricsExecutor(),
         grpcServerExecutorSupplier.getExecutor(metricsServerCall, mockMetadata));
     assertEquals(
-        grpcServerExecutorSupplier.getLuceneServerThreadPoolExecutor(),
+        grpcServerExecutorSupplier.getServerExecutor(),
         grpcServerExecutorSupplier.getExecutor(searchServerCall, mockMetadata));
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/index/ImmutableIndexStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/index/ImmutableIndexStateTest.java
@@ -137,7 +137,7 @@ public class ImmutableIndexStateTest {
     when(mockGlobalState.getConfiguration()).thenReturn(dummyConfig);
     when(mockGlobalState.getThreadPoolConfiguration())
         .thenReturn(dummyConfig.getThreadPoolConfiguration());
-    when(mockGlobalState.getFetchService()).thenReturn(mock(ExecutorService.class));
+    when(mockGlobalState.getFetchExecutor()).thenReturn(mock(ExecutorService.class));
     return new ImmutableIndexState(
         mockManager,
         mockGlobalState,
@@ -630,7 +630,7 @@ public class ImmutableIndexStateTest {
     when(mockGlobalState.getConfiguration()).thenReturn(dummyConfig);
     when(mockGlobalState.getThreadPoolConfiguration())
         .thenReturn(dummyConfig.getThreadPoolConfiguration());
-    when(mockGlobalState.getFetchService()).thenReturn(mock(ExecutorService.class));
+    when(mockGlobalState.getFetchExecutor()).thenReturn(mock(ExecutorService.class));
     return new ImmutableIndexState(
         mockManager,
         mockGlobalState,
@@ -879,7 +879,7 @@ public class ImmutableIndexStateTest {
     when(mockGlobalState.getConfiguration()).thenReturn(config);
     when(mockGlobalState.getThreadPoolConfiguration())
         .thenReturn(config.getThreadPoolConfiguration());
-    when(mockGlobalState.getFetchService()).thenReturn(mock(ExecutorService.class));
+    when(mockGlobalState.getFetchExecutor()).thenReturn(mock(ExecutorService.class));
     IndexState indexState =
         new ImmutableIndexState(
             mockManager,
@@ -955,7 +955,7 @@ public class ImmutableIndexStateTest {
     when(mockGlobalState.getConfiguration()).thenReturn(dummyConfig);
     when(mockGlobalState.getThreadPoolConfiguration())
         .thenReturn(dummyConfig.getThreadPoolConfiguration());
-    when(mockGlobalState.getFetchService()).thenReturn(mock(ExecutorService.class));
+    when(mockGlobalState.getFetchExecutor()).thenReturn(mock(ExecutorService.class));
     return new ImmutableIndexState(
         mockManager,
         mockGlobalState,

--- a/src/test/java/com/yelp/nrtsearch/server/search/MyIndexSearcherTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/MyIndexSearcherTest.java
@@ -141,7 +141,7 @@ public class MyIndexSearcherTest extends ServerTestCase {
       assertTrue(searcher.getExecutor() instanceof MyIndexSearcher.ExecutorWithParams);
       MyIndexSearcher.ExecutorWithParams params =
           (MyIndexSearcher.ExecutorWithParams) searcher.getExecutor();
-      assertSame(indexState.getSearchThreadPoolExecutor(), params.wrapped);
+      assertSame(indexState.getSearchExecutor(), params.wrapped);
       assertEquals(maxDocs, params.sliceMaxDocs);
       assertEquals(maxSegments, params.sliceMaxSegments);
     } finally {

--- a/src/test/java/com/yelp/nrtsearch/server/state/BackendGlobalStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/state/BackendGlobalStateTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.protobuf.Int32Value;
-import com.yelp.nrtsearch.server.concurrent.ThreadPoolExecutorFactory;
+import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.field.FieldDefCreator;
 import com.yelp.nrtsearch.server.grpc.GlobalStateInfo;
@@ -91,7 +91,7 @@ public class BackendGlobalStateTest {
     // these must be initialized to create an IndexState
     FieldDefCreator.initialize(dummyConfig, dummyPlugins);
     SimilarityCreator.initialize(dummyConfig, dummyPlugins);
-    ThreadPoolExecutorFactory.init(dummyConfig.getThreadPoolConfiguration());
+    ExecutorFactory.init(dummyConfig.getThreadPoolConfiguration());
   }
 
   @Before


### PR DESCRIPTION
Change usage of `ThreadPoolExecutor` to use the more generic `ExecutorService`. This will be helpful for future changes to concurrency strategies, and will also make it easy to experiment with using virtual threads.