### PR TITLE
Use FieldDefCreatorContext for field creation

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/field/AtomFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/AtomFieldDef.java
@@ -32,8 +32,9 @@ import org.apache.lucene.util.BytesRef;
 public class AtomFieldDef extends TextBaseFieldDef implements Sortable {
   private static final Analyzer keywordAnalyzer = new KeywordAnalyzer();
 
-  public AtomFieldDef(String name, Field requestField) {
-    super(name, requestField);
+  public AtomFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    super(name, requestField, context);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/field/BooleanFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/BooleanFieldDef.java
@@ -37,8 +37,9 @@ import org.apache.lucene.search.Query;
 
 /** Field class for 'BOOLEAN' field type. */
 public class BooleanFieldDef extends IndexableFieldDef<Boolean> implements TermQueryable {
-  protected BooleanFieldDef(String name, Field requestField) {
-    super(name, requestField, Boolean.class);
+  protected BooleanFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    super(name, requestField, context, Boolean.class);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/field/ContextSuggestFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/ContextSuggestFieldDef.java
@@ -36,9 +36,11 @@ public class ContextSuggestFieldDef extends IndexableFieldDef<Void> {
   /**
    * @param name name of field
    * @param requestField field definition from grpc request
+   * @param context creation context
    */
-  protected ContextSuggestFieldDef(String name, Field requestField) {
-    super(name, requestField, Void.class);
+  protected ContextSuggestFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    super(name, requestField, context, Void.class);
     this.indexAnalyzer = this.parseIndexAnalyzer(requestField);
     this.searchAnalyzer = this.parseSearchAnalyzer(requestField);
   }

--- a/src/main/java/com/yelp/nrtsearch/server/field/DateTimeFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/DateTimeFieldDef.java
@@ -79,8 +79,9 @@ public class DateTimeFieldDef extends IndexableFieldDef<Instant>
     }
   }
 
-  public DateTimeFieldDef(String name, Field requestField) {
-    super(name, requestField, Instant.class);
+  public DateTimeFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    super(name, requestField, context, Instant.class);
     dateTimeFormat = requestField.getDateTimeFormat();
     dateTimeFormatter = createDateTimeFormatter(dateTimeFormat);
   }

--- a/src/main/java/com/yelp/nrtsearch/server/field/DoubleFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/DoubleFieldDef.java
@@ -37,8 +37,9 @@ import org.apache.lucene.util.NumericUtils;
 /** Field class for 'DOUBLE' field type. */
 public class DoubleFieldDef extends NumberFieldDef<Double> {
 
-  public DoubleFieldDef(String name, Field requestField) {
-    super(name, requestField, DOUBLE_PARSER, Double.class);
+  public DoubleFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    super(name, requestField, DOUBLE_PARSER, context, Double.class);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/field/FieldDefProvider.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/FieldDefProvider.java
@@ -30,7 +30,8 @@ public interface FieldDefProvider<T extends FieldDef> {
    *
    * @param name field name
    * @param requestField field request definition
+   * @param context creation context
    * @return concrete {@link FieldDef} instance for field
    */
-  T get(String name, Field requestField);
+  T get(String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context);
 }

--- a/src/main/java/com/yelp/nrtsearch/server/field/FloatFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/FloatFieldDef.java
@@ -37,8 +37,9 @@ import org.apache.lucene.util.NumericUtils;
 /** Field class for 'FLOAT' field type. */
 public class FloatFieldDef extends NumberFieldDef<Float> {
 
-  public FloatFieldDef(String name, Field requestField) {
-    super(name, requestField, FLOAT_PARSER, Float.class);
+  public FloatFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    super(name, requestField, FLOAT_PARSER, context, Float.class);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/field/IdFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/IdFieldDef.java
@@ -38,8 +38,9 @@ import org.apache.lucene.util.BytesRef;
 /** Field class for defining '_ID' fields which are used to update documents */
 public class IdFieldDef extends IndexableFieldDef<String> implements TermQueryable {
 
-  protected IdFieldDef(String name, Field requestField) {
-    super(name, requestField, String.class);
+  protected IdFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    super(name, requestField, context, String.class);
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/field/IndexableFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/IndexableFieldDef.java
@@ -73,10 +73,14 @@ public abstract class IndexableFieldDef<T> extends FieldDef {
    *
    * @param name name of field
    * @param requestField field definition from grpc request
+   * @param context creation context
    * @param docValuesObjectClass class of doc values object
    */
   protected IndexableFieldDef(
-      String name, Field requestField, Class<? super T> docValuesObjectClass) {
+      String name,
+      Field requestField,
+      FieldDefCreator.FieldDefCreatorContext context,
+      Class<? super T> docValuesObjectClass) {
     super(name);
 
     validateRequest(requestField);
@@ -116,7 +120,7 @@ public abstract class IndexableFieldDef<T> extends FieldDef {
       for (Field field : requestField.getChildFieldsList()) {
         checkChildName(field.getName());
         String childName = getName() + IndexState.CHILD_FIELD_SEPARATOR + field.getName();
-        FieldDef fieldDef = FieldDefCreator.getInstance().createFieldDef(childName, field);
+        FieldDef fieldDef = FieldDefCreator.getInstance().createFieldDef(childName, field, context);
         if (!(fieldDef instanceof IndexableFieldDef)) {
           throw new IllegalArgumentException("Child field is not indexable: " + childName);
         }

--- a/src/main/java/com/yelp/nrtsearch/server/field/IntFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/IntFieldDef.java
@@ -36,8 +36,9 @@ import org.apache.lucene.search.SortField;
 /** Field class for 'INT' field type. */
 public class IntFieldDef extends NumberFieldDef<Integer> {
 
-  public IntFieldDef(String name, Field requestField) {
-    super(name, requestField, INT_PARSER, Integer.class);
+  public IntFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    super(name, requestField, INT_PARSER, context, Integer.class);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/field/LatLonFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/LatLonFieldDef.java
@@ -47,8 +47,9 @@ import org.apache.lucene.search.SortField;
 
 /** Field class for 'LAT_LON' field type. */
 public class LatLonFieldDef extends IndexableFieldDef<GeoPoint> implements Sortable, GeoQueryable {
-  public LatLonFieldDef(String name, Field requestField) {
-    super(name, requestField, GeoPoint.class);
+  public LatLonFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    super(name, requestField, context, GeoPoint.class);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/field/LongFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/LongFieldDef.java
@@ -36,8 +36,9 @@ import org.apache.lucene.search.SortField;
 /** Field class for 'LONG' field type. */
 public class LongFieldDef extends NumberFieldDef<Long> {
 
-  public LongFieldDef(String name, Field requestField) {
-    super(name, requestField, LONG_PARSER, Long.class);
+  public LongFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    super(name, requestField, LONG_PARSER, context, Long.class);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/field/NumberFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/NumberFieldDef.java
@@ -69,8 +69,9 @@ public abstract class NumberFieldDef<T> extends IndexableFieldDef<T>
       String name,
       Field requestField,
       Function<String, Number> fieldParser,
+      FieldDefCreator.FieldDefCreatorContext context,
       Class<T> docValuesClass) {
-    super(name, requestField, docValuesClass);
+    super(name, requestField, context, docValuesClass);
     this.fieldParser = fieldParser;
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/field/ObjectFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/ObjectFieldDef.java
@@ -47,8 +47,9 @@ public class ObjectFieldDef extends IndexableFieldDef<Struct> {
   private final Gson gson;
   private final boolean isNestedDoc;
 
-  protected ObjectFieldDef(String name, Field requestField) {
-    super(name, requestField, Struct.class);
+  protected ObjectFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    super(name, requestField, context, Struct.class);
     this.isNestedDoc = requestField.getNestedDoc();
     gson = new GsonBuilder().serializeNulls().create();
   }

--- a/src/main/java/com/yelp/nrtsearch/server/field/PolygonfieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/PolygonfieldDef.java
@@ -38,8 +38,9 @@ import org.apache.lucene.util.BytesRef;
 
 public class PolygonfieldDef extends IndexableFieldDef<Struct> implements PolygonQueryable {
 
-  protected PolygonfieldDef(String name, Field requestField) {
-    super(name, requestField, Struct.class);
+  protected PolygonfieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    super(name, requestField, context, Struct.class);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/field/TextBaseFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/TextBaseFieldDef.java
@@ -65,15 +65,18 @@ public abstract class TextBaseFieldDef extends IndexableFieldDef<String>
   private final int ignoreAbove;
 
   /**
-   * Field constructor. Uses {@link IndexableFieldDef#IndexableFieldDef(String, Field, Class)} to do
-   * common initialization, then sets up analyzers. Analyzers are parsed through calls to the
-   * protected methods {@link #parseIndexAnalyzer(Field)} and {@link #parseSearchAnalyzer(Field)}.
+   * Field constructor. Uses {@link IndexableFieldDef#IndexableFieldDef(String, Field,
+   * FieldDefCreator.FieldDefCreatorContext, Class)} to do common initialization, then sets up
+   * analyzers. Analyzers are parsed through calls to the protected methods {@link
+   * #parseIndexAnalyzer(Field)} and {@link #parseSearchAnalyzer(Field)}.
    *
    * @param name field name
    * @param requestField field definition from grpc request
+   * @param context creation context
    */
-  protected TextBaseFieldDef(String name, Field requestField) {
-    super(name, requestField, String.class);
+  protected TextBaseFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    super(name, requestField, context, String.class);
     indexAnalyzer = parseIndexAnalyzer(requestField);
     searchAnalyzer = parseSearchAnalyzer(requestField);
     eagerFieldGlobalOrdinals = requestField.getEagerFieldGlobalOrdinals();

--- a/src/main/java/com/yelp/nrtsearch/server/field/TextFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/TextFieldDef.java
@@ -21,8 +21,9 @@ import org.apache.lucene.index.IndexOptions;
 
 /** Field class for 'TEXT' field type. */
 public class TextFieldDef extends TextBaseFieldDef {
-  public TextFieldDef(String name, Field requestField) {
-    super(name, requestField);
+  public TextFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    super(name, requestField, context);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/field/VectorFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/VectorFieldDef.java
@@ -208,12 +208,14 @@ public abstract class VectorFieldDef<T> extends IndexableFieldDef<T> implements 
    *
    * @param name name of field
    * @param field field definition from grpc request
+   * @param context creation context
    * @return new VectorFieldDef
    */
-  static VectorFieldDef<?> createField(String name, Field field) {
+  static VectorFieldDef<?> createField(
+      String name, Field field, FieldDefCreator.FieldDefCreatorContext context) {
     return switch (field.getVectorElementType()) {
-      case VECTOR_ELEMENT_FLOAT -> new FloatVectorFieldDef(name, field);
-      case VECTOR_ELEMENT_BYTE -> new ByteVectorFieldDef(name, field);
+      case VECTOR_ELEMENT_FLOAT -> new FloatVectorFieldDef(name, field, context);
+      case VECTOR_ELEMENT_BYTE -> new ByteVectorFieldDef(name, field, context);
       default -> throw new IllegalArgumentException(
           "Invalid field type: " + field.getVectorElementType());
     };
@@ -222,10 +224,15 @@ public abstract class VectorFieldDef<T> extends IndexableFieldDef<T> implements 
   /**
    * @param name name of field
    * @param requestField field definition from grpc request
+   * @param context creation context
    * @param docValuesClass class of doc values object
    */
-  protected VectorFieldDef(String name, Field requestField, Class<T> docValuesClass) {
-    super(name, requestField, docValuesClass);
+  protected VectorFieldDef(
+      String name,
+      Field requestField,
+      FieldDefCreator.FieldDefCreatorContext context,
+      Class<T> docValuesClass) {
+    super(name, requestField, context, docValuesClass);
     this.vectorDimensions = requestField.getVectorDimensions();
     if (isSearchable()) {
       VectorSearchType vectorSearchType = getSearchType(requestField.getVectorIndexingOptions());
@@ -322,8 +329,9 @@ public abstract class VectorFieldDef<T> extends IndexableFieldDef<T> implements 
 
   /** Field class for 'FLOAT' vector field type. */
   public static class FloatVectorFieldDef extends VectorFieldDef<FloatVectorType> {
-    public FloatVectorFieldDef(String name, Field requestField) {
-      super(name, requestField, FloatVectorType.class);
+    public FloatVectorFieldDef(
+        String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+      super(name, requestField, context, FloatVectorType.class);
     }
 
     @Override
@@ -462,8 +470,9 @@ public abstract class VectorFieldDef<T> extends IndexableFieldDef<T> implements 
 
   /** Field class for 'BYTE' vector field type. */
   public static class ByteVectorFieldDef extends VectorFieldDef<ByteVectorType> {
-    public ByteVectorFieldDef(String name, Field requestField) {
-      super(name, requestField, ByteVectorType.class);
+    public ByteVectorFieldDef(
+        String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+      super(name, requestField, context, ByteVectorType.class);
     }
 
     @Override

--- a/src/main/java/com/yelp/nrtsearch/server/index/BackendStateManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/BackendStateManager.java
@@ -16,6 +16,7 @@
 package com.yelp.nrtsearch.server.index;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.yelp.nrtsearch.server.field.FieldDefCreator;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.IndexLiveSettings;
 import com.yelp.nrtsearch.server.grpc.IndexSettings;
@@ -87,7 +88,10 @@ public class BackendStateManager implements IndexStateManager {
     stateInfo = fixIndexName(stateInfo, indexName);
     UpdatedFieldInfo updatedFieldInfo =
         FieldUpdateUtils.updateFields(
-            new FieldAndFacetState(), Collections.emptyMap(), stateInfo.getFieldsMap().values());
+            new FieldAndFacetState(),
+            Collections.emptyMap(),
+            stateInfo.getFieldsMap().values(),
+            FieldDefCreator.createContext(globalState));
     currentState =
         createIndexState(stateInfo, updatedFieldInfo.fieldAndFacetState, liveSettingsOverrides);
   }
@@ -203,7 +207,8 @@ public class BackendStateManager implements IndexStateManager {
         FieldUpdateUtils.updateFields(
             currentState.getFieldAndFacetState(),
             currentState.getIndexStateInfo().getFieldsMap(),
-            fields);
+            fields,
+            FieldDefCreator.createContext(globalState));
     IndexStateInfo updatedStateInfo =
         replaceFields(currentState.getIndexStateInfo(), updatedFieldInfo.fields);
     ImmutableIndexState updatedIndexState =

--- a/src/main/java/com/yelp/nrtsearch/server/index/FieldUpdateUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/FieldUpdateUtils.java
@@ -60,12 +60,14 @@ public class FieldUpdateUtils {
    * @param currentState built state from the current fields
    * @param currentFields current fields
    * @param updateFields field updates
+   * @param context creation context
    * @return state after applying field updates
    */
   public static UpdatedFieldInfo updateFields(
       FieldAndFacetState currentState,
       Map<String, Field> currentFields,
-      Iterable<Field> updateFields) {
+      Iterable<Field> updateFields,
+      FieldDefCreator.FieldDefCreatorContext context) {
 
     Map<String, Field> newFields = new HashMap<>(currentFields);
     FieldAndFacetState.Builder fieldStateBuilder = currentState.toBuilder();
@@ -85,7 +87,7 @@ public class FieldUpdateUtils {
       if (newFields.containsKey(field.getName())) {
         throw new IllegalArgumentException("Duplicate field registration: " + field.getName());
       }
-      parseField(field, fieldStateBuilder);
+      parseField(field, fieldStateBuilder, context);
       newFields.put(field.getName(), field);
     }
 
@@ -126,9 +128,14 @@ public class FieldUpdateUtils {
    *
    * @param field field to process
    * @param fieldStateBuilder builder for new field state
+   * @param context creation context
    */
-  public static void parseField(Field field, FieldAndFacetState.Builder fieldStateBuilder) {
-    FieldDef fieldDef = FieldDefCreator.getInstance().createFieldDef(field.getName(), field);
+  public static void parseField(
+      Field field,
+      FieldAndFacetState.Builder fieldStateBuilder,
+      FieldDefCreator.FieldDefCreatorContext context) {
+    FieldDef fieldDef =
+        FieldDefCreator.getInstance().createFieldDef(field.getName(), field, context);
     fieldStateBuilder.addField(fieldDef, field);
     if (fieldDef instanceof IndexableFieldDef) {
       addChildFields((IndexableFieldDef<?>) fieldDef, fieldStateBuilder);

--- a/src/main/java/com/yelp/nrtsearch/server/index/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/IndexState.java
@@ -227,7 +227,7 @@ public abstract class IndexState implements Closeable {
     this.rootDir = rootDir;
 
     // add meta data fields
-    metaFields = getPredefinedMetaFields();
+    metaFields = getPredefinedMetaFields(globalState);
 
     if (!Files.exists(rootDir)) {
       Files.createDirectories(rootDir);
@@ -506,7 +506,7 @@ public abstract class IndexState implements Closeable {
   public void close() throws IOException {}
 
   // Get all predifined meta fields
-  private static Map<String, FieldDef> getPredefinedMetaFields() {
+  private static Map<String, FieldDef> getPredefinedMetaFields(GlobalState globalState) {
     return ImmutableMap.of(
         NESTED_PATH,
         FieldDefCreator.getInstance()
@@ -516,7 +516,8 @@ public abstract class IndexState implements Closeable {
                     .setName(IndexState.NESTED_PATH)
                     .setType(FieldType.ATOM)
                     .setSearch(true)
-                    .build()),
+                    .build(),
+                FieldDefCreator.createContext(globalState)),
         FIELD_NAMES,
         FieldDefCreator.getInstance()
             .createFieldDef(
@@ -526,6 +527,7 @@ public abstract class IndexState implements Closeable {
                     .setType(FieldType.ATOM)
                     .setSearch(true)
                     .setMultiValued(true)
-                    .build()));
+                    .build(),
+                FieldDefCreator.createContext(globalState)));
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/field/AtomFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/AtomFieldDefTest.java
@@ -16,6 +16,7 @@
 package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.Field;
@@ -39,7 +40,8 @@ public class AtomFieldDefTest {
   }
 
   private AtomFieldDef createFieldDef(Field field) {
-    return new AtomFieldDef("test_field", field);
+    return new AtomFieldDef(
+        "test_field", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/field/ContextSuggestFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/ContextSuggestFieldDefTest.java
@@ -19,6 +19,7 @@ import static com.yelp.nrtsearch.server.search.collectors.MyTopSuggestDocsCollec
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
 import com.yelp.nrtsearch.server.grpc.Analyzer;
@@ -69,7 +70,9 @@ public class ContextSuggestFieldDefTest extends ServerTestCase {
             .setIndexAnalyzer(standardAnalyzer) // should be ignored as analyzer takes precedence
             .setAnalyzer(analyzer)
             .build();
-    ContextSuggestFieldDef contextSuggestFieldDef = new ContextSuggestFieldDef("test_field", field);
+    ContextSuggestFieldDef contextSuggestFieldDef =
+        new ContextSuggestFieldDef(
+            "test_field", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
     assertEquals(
         ClassicAnalyzer.class, contextSuggestFieldDef.getSearchAnalyzer().get().getClass());
     assertEquals(ClassicAnalyzer.class, contextSuggestFieldDef.getIndexAnalyzer().get().getClass());
@@ -84,7 +87,9 @@ public class ContextSuggestFieldDefTest extends ServerTestCase {
             .setSearchAnalyzer(searchAnalyzer)
             .setIndexAnalyzer(indexAnalyzer)
             .build();
-    ContextSuggestFieldDef contextSuggestFieldDef = new ContextSuggestFieldDef("test_field", field);
+    ContextSuggestFieldDef contextSuggestFieldDef =
+        new ContextSuggestFieldDef(
+            "test_field", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
     assertSame(
         BulgarianAnalyzer.class, contextSuggestFieldDef.getSearchAnalyzer().get().getClass());
     assertSame(EnglishAnalyzer.class, contextSuggestFieldDef.getIndexAnalyzer().get().getClass());
@@ -93,7 +98,9 @@ public class ContextSuggestFieldDefTest extends ServerTestCase {
   @Test
   public void validDefaultSearchAndIndexAnalyzerNoAnalyzersAreProvided() {
     Field field = Field.newBuilder().build();
-    ContextSuggestFieldDef contextSuggestFieldDef = new ContextSuggestFieldDef("test_field", field);
+    ContextSuggestFieldDef contextSuggestFieldDef =
+        new ContextSuggestFieldDef(
+            "test_field", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
     assertSame(StandardAnalyzer.class, contextSuggestFieldDef.getSearchAnalyzer().get().getClass());
     assertSame(StandardAnalyzer.class, contextSuggestFieldDef.getIndexAnalyzer().get().getClass());
   }

--- a/src/test/java/com/yelp/nrtsearch/server/field/TestFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/TestFieldDefTest.java
@@ -16,6 +16,7 @@
 package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.Field;
@@ -36,7 +37,8 @@ public class TestFieldDefTest {
   }
 
   private TextFieldDef createFieldDef(Field field) {
-    return new TextFieldDef("test_field", field);
+    return new TextFieldDef(
+        "test_field", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/field/TextFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/TextFieldDefTest.java
@@ -16,6 +16,7 @@
 package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
 
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.Field;
@@ -39,7 +40,8 @@ public class TextFieldDefTest {
   }
 
   private TextFieldDef createFieldDef(Field field) {
-    return new TextFieldDef("test_field", field);
+    return new TextFieldDef(
+        "test_field", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/field/VectorFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/VectorFieldDefTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import com.google.common.primitives.Floats;
 import com.google.protobuf.ByteString;
@@ -858,7 +859,9 @@ public class VectorFieldDefTest extends ServerTestCase {
             .setVectorDimensions(3)
             .setVectorSimilarity("l2_norm")
             .build();
-    VectorFieldDef<?> vectorFieldDef = VectorFieldDef.createField("vector", field);
+    VectorFieldDef<?> vectorFieldDef =
+        VectorFieldDef.createField(
+            "vector", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
     KnnVectorsFormat format = vectorFieldDef.getVectorsFormat();
     assertNotNull(format);
     assertEquals(
@@ -878,7 +881,9 @@ public class VectorFieldDefTest extends ServerTestCase {
             .setVectorIndexingOptions(
                 VectorIndexingOptions.newBuilder().setType("hnsw").setHnswM(5).build())
             .build();
-    VectorFieldDef<?> vectorFieldDef = VectorFieldDef.createField("vector", field);
+    VectorFieldDef<?> vectorFieldDef =
+        VectorFieldDef.createField(
+            "vector", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
     KnnVectorsFormat format = vectorFieldDef.getVectorsFormat();
     assertNotNull(format);
     assertEquals(
@@ -901,7 +906,9 @@ public class VectorFieldDefTest extends ServerTestCase {
                     .setHnswEfConstruction(50)
                     .build())
             .build();
-    VectorFieldDef<?> vectorFieldDef = VectorFieldDef.createField("vector", field);
+    VectorFieldDef<?> vectorFieldDef =
+        VectorFieldDef.createField(
+            "vector", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
     KnnVectorsFormat format = vectorFieldDef.getVectorsFormat();
     assertNotNull(format);
     assertEquals(
@@ -921,7 +928,8 @@ public class VectorFieldDefTest extends ServerTestCase {
             .setVectorIndexingOptions(VectorIndexingOptions.newBuilder().setType("invalid").build())
             .build();
     try {
-      VectorFieldDef.createField("vector", field);
+      VectorFieldDef.createField(
+          "vector", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(
@@ -941,7 +949,8 @@ public class VectorFieldDefTest extends ServerTestCase {
             .setVectorSimilarity("invalid")
             .build();
     try {
-      VectorFieldDef.createField("vector", field);
+      VectorFieldDef.createField(
+          "vector", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(
@@ -960,7 +969,8 @@ public class VectorFieldDefTest extends ServerTestCase {
             .setStoreDocValues(true)
             .build();
     try {
-      VectorFieldDef.createField("vector", field);
+      VectorFieldDef.createField(
+          "vector", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("Vector dimension must be <= 4096", e.getMessage());
@@ -978,7 +988,8 @@ public class VectorFieldDefTest extends ServerTestCase {
             .setVectorSimilarity("cosine")
             .build();
     try {
-      VectorFieldDef.createField("vector", field);
+      VectorFieldDef.createField(
+          "vector", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("Vector dimension must be <= 4096", e.getMessage());
@@ -1334,7 +1345,8 @@ public class VectorFieldDefTest extends ServerTestCase {
                     .build())
             .build();
     try {
-      VectorFieldDef.createField("vector", field);
+      VectorFieldDef.createField(
+          "vector", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals(
@@ -1359,7 +1371,8 @@ public class VectorFieldDefTest extends ServerTestCase {
                     .build())
             .build();
     try {
-      VectorFieldDef.createField("vector", field);
+      VectorFieldDef.createField(
+          "vector", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("bits must be one of: 4, 7; bits=9", e.getMessage());
@@ -1380,7 +1393,8 @@ public class VectorFieldDefTest extends ServerTestCase {
                 VectorIndexingOptions.newBuilder().setType("hnsw_scalar_quantized").build())
             .build();
     try {
-      VectorFieldDef.createField("vector", field);
+      VectorFieldDef.createField(
+          "vector", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals(
@@ -1404,7 +1418,8 @@ public class VectorFieldDefTest extends ServerTestCase {
                     .build())
             .build();
     try {
-      VectorFieldDef.createField("vector", field);
+      VectorFieldDef.createField(
+          "vector", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals(

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/CustomFieldTypeTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/CustomFieldTypeTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.doc.LoadedDocValues;
 import com.yelp.nrtsearch.server.field.FieldDef;
+import com.yelp.nrtsearch.server.field.FieldDefCreator;
 import com.yelp.nrtsearch.server.field.FieldDefProvider;
 import com.yelp.nrtsearch.server.field.IndexableFieldDef;
 import com.yelp.nrtsearch.server.plugins.FieldTypePlugin;
@@ -98,8 +99,9 @@ public class CustomFieldTypeTest {
 
   static class TestFieldDef extends IndexableFieldDef<Integer> {
 
-    public TestFieldDef(String name, Field requestField) {
-      super(name, requestField, Integer.class);
+    public TestFieldDef(
+        String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+      super(name, requestField, context, Integer.class);
     }
 
     @Override

--- a/src/test/java/com/yelp/nrtsearch/server/index/BackendStateManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/index/BackendStateManagerTest.java
@@ -145,6 +145,7 @@ public class BackendStateManagerTest {
 
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+    verify(mockGlobalState, times(1)).getConfiguration();
 
     verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState);
   }
@@ -172,6 +173,7 @@ public class BackendStateManagerTest {
 
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+    verify(mockGlobalState, times(1)).getConfiguration();
 
     verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState);
   }
@@ -199,6 +201,7 @@ public class BackendStateManagerTest {
 
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+    verify(mockGlobalState, times(1)).getConfiguration();
 
     verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState);
   }
@@ -331,6 +334,7 @@ public class BackendStateManagerTest {
 
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+    verify(mockGlobalState, times(1)).getConfiguration();
     verify(mockState, times(1)).getMergedSettings();
 
     verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState);
@@ -396,6 +400,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
+    verify(mockGlobalState, times(1)).getConfiguration();
     verify(mockState, times(1)).isStarted();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
@@ -458,6 +463,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
+    verify(mockGlobalState, times(1)).getConfiguration();
     verify(mockState, times(1)).isStarted();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
@@ -538,6 +544,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
+    verify(mockGlobalState, times(1)).getConfiguration();
     verify(mockState, times(1)).isStarted();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
@@ -621,6 +628,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
+    verify(mockGlobalState, times(1)).getConfiguration();
     verify(mockState, times(1)).isStarted();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
@@ -712,6 +720,7 @@ public class BackendStateManagerTest {
 
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+    verify(mockGlobalState, times(1)).getConfiguration();
     verify(mockState, times(1)).getMergedLiveSettings(false);
 
     verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState);
@@ -759,6 +768,7 @@ public class BackendStateManagerTest {
 
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+    verify(mockGlobalState, times(1)).getConfiguration();
     verify(mockState, times(1)).getMergedLiveSettings(false);
     verify(mockState, times(1)).getMergedLiveSettings(true);
 
@@ -829,6 +839,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
+    verify(mockGlobalState, times(1)).getConfiguration();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
     verify(mockState2, times(1)).getMergedLiveSettings(false);
@@ -895,6 +906,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
+    verify(mockGlobalState, times(1)).getConfiguration();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
     verify(mockState2, times(1)).getMergedLiveSettings(false);
@@ -976,6 +988,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
+    verify(mockGlobalState, times(1)).getConfiguration();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
     verify(mockState2, times(1)).getMergedLiveSettings(false);
@@ -1060,6 +1073,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
+    verify(mockGlobalState, times(1)).getConfiguration();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
     verify(mockState2, times(1)).getMergedLiveSettings(false);
@@ -1148,6 +1162,7 @@ public class BackendStateManagerTest {
 
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+    verify(mockGlobalState, times(1)).getConfiguration();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
     verify(mockState2, times(1)).getMergedLiveSettings(true);
@@ -1224,6 +1239,7 @@ public class BackendStateManagerTest {
 
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+    verify(mockGlobalState, times(1)).getConfiguration();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
     verify(mockState2, times(1)).getMergedLiveSettings(true);
@@ -1297,6 +1313,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedState);
+    verify(mockGlobalState, times(2)).getConfiguration();
     verify(mockState, times(2)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
     verify(mockState2, times(1)).getAllFieldsJSON();
@@ -1371,6 +1388,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedState);
+    verify(mockGlobalState, times(2)).getConfiguration();
     verify(mockState, times(2)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
     verify(mockState2, times(1)).getAllFieldsJSON();
@@ -1470,6 +1488,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedState);
+    verify(mockGlobalState, times(2)).getConfiguration();
     verify(mockState, times(2)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
     verify(mockState2, times(1)).getAllFieldsJSON();
@@ -1528,6 +1547,7 @@ public class BackendStateManagerTest {
 
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+    verify(mockGlobalState, times(1)).getConfiguration();
 
     verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState);
   }
@@ -1578,6 +1598,7 @@ public class BackendStateManagerTest {
 
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+    verify(mockGlobalState, times(1)).getConfiguration();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).isStarted();
     verify(mockState, times(1)).start(Mode.PRIMARY, mockDataManager, 1, mockReplicationClient);
@@ -1614,6 +1635,7 @@ public class BackendStateManagerTest {
 
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+    verify(mockGlobalState, times(1)).getConfiguration();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).isStarted();
     verify(mockState, times(1)).start(Mode.PRIMARY, mockDataManager, 1, mockReplicationClient);
@@ -1647,6 +1669,7 @@ public class BackendStateManagerTest {
 
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
+    verify(mockGlobalState, times(1)).getConfiguration();
     verify(mockState, times(1)).isStarted();
     verify(mockState, times(1)).start(Mode.REPLICA, mockDataManager, 1, mockReplicationClient);
 
@@ -1690,6 +1713,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), updatedState);
+    verify(mockGlobalState, times(1)).getConfiguration();
     verify(mockState, times(3)).getIndexStateInfo();
     verify(mockState, times(1)).isStarted();
     verify(mockState, times(1)).start(Mode.PRIMARY, mockDataManager, 1, mockReplicationClient);

--- a/src/test/java/com/yelp/nrtsearch/server/index/FieldUpdateUtilsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/index/FieldUpdateUtilsTest.java
@@ -99,7 +99,11 @@ public class FieldUpdateUtilsTest {
     Map<String, Field> initialFields = Collections.emptyMap();
 
     UpdatedFieldInfo updatedFieldInfo =
-        FieldUpdateUtils.updateFields(initialState, initialFields, simpleUpdates);
+        FieldUpdateUtils.updateFields(
+            initialState,
+            initialFields,
+            simpleUpdates,
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
     Map<String, Field> fields = updatedFieldInfo.fields;
     assertEquals(2, fields.size());
     assertEquals(simpleUpdates.get(0), fields.get("field1"));
@@ -146,7 +150,10 @@ public class FieldUpdateUtilsTest {
 
     UpdatedFieldInfo updatedFieldInfo =
         FieldUpdateUtils.updateFields(
-            initialInfo.fieldAndFacetState, initialInfo.fields, fieldUpdates);
+            initialInfo.fieldAndFacetState,
+            initialInfo.fields,
+            fieldUpdates,
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
     Map<String, Field> fields = updatedFieldInfo.fields;
     assertEquals(4, fields.size());
     assertEquals(simpleUpdates.get(0), fields.get("field1"));
@@ -190,7 +197,10 @@ public class FieldUpdateUtilsTest {
 
     UpdatedFieldInfo updatedFieldInfo =
         FieldUpdateUtils.updateFields(
-            initialInfo.fieldAndFacetState, initialInfo.fields, fieldUpdates);
+            initialInfo.fieldAndFacetState,
+            initialInfo.fields,
+            fieldUpdates,
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
     Map<String, Field> fields = updatedFieldInfo.fields;
     assertEquals(4, fields.size());
     assertEquals(simpleUpdates.get(0), fields.get("field1"));
@@ -236,7 +246,10 @@ public class FieldUpdateUtilsTest {
 
     UpdatedFieldInfo updatedFieldInfo =
         FieldUpdateUtils.updateFields(
-            initialInfo.fieldAndFacetState, initialInfo.fields, fieldUpdates);
+            initialInfo.fieldAndFacetState,
+            initialInfo.fields,
+            fieldUpdates,
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
 
     try {
       FieldUpdateUtils.updateFields(
@@ -247,7 +260,8 @@ public class FieldUpdateUtilsTest {
                   .setName("second_id")
                   .setType(FieldType._ID)
                   .setStoreDocValues(true)
-                  .build()));
+                  .build()),
+          mock(FieldDefCreator.FieldDefCreatorContext.class));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals(
@@ -278,7 +292,10 @@ public class FieldUpdateUtilsTest {
 
     UpdatedFieldInfo updatedFieldInfo =
         FieldUpdateUtils.updateFields(
-            initialInfo.fieldAndFacetState, initialInfo.fields, fieldUpdates);
+            initialInfo.fieldAndFacetState,
+            initialInfo.fields,
+            fieldUpdates,
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
     Map<String, Field> fields = updatedFieldInfo.fields;
     assertEquals(4, fields.size());
     assertEquals(simpleUpdates.get(0), fields.get("field1"));
@@ -316,7 +333,10 @@ public class FieldUpdateUtilsTest {
 
     UpdatedFieldInfo updatedFieldInfo =
         FieldUpdateUtils.updateFields(
-            initialInfo.fieldAndFacetState, initialInfo.fields, fieldUpdates);
+            initialInfo.fieldAndFacetState,
+            initialInfo.fields,
+            fieldUpdates,
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
     Map<String, Field> fields = updatedFieldInfo.fields;
     assertEquals(3, fields.size());
     assertEquals(simpleUpdates.get(0), fields.get("field1"));
@@ -359,7 +379,10 @@ public class FieldUpdateUtilsTest {
 
     UpdatedFieldInfo updatedFieldInfo =
         FieldUpdateUtils.updateFields(
-            initialInfo.fieldAndFacetState, initialInfo.fields, fieldUpdates);
+            initialInfo.fieldAndFacetState,
+            initialInfo.fields,
+            fieldUpdates,
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
     Map<String, Field> fields = updatedFieldInfo.fields;
     assertEquals(4, fields.size());
     assertEquals(simpleUpdates.get(0), fields.get("field1"));
@@ -423,7 +446,10 @@ public class FieldUpdateUtilsTest {
 
     UpdatedFieldInfo updatedFieldInfo =
         FieldUpdateUtils.updateFields(
-            initialInfo.fieldAndFacetState, initialInfo.fields, fieldUpdates);
+            initialInfo.fieldAndFacetState,
+            initialInfo.fields,
+            fieldUpdates,
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
     Map<String, Field> fields = updatedFieldInfo.fields;
     assertEquals(3, fields.size());
     assertEquals(simpleUpdates.get(0), fields.get("field1"));
@@ -493,7 +519,10 @@ public class FieldUpdateUtilsTest {
 
     UpdatedFieldInfo updatedFieldInfo =
         FieldUpdateUtils.updateFields(
-            initialInfo.fieldAndFacetState, initialInfo.fields, fieldUpdates);
+            initialInfo.fieldAndFacetState,
+            initialInfo.fields,
+            fieldUpdates,
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
     Map<String, Field> fields = updatedFieldInfo.fields;
     assertEquals(3, fields.size());
     assertEquals(simpleUpdates.get(0), fields.get("field1"));
@@ -548,7 +577,10 @@ public class FieldUpdateUtilsTest {
 
     UpdatedFieldInfo updatedFieldInfo =
         FieldUpdateUtils.updateFields(
-            initialInfo.fieldAndFacetState, initialInfo.fields, fieldUpdates);
+            initialInfo.fieldAndFacetState,
+            initialInfo.fields,
+            fieldUpdates,
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
     Map<String, Field> fields = updatedFieldInfo.fields;
     assertEquals(4, fields.size());
     assertEquals(simpleUpdates.get(0), fields.get("field1"));
@@ -586,7 +618,10 @@ public class FieldUpdateUtilsTest {
 
     updatedFieldInfo =
         FieldUpdateUtils.updateFields(
-            updatedFieldInfo.fieldAndFacetState, updatedFieldInfo.fields, fieldUpdates2);
+            updatedFieldInfo.fieldAndFacetState,
+            updatedFieldInfo.fields,
+            fieldUpdates2,
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
     fields = updatedFieldInfo.fields;
     assertEquals(5, fields.size());
     assertEquals(simpleUpdates.get(0), fields.get("field1"));
@@ -634,7 +669,10 @@ public class FieldUpdateUtilsTest {
 
     try {
       FieldUpdateUtils.updateFields(
-          initialInfo.fieldAndFacetState, initialInfo.fields, fieldUpdates);
+          initialInfo.fieldAndFacetState,
+          initialInfo.fields,
+          fieldUpdates,
+          mock(FieldDefCreator.FieldDefCreatorContext.class));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("Duplicate field registration: field2", e.getMessage());

--- a/src/test/java/com/yelp/nrtsearch/server/index/ImmutableIndexStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/index/ImmutableIndexStateTest.java
@@ -382,7 +382,10 @@ public class ImmutableIndexStateTest {
             .build();
     UpdatedFieldInfo fieldInfo =
         FieldUpdateUtils.updateFields(
-            new FieldAndFacetState(), Collections.emptyMap(), Collections.singleton(sortField));
+            new FieldAndFacetState(),
+            Collections.emptyMap(),
+            Collections.singleton(sortField),
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
     ImmutableIndexState indexState =
         getIndexState(
             getStateWithSettings(
@@ -1021,7 +1024,10 @@ public class ImmutableIndexStateTest {
             .build();
     UpdatedFieldInfo fieldInfo =
         FieldUpdateUtils.updateFields(
-            new FieldAndFacetState(), Collections.emptyMap(), Collections.singleton(field));
+            new FieldAndFacetState(),
+            Collections.emptyMap(),
+            Collections.singleton(field),
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
     IndexStateInfo indexStateInfo =
         getEmptyState().toBuilder().putAllFields(fieldInfo.fields).build();
     ImmutableIndexState indexState = getIndexState(indexStateInfo, fieldInfo.fieldAndFacetState);
@@ -1053,7 +1059,10 @@ public class ImmutableIndexStateTest {
             .build();
     UpdatedFieldInfo fieldInfo =
         FieldUpdateUtils.updateFields(
-            new FieldAndFacetState(), Collections.emptyMap(), Collections.singleton(field));
+            new FieldAndFacetState(),
+            Collections.emptyMap(),
+            Collections.singleton(field),
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
     IndexStateInfo indexStateInfo =
         getEmptyState().toBuilder().putAllFields(fieldInfo.fields).build();
     ImmutableIndexState indexState = getIndexState(indexStateInfo, fieldInfo.fieldAndFacetState);
@@ -1090,7 +1099,10 @@ public class ImmutableIndexStateTest {
             .build();
     UpdatedFieldInfo fieldInfo =
         FieldUpdateUtils.updateFields(
-            new FieldAndFacetState(), Collections.emptyMap(), Collections.singleton(field));
+            new FieldAndFacetState(),
+            Collections.emptyMap(),
+            Collections.singleton(field),
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
     IndexStateInfo indexStateInfo =
         getEmptyState().toBuilder().putAllFields(fieldInfo.fields).build();
     ImmutableIndexState indexState = getIndexState(indexStateInfo, fieldInfo.fieldAndFacetState);
@@ -1108,7 +1120,10 @@ public class ImmutableIndexStateTest {
             .build();
     UpdatedFieldInfo fieldInfo =
         FieldUpdateUtils.updateFields(
-            new FieldAndFacetState(), Collections.emptyMap(), Collections.singleton(field));
+            new FieldAndFacetState(),
+            Collections.emptyMap(),
+            Collections.singleton(field),
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
     IndexStateInfo indexStateInfo =
         getEmptyState().toBuilder().putAllFields(fieldInfo.fields).build();
     ImmutableIndexState indexState = getIndexState(indexStateInfo, fieldInfo.fieldAndFacetState);


### PR DESCRIPTION
Add the context class `FieldDefCreatorContext` to be used by `FieldDef` implementations during creation. The context currently only contains `NrtsearchConfig`, but more items can be added as needed.