### PR TITLE
Allow whitespace in mappingV2 rules

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/analysis/MappingV2CharFilterFactory.java
+++ b/src/main/java/com/yelp/nrtsearch/server/analysis/MappingV2CharFilterFactory.java
@@ -91,7 +91,7 @@ public class MappingV2CharFilterFactory extends CharFilterFactory {
     return Arrays.asList(mappings.split(separator));
   }
 
-  static Pattern p = Pattern.compile("(.*)\\s*=>\\s*(.*)\\s*$");
+  static Pattern p = Pattern.compile("(.*)=>(.*)$");
 
   protected void parseRules(List<String> rules, NormalizeCharMap.Builder builder) {
     for (String rule : rules) {

--- a/src/test/java/com/yelp/nrtsearch/server/analysis/MappingV2CharFilterFactoryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/analysis/MappingV2CharFilterFactoryTest.java
@@ -55,6 +55,13 @@ public class MappingV2CharFilterFactoryTest {
   }
 
   @Test
+  public void testWhitespaceInRule() throws IOException {
+    MappingV2CharFilterFactory factory = getFactory(". =>|,=> ");
+    String output = getFiltered(factory, "this. is, a test, string");
+    assertEquals("thisis  a test  string", output);
+  }
+
+  @Test
   public void testNoMappings() {
     try {
       newFactoryClassInstance(MappingV2CharFilterFactory.class, new HashMap<>());


### PR DESCRIPTION
When specifying rules for the `mappingV2` character filter, whitespace will now be treated as significant characters.