### PR TITLE
Use handleUnaryRequest for replication server methods

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
@@ -694,9 +694,6 @@ public class NrtsearchServer {
   }
 
   static class ReplicationServerImpl extends ReplicationServerGrpc.ReplicationServerImplBase {
-    private final GlobalState globalState;
-    private final boolean verifyIndexId;
-
     private final AddReplicaHandler addReplicaHandler;
     private final CopyFilesHandler copyFilesHandler;
     private final GetNodesInfoHandler getNodesInfoHandler;
@@ -709,8 +706,6 @@ public class NrtsearchServer {
     private final WriteNRTPointHandler writeNRTPointHandler;
 
     public ReplicationServerImpl(GlobalState globalState, boolean verifyIndexId) {
-      this.globalState = globalState;
-      this.verifyIndexId = verifyIndexId;
 
       addReplicaHandler = new AddReplicaHandler(globalState, verifyIndexId);
       copyFilesHandler = new CopyFilesHandler(globalState, verifyIndexId);
@@ -729,7 +724,8 @@ public class NrtsearchServer {
     public void addReplicas(
         AddReplicaRequest addReplicaRequest,
         StreamObserver<AddReplicaResponse> responseStreamObserver) {
-      addReplicaHandler.handle(addReplicaRequest, responseStreamObserver);
+      Handler.handleUnaryRequest(
+          "addReplicas", addReplicaRequest, responseStreamObserver, addReplicaHandler);
     }
 
     @Override
@@ -753,7 +749,7 @@ public class NrtsearchServer {
     @Override
     public void recvCopyState(
         CopyStateRequest request, StreamObserver<CopyState> responseObserver) {
-      recvCopyStateHandler.handle(request, responseObserver);
+      Handler.handleUnaryRequest("recvCopyState", request, responseObserver, recvCopyStateHandler);
     }
 
     @Override
@@ -763,25 +759,31 @@ public class NrtsearchServer {
 
     @Override
     public void newNRTPoint(NewNRTPoint request, StreamObserver<TransferStatus> responseObserver) {
-      newNRTPointHandler.handle(request, responseObserver);
+      Handler.handleUnaryRequest("newNRTPoint", request, responseObserver, newNRTPointHandler);
     }
 
     @Override
     public void writeNRTPoint(
         IndexName indexNameRequest, StreamObserver<SearcherVersion> responseObserver) {
-      writeNRTPointHandler.handle(indexNameRequest, responseObserver);
+      Handler.handleUnaryRequest(
+          "writeNRTPoint", indexNameRequest, responseObserver, writeNRTPointHandler);
     }
 
     @Override
     public void getCurrentSearcherVersion(
         IndexName indexNameRequest, StreamObserver<SearcherVersion> responseObserver) {
-      replicaCurrentSearchingVersionHandler.handle(indexNameRequest, responseObserver);
+      Handler.handleUnaryRequest(
+          "getCurrentSearcherVersion",
+          indexNameRequest,
+          responseObserver,
+          replicaCurrentSearchingVersionHandler);
     }
 
     @Override
     public void getConnectedNodes(
         GetNodesRequest getNodesRequest, StreamObserver<GetNodesResponse> responseObserver) {
-      getNodesInfoHandler.handle(getNodesRequest, responseObserver);
+      Handler.handleUnaryRequest(
+          "getConnectedNodes", getNodesRequest, responseObserver, getNodesInfoHandler);
     }
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/handler/DeleteByQueryHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/DeleteByQueryHandler.java
@@ -38,9 +38,9 @@ public class DeleteByQueryHandler extends Handler<DeleteByQueryRequest, AddDocum
 
   @Override
   public AddDocumentResponse handle(DeleteByQueryRequest deleteByQueryRequest) throws Exception {
-    IndexState indexState = getGlobalState().getIndexOrThrow(deleteByQueryRequest.getIndexName());
+    IndexState indexState = getIndexState(deleteByQueryRequest.getIndexName());
     AddDocumentResponse reply = handle(indexState, deleteByQueryRequest);
-    logger.debug("DeleteDocumentsHandler returned " + reply);
+    logger.debug("DeleteDocumentsHandler returned {}", reply);
     return reply;
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/handler/DeleteDocumentsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/DeleteDocumentsHandler.java
@@ -39,7 +39,7 @@ public class DeleteDocumentsHandler extends Handler<AddDocumentRequest, AddDocum
 
   @Override
   public AddDocumentResponse handle(AddDocumentRequest addDocumentRequest) throws Exception {
-    IndexState indexState = getGlobalState().getIndexOrThrow(addDocumentRequest.getIndexName());
+    IndexState indexState = getIndexState(addDocumentRequest.getIndexName());
     AddDocumentResponse reply = handleInternal(indexState, addDocumentRequest);
     logger.debug("DeleteDocumentsHandler returned {}", reply);
     return reply;

--- a/src/main/java/com/yelp/nrtsearch/server/handler/DeleteIndexHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/DeleteIndexHandler.java
@@ -35,7 +35,7 @@ public class DeleteIndexHandler extends Handler<DeleteIndexRequest, DeleteIndexR
     logger.info("Received delete index request: {}", deleteIndexRequest);
     IndexState indexState = getIndexState(deleteIndexRequest.getIndexName());
     DeleteIndexResponse reply = handle(indexState);
-    logger.info("DeleteIndexHandler returned " + reply);
+    logger.info("DeleteIndexHandler returned {}", reply);
     return reply;
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/handler/ForceMergeDeletesHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/ForceMergeDeletesHandler.java
@@ -42,7 +42,7 @@ public class ForceMergeDeletesHandler
     }
 
     try {
-      IndexState indexState = getGlobalState().getIndexOrThrow(forceMergeRequest.getIndexName());
+      IndexState indexState = getIndexState(forceMergeRequest.getIndexName());
       ShardState shardState = indexState.getShards().get(0);
       logger.info("Beginning force merge deletes for index: {}", forceMergeRequest.getIndexName());
       shardState.writer.forceMergeDeletes(forceMergeRequest.getDoWait());

--- a/src/main/java/com/yelp/nrtsearch/server/handler/ForceMergeHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/ForceMergeHandler.java
@@ -40,7 +40,7 @@ public class ForceMergeHandler extends Handler<ForceMergeRequest, ForceMergeResp
       throw new IllegalArgumentException("Cannot have 0 max segments");
     }
 
-    IndexState indexState = getGlobalState().getIndexOrThrow(forceMergeRequest.getIndexName());
+    IndexState indexState = getIndexState(forceMergeRequest.getIndexName());
     ShardState shardState = indexState.getShards().get(0);
     logger.info("Beginning force merge for index: {}", forceMergeRequest.getIndexName());
     shardState.writer.forceMerge(

--- a/src/main/java/com/yelp/nrtsearch/server/handler/GetAllSnapshotIndexGenHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/GetAllSnapshotIndexGenHandler.java
@@ -33,11 +33,7 @@ public class GetAllSnapshotIndexGenHandler
   @Override
   public GetAllSnapshotGenResponse handle(GetAllSnapshotGenRequest request) throws Exception {
     Set<Long> snapshotGens =
-        getGlobalState()
-            .getIndexOrThrow(request.getIndexName())
-            .getShard(0)
-            .snapshotGenToVersion
-            .keySet();
+        getIndexState(request.getIndexName()).getShard(0).snapshotGenToVersion.keySet();
     return GetAllSnapshotGenResponse.newBuilder().addAllIndexGens(snapshotGens).build();
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/handler/RecvCopyStateHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/RecvCopyStateHandler.java
@@ -25,9 +25,6 @@ import com.yelp.nrtsearch.server.index.IndexStateManager;
 import com.yelp.nrtsearch.server.index.ShardState;
 import com.yelp.nrtsearch.server.nrt.NRTPrimaryNode;
 import com.yelp.nrtsearch.server.state.GlobalState;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
-import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.lucene.replicator.nrt.FileMetaData;
@@ -45,37 +42,16 @@ public class RecvCopyStateHandler extends Handler<CopyStateRequest, CopyState> {
   }
 
   @Override
-  public void handle(CopyStateRequest request, StreamObserver<CopyState> responseObserver) {
-    try {
-      IndexStateManager indexStateManager =
-          getGlobalState().getIndexStateManagerOrThrow(request.getIndexName());
-      checkIndexId(request.getIndexId(), indexStateManager.getIndexId(), verifyIndexId);
+  public CopyState handle(CopyStateRequest request) throws Exception {
+    IndexStateManager indexStateManager = getIndexStateManager(request.getIndexName());
+    checkIndexId(request.getIndexId(), indexStateManager.getIndexId(), verifyIndexId);
 
-      IndexState indexState = indexStateManager.getCurrent();
-      CopyState reply = handle(indexState, request);
-      logger.debug(
-          "RecvCopyStateHandler returned, completedMergeFiles count: "
-              + reply.getCompletedMergeFilesCount());
-      responseObserver.onNext(reply);
-      responseObserver.onCompleted();
-    } catch (StatusRuntimeException e) {
-      logger.warn("error while trying recvCopyState " + request.getIndexName(), e);
-      responseObserver.onError(e);
-    } catch (Exception e) {
-      logger.warn(
-          String.format(
-              "error on recvCopyState for replicaId: %s, for index: %s",
-              request.getReplicaId(), request.getIndexName()),
-          e);
-      responseObserver.onError(
-          Status.INTERNAL
-              .withDescription(
-                  String.format(
-                      "error on recvCopyState for replicaId: %s, for index: %s",
-                      request.getReplicaId(), request.getIndexName()))
-              .augmentDescription(e.getMessage())
-              .asRuntimeException());
-    }
+    IndexState indexState = indexStateManager.getCurrent();
+    CopyState reply = handle(indexState, request);
+    logger.debug(
+        "RecvCopyStateHandler returned, completedMergeFiles count: {}",
+        reply.getCompletedMergeFilesCount());
+    return reply;
   }
 
   private CopyState handle(IndexState indexState, CopyStateRequest copyStateRequest) {

--- a/src/main/java/com/yelp/nrtsearch/server/handler/RecvRawFileHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/RecvRawFileHandler.java
@@ -42,8 +42,7 @@ public class RecvRawFileHandler extends Handler<FileInfo, RawFileChunk> {
   @Override
   public void handle(FileInfo fileInfoRequest, StreamObserver<RawFileChunk> responseObserver) {
     try {
-      IndexStateManager indexStateManager =
-          getGlobalState().getIndexStateManagerOrThrow(fileInfoRequest.getIndexName());
+      IndexStateManager indexStateManager = getIndexStateManager(fileInfoRequest.getIndexName());
       checkIndexId(fileInfoRequest.getIndexId(), indexStateManager.getIndexId(), verifyIndexId);
 
       IndexState indexState = indexStateManager.getCurrent();

--- a/src/main/java/com/yelp/nrtsearch/server/handler/RecvRawFileV2Handler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/RecvRawFileV2Handler.java
@@ -59,7 +59,7 @@ public class RecvRawFileV2Handler extends Handler<FileInfo, RawFileChunk> {
           if (indexState == null) {
             // Start transfer
             IndexStateManager indexStateManager =
-                getGlobalState().getIndexStateManagerOrThrow(fileInfoRequest.getIndexName());
+                getIndexStateManager(fileInfoRequest.getIndexName());
             checkIndexId(
                 fileInfoRequest.getIndexId(), indexStateManager.getIndexId(), verifyIndexId);
 

--- a/src/main/java/com/yelp/nrtsearch/server/handler/RegisterFieldsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/RegisterFieldsHandler.java
@@ -35,7 +35,7 @@ public class RegisterFieldsHandler extends Handler<FieldDefRequest, FieldDefResp
     IndexStateManager indexStateManager = getIndexStateManager(fieldDefRequest.getIndexName());
     String updatedFields = indexStateManager.updateFields(fieldDefRequest.getFieldList());
     FieldDefResponse reply = FieldDefResponse.newBuilder().setResponse(updatedFields).build();
-    logger.info("RegisterFieldsHandler registered fields " + reply);
+    logger.info("RegisterFieldsHandler registered fields {}", reply);
     return reply;
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/handler/SettingsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SettingsHandler.java
@@ -42,7 +42,7 @@ public class SettingsHandler extends Handler<SettingsRequest, SettingsResponse> 
     logger.info("Received settings request: {}", settingsRequest);
     IndexState indexState = getIndexState(settingsRequest.getIndexName());
     SettingsResponse reply = handle(indexState, settingsRequest);
-    logger.info("SettingsHandler returned " + reply);
+    logger.info("SettingsHandler returned {}", reply);
     return reply;
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/handler/StartIndexHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/StartIndexHandler.java
@@ -40,7 +40,7 @@ public class StartIndexHandler extends Handler<StartIndexRequest, StartIndexResp
     }
 
     StartIndexResponse reply = getGlobalState().startIndex(startIndexRequest);
-    logger.info("StartIndexHandler returned " + reply.toString());
+    logger.info("StartIndexHandler returned {}", reply.toString());
     return reply;
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/handler/StartIndexV2Handler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/StartIndexV2Handler.java
@@ -40,7 +40,7 @@ public class StartIndexV2Handler extends Handler<StartIndexV2Request, StartIndex
     }
 
     StartIndexResponse reply = getGlobalState().startIndexV2(startIndexRequest);
-    logger.info("StartIndexV2Handler returned " + reply.toString());
+    logger.info("StartIndexV2Handler returned {}", reply.toString());
     return reply;
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/handler/StatusHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/StatusHandler.java
@@ -32,7 +32,7 @@ public class StatusHandler extends Handler<HealthCheckRequest, HealthCheckRespon
   public HealthCheckResponse handle(HealthCheckRequest request) throws Exception {
     HealthCheckResponse reply =
         HealthCheckResponse.newBuilder().setHealth(TransferStatusCode.Done).build();
-    logger.debug("HealthCheckResponse returned " + reply);
+    logger.debug("HealthCheckResponse returned {}", reply);
     return reply;
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/handler/StopIndexHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/StopIndexHandler.java
@@ -33,7 +33,7 @@ public class StopIndexHandler extends Handler<StopIndexRequest, DummyResponse> {
     logger.info("Received stop index request: {}", stopIndexRequest);
     DummyResponse reply = getGlobalState().stopIndex(stopIndexRequest);
 
-    logger.info("StopIndexHandler returned " + reply);
+    logger.info("StopIndexHandler returned {}", reply);
     return reply;
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/handler/UpdateFieldsHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/UpdateFieldsHandler.java
@@ -35,7 +35,7 @@ public class UpdateFieldsHandler extends Handler<FieldDefRequest, FieldDefRespon
     IndexStateManager indexStateManager = getIndexStateManager(fieldDefRequest.getIndexName());
     String updatedFields = indexStateManager.updateFields(fieldDefRequest.getFieldList());
     FieldDefResponse reply = FieldDefResponse.newBuilder().setResponse(updatedFields).build();
-    logger.info("UpdateFieldsHandler registered fields " + reply);
+    logger.info("UpdateFieldsHandler registered fields {}", reply);
     return reply;
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/field/DateTimeFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/DateTimeFieldDefTest.java
@@ -350,7 +350,7 @@ public class DateTimeFieldDefTest extends ServerTestCase {
     } catch (RuntimeException e) {
       assertEquals(
           String.format(
-              "UNKNOWN: error while trying to execute search for index test_index. check logs for full searchRequest.\n"
+              "INTERNAL: Error while trying to execute search for index test_index. check logs for full searchRequest.\n"
                   + "Text \'%s\' could not be parsed, unparsed text found at index 23",
               dateTimeValueUpper),
           e.getMessage());
@@ -377,7 +377,7 @@ public class DateTimeFieldDefTest extends ServerTestCase {
     } catch (RuntimeException e) {
       assertEquals(
           String.format(
-              "UNKNOWN: error while trying to execute search for index test_index. check logs for full searchRequest.\n"
+              "INTERNAL: Error while trying to execute search for index test_index. check logs for full searchRequest.\n"
                   + "For input string: \"%s\"",
               dateTimeValueLower),
           e.getMessage());
@@ -404,7 +404,7 @@ public class DateTimeFieldDefTest extends ServerTestCase {
     } catch (RuntimeException e) {
       assertEquals(
           String.format(
-              "UNKNOWN: error while trying to execute search for index test_index. check logs for full searchRequest.\n"
+              "INTERNAL: Error while trying to execute search for index test_index. check logs for full searchRequest.\n"
                   + "Text '%s' could not be parsed at index 0",
               dateTimeValueLower),
           e.getMessage());

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClientTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClientTest.java
@@ -72,8 +72,6 @@ public class ReplicationServerClientTest {
   private Server getBasicReplicationServer() throws IOException {
     // we only need to test connectivity for now
     GlobalState mockGlobalState = mock(GlobalState.class);
-    when(mockGlobalState.getIndexOrThrow(any(String.class)))
-        .thenThrow(new RuntimeException("Expected"));
     NrtsearchConfig mockConfiguration = mock(NrtsearchConfig.class);
     when(mockGlobalState.getConfiguration()).thenReturn(mockConfiguration);
     when(mockConfiguration.getUseKeepAliveForReplication()).thenReturn(true);
@@ -89,7 +87,7 @@ public class ReplicationServerClientTest {
       client.getConnectedNodes("test_index");
       fail();
     } catch (StatusRuntimeException e) {
-      assertEquals("INTERNAL: error on GetNodesInfoHandler\nExpected", e.getMessage());
+      assertEquals("NOT_FOUND: Index test_index not found", e.getMessage());
     }
   }
 


### PR DESCRIPTION
Use the `handleUnaryRequest` utility method where applicable for the replication server.

Also:
- For the methods that cannot use this, I tried to make error handling more consistent
- Made sure handlers are using the `getIndexState` and `getIndexStateManager` versions that throw `NOT_FOUND` status
- Other logging cleanup

