### PR TITLE
Use READONCE io context for nrt, add MMap grouping options

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java
@@ -19,6 +19,7 @@ import com.google.inject.Inject;
 import com.google.protobuf.util.JsonFormat;
 import com.yelp.nrtsearch.server.grpc.IndexLiveSettings;
 import com.yelp.nrtsearch.server.grpc.ReplicationServerClient;
+import com.yelp.nrtsearch.server.index.DirectoryFactory;
 import com.yelp.nrtsearch.server.utils.JsonUtils;
 import com.yelp.nrtsearch.server.warming.WarmerConfig;
 import java.io.IOException;
@@ -108,6 +109,7 @@ public class NrtsearchConfig {
   private final int lowPriorityCopyPercentage;
   private final boolean verifyReplicationIndexId;
   private final boolean useKeepAliveForReplication;
+  private final DirectoryFactory.MMapGrouping mmapGrouping;
 
   @Inject
   public NrtsearchConfig(InputStream yamlStream) {
@@ -180,6 +182,11 @@ public class NrtsearchConfig {
     lowPriorityCopyPercentage = configReader.getInteger("lowPriorityCopyPercentage", 0);
     verifyReplicationIndexId = configReader.getBoolean("verifyReplicationIndexId", true);
     useKeepAliveForReplication = configReader.getBoolean("useKeepAliveForReplication", false);
+    mmapGrouping =
+        configReader.get(
+            "mmapGrouping",
+            o -> DirectoryFactory.parseMMapGrouping(o.toString()),
+            DirectoryFactory.MMapGrouping.SEGMENT);
 
     List<String> indicesWithOverrides = configReader.getKeysOrEmpty("indexLiveSettingsOverrides");
     Map<String, IndexLiveSettings> liveSettingsMap = new HashMap<>();
@@ -358,6 +365,10 @@ public class NrtsearchConfig {
 
   public boolean getUseKeepAliveForReplication() {
     return useKeepAliveForReplication;
+  }
+
+  public DirectoryFactory.MMapGrouping getMMapGrouping() {
+    return mmapGrouping;
   }
 
   public IndexLiveSettings getLiveSettingsOverride(String indexName) {

--- a/src/main/java/com/yelp/nrtsearch/server/handler/RecvRawFileHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/RecvRawFileHandler.java
@@ -48,7 +48,7 @@ public class RecvRawFileHandler extends Handler<FileInfo, RawFileChunk> {
       IndexState indexState = indexStateManager.getCurrent();
       ShardState shardState = indexState.getShard(0);
       try (IndexInput luceneFile =
-          shardState.indexDir.openInput(fileInfoRequest.getFileName(), IOContext.DEFAULT)) {
+          shardState.indexDir.openInput(fileInfoRequest.getFileName(), IOContext.READONCE)) {
         long len = luceneFile.length();
         long pos = fileInfoRequest.getFpStart();
         luceneFile.seek(pos);

--- a/src/main/java/com/yelp/nrtsearch/server/index/ImmutableIndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/ImmutableIndexState.java
@@ -237,7 +237,9 @@ public class ImmutableIndexState extends IndexState {
     }
     indexMergeSchedulerAutoThrottle =
         mergedSettings.getIndexMergeSchedulerAutoThrottle().getValue();
-    directoryFactory = DirectoryFactory.get(mergedSettings.getDirectory().getValue());
+    directoryFactory =
+        DirectoryFactory.get(
+            mergedSettings.getDirectory().getValue(), globalState.getConfiguration());
 
     // live settings
     mergedLiveSettings =

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NRTPrimaryNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NRTPrimaryNode.java
@@ -579,4 +579,9 @@ public class NRTPrimaryNode extends PrimaryNode {
     nrtDataManager.close();
     super.close();
   }
+
+  @Override
+  public FileMetaData readLocalFileMetaData(String fileName) throws IOException {
+    return NrtUtils.readOnceLocalFileMetaData(fileName, lastFileMetaData, this);
+  }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NRTReplicaNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NRTReplicaNode.java
@@ -383,4 +383,9 @@ public class NRTReplicaNode extends ReplicaNode {
     }
     logger.info("Finished syncing nrt point from current primary, current version: {}", curVersion);
   }
+
+  @Override
+  public FileMetaData readLocalFileMetaData(String fileName) throws IOException {
+    return NrtUtils.readOnceLocalFileMetaData(fileName, lastFileMetaData, this);
+  }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NrtUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NrtUtils.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.nrt;
+
+import static org.apache.lucene.replicator.nrt.Node.VERBOSE_FILES;
+import static org.apache.lucene.replicator.nrt.Node.bytesToString;
+
+import java.io.EOFException;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+import java.util.Map;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.replicator.nrt.FileMetaData;
+import org.apache.lucene.replicator.nrt.Node;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+
+public class NrtUtils {
+
+  /**
+   * Modified version of {@link Node} implementation that opens files with the READONCE io context.
+   *
+   * @param fileName the name of the file to read
+   * @param cache a map to cache file metadata
+   * @param node the nrt node reading the metadata
+   * @return the metadata of the file, or null if the file is corrupt or does not exist
+   * @throws IOException if an I/O error occurs
+   */
+  public static FileMetaData readOnceLocalFileMetaData(
+      String fileName, Map<String, FileMetaData> cache, Node node) throws IOException {
+
+    FileMetaData result;
+    if (cache != null) {
+      // We may already have this file cached from the last NRT point:
+      result = cache.get(fileName);
+    } else {
+      result = null;
+    }
+
+    if (result == null) {
+      // Pull from the filesystem
+      long checksum;
+      long length;
+      byte[] header;
+      byte[] footer;
+      try (IndexInput in = node.getDirectory().openInput(fileName, IOContext.READONCE)) {
+        try {
+          length = in.length();
+          header = CodecUtil.readIndexHeader(in);
+          footer = CodecUtil.readFooter(in);
+          checksum = CodecUtil.retrieveChecksum(in);
+        } catch (@SuppressWarnings("unused") EOFException | CorruptIndexException cie) {
+          // File exists but is busted: we must copy it.  This happens when node had crashed,
+          // corrupting an un-fsync'd file.  On init we try
+          // to delete such unreferenced files, but virus checker can block that, leaving this bad
+          // file.
+          if (VERBOSE_FILES) {
+            node.message("file " + fileName + ": will copy [existing file is corrupt]");
+          }
+          return null;
+        }
+        if (VERBOSE_FILES) {
+          node.message("file " + fileName + " has length=" + bytesToString(length));
+        }
+      } catch (@SuppressWarnings("unused") FileNotFoundException | NoSuchFileException e) {
+        if (VERBOSE_FILES) {
+          node.message("file " + fileName + ": will copy [file does not exist]");
+        }
+        return null;
+      }
+
+      // NOTE: checksum is redundant w/ footer, but we break it out separately because when the bits
+      // cross the wire we need direct access to
+      // checksum when copying to catch bit flips:
+      result = new FileMetaData(header, footer, length, checksum);
+    }
+
+    return result;
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/config/NrtsearchConfigTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/NrtsearchConfigTest.java
@@ -21,6 +21,7 @@ import com.google.protobuf.DoubleValue;
 import com.google.protobuf.Int32Value;
 import com.yelp.nrtsearch.server.grpc.IndexLiveSettings;
 import com.yelp.nrtsearch.server.grpc.ReplicationServerClient;
+import com.yelp.nrtsearch.server.index.DirectoryFactory;
 import java.io.ByteArrayInputStream;
 import org.apache.lucene.search.suggest.document.CompletionPostingsFormat.FSTLoadMode;
 import org.junit.Test;
@@ -205,5 +206,19 @@ public class NrtsearchConfigTest {
     String config = "verifyReplicationIndexId: false";
     NrtsearchConfig luceneConfig = getForConfig(config);
     assertFalse(luceneConfig.getVerifyReplicationIndexId());
+  }
+
+  @Test
+  public void testMMapGrouping_default() {
+    String config = "nodeName: \"lucene_server_foo\"";
+    NrtsearchConfig luceneConfig = getForConfig(config);
+    assertEquals(DirectoryFactory.MMapGrouping.SEGMENT, luceneConfig.getMMapGrouping());
+  }
+
+  @Test
+  public void testMMapGrouping_set() {
+    String config = "mmapGrouping: NONE";
+    NrtsearchConfig luceneConfig = getForConfig(config);
+    assertEquals(DirectoryFactory.MMapGrouping.NONE, luceneConfig.getMMapGrouping());
   }
 }


### PR DESCRIPTION
The `MMapDirectory` in the newer lucene versions use the new java native memory api, if available. By default, mapping files from the same segment use a ref counted memory `Arena`. When we open files for nrt operations, the mappings will persist until the segment is closed. This can lead to an accumulation of mappings of the same files.

Opening files for nrt operations have been changed to use the `READONCE` io context. This avoids use of mmap file groupings. This could not be used for `RecvRawFileV2Handler`, since this type of mapping can only be used by the opening thread. We will need to handle this another way in the future for acked copy.

The config now exposes `mmapGrouping` to set the grouping function:
- `SEGMENT` (default) - All files from the same segment are grouped
- `SEGMENT_EXCEPT_SI` - All files from the same segment are grouped, except `.si` files. The segment info file for all index segments are read on completion of an nrt point. This option may be useful to stop accumulation of these mappings on replicas.
- `NONE` - No file grouping