### PR TITLE
Add vector search support for fields in nested objects

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/field/VectorFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/VectorFieldDef.java
@@ -25,6 +25,8 @@ import com.yelp.nrtsearch.server.field.properties.VectorQueryable;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.KnnQuery;
 import com.yelp.nrtsearch.server.grpc.VectorIndexingOptions;
+import com.yelp.nrtsearch.server.query.vector.NrtDiversifyingChildrenByteKnnVectorQuery;
+import com.yelp.nrtsearch.server.query.vector.NrtDiversifyingChildrenFloatKnnVectorQuery;
 import com.yelp.nrtsearch.server.query.vector.NrtKnnByteVectorQuery;
 import com.yelp.nrtsearch.server.query.vector.NrtKnnFloatVectorQuery;
 import com.yelp.nrtsearch.server.vector.ByteVectorType;
@@ -51,6 +53,7 @@ import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.VectorUtil;
 
@@ -113,9 +116,15 @@ public abstract class VectorFieldDef<T> extends IndexableFieldDef<T> implements 
    * @param k number of nearest neighbors to return
    * @param filterQuery filter query
    * @param numCandidates number of candidates to search per segment
+   * @param parentBitSetProducer parent bit set producer for searching nested fields, or null
    * @return knn query
    */
-  abstract Query getTypeKnnQuery(KnnQuery knnQuery, int k, Query filterQuery, int numCandidates);
+  abstract Query getTypeKnnQuery(
+      KnnQuery knnQuery,
+      int k,
+      Query filterQuery,
+      int numCandidates,
+      BitSetProducer parentBitSetProducer);
 
   private static VectorSimilarityFunction getSimilarityFunction(String vectorSimilarity) {
     VectorSimilarityFunction similarityFunction = SIMILARITY_FUNCTION_MAP.get(vectorSimilarity);
@@ -307,7 +316,8 @@ public abstract class VectorFieldDef<T> extends IndexableFieldDef<T> implements 
   }
 
   @Override
-  public Query getKnnQuery(KnnQuery knnQuery, Query filterQuery) {
+  public Query getKnnQuery(
+      KnnQuery knnQuery, Query filterQuery, BitSetProducer parentBitSetProducer) {
     if (!isSearchable()) {
       throw new IllegalArgumentException("Vector field is not searchable: " + getName());
     }
@@ -324,7 +334,7 @@ public abstract class VectorFieldDef<T> extends IndexableFieldDef<T> implements 
       throw new IllegalArgumentException("Vector search numCandidates > " + NUM_CANDIDATES_LIMIT);
     }
 
-    return getTypeKnnQuery(knnQuery, k, filterQuery, numCandidates);
+    return getTypeKnnQuery(knnQuery, k, filterQuery, numCandidates, parentBitSetProducer);
   }
 
   /** Field class for 'FLOAT' vector field type. */
@@ -420,7 +430,12 @@ public abstract class VectorFieldDef<T> extends IndexableFieldDef<T> implements 
     }
 
     @Override
-    Query getTypeKnnQuery(KnnQuery knnQuery, int k, Query filterQuery, int numCandidates) {
+    Query getTypeKnnQuery(
+        KnnQuery knnQuery,
+        int k,
+        Query filterQuery,
+        int numCandidates,
+        BitSetProducer parentBitSetProducer) {
       if (knnQuery.getQueryVectorCount() != getVectorDimensions()) {
         throw new IllegalArgumentException(
             "Invalid query vector size, expected: "
@@ -433,7 +448,12 @@ public abstract class VectorFieldDef<T> extends IndexableFieldDef<T> implements 
         queryVector[i] = knnQuery.getQueryVector(i);
       }
       validateVectorForSearch(queryVector);
-      return new NrtKnnFloatVectorQuery(getName(), queryVector, k, filterQuery, numCandidates);
+      if (parentBitSetProducer != null) {
+        return new NrtDiversifyingChildrenFloatKnnVectorQuery(
+            getName(), queryVector, filterQuery, k, numCandidates, parentBitSetProducer);
+      } else {
+        return new NrtKnnFloatVectorQuery(getName(), queryVector, k, filterQuery, numCandidates);
+      }
     }
 
     /**
@@ -560,7 +580,12 @@ public abstract class VectorFieldDef<T> extends IndexableFieldDef<T> implements 
     }
 
     @Override
-    Query getTypeKnnQuery(KnnQuery knnQuery, int k, Query filterQuery, int numCandidates) {
+    Query getTypeKnnQuery(
+        KnnQuery knnQuery,
+        int k,
+        Query filterQuery,
+        int numCandidates,
+        BitSetProducer parentBitSetProducer) {
       if (knnQuery.getQueryByteVector().size() != getVectorDimensions()) {
         throw new IllegalArgumentException(
             "Invalid query byte vector size, expected: "
@@ -570,7 +595,12 @@ public abstract class VectorFieldDef<T> extends IndexableFieldDef<T> implements 
       }
       byte[] queryVector = knnQuery.getQueryByteVector().toByteArray();
       validateVectorForSearch(queryVector);
-      return new NrtKnnByteVectorQuery(getName(), queryVector, k, filterQuery, numCandidates);
+      if (parentBitSetProducer != null) {
+        return new NrtDiversifyingChildrenByteKnnVectorQuery(
+            getName(), queryVector, filterQuery, k, numCandidates, parentBitSetProducer);
+      } else {
+        return new NrtKnnByteVectorQuery(getName(), queryVector, k, filterQuery, numCandidates);
+      }
     }
 
     /**

--- a/src/main/java/com/yelp/nrtsearch/server/field/properties/VectorQueryable.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/properties/VectorQueryable.java
@@ -18,6 +18,7 @@ package com.yelp.nrtsearch.server.field.properties;
 import com.yelp.nrtsearch.server.field.FieldDef;
 import com.yelp.nrtsearch.server.grpc.KnnQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.join.BitSetProducer;
 
 /** Trait interface for {@link FieldDef} types that can be queried by a {@link KnnQuery}. */
 public interface VectorQueryable {
@@ -26,7 +27,9 @@ public interface VectorQueryable {
    *
    * @param knnQuery knn query configuration
    * @param filterQuery query to filter knn search, or null
+   * @param parentBitSetProducer bit set producer for parent documents when searching a nested
+   *     field, or null
    * @return lucene knn query
    */
-  Query getKnnQuery(KnnQuery knnQuery, Query filterQuery);
+  Query getKnnQuery(KnnQuery knnQuery, Query filterQuery, BitSetProducer parentBitSetProducer);
 }

--- a/src/main/java/com/yelp/nrtsearch/server/index/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/IndexState.java
@@ -317,6 +317,30 @@ public abstract class IndexState implements Closeable {
     throw new IllegalArgumentException("Nested path is not a nested object field: " + path);
   }
 
+  /**
+   * Get the base path for the nested document containing the field at the given path. For fields in
+   * the base document, this returns _root. The base nested path for _root is null.
+   *
+   * @param path field path
+   * @return nested base path, or null
+   */
+  public static String getFieldBaseNestedPath(String path, IndexState indexState) {
+    Objects.requireNonNull(path, "path cannot be null");
+    if (path.equals(IndexState.ROOT)) {
+      return null;
+    }
+
+    String currentPath = path;
+    while (currentPath.contains(".")) {
+      currentPath = currentPath.substring(0, currentPath.lastIndexOf("."));
+      FieldDef fieldDef = indexState.getFieldOrThrow(currentPath);
+      if (fieldDef instanceof ObjectFieldDef objFieldDef && objFieldDef.isNestedDoc()) {
+        return currentPath;
+      }
+    }
+    return IndexState.ROOT;
+  }
+
   /** Get index state info. */
   public abstract IndexStateInfo getIndexStateInfo();
 

--- a/src/main/java/com/yelp/nrtsearch/server/query/vector/NrtDiversifyingChildrenByteKnnVectorQuery.java
+++ b/src/main/java/com/yelp/nrtsearch/server/query/vector/NrtDiversifyingChildrenByteKnnVectorQuery.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.query.vector;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.search.join.DiversifyingChildrenByteKnnVectorQuery;
+
+/**
+ * A {@link DiversifyingChildrenByteKnnVectorQuery} that has its functionality slightly modified.
+ * The {@link TotalHits} from the vector search are available after the query has been rewritten
+ * using the {@link WithVectorTotalHits} interface. The results merging has also been modified to
+ * produce the top k hits from the top numCandidates hits from each leaf.
+ */
+public class NrtDiversifyingChildrenByteKnnVectorQuery
+    extends DiversifyingChildrenByteKnnVectorQuery implements WithVectorTotalHits {
+  private final int topHits;
+  private TotalHits totalHits;
+
+  public NrtDiversifyingChildrenByteKnnVectorQuery(
+      String field,
+      byte[] target,
+      Query filter,
+      int k,
+      int numCandidates,
+      BitSetProducer parentsFilter) {
+    super(field, target, filter, numCandidates, parentsFilter);
+    this.topHits = k;
+  }
+
+  @Override
+  public TotalHits getTotalHits() {
+    return totalHits;
+  }
+
+  @Override
+  protected TopDocs mergeLeafResults(TopDocs[] perLeafResults) {
+    TopDocs topDocs = TopDocs.merge(topHits, perLeafResults);
+    totalHits = topDocs.totalHits;
+    return topDocs;
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/query/vector/NrtDiversifyingChildrenFloatKnnVectorQuery.java
+++ b/src/main/java/com/yelp/nrtsearch/server/query/vector/NrtDiversifyingChildrenFloatKnnVectorQuery.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.query.vector;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
+
+/**
+ * A {@link DiversifyingChildrenFloatKnnVectorQuery} that has its functionality slightly modified.
+ * The {@link TotalHits} from the vector search are available after the query has been rewritten
+ * using the {@link WithVectorTotalHits} interface. The results merging has also been modified to
+ * produce the top k hits from the top numCandidates hits from each leaf.
+ */
+public class NrtDiversifyingChildrenFloatKnnVectorQuery
+    extends DiversifyingChildrenFloatKnnVectorQuery implements WithVectorTotalHits {
+  private final int topHits;
+  private TotalHits totalHits;
+
+  public NrtDiversifyingChildrenFloatKnnVectorQuery(
+      String field,
+      float[] target,
+      Query filter,
+      int k,
+      int numCandidates,
+      BitSetProducer parentsFilter) {
+    super(field, target, filter, numCandidates, parentsFilter);
+    this.topHits = k;
+  }
+
+  @Override
+  public TotalHits getTotalHits() {
+    return totalHits;
+  }
+
+  @Override
+  protected TopDocs mergeLeafResults(TopDocs[] perLeafResults) {
+    TopDocs topDocs = TopDocs.merge(topHits, perLeafResults);
+    totalHits = topDocs.totalHits;
+    return topDocs;
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/index/IndexStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/index/IndexStateTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.index;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yelp.nrtsearch.server.field.ObjectFieldDef;
+import com.yelp.nrtsearch.server.field.TextFieldDef;
+import org.junit.Test;
+
+public class IndexStateTest {
+  @Test
+  public void testGetFieldBaseNestedPath_null() {
+    IndexState mockState = mock(IndexState.class);
+    try {
+      IndexState.getFieldBaseNestedPath(null, mockState);
+      fail();
+    } catch (NullPointerException e) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void testGetFieldBaseNestedPath_root() {
+    IndexState mockState = mock(IndexState.class);
+    String path = IndexState.getFieldBaseNestedPath(IndexState.ROOT, mockState);
+    assertNull(path);
+  }
+
+  @Test
+  public void testGetFieldBaseNestedPath_inBaseDoc() {
+    IndexState mockState = mock(IndexState.class);
+    when(mockState.getFieldOrThrow("field")).thenReturn(mock(TextFieldDef.class));
+    String path = IndexState.getFieldBaseNestedPath("field", mockState);
+    assertEquals(IndexState.ROOT, path);
+  }
+
+  @Test
+  public void testGetFieldBaseNestedPath_objectInBaseDoc() {
+    IndexState mockState = mock(IndexState.class);
+    ObjectFieldDef mockObject = mock(ObjectFieldDef.class);
+    when(mockObject.isNestedDoc()).thenReturn(false);
+    when(mockState.getFieldOrThrow("object")).thenReturn(mockObject);
+    String path = IndexState.getFieldBaseNestedPath("object", mockState);
+    assertEquals(IndexState.ROOT, path);
+  }
+
+  @Test
+  public void testGetFieldBaseNestedPath_nestedObjectInBaseDoc() {
+    IndexState mockState = mock(IndexState.class);
+    ObjectFieldDef mockObject = mock(ObjectFieldDef.class);
+    when(mockObject.isNestedDoc()).thenReturn(true);
+    when(mockState.getFieldOrThrow("object")).thenReturn(mockObject);
+    String path = IndexState.getFieldBaseNestedPath("object", mockState);
+    assertEquals(IndexState.ROOT, path);
+  }
+
+  @Test
+  public void testGetFieldBaseNestedPath_fieldOfObject() {
+    IndexState mockState = mock(IndexState.class);
+    ObjectFieldDef mockObject = mock(ObjectFieldDef.class);
+    when(mockObject.isNestedDoc()).thenReturn(false);
+    when(mockState.getFieldOrThrow("object")).thenReturn(mockObject);
+    when(mockState.getFieldOrThrow("object.field")).thenReturn(mock(TextFieldDef.class));
+    String path = IndexState.getFieldBaseNestedPath("object.field", mockState);
+    assertEquals(IndexState.ROOT, path);
+  }
+
+  @Test
+  public void testGetFieldBaseNestedPath_fieldOfNestedObject() {
+    IndexState mockState = mock(IndexState.class);
+    ObjectFieldDef mockObject = mock(ObjectFieldDef.class);
+    when(mockObject.isNestedDoc()).thenReturn(true);
+    when(mockState.getFieldOrThrow("object")).thenReturn(mockObject);
+    when(mockState.getFieldOrThrow("object.field")).thenReturn(mock(TextFieldDef.class));
+    String path = IndexState.getFieldBaseNestedPath("object.field", mockState);
+    assertEquals("object", path);
+  }
+
+  @Test
+  public void testGetFieldBaseNestedPath_multipleNestedObjects() {
+    IndexState mockState = mock(IndexState.class);
+    ObjectFieldDef mockObject = mock(ObjectFieldDef.class);
+    when(mockObject.isNestedDoc()).thenReturn(true);
+    when(mockState.getFieldOrThrow("object1")).thenReturn(mockObject);
+    when(mockState.getFieldOrThrow("object1.object2")).thenReturn(mockObject);
+    when(mockState.getFieldOrThrow("object1.object2.field")).thenReturn(mock(TextFieldDef.class));
+    String path = IndexState.getFieldBaseNestedPath("object1.object2.field", mockState);
+    assertEquals("object1.object2", path);
+  }
+
+  @Test
+  public void testGetFieldBaseNestedPath_unknownField() {
+    IndexState mockState = mock(IndexState.class);
+    ObjectFieldDef mockObject = mock(ObjectFieldDef.class);
+    when(mockObject.isNestedDoc()).thenReturn(true);
+    when(mockState.getFieldOrThrow("object")).thenThrow(new IllegalArgumentException("error"));
+    try {
+      IndexState.getFieldBaseNestedPath("object.field", mockState);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("error", e.getMessage());
+    }
+  }
+}

--- a/src/test/resources/field/registerFieldsNestedVectorSearch.json
+++ b/src/test/resources/field/registerFieldsNestedVectorSearch.json
@@ -1,0 +1,39 @@
+{
+  "indexName": "nested_vector_search_index",
+  "field": [
+    {
+      "name": "id",
+      "type": "_ID",
+      "storeDocValues": true
+    },
+    {
+      "name": "filter_field",
+      "type": "INT",
+      "search": true,
+      "storeDocValues": true
+    },
+    {
+      "name": "nested_object",
+      "type": "OBJECT",
+      "nestedDoc": true,
+      "multiValued": true,
+      "childFields": [
+        {
+          "name": "float_vector",
+          "type": "VECTOR",
+          "search": true,
+          "vectorDimensions": 3,
+          "vectorSimilarity": "cosine"
+        },
+        {
+          "name": "byte_vector",
+          "type": "VECTOR",
+          "search": true,
+          "vectorDimensions": 3,
+          "vectorSimilarity": "cosine",
+          "vectorElementType": "VECTOR_ELEMENT_BYTE"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add the ability to do a knn vector search query over fields in nested objects (documents). This is supported for both float and byte vector types.

When constructing the vector query, the parent document nested path is determined. Knn filter queries, if present, apply at the parent document level.

The `DiversifyingChildren*KnnVectorQuery`s are used to score the parent docs based on the best child vector similarity. These queries have been extended to allow for top k and diagnostics support.