### PR TITLE
Use handleUnaryRequest utility method for most server handlers

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
@@ -457,56 +457,61 @@ public class NrtsearchServer {
     @Override
     public void createIndex(
         CreateIndexRequest req, StreamObserver<CreateIndexResponse> responseObserver) {
-      createIndexHandler.handle(req, responseObserver);
+      Handler.handleUnaryRequest("createIndex", req, responseObserver, createIndexHandler);
     }
 
     @Override
     public void liveSettings(
         LiveSettingsRequest req, StreamObserver<LiveSettingsResponse> responseObserver) {
-      liveSettingsHandler.handle(req, responseObserver);
+      Handler.handleUnaryRequest("liveSettings", req, responseObserver, liveSettingsHandler);
     }
 
     @Override
     public void liveSettingsV2(
         LiveSettingsV2Request req, StreamObserver<LiveSettingsV2Response> responseObserver) {
-      liveSettingsV2Handler.handle(req, responseObserver);
+      Handler.handleUnaryRequest("liveSettingsV2", req, responseObserver, liveSettingsV2Handler);
     }
 
     @Override
     public void registerFields(
         FieldDefRequest fieldDefRequest, StreamObserver<FieldDefResponse> responseObserver) {
-      registerFieldsHandler.handle(fieldDefRequest, responseObserver);
+      Handler.handleUnaryRequest(
+          "registerFields", fieldDefRequest, responseObserver, registerFieldsHandler);
     }
 
     @Override
     public void updateFields(
         FieldDefRequest fieldDefRequest, StreamObserver<FieldDefResponse> responseObserver) {
-      updateFieldsHandler.handle(fieldDefRequest, responseObserver);
+      Handler.handleUnaryRequest(
+          "updateFields", fieldDefRequest, responseObserver, updateFieldsHandler);
     }
 
     @Override
     public void settings(
         SettingsRequest settingsRequest, StreamObserver<SettingsResponse> responseObserver) {
-      settingsHandler.handle(settingsRequest, responseObserver);
+      Handler.handleUnaryRequest("settings", settingsRequest, responseObserver, settingsHandler);
     }
 
     @Override
     public void settingsV2(
         SettingsV2Request settingsRequest, StreamObserver<SettingsV2Response> responseObserver) {
-      settingsV2Handler.handle(settingsRequest, responseObserver);
+      Handler.handleUnaryRequest(
+          "settingsV2", settingsRequest, responseObserver, settingsV2Handler);
     }
 
     @Override
     public void startIndex(
         StartIndexRequest startIndexRequest, StreamObserver<StartIndexResponse> responseObserver) {
-      startIndexHandler.handle(startIndexRequest, responseObserver);
+      Handler.handleUnaryRequest(
+          "startIndex", startIndexRequest, responseObserver, startIndexHandler);
     }
 
     @Override
     public void startIndexV2(
         StartIndexV2Request startIndexRequest,
         StreamObserver<StartIndexResponse> responseObserver) {
-      startIndexV2Handler.handle(startIndexRequest, responseObserver);
+      Handler.handleUnaryRequest(
+          "startIndexV2", startIndexRequest, responseObserver, startIndexV2Handler);
     }
 
     @Override
@@ -519,7 +524,8 @@ public class NrtsearchServer {
     public void refresh(
         RefreshRequest refreshRequest,
         StreamObserver<RefreshResponse> refreshResponseStreamObserver) {
-      refreshHandler.handle(refreshRequest, refreshResponseStreamObserver);
+      Handler.handleUnaryRequest(
+          "refresh", refreshRequest, refreshResponseStreamObserver, refreshHandler);
     }
 
     @Override
@@ -531,7 +537,7 @@ public class NrtsearchServer {
     @Override
     public void stats(
         StatsRequest statsRequest, StreamObserver<StatsResponse> statsResponseStreamObserver) {
-      statsHandler.handle(statsRequest, statsResponseStreamObserver);
+      Handler.handleUnaryRequest("stats", statsRequest, statsResponseStreamObserver, statsHandler);
     }
 
     @Override
@@ -550,46 +556,50 @@ public class NrtsearchServer {
     public void delete(
         AddDocumentRequest addDocumentRequest,
         StreamObserver<AddDocumentResponse> responseObserver) {
-      deleteDocumentsHandler.handle(addDocumentRequest, responseObserver);
+      Handler.handleUnaryRequest(
+          "delete", addDocumentRequest, responseObserver, deleteDocumentsHandler);
     }
 
     @Override
     public void deleteByQuery(
         DeleteByQueryRequest deleteByQueryRequest,
         StreamObserver<AddDocumentResponse> responseObserver) {
-      deleteByQueryHandler.handle(deleteByQueryRequest, responseObserver);
+      Handler.handleUnaryRequest(
+          "deleteByQuery", deleteByQueryRequest, responseObserver, deleteByQueryHandler);
     }
 
     @Override
     public void deleteAll(
         DeleteAllDocumentsRequest deleteAllDocumentsRequest,
         StreamObserver<DeleteAllDocumentsResponse> responseObserver) {
-      deleteAllDocumentsHandler.handle(deleteAllDocumentsRequest, responseObserver);
+      Handler.handleUnaryRequest(
+          "deleteAll", deleteAllDocumentsRequest, responseObserver, deleteAllDocumentsHandler);
     }
 
     @Override
     public void deleteIndex(
         DeleteIndexRequest deleteIndexRequest,
         StreamObserver<DeleteIndexResponse> responseObserver) {
-      deleteIndexHandler.handle(deleteIndexRequest, responseObserver);
+      Handler.handleUnaryRequest(
+          "deleteIndex", deleteIndexRequest, responseObserver, deleteIndexHandler);
     }
 
     @Override
     public void stopIndex(
         StopIndexRequest stopIndexRequest, StreamObserver<DummyResponse> responseObserver) {
-      stopIndexHandler.handle(stopIndexRequest, responseObserver);
+      Handler.handleUnaryRequest("stopIndex", stopIndexRequest, responseObserver, stopIndexHandler);
     }
 
     @Override
     public void reloadState(
         ReloadStateRequest request, StreamObserver<ReloadStateResponse> responseObserver) {
-      reloadStateHandler.handle(request, responseObserver);
+      Handler.handleUnaryRequest("reloadState", request, responseObserver, reloadStateHandler);
     }
 
     @Override
     public void status(
         HealthCheckRequest request, StreamObserver<HealthCheckResponse> responseObserver) {
-      statusHandler.handle(request, responseObserver);
+      Handler.handleUnaryRequest("status", request, responseObserver, statusHandler);
     }
 
     /**
@@ -600,45 +610,49 @@ public class NrtsearchServer {
     @Override
     public void ready(
         ReadyCheckRequest request, StreamObserver<HealthCheckResponse> responseObserver) {
-      readyHandler.handle(request, responseObserver);
+      Handler.handleUnaryRequest("ready", request, responseObserver, readyHandler);
     }
 
     @Override
     public void createSnapshot(
         CreateSnapshotRequest createSnapshotRequest,
         StreamObserver<CreateSnapshotResponse> responseObserver) {
-      createSnapshotHandler.handle(createSnapshotRequest, responseObserver);
+      Handler.handleUnaryRequest(
+          "createSnapshot", createSnapshotRequest, responseObserver, createSnapshotHandler);
     }
 
     @Override
     public void releaseSnapshot(
         ReleaseSnapshotRequest releaseSnapshotRequest,
         StreamObserver<ReleaseSnapshotResponse> responseObserver) {
-      releaseSnapshotHandler.handle(releaseSnapshotRequest, responseObserver);
+      Handler.handleUnaryRequest(
+          "releaseSnapshot", releaseSnapshotRequest, responseObserver, releaseSnapshotHandler);
     }
 
     @Override
     public void getAllSnapshotIndexGen(
         GetAllSnapshotGenRequest request,
         StreamObserver<GetAllSnapshotGenResponse> responseObserver) {
-      getAllSnapshotIndexGenHandler.handle(request, responseObserver);
+      Handler.handleUnaryRequest(
+          "getAllSnapshotIndexGen", request, responseObserver, getAllSnapshotIndexGenHandler);
     }
 
     @Override
     public void backupWarmingQueries(
         BackupWarmingQueriesRequest request,
         StreamObserver<BackupWarmingQueriesResponse> responseObserver) {
-      backupWarmingQueriesHandler.handle(request, responseObserver);
+      Handler.handleUnaryRequest(
+          "backupWarmingQueries", request, responseObserver, backupWarmingQueriesHandler);
     }
 
     @Override
     public void metrics(Empty request, StreamObserver<HttpBody> responseObserver) {
-      metricsHandler.handle(request, responseObserver);
+      Handler.handleUnaryRequest("metrics", request, responseObserver, metricsHandler);
     }
 
     @Override
     public void indices(IndicesRequest request, StreamObserver<IndicesResponse> responseObserver) {
-      indicesHandler.handle(request, responseObserver);
+      Handler.handleUnaryRequest("indices", request, responseObserver, indicesHandler);
     }
 
     @Override
@@ -650,30 +664,32 @@ public class NrtsearchServer {
     @Override
     public void globalState(
         GlobalStateRequest request, StreamObserver<GlobalStateResponse> responseObserver) {
-      globalStateHandler.handle(request, responseObserver);
+      Handler.handleUnaryRequest("globalState", request, responseObserver, globalStateHandler);
     }
 
     @Override
     public void state(StateRequest request, StreamObserver<StateResponse> responseObserver) {
-      getStateHandler.handle(request, responseObserver);
+      Handler.handleUnaryRequest("state", request, responseObserver, getStateHandler);
     }
 
     @Override
     public void forceMerge(
         ForceMergeRequest forceMergeRequest, StreamObserver<ForceMergeResponse> responseObserver) {
-      forceMergeHandler.handle(forceMergeRequest, responseObserver);
+      Handler.handleUnaryRequest(
+          "forceMerge", forceMergeRequest, responseObserver, forceMergeHandler);
     }
 
     @Override
     public void forceMergeDeletes(
         ForceMergeDeletesRequest forceMergeRequest,
         StreamObserver<ForceMergeDeletesResponse> responseObserver) {
-      forceMergeDeletesHandler.handle(forceMergeRequest, responseObserver);
+      Handler.handleUnaryRequest(
+          "forceMergeDeletes", forceMergeRequest, responseObserver, forceMergeDeletesHandler);
     }
 
     @Override
     public void custom(CustomRequest request, StreamObserver<CustomResponse> responseObserver) {
-      customHandler.handle(request, responseObserver);
+      Handler.handleUnaryRequest("custom", request, responseObserver, customHandler);
     }
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/handler/CreateSnapshotHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/CreateSnapshotHandler.java
@@ -22,8 +22,6 @@ import com.yelp.nrtsearch.server.grpc.SnapshotId;
 import com.yelp.nrtsearch.server.index.IndexState;
 import com.yelp.nrtsearch.server.index.ShardState;
 import com.yelp.nrtsearch.server.state.GlobalState;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager;
 import org.apache.lucene.index.DirectoryReader;
@@ -42,31 +40,12 @@ public class CreateSnapshotHandler extends Handler<CreateSnapshotRequest, Create
   }
 
   @Override
-  public void handle(
-      CreateSnapshotRequest createSnapshotRequest,
-      StreamObserver<CreateSnapshotResponse> responseObserver) {
-    try {
-      IndexState indexState =
-          getGlobalState().getIndexOrThrow(createSnapshotRequest.getIndexName());
-      CreateSnapshotResponse reply = createSnapshot(indexState, createSnapshotRequest);
-      logger.info(String.format("CreateSnapshotHandler returned results %s", reply.toString()));
-      responseObserver.onNext(reply);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      logger.warn(
-          String.format(
-              "error while trying to createSnapshot for index %s",
-              createSnapshotRequest.getIndexName()),
-          e);
-      responseObserver.onError(
-          Status.UNKNOWN
-              .withDescription(
-                  String.format(
-                      "error while trying to createSnapshot for index %s",
-                      createSnapshotRequest.getIndexName()))
-              .augmentDescription(e.getMessage())
-              .asRuntimeException());
-    }
+  public CreateSnapshotResponse handle(CreateSnapshotRequest createSnapshotRequest)
+      throws Exception {
+    IndexState indexState = getIndexState(createSnapshotRequest.getIndexName());
+    CreateSnapshotResponse reply = createSnapshot(indexState, createSnapshotRequest);
+    logger.info(String.format("CreateSnapshotHandler returned results %s", reply));
+    return reply;
   }
 
   private CreateSnapshotResponse createSnapshot(

--- a/src/main/java/com/yelp/nrtsearch/server/handler/CustomHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/CustomHandler.java
@@ -19,8 +19,6 @@ import com.yelp.nrtsearch.server.custom.request.CustomRequestProcessor;
 import com.yelp.nrtsearch.server.grpc.CustomRequest;
 import com.yelp.nrtsearch.server.grpc.CustomResponse;
 import com.yelp.nrtsearch.server.state.GlobalState;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,17 +30,8 @@ public class CustomHandler extends Handler<CustomRequest, CustomResponse> {
   }
 
   @Override
-  public void handle(CustomRequest request, StreamObserver<CustomResponse> responseObserver) {
+  public CustomResponse handle(CustomRequest request) throws Exception {
     logger.info("Received custom request: {}", request);
-    try {
-      CustomResponse response = CustomRequestProcessor.processCustomRequest(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      String error =
-          String.format("Error processing custom request %s, error: %s", request, e.getMessage());
-      logger.error(error);
-      responseObserver.onError(Status.INTERNAL.withDescription(error).withCause(e).asException());
-    }
+    return CustomRequestProcessor.processCustomRequest(request);
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/handler/DeleteAllDocumentsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/DeleteAllDocumentsHandler.java
@@ -19,8 +19,6 @@ import com.yelp.nrtsearch.server.grpc.*;
 import com.yelp.nrtsearch.server.index.IndexState;
 import com.yelp.nrtsearch.server.index.ShardState;
 import com.yelp.nrtsearch.server.state.GlobalState;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,29 +33,13 @@ public class DeleteAllDocumentsHandler
   }
 
   @Override
-  public void handle(
-      DeleteAllDocumentsRequest deleteAllDocumentsRequest,
-      StreamObserver<DeleteAllDocumentsResponse> responseObserver) {
+  public DeleteAllDocumentsResponse handle(DeleteAllDocumentsRequest deleteAllDocumentsRequest)
+      throws Exception {
     logger.info("Received delete all documents request: {}", deleteAllDocumentsRequest);
-    try {
-      IndexState indexState =
-          getGlobalState().getIndexOrThrow(deleteAllDocumentsRequest.getIndexName());
-      DeleteAllDocumentsResponse reply = handle(indexState);
-      logger.info("DeleteAllDocumentsHandler returned " + reply);
-      responseObserver.onNext(reply);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      logger.warn(
-          "error while trying to deleteAll for index " + deleteAllDocumentsRequest.getIndexName(),
-          e);
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT
-              .withDescription(
-                  "error while trying to deleteAll for index: "
-                      + deleteAllDocumentsRequest.getIndexName())
-              .augmentDescription(e.getMessage())
-              .asRuntimeException());
-    }
+    IndexState indexState = getIndexState(deleteAllDocumentsRequest.getIndexName());
+    DeleteAllDocumentsResponse reply = handle(indexState);
+    logger.info("DeleteAllDocumentsHandler returned " + reply);
+    return reply;
   }
 
   private DeleteAllDocumentsResponse handle(IndexState indexState)

--- a/src/main/java/com/yelp/nrtsearch/server/handler/DeleteByQueryHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/DeleteByQueryHandler.java
@@ -21,8 +21,6 @@ import com.yelp.nrtsearch.server.index.IndexState;
 import com.yelp.nrtsearch.server.index.ShardState;
 import com.yelp.nrtsearch.server.query.QueryNodeMapper;
 import com.yelp.nrtsearch.server.state.GlobalState;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -39,28 +37,11 @@ public class DeleteByQueryHandler extends Handler<DeleteByQueryRequest, AddDocum
   }
 
   @Override
-  public void handle(
-      DeleteByQueryRequest deleteByQueryRequest,
-      StreamObserver<AddDocumentResponse> responseObserver) {
-    try {
-      IndexState indexState = getGlobalState().getIndexOrThrow(deleteByQueryRequest.getIndexName());
-      AddDocumentResponse reply = handle(indexState, deleteByQueryRequest);
-      logger.debug("DeleteDocumentsHandler returned " + reply.toString());
-      responseObserver.onNext(reply);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      logger.warn(
-          "Error while trying to delete documents from index: {}",
-          deleteByQueryRequest.getIndexName(),
-          e);
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT
-              .withDescription(
-                  "Error while trying to delete documents from index: "
-                      + deleteByQueryRequest.getIndexName())
-              .augmentDescription(e.getMessage())
-              .asRuntimeException());
-    }
+  public AddDocumentResponse handle(DeleteByQueryRequest deleteByQueryRequest) throws Exception {
+    IndexState indexState = getGlobalState().getIndexOrThrow(deleteByQueryRequest.getIndexName());
+    AddDocumentResponse reply = handle(indexState, deleteByQueryRequest);
+    logger.debug("DeleteDocumentsHandler returned " + reply);
+    return reply;
   }
 
   private AddDocumentResponse handle(

--- a/src/main/java/com/yelp/nrtsearch/server/handler/DeleteDocumentsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/DeleteDocumentsHandler.java
@@ -21,8 +21,6 @@ import com.yelp.nrtsearch.server.grpc.AddDocumentResponse;
 import com.yelp.nrtsearch.server.index.IndexState;
 import com.yelp.nrtsearch.server.index.ShardState;
 import com.yelp.nrtsearch.server.state.GlobalState;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,27 +38,11 @@ public class DeleteDocumentsHandler extends Handler<AddDocumentRequest, AddDocum
   }
 
   @Override
-  public void handle(
-      AddDocumentRequest addDocumentRequest, StreamObserver<AddDocumentResponse> responseObserver) {
-    try {
-      IndexState indexState = getGlobalState().getIndexOrThrow(addDocumentRequest.getIndexName());
-      AddDocumentResponse reply = handleInternal(indexState, addDocumentRequest);
-      logger.debug("DeleteDocumentsHandler returned {}", reply);
-      responseObserver.onNext(reply);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      logger.error(
-          "error while trying to delete documents for index {}",
-          addDocumentRequest.getIndexName(),
-          e);
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT
-              .withDescription(
-                  "error while trying to delete documents for index: "
-                      + addDocumentRequest.getIndexName())
-              .augmentDescription(e.getMessage())
-              .asRuntimeException());
-    }
+  public AddDocumentResponse handle(AddDocumentRequest addDocumentRequest) throws Exception {
+    IndexState indexState = getGlobalState().getIndexOrThrow(addDocumentRequest.getIndexName());
+    AddDocumentResponse reply = handleInternal(indexState, addDocumentRequest);
+    logger.debug("DeleteDocumentsHandler returned {}", reply);
+    return reply;
   }
 
   private AddDocumentResponse handleInternal(

--- a/src/main/java/com/yelp/nrtsearch/server/handler/DeleteIndexHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/DeleteIndexHandler.java
@@ -19,8 +19,6 @@ import com.yelp.nrtsearch.server.grpc.DeleteIndexRequest;
 import com.yelp.nrtsearch.server.grpc.DeleteIndexResponse;
 import com.yelp.nrtsearch.server.index.IndexState;
 import com.yelp.nrtsearch.server.state.GlobalState;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,24 +31,12 @@ public class DeleteIndexHandler extends Handler<DeleteIndexRequest, DeleteIndexR
   }
 
   @Override
-  public void handle(
-      DeleteIndexRequest deleteIndexRequest, StreamObserver<DeleteIndexResponse> responseObserver) {
+  public DeleteIndexResponse handle(DeleteIndexRequest deleteIndexRequest) throws Exception {
     logger.info("Received delete index request: {}", deleteIndexRequest);
-    try {
-      IndexState indexState = getGlobalState().getIndexOrThrow(deleteIndexRequest.getIndexName());
-      DeleteIndexResponse reply = handle(indexState);
-      logger.info("DeleteIndexHandler returned " + reply);
-      responseObserver.onNext(reply);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      logger.warn("error while trying to delete index " + deleteIndexRequest.getIndexName(), e);
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT
-              .withDescription(
-                  "error while trying to delete index: " + deleteIndexRequest.getIndexName())
-              .augmentDescription(e.getMessage())
-              .asRuntimeException());
-    }
+    IndexState indexState = getIndexState(deleteIndexRequest.getIndexName());
+    DeleteIndexResponse reply = handle(indexState);
+    logger.info("DeleteIndexHandler returned " + reply);
+    return reply;
   }
 
   private DeleteIndexResponse handle(IndexState indexState) throws DeleteIndexHandlerException {

--- a/src/main/java/com/yelp/nrtsearch/server/handler/GetAllSnapshotIndexGenHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/GetAllSnapshotIndexGenHandler.java
@@ -18,8 +18,6 @@ package com.yelp.nrtsearch.server.handler;
 import com.yelp.nrtsearch.server.grpc.GetAllSnapshotGenRequest;
 import com.yelp.nrtsearch.server.grpc.GetAllSnapshotGenResponse;
 import com.yelp.nrtsearch.server.state.GlobalState;
-import io.grpc.stub.StreamObserver;
-import java.io.IOException;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,24 +31,13 @@ public class GetAllSnapshotIndexGenHandler
   }
 
   @Override
-  public void handle(
-      GetAllSnapshotGenRequest request,
-      StreamObserver<GetAllSnapshotGenResponse> responseObserver) {
-    try {
-      Set<Long> snapshotGens =
-          getGlobalState()
-              .getIndexOrThrow(request.getIndexName())
-              .getShard(0)
-              .snapshotGenToVersion
-              .keySet();
-      GetAllSnapshotGenResponse response =
-          GetAllSnapshotGenResponse.newBuilder().addAllIndexGens(snapshotGens).build();
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (IOException e) {
-      logger.error(
-          "Error getting all snapshotted index gens for index: {}", request.getIndexName(), e);
-      responseObserver.onError(e);
-    }
+  public GetAllSnapshotGenResponse handle(GetAllSnapshotGenRequest request) throws Exception {
+    Set<Long> snapshotGens =
+        getGlobalState()
+            .getIndexOrThrow(request.getIndexName())
+            .getShard(0)
+            .snapshotGenToVersion
+            .keySet();
+    return GetAllSnapshotGenResponse.newBuilder().addAllIndexGens(snapshotGens).build();
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/handler/GetStateHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/GetStateHandler.java
@@ -20,8 +20,6 @@ import com.yelp.nrtsearch.server.grpc.StateRequest;
 import com.yelp.nrtsearch.server.grpc.StateResponse;
 import com.yelp.nrtsearch.server.index.IndexState;
 import com.yelp.nrtsearch.server.state.GlobalState;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,22 +33,11 @@ public class GetStateHandler extends Handler<StateRequest, StateResponse> {
   }
 
   @Override
-  public void handle(StateRequest request, StreamObserver<StateResponse> responseObserver) {
-    try {
-      IndexState indexState = getGlobalState().getIndexOrThrow(request.getIndexName());
-      StateResponse reply = handle(indexState);
-      logger.debug("GetStateHandler returned " + reply);
-      responseObserver.onNext(reply);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      logger.warn("error while trying to get state for index " + request.getIndexName(), e);
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT
-              .withDescription(
-                  "error while trying to get state for index " + request.getIndexName())
-              .augmentDescription(e.getMessage())
-              .asRuntimeException());
-    }
+  public StateResponse handle(StateRequest request) throws Exception {
+    IndexState indexState = getIndexState(request.getIndexName());
+    StateResponse reply = handle(indexState);
+    logger.debug("GetStateHandler returned {}", reply);
+    return reply;
   }
 
   private StateResponse handle(IndexState indexState) throws HandlerException {

--- a/src/main/java/com/yelp/nrtsearch/server/handler/GlobalStateHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/GlobalStateHandler.java
@@ -18,8 +18,6 @@ package com.yelp.nrtsearch.server.handler;
 import com.yelp.nrtsearch.server.grpc.GlobalStateRequest;
 import com.yelp.nrtsearch.server.grpc.GlobalStateResponse;
 import com.yelp.nrtsearch.server.state.GlobalState;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,19 +29,7 @@ public class GlobalStateHandler extends Handler<GlobalStateRequest, GlobalStateR
   }
 
   @Override
-  public void handle(
-      GlobalStateRequest request, StreamObserver<GlobalStateResponse> responseObserver) {
-    try {
-      responseObserver.onNext(
-          GlobalStateResponse.newBuilder().setGlobalState(getGlobalState().getStateInfo()).build());
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      logger.warn("error while trying to get global state", e);
-      responseObserver.onError(
-          Status.UNKNOWN
-              .withDescription("error while trying to get global state")
-              .augmentDescription(e.getMessage())
-              .asRuntimeException());
-    }
+  public GlobalStateResponse handle(GlobalStateRequest request) throws Exception {
+    return GlobalStateResponse.newBuilder().setGlobalState(getGlobalState().getStateInfo()).build();
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/handler/Handler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/Handler.java
@@ -21,12 +21,15 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.yelp.nrtsearch.server.grpc.LuceneServerStubBuilder;
 import com.yelp.nrtsearch.server.grpc.NrtsearchServer;
 import com.yelp.nrtsearch.server.grpc.ReplicationServerClient;
+import com.yelp.nrtsearch.server.index.IndexState;
+import com.yelp.nrtsearch.server.index.IndexStateManager;
 import com.yelp.nrtsearch.server.state.GlobalState;
 import com.yelp.nrtsearch.server.utils.ProtoMessagePrinter;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +61,7 @@ public abstract class Handler<T extends GeneratedMessageV3, S extends GeneratedM
     throw new UnsupportedOperationException("This method is not supported");
   }
 
-  public S handle(T protoRequest) {
+  public S handle(T protoRequest) throws Exception {
     throw new UnsupportedOperationException("This method is not supported");
   }
 
@@ -101,6 +104,27 @@ public abstract class Handler<T extends GeneratedMessageV3, S extends GeneratedM
                 .asException());
       }
     }
+  }
+
+  protected IndexState getIndexState(String indexName) throws IOException, StatusRuntimeException {
+    IndexState indexState = getGlobalState().getIndex(indexName);
+    if (indexState == null) {
+      throw Status.NOT_FOUND
+          .withDescription("Index " + indexName + " not found")
+          .asRuntimeException();
+    }
+    return indexState;
+  }
+
+  protected IndexStateManager getIndexStateManager(String indexName)
+      throws IOException, StatusRuntimeException {
+    IndexStateManager indexStateManager = getGlobalState().getIndexStateManager(indexName);
+    if (indexStateManager == null) {
+      throw Status.NOT_FOUND
+          .withDescription("Index " + indexName + " not found")
+          .asRuntimeException();
+    }
+    return indexStateManager;
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/handler/IndicesHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/IndicesHandler.java
@@ -21,8 +21,6 @@ import com.yelp.nrtsearch.server.grpc.IndicesResponse;
 import com.yelp.nrtsearch.server.grpc.StatsResponse;
 import com.yelp.nrtsearch.server.index.IndexState;
 import com.yelp.nrtsearch.server.state.GlobalState;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.Set;
 import org.slf4j.Logger;
@@ -36,21 +34,10 @@ public class IndicesHandler extends Handler<IndicesRequest, IndicesResponse> {
   }
 
   @Override
-  public void handle(
-      IndicesRequest indicesRequest, StreamObserver<IndicesResponse> responseObserver) {
-    try {
-      IndicesResponse reply = getIndicesResponse(getGlobalState());
-      logger.debug("IndicesRequestHandler returned " + reply);
-      responseObserver.onNext(reply);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      logger.warn("error while trying to get indices stats", e);
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT
-              .withDescription("error while trying to get indices stats")
-              .augmentDescription(e.getMessage())
-              .asRuntimeException());
-    }
+  public IndicesResponse handle(IndicesRequest indicesRequest) throws Exception {
+    IndicesResponse reply = getIndicesResponse(getGlobalState());
+    logger.debug("IndicesRequestHandler returned {}", reply);
+    return reply;
   }
 
   private static IndicesResponse getIndicesResponse(GlobalState globalState) throws IOException {

--- a/src/main/java/com/yelp/nrtsearch/server/handler/LiveSettingsV2Handler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/LiveSettingsV2Handler.java
@@ -21,8 +21,6 @@ import com.yelp.nrtsearch.server.grpc.LiveSettingsV2Request;
 import com.yelp.nrtsearch.server.grpc.LiveSettingsV2Response;
 import com.yelp.nrtsearch.server.index.IndexStateManager;
 import com.yelp.nrtsearch.server.state.GlobalState;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,36 +34,12 @@ public class LiveSettingsV2Handler extends Handler<LiveSettingsV2Request, LiveSe
   }
 
   @Override
-  public void handle(
-      LiveSettingsV2Request req, StreamObserver<LiveSettingsV2Response> responseObserver) {
+  public LiveSettingsV2Response handle(LiveSettingsV2Request req) throws Exception {
     logger.info("Received live settings V2 request: {}", req);
-    try {
-      IndexStateManager indexStateManager =
-          getGlobalState().getIndexStateManagerOrThrow(req.getIndexName());
-      LiveSettingsV2Response reply = handle(indexStateManager, req);
-      logger.info("LiveSettingsV2Handler returned " + JsonFormat.printer().print(reply));
-      responseObserver.onNext(reply);
-      responseObserver.onCompleted();
-    } catch (IllegalArgumentException e) {
-      logger.warn("index: " + req.getIndexName() + " was not yet created", e);
-      responseObserver.onError(
-          Status.ALREADY_EXISTS
-              .withDescription("invalid indexName: " + req.getIndexName())
-              .augmentDescription("IllegalArgumentException()")
-              .withCause(e)
-              .asRuntimeException());
-    } catch (Exception e) {
-      logger.warn(
-          "error while trying to process live settings for indexName: " + req.getIndexName(), e);
-      responseObserver.onError(
-          Status.INTERNAL
-              .withDescription(
-                  "error while trying to process live settings for indexName: "
-                      + req.getIndexName())
-              .augmentDescription("Exception()")
-              .withCause(e)
-              .asRuntimeException());
-    }
+    IndexStateManager indexStateManager = getIndexStateManager(req.getIndexName());
+    LiveSettingsV2Response reply = handle(indexStateManager, req);
+    logger.info("LiveSettingsV2Handler returned " + JsonFormat.printer().print(reply));
+    return reply;
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/handler/MetricsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/MetricsHandler.java
@@ -18,8 +18,6 @@ package com.yelp.nrtsearch.server.handler;
 import com.google.api.HttpBody;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 import io.prometheus.metrics.expositionformats.PrometheusTextFormatWriter;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.ByteArrayOutputStream;
@@ -37,20 +35,10 @@ public class MetricsHandler extends Handler<Empty, HttpBody> {
   }
 
   @Override
-  public void handle(Empty request, StreamObserver<HttpBody> responseObserver) {
-    try {
-      HttpBody reply = process();
-      logger.debug("MetricsRequestHandler returned " + reply.toString());
-      responseObserver.onNext(reply);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      logger.warn("error while trying to get metrics", e);
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT
-              .withDescription("error while trying to get metrics")
-              .augmentDescription(e.getMessage())
-              .asRuntimeException());
-    }
+  public HttpBody handle(Empty request) throws Exception {
+    HttpBody reply = process();
+    logger.debug("MetricsRequestHandler returned {}", reply);
+    return reply;
   }
 
   private HttpBody process() throws IOException {

--- a/src/main/java/com/yelp/nrtsearch/server/handler/RefreshHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/RefreshHandler.java
@@ -20,9 +20,6 @@ import com.yelp.nrtsearch.server.grpc.RefreshResponse;
 import com.yelp.nrtsearch.server.index.IndexState;
 import com.yelp.nrtsearch.server.index.ShardState;
 import com.yelp.nrtsearch.server.state.GlobalState;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,43 +31,18 @@ public class RefreshHandler extends Handler<RefreshRequest, RefreshResponse> {
   }
 
   @Override
-  public void handle(
-      RefreshRequest refreshRequest, StreamObserver<RefreshResponse> responseObserver) {
-    try {
-      IndexState indexState = getGlobalState().getIndexOrThrow(refreshRequest.getIndexName());
-      final ShardState shardState = indexState.getShard(0);
-      long t0 = System.nanoTime();
-      shardState.maybeRefreshBlocking();
-      long t1 = System.nanoTime();
-      double refreshTimeMs = (t1 - t0) / 1000000.0;
-      RefreshResponse reply = RefreshResponse.newBuilder().setRefreshTimeMS(refreshTimeMs).build();
-      logger.info(
-          String.format(
-              "RefreshHandler refreshed index: %s in %f",
-              refreshRequest.getIndexName(), refreshTimeMs));
-      responseObserver.onNext(reply);
-      responseObserver.onCompleted();
-    } catch (IOException e) {
-      logger.warn(
-          "error while trying to read index state dir for indexName: "
-              + refreshRequest.getIndexName(),
-          e);
-      responseObserver.onError(
-          Status.INTERNAL
-              .withDescription(
-                  "error while trying to read index state dir for indexName: "
-                      + refreshRequest.getIndexName())
-              .augmentDescription(e.getMessage())
-              .withCause(e)
-              .asRuntimeException());
-    } catch (Exception e) {
-      logger.warn("error while trying to refresh index " + refreshRequest.getIndexName(), e);
-      responseObserver.onError(
-          Status.UNKNOWN
-              .withDescription(
-                  "error while trying to refresh index: " + refreshRequest.getIndexName())
-              .augmentDescription(e.getMessage())
-              .asRuntimeException());
-    }
+  public RefreshResponse handle(RefreshRequest refreshRequest) throws Exception {
+    IndexState indexState = getIndexState(refreshRequest.getIndexName());
+    final ShardState shardState = indexState.getShard(0);
+    long t0 = System.nanoTime();
+    shardState.maybeRefreshBlocking();
+    long t1 = System.nanoTime();
+    double refreshTimeMs = (t1 - t0) / 1000000.0;
+    RefreshResponse reply = RefreshResponse.newBuilder().setRefreshTimeMS(refreshTimeMs).build();
+    logger.info(
+        String.format(
+            "RefreshHandler refreshed index: %s in %f",
+            refreshRequest.getIndexName(), refreshTimeMs));
+    return reply;
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/handler/RegisterFieldsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/RegisterFieldsHandler.java
@@ -19,9 +19,6 @@ import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
 import com.yelp.nrtsearch.server.grpc.FieldDefResponse;
 import com.yelp.nrtsearch.server.index.IndexStateManager;
 import com.yelp.nrtsearch.server.state.GlobalState;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,40 +30,12 @@ public class RegisterFieldsHandler extends Handler<FieldDefRequest, FieldDefResp
   }
 
   @Override
-  public void handle(
-      FieldDefRequest fieldDefRequest, StreamObserver<FieldDefResponse> responseObserver) {
+  public FieldDefResponse handle(FieldDefRequest fieldDefRequest) throws Exception {
     logger.info("Received register fields request: {}", fieldDefRequest);
-    try {
-      IndexStateManager indexStateManager =
-          getGlobalState().getIndexStateManagerOrThrow(fieldDefRequest.getIndexName());
-      String updatedFields = indexStateManager.updateFields(fieldDefRequest.getFieldList());
-      FieldDefResponse reply = FieldDefResponse.newBuilder().setResponse(updatedFields).build();
-      logger.info("RegisterFieldsHandler registered fields " + reply);
-      responseObserver.onNext(reply);
-      responseObserver.onCompleted();
-    } catch (IOException e) {
-      logger.warn(
-          "error while trying to read index state dir for indexName: "
-              + fieldDefRequest.getIndexName(),
-          e);
-      responseObserver.onError(
-          Status.INTERNAL
-              .withDescription(
-                  "error while trying to read index state dir for indexName: "
-                      + fieldDefRequest.getIndexName())
-              .augmentDescription("IOException()")
-              .withCause(e)
-              .asRuntimeException());
-    } catch (Exception e) {
-      logger.warn(
-          "error while trying to RegisterFields for index " + fieldDefRequest.getIndexName(), e);
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT
-              .withDescription(
-                  "error while trying to RegisterFields for index: "
-                      + fieldDefRequest.getIndexName())
-              .augmentDescription(e.getMessage())
-              .asRuntimeException());
-    }
+    IndexStateManager indexStateManager = getIndexStateManager(fieldDefRequest.getIndexName());
+    String updatedFields = indexStateManager.updateFields(fieldDefRequest.getFieldList());
+    FieldDefResponse reply = FieldDefResponse.newBuilder().setResponse(updatedFields).build();
+    logger.info("RegisterFieldsHandler registered fields " + reply);
+    return reply;
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/handler/ReleaseSnapshotHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/ReleaseSnapshotHandler.java
@@ -20,8 +20,6 @@ import com.yelp.nrtsearch.server.grpc.ReleaseSnapshotResponse;
 import com.yelp.nrtsearch.server.index.IndexState;
 import com.yelp.nrtsearch.server.index.ShardState;
 import com.yelp.nrtsearch.server.state.GlobalState;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,31 +33,12 @@ public class ReleaseSnapshotHandler
   }
 
   @Override
-  public void handle(
-      ReleaseSnapshotRequest releaseSnapshotRequest,
-      StreamObserver<ReleaseSnapshotResponse> responseObserver) {
-    try {
-      IndexState indexState =
-          getGlobalState().getIndexOrThrow(releaseSnapshotRequest.getIndexName());
-      ReleaseSnapshotResponse reply = handle(indexState, releaseSnapshotRequest);
-      logger.info(String.format("CreateSnapshotHandler returned results %s", reply.toString()));
-      responseObserver.onNext(reply);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      logger.warn(
-          String.format(
-              "error while trying to releaseSnapshot for index %s",
-              releaseSnapshotRequest.getIndexName()),
-          e);
-      responseObserver.onError(
-          Status.UNKNOWN
-              .withDescription(
-                  String.format(
-                      "error while trying to releaseSnapshot for index %s",
-                      releaseSnapshotRequest.getIndexName()))
-              .augmentDescription(e.getMessage())
-              .asRuntimeException());
-    }
+  public ReleaseSnapshotResponse handle(ReleaseSnapshotRequest releaseSnapshotRequest)
+      throws Exception {
+    IndexState indexState = getIndexState(releaseSnapshotRequest.getIndexName());
+    ReleaseSnapshotResponse reply = handle(indexState, releaseSnapshotRequest);
+    logger.info(String.format("CreateSnapshotHandler returned results %s", reply));
+    return reply;
   }
 
   private ReleaseSnapshotResponse handle(

--- a/src/main/java/com/yelp/nrtsearch/server/handler/ReloadStateHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/ReloadStateHandler.java
@@ -19,8 +19,6 @@ import com.yelp.nrtsearch.server.grpc.Mode;
 import com.yelp.nrtsearch.server.grpc.ReloadStateRequest;
 import com.yelp.nrtsearch.server.grpc.ReloadStateResponse;
 import com.yelp.nrtsearch.server.state.GlobalState;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,28 +30,12 @@ public class ReloadStateHandler extends Handler<ReloadStateRequest, ReloadStateR
   }
 
   @Override
-  public void handle(
-      ReloadStateRequest request, StreamObserver<ReloadStateResponse> responseObserver) {
-    try {
-      if (getGlobalState()
-          .getConfiguration()
-          .getIndexStartConfig()
-          .getMode()
-          .equals(Mode.REPLICA)) {
-        getGlobalState().reloadStateFromBackend();
-      } else {
-        logger.info("Skip reloading state since it is not replica");
-      }
-      ReloadStateResponse reloadStateResponse = ReloadStateResponse.newBuilder().build();
-      responseObserver.onNext(reloadStateResponse);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      logger.warn("error while trying to sync the index state", e);
-      responseObserver.onError(
-          Status.INTERNAL
-              .withDescription("error while trying to sync the index state")
-              .augmentDescription(e.getMessage())
-              .asRuntimeException());
+  public ReloadStateResponse handle(ReloadStateRequest request) throws Exception {
+    if (getGlobalState().getConfiguration().getIndexStartConfig().getMode().equals(Mode.REPLICA)) {
+      getGlobalState().reloadStateFromBackend();
+    } else {
+      logger.info("Skip reloading state since it is not replica");
     }
+    return ReloadStateResponse.newBuilder().build();
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/handler/SettingsV2Handler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SettingsV2Handler.java
@@ -21,8 +21,6 @@ import com.yelp.nrtsearch.server.grpc.SettingsV2Request;
 import com.yelp.nrtsearch.server.grpc.SettingsV2Response;
 import com.yelp.nrtsearch.server.index.IndexStateManager;
 import com.yelp.nrtsearch.server.state.GlobalState;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,41 +34,12 @@ public class SettingsV2Handler extends Handler<SettingsV2Request, SettingsV2Resp
   }
 
   @Override
-  public void handle(
-      SettingsV2Request settingsRequest, StreamObserver<SettingsV2Response> responseObserver) {
+  public SettingsV2Response handle(SettingsV2Request settingsRequest) throws Exception {
     logger.info("Received settings V2 request: {}", settingsRequest);
-    try {
-      IndexStateManager indexStateManager =
-          getGlobalState().getIndexStateManagerOrThrow(settingsRequest.getIndexName());
-      SettingsV2Response reply = handle(indexStateManager, settingsRequest);
-      logger.info("SettingsV2Handler returned: " + JsonFormat.printer().print(reply));
-      responseObserver.onNext(reply);
-      responseObserver.onCompleted();
-    } catch (IOException e) {
-      logger.warn(
-          "error while trying to read index state dir for indexName: "
-              + settingsRequest.getIndexName(),
-          e);
-      responseObserver.onError(
-          Status.INTERNAL
-              .withDescription(
-                  "error while trying to read index state dir for indexName: "
-                      + settingsRequest.getIndexName())
-              .augmentDescription("IOException()")
-              .withCause(e)
-              .asRuntimeException());
-    } catch (Exception e) {
-      logger.warn(
-          "error while trying to update/get settings for index " + settingsRequest.getIndexName(),
-          e);
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT
-              .withDescription(
-                  "error while trying to update/get settings for index: "
-                      + settingsRequest.getIndexName())
-              .augmentDescription(e.getMessage())
-              .asRuntimeException());
-    }
+    IndexStateManager indexStateManager = getIndexStateManager(settingsRequest.getIndexName());
+    SettingsV2Response reply = handle(indexStateManager, settingsRequest);
+    logger.info("SettingsV2Handler returned: " + JsonFormat.printer().print(reply));
+    return reply;
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/handler/StartIndexHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/StartIndexHandler.java
@@ -19,8 +19,6 @@ import com.yelp.nrtsearch.server.grpc.StartIndexRequest;
 import com.yelp.nrtsearch.server.grpc.StartIndexResponse;
 import com.yelp.nrtsearch.server.state.GlobalState;
 import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,46 +30,17 @@ public class StartIndexHandler extends Handler<StartIndexRequest, StartIndexResp
   }
 
   @Override
-  public void handle(
-      StartIndexRequest startIndexRequest, StreamObserver<StartIndexResponse> responseObserver) {
+  public StartIndexResponse handle(StartIndexRequest startIndexRequest) throws Exception {
     logger.info("Received start index request: {}", startIndexRequest);
     if (startIndexRequest.getIndexName().isEmpty()) {
       logger.warn("error while trying to start index with empty index name.");
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT
-              .withDescription(
-                  String.format("error while trying to start index since indexName was empty."))
-              .asRuntimeException());
-      return;
+      throw Status.INVALID_ARGUMENT
+          .withDescription("error while trying to start index since indexName was empty.")
+          .asRuntimeException();
     }
-    try {
-      StartIndexResponse reply = getGlobalState().startIndex(startIndexRequest);
 
-      logger.info("StartIndexHandler returned " + reply.toString());
-      responseObserver.onNext(reply);
-      responseObserver.onCompleted();
-
-    } catch (IOException e) {
-      logger.warn(
-          "error while trying to read index state dir for indexName: "
-              + startIndexRequest.getIndexName(),
-          e);
-      responseObserver.onError(
-          Status.INTERNAL
-              .withDescription(
-                  "error while trying to read index state dir for indexName: "
-                      + startIndexRequest.getIndexName())
-              .augmentDescription(e.getMessage())
-              .withCause(e)
-              .asRuntimeException());
-    } catch (Exception e) {
-      logger.warn("error while trying to start index " + startIndexRequest.getIndexName(), e);
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT
-              .withDescription(
-                  "error while trying to start index: " + startIndexRequest.getIndexName())
-              .augmentDescription(e.getMessage())
-              .asRuntimeException());
-    }
+    StartIndexResponse reply = getGlobalState().startIndex(startIndexRequest);
+    logger.info("StartIndexHandler returned " + reply.toString());
+    return reply;
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/handler/StatusHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/StatusHandler.java
@@ -18,8 +18,6 @@ package com.yelp.nrtsearch.server.handler;
 import com.yelp.nrtsearch.server.grpc.HealthCheckRequest;
 import com.yelp.nrtsearch.server.grpc.HealthCheckResponse;
 import com.yelp.nrtsearch.server.grpc.TransferStatusCode;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,21 +29,10 @@ public class StatusHandler extends Handler<HealthCheckRequest, HealthCheckRespon
   }
 
   @Override
-  public void handle(
-      HealthCheckRequest request, StreamObserver<HealthCheckResponse> responseObserver) {
-    try {
-      HealthCheckResponse reply =
-          HealthCheckResponse.newBuilder().setHealth(TransferStatusCode.Done).build();
-      logger.debug("HealthCheckResponse returned " + reply);
-      responseObserver.onNext(reply);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      logger.warn("error while trying to get status", e);
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT
-              .withDescription("error while trying to get status")
-              .augmentDescription(e.getMessage())
-              .asRuntimeException());
-    }
+  public HealthCheckResponse handle(HealthCheckRequest request) throws Exception {
+    HealthCheckResponse reply =
+        HealthCheckResponse.newBuilder().setHealth(TransferStatusCode.Done).build();
+    logger.debug("HealthCheckResponse returned " + reply);
+    return reply;
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/handler/StopIndexHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/StopIndexHandler.java
@@ -18,8 +18,6 @@ package com.yelp.nrtsearch.server.handler;
 import com.yelp.nrtsearch.server.grpc.DummyResponse;
 import com.yelp.nrtsearch.server.grpc.StopIndexRequest;
 import com.yelp.nrtsearch.server.state.GlobalState;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,23 +29,11 @@ public class StopIndexHandler extends Handler<StopIndexRequest, DummyResponse> {
   }
 
   @Override
-  public void handle(
-      StopIndexRequest stopIndexRequest, StreamObserver<DummyResponse> responseObserver) {
+  public DummyResponse handle(StopIndexRequest stopIndexRequest) throws Exception {
     logger.info("Received stop index request: {}", stopIndexRequest);
-    try {
-      DummyResponse reply = getGlobalState().stopIndex(stopIndexRequest);
+    DummyResponse reply = getGlobalState().stopIndex(stopIndexRequest);
 
-      logger.info("StopIndexHandler returned " + reply);
-      responseObserver.onNext(reply);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      logger.warn("error while trying to stop index " + stopIndexRequest.getIndexName(), e);
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT
-              .withDescription(
-                  "error while trying to stop index: " + stopIndexRequest.getIndexName())
-              .augmentDescription(e.getMessage())
-              .asRuntimeException());
-    }
+    logger.info("StopIndexHandler returned " + reply);
+    return reply;
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/NrtsearchServerIdFieldTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/NrtsearchServerIdFieldTest.java
@@ -263,7 +263,7 @@ public class NrtsearchServerIdFieldTest {
                   .build());
     } catch (RuntimeException e) {
       String message =
-          "INVALID_ARGUMENT: error while trying to UpdateFieldsHandler for index: test_index\n"
+          "INTERNAL: Error handling updateFields request\n"
               + "Index can only register one id field, found: doc_id and new_text_field";
       assertEquals(message, e.getMessage());
       throw e;
@@ -276,7 +276,7 @@ public class NrtsearchServerIdFieldTest {
       registerFields(List.of(getFieldBuilder("doc_id", true, true, true)));
     } catch (RuntimeException e) {
       String message =
-          "INVALID_ARGUMENT: error while trying to RegisterFields for index: test_index\n"
+          "INTERNAL: Error handling registerFields request\n"
               + "field: doc_id cannot have multivalued fields as it's an _ID field";
       assertEquals(message, e.getMessage());
       throw e;
@@ -289,7 +289,7 @@ public class NrtsearchServerIdFieldTest {
       registerFields(List.of(getFieldBuilder("doc_id", false, false, false)));
     } catch (RuntimeException e) {
       String message =
-          "INVALID_ARGUMENT: error while trying to RegisterFields for index: test_index\n"
+          "INTERNAL: Error handling registerFields request\n"
               + "field: doc_id is an _ID field and should be retrievable by either store=true or storeDocValues=true";
       assertEquals(message, e.getMessage());
       throw e;
@@ -315,7 +315,7 @@ public class NrtsearchServerIdFieldTest {
               getFieldBuilder("doc_id_2", true, true, false)));
     } catch (RuntimeException e) {
       String message =
-          "INVALID_ARGUMENT: error while trying to RegisterFields for index: test_index\n"
+          "INTERNAL: Error handling registerFields request\n"
               + "Index can only register one id field, found: doc_id and doc_id_2";
       assertEquals(message, e.getMessage());
       throw e;

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/StateBackendServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/StateBackendServerTest.java
@@ -1251,9 +1251,7 @@ public class StateBackendServerTest {
       fail();
     } catch (StatusRuntimeException e) {
       assertEquals(Status.ALREADY_EXISTS.getCode(), e.getStatus().getCode());
-      assertEquals(
-          "ALREADY_EXISTS: invalid indexName: test_index\nIllegalArgumentException()",
-          e.getMessage());
+      assertEquals("ALREADY_EXISTS: Index test_index already exists", e.getMessage());
     }
   }
 
@@ -1452,7 +1450,7 @@ public class StateBackendServerTest {
       fail();
     } catch (StatusRuntimeException e) {
       assertEquals(
-          "INVALID_ARGUMENT: error while trying to start index: test_index\nIndex test_index is already started",
+          "INTERNAL: Error handling startIndex request\nIndex test_index is already started",
           e.getMessage());
     }
   }


### PR DESCRIPTION
Use the `handleUnaryRequest` for most of the server gRPC method handling. This does not include the replication server, or more complicated methods (search, searchV2, commit). A lot of redundant/inconsistent request error handling code has been removed.

I added additional utility methods to `Handler` to get `IndexState` and `IndexStateManager`. This methods throw a `NOT_FOUND` status exception if the index does not exist.