### PR TITLE
Remove replicas on NOT_FOUND status exception

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NRTPrimaryNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NRTPrimaryNode.java
@@ -216,18 +216,20 @@ public class NRTPrimaryNode extends PrimaryNode {
         Status status = e.getStatus();
         if (status.getCode().equals(Status.UNAVAILABLE.getCode())) {
           logger.warn(
-              "NRTPRimaryNode: sendNRTPoint, lost connection to replicaId: {} host: {} port: {}",
+              "NRTPrimaryNode: sendNRTPoint, lost connection to replicaId: {} host: {} port: {}",
               replicaDetails.replicaId,
               replicaDetails.replicationServerClient.getHost(),
               replicaDetails.replicationServerClient.getPort());
           currentReplicaServerClient.close();
           it.remove();
-        } else if (status.getCode().equals(Status.FAILED_PRECONDITION.getCode())) {
+        } else if (status.getCode().equals(Status.FAILED_PRECONDITION.getCode())
+            || status.getCode().equals(Status.NOT_FOUND.getCode())) {
           logger.warn(
-              "NRTPRimaryNode: sendNRTPoint, replicaId: {} host: {} port: {} cannot process nrt point, closing connection",
+              "NRTPrimaryNode: sendNRTPoint, replicaId: {} host: {} port: {} cannot process nrt point, closing connection: {}",
               replicaDetails.replicaId,
               replicaDetails.replicationServerClient.getHost(),
-              replicaDetails.replicationServerClient.getPort());
+              replicaDetails.replicationServerClient.getPort(),
+              status);
           currentReplicaServerClient.close();
           it.remove();
         }


### PR DESCRIPTION
The replication server will now return the `NOT_FOUND` status if the requested index does not exist. This change makes it so the primary will remove replicas if it receives that status. This is useful when ip reuse causes the primary to send requests to replicas from different clusters.