### PR TITLE
Cleanup ReplicationServerTest and AckedCopyTest

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/handler/AddDocumentHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/AddDocumentHandler.java
@@ -520,6 +520,10 @@ public class AddDocumentHandler extends Handler<AddDocumentRequest, AddDocumentR
         IndexState indexState,
         ShardState shardState)
         throws IOException {
+      if (shardState.isReplica()) {
+        throw new IllegalStateException(
+            "Adding documents to an index on a replica node is not supported");
+      }
       for (Document nextDoc : documents) {
         nextDoc = handleFacets(indexState, shardState, nextDoc);
         shardState.writer.updateDocument(idFieldDef.getTerm(nextDoc), nextDoc);


### PR DESCRIPTION
Refactor `ReplicationServerTest` and `AckedCopyTest` to use the new `TestServer`. I was seeing some port conflicts locally from the hard coded port usage.