### PR TITLE
Support doc value only range queries

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/doc/LoadedDocValues.java
+++ b/src/main/java/com/yelp/nrtsearch/server/doc/LoadedDocValues.java
@@ -275,7 +275,7 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
     @Override
     public void setDocId(int docID) throws IOException {
       if (docValues.advanceExact(docID)) {
-        value = Float.intBitsToFloat((int) docValues.longValue());
+        value = NumericUtils.sortableIntToFloat((int) docValues.longValue());
         isSet = true;
       } else {
         isSet = false;
@@ -324,7 +324,7 @@ public abstract class LoadedDocValues<T> extends AbstractList<T> {
     @Override
     public void setDocId(int docID) throws IOException {
       if (docValues.advanceExact(docID)) {
-        value = Double.longBitsToDouble(docValues.longValue());
+        value = NumericUtils.sortableLongToDouble(docValues.longValue());
         isSet = true;
       } else {
         isSet = false;

--- a/src/main/java/com/yelp/nrtsearch/server/field/BindingValuesSources.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/BindingValuesSources.java
@@ -37,9 +37,6 @@ public class BindingValuesSources {
   // decoders to convert the long value read from doc value fields into a double
   public static LongToDoubleFunction INT_DECODER = value -> (double) value;
   public static LongToDoubleFunction LONG_DECODER = value -> (double) value;
-  public static LongToDoubleFunction FLOAT_DECODER =
-      value -> (double) Float.intBitsToFloat((int) value);
-  public static LongToDoubleFunction DOUBLE_DECODER = Double::longBitsToDouble;
   public static LongToDoubleFunction SORTED_FLOAT_DECODER =
       value -> (double) NumericUtils.sortableIntToFloat((int) value);
   public static LongToDoubleFunction SORTED_DOUBLE_DECODER = NumericUtils::sortableLongToDouble;

--- a/src/main/java/com/yelp/nrtsearch/server/field/DateTimeFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/DateTimeFieldDef.java
@@ -105,6 +105,7 @@ public class DateTimeFieldDef extends IndexableFieldDef<Instant>
 
   @Override
   public Query getRangeQuery(RangeQuery rangeQuery) {
+    verifySearchableOrDocValues("Range query");
     long lower =
         rangeQuery.getLower().isEmpty()
             ? Long.MIN_VALUE
@@ -122,14 +123,20 @@ public class DateTimeFieldDef extends IndexableFieldDef<Instant>
     }
     ensureUpperIsMoreThanLower(rangeQuery, lower, upper);
 
-    Query pointQuery = LongPoint.newRangeQuery(rangeQuery.getField(), lower, upper);
-
-    if (!hasDocValues()) {
-      return pointQuery;
+    Query pointQuery = null;
+    Query dvQuery = null;
+    if (isSearchable()) {
+      pointQuery = LongPoint.newRangeQuery(rangeQuery.getField(), lower, upper);
+      if (!hasDocValues()) {
+        return pointQuery;
+      }
     }
-
-    Query dvQuery =
-        SortedNumericDocValuesField.newSlowRangeQuery(rangeQuery.getField(), lower, upper);
+    if (hasDocValues()) {
+      dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(rangeQuery.getField(), lower, upper);
+      if (!isSearchable()) {
+        return dvQuery;
+      }
+    }
     return new IndexOrDocValuesQuery(pointQuery, dvQuery);
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/field/FloatFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/FloatFieldDef.java
@@ -22,8 +22,8 @@ import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.LongToDoubleFunction;
-import org.apache.lucene.document.FloatDocValuesField;
 import org.apache.lucene.document.FloatPoint;
+import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredValue;
 import org.apache.lucene.index.DocValuesType;
@@ -45,7 +45,7 @@ public class FloatFieldDef extends NumberFieldDef<Float> {
   @Override
   protected org.apache.lucene.document.Field getDocValueField(Number fieldValue) {
     if (docValuesType == DocValuesType.NUMERIC) {
-      return new FloatDocValuesField(getName(), fieldValue.floatValue());
+      return new NumericDocValuesField(getName(), SORTED_FLOAT_ENCODER.applyAsLong(fieldValue));
     } else if (docValuesType == DocValuesType.SORTED_NUMERIC) {
       return new SortedNumericDocValuesField(
           getName(), SORTED_FLOAT_ENCODER.applyAsLong(fieldValue));
@@ -71,11 +71,7 @@ public class FloatFieldDef extends NumberFieldDef<Float> {
 
   @Override
   protected LongToDoubleFunction getBindingDecoder() {
-    if (isMultiValue()) {
-      return BindingValuesSources.SORTED_FLOAT_DECODER;
-    } else {
-      return BindingValuesSources.FLOAT_DECODER;
-    }
+    return BindingValuesSources.SORTED_FLOAT_DECODER;
   }
 
   @Override
@@ -105,6 +101,7 @@ public class FloatFieldDef extends NumberFieldDef<Float> {
 
   @Override
   public Query getRangeQuery(RangeQuery rangeQuery) {
+    verifySearchableOrDocValues("Range query");
     float lower =
         rangeQuery.getLower().isEmpty()
             ? Float.NEGATIVE_INFINITY
@@ -122,17 +119,24 @@ public class FloatFieldDef extends NumberFieldDef<Float> {
     }
     ensureUpperIsMoreThanLower(rangeQuery, lower, upper);
 
-    Query pointQuery = FloatPoint.newRangeQuery(rangeQuery.getField(), lower, upper);
-
-    if (!hasDocValues()) {
-      return pointQuery;
+    Query pointQuery = null;
+    Query dvQuery = null;
+    if (isSearchable()) {
+      pointQuery = FloatPoint.newRangeQuery(rangeQuery.getField(), lower, upper);
+      if (!hasDocValues()) {
+        return pointQuery;
+      }
     }
-
-    Query dvQuery =
-        SortedNumericDocValuesField.newSlowRangeQuery(
-            rangeQuery.getField(),
-            NumericUtils.floatToSortableInt(lower),
-            NumericUtils.floatToSortableInt(upper));
+    if (hasDocValues()) {
+      dvQuery =
+          SortedNumericDocValuesField.newSlowRangeQuery(
+              rangeQuery.getField(),
+              NumericUtils.floatToSortableInt(lower),
+              NumericUtils.floatToSortableInt(upper));
+      if (!isSearchable()) {
+        return dvQuery;
+      }
+    }
     return new IndexOrDocValuesQuery(pointQuery, dvQuery);
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/field/IndexableFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/IndexableFieldDef.java
@@ -145,19 +145,21 @@ public abstract class IndexableFieldDef<T> extends FieldDef {
   }
 
   /**
-   * Method called by {@link #IndexableFieldDef(String, Field, Class)} to validate the provided
-   * {@link Field}. Field definitions should define a version that checks for incompatible
-   * parameters and any other potential issues. It is recommended to also call the super version of
-   * this method, so that general checks do not need to be repeated everywhere.
+   * Method called by {@link #IndexableFieldDef(String, Field,
+   * FieldDefCreator.FieldDefCreatorContext, Class)} to validate the provided {@link Field}. Field
+   * definitions should define a version that checks for incompatible parameters and any other
+   * potential issues. It is recommended to also call the super version of this method, so that
+   * general checks do not need to be repeated everywhere.
    *
    * @param requestField field properties to validate
    */
   protected void validateRequest(Field requestField) {}
 
   /**
-   * Method called by {@link #IndexableFieldDef(String, Field, Class)} to determine the doc value
-   * type used by this field. Fields are not necessarily limited to one doc value, but this should
-   * represent the primary value that will be accessible to scripts and search through {@link
+   * Method called by {@link #IndexableFieldDef(String, Field,
+   * FieldDefCreator.FieldDefCreatorContext, Class)} to determine the doc value type used by this
+   * field. Fields are not necessarily limited to one doc value, but this should represent the
+   * primary value that will be accessible to scripts and search through {@link
    * #getDocValues(LeafReaderContext)}. A value of NONE implies that the field does not support doc
    * values.
    *
@@ -169,9 +171,10 @@ public abstract class IndexableFieldDef<T> extends FieldDef {
   }
 
   /**
-   * Method called by {@link #IndexableFieldDef(String, Field, Class)} to determine the facet value
-   * type for this field. The result of this method is exposed externally through {@link
-   * #getFacetValueType()}. A value of NO_FACETS implies that the field does not support facets.
+   * Method called by {@link #IndexableFieldDef(String, Field,
+   * FieldDefCreator.FieldDefCreatorContext, Class)} to determine the facet value type for this
+   * field. The result of this method is exposed externally through {@link #getFacetValueType()}. A
+   * value of NO_FACETS implies that the field does not support facets.
    *
    * @param requestField field from request
    * @return field facet value type
@@ -181,12 +184,13 @@ public abstract class IndexableFieldDef<T> extends FieldDef {
   }
 
   /**
-   * Method called by {@link #IndexableFieldDef(String, Field, Class)} to set the search properties
-   * on the given {@link FieldType}. The {@link FieldType#setStored(boolean)} has already been set
-   * to the value from {@link Field#getStore()}. This method should set any other needed properties,
-   * such as index options, tokenization, term vectors, etc. It likely should not set a doc value
-   * type, as those are usually added separately. The common use of this {@link FieldType} is to add
-   * a {@link FieldWithData} during indexing. This method should not freeze the field type.
+   * Method called by {@link #IndexableFieldDef(String, Field,
+   * FieldDefCreator.FieldDefCreatorContext, Class)} to set the search properties on the given
+   * {@link FieldType}. The {@link FieldType#setStored(boolean)} has already been set to the value
+   * from {@link Field#getStore()}. This method should set any other needed properties, such as
+   * index options, tokenization, term vectors, etc. It likely should not set a doc value type, as
+   * those are usually added separately. The common use of this {@link FieldType} is to add a {@link
+   * FieldWithData} during indexing. This method should not freeze the field type.
    *
    * @param fieldType type that needs search properties set
    * @param requestField field from request
@@ -370,5 +374,44 @@ public abstract class IndexableFieldDef<T> extends FieldDef {
    */
   public FieldType getFieldType() {
     return fieldType;
+  }
+
+  /**
+   * Verify that the field is searchable or has doc values.
+   *
+   * @param featureName name of feature that requires searchable or doc values
+   * @throws IllegalStateException if field is not searchable and does not have doc values
+   */
+  protected void verifySearchableOrDocValues(String featureName) {
+    if (!isSearchable() && !hasDocValues()) {
+      throw new IllegalStateException(
+          featureName + " requires field to be searchable or have doc values: " + getName());
+    }
+  }
+
+  /**
+   * Verify that the field is searchable.
+   *
+   * @param featureName name of feature that requires searchable
+   * @throws IllegalStateException if field is not searchable
+   */
+  protected void verifySearchable(String featureName) {
+    if (!isSearchable()) {
+      throw new IllegalStateException(
+          featureName + " requires field to be searchable: " + getName());
+    }
+  }
+
+  /**
+   * Verify that the field has doc values.
+   *
+   * @param featureName name of feature that requires doc values
+   * @throws IllegalStateException if field does not have doc values
+   */
+  protected void verifyDocValues(String featureName) {
+    if (!hasDocValues()) {
+      throw new IllegalStateException(
+          featureName + " requires field to have doc values: " + getName());
+    }
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/doc/SingleDoubleTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/doc/SingleDoubleTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import java.io.IOException;
 import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.util.NumericUtils;
 import org.junit.Test;
 
 public class SingleDoubleTest {
@@ -58,12 +59,12 @@ public class SingleDoubleTest {
         .thenReturn(true, true, true, true, true, true, false);
     when(mockDocValues.longValue())
         .thenReturn(
-            Double.doubleToRawLongBits(Double.NEGATIVE_INFINITY),
-            Double.doubleToRawLongBits(15.0),
-            Double.doubleToRawLongBits(Double.POSITIVE_INFINITY),
-            Double.doubleToRawLongBits(Double.NaN),
-            Double.doubleToRawLongBits(Double.MAX_VALUE),
-            Double.doubleToRawLongBits(Double.MIN_VALUE));
+            NumericUtils.doubleToSortableLong(Double.NEGATIVE_INFINITY),
+            NumericUtils.doubleToSortableLong(15.0),
+            NumericUtils.doubleToSortableLong(Double.POSITIVE_INFINITY),
+            NumericUtils.doubleToSortableLong(Double.NaN),
+            NumericUtils.doubleToSortableLong(Double.MAX_VALUE),
+            NumericUtils.doubleToSortableLong(Double.MIN_VALUE));
 
     LoadedDocValues.SingleDouble loadedData = new LoadedDocValues.SingleDouble(mockDocValues);
     loadedData.setDocId(0);
@@ -92,7 +93,7 @@ public class SingleDoubleTest {
   public void testSetDocValuesOutOfBounds() throws IOException {
     NumericDocValues mockDocValues = mock(NumericDocValues.class);
     when(mockDocValues.advanceExact(anyInt())).thenReturn(true);
-    when(mockDocValues.longValue()).thenReturn(Double.doubleToRawLongBits(15.0f));
+    when(mockDocValues.longValue()).thenReturn(NumericUtils.doubleToSortableLong(15.0));
 
     LoadedDocValues.SingleDouble loadedData = new LoadedDocValues.SingleDouble(mockDocValues);
     loadedData.setDocId(0);

--- a/src/test/java/com/yelp/nrtsearch/server/doc/SingleFloatTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/doc/SingleFloatTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import java.io.IOException;
 import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.util.NumericUtils;
 import org.junit.Test;
 
 public class SingleFloatTest {
@@ -58,12 +59,12 @@ public class SingleFloatTest {
         .thenReturn(true, true, true, true, true, true, false);
     when(mockDocValues.longValue())
         .thenReturn(
-            (long) Float.floatToRawIntBits(Float.NEGATIVE_INFINITY),
-            (long) Float.floatToRawIntBits(15.0f),
-            (long) Float.floatToRawIntBits(Float.POSITIVE_INFINITY),
-            (long) Float.floatToRawIntBits(Float.NaN),
-            (long) Float.floatToRawIntBits(Float.MAX_VALUE),
-            (long) Float.floatToRawIntBits(Float.MIN_VALUE));
+            (long) NumericUtils.floatToSortableInt(Float.NEGATIVE_INFINITY),
+            (long) NumericUtils.floatToSortableInt(15.0f),
+            (long) NumericUtils.floatToSortableInt(Float.POSITIVE_INFINITY),
+            (long) NumericUtils.floatToSortableInt(Float.NaN),
+            (long) NumericUtils.floatToSortableInt(Float.MAX_VALUE),
+            (long) NumericUtils.floatToSortableInt(Float.MIN_VALUE));
 
     LoadedDocValues.SingleFloat loadedData = new LoadedDocValues.SingleFloat(mockDocValues);
     loadedData.setDocId(0);
@@ -92,7 +93,7 @@ public class SingleFloatTest {
   public void testSetDocValuesOutOfBounds() throws IOException {
     NumericDocValues mockDocValues = mock(NumericDocValues.class);
     when(mockDocValues.advanceExact(anyInt())).thenReturn(true);
-    when(mockDocValues.longValue()).thenReturn((long) Float.floatToRawIntBits(15.0f));
+    when(mockDocValues.longValue()).thenReturn((long) NumericUtils.floatToSortableInt(15.0f));
 
     LoadedDocValues.SingleFloat loadedData = new LoadedDocValues.SingleFloat(mockDocValues);
     loadedData.setDocId(0);

--- a/src/test/java/com/yelp/nrtsearch/server/field/DateTimeFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/DateTimeFieldDefTest.java
@@ -16,6 +16,8 @@
 package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
@@ -25,6 +27,7 @@ import com.yelp.nrtsearch.server.grpc.Query;
 import com.yelp.nrtsearch.server.grpc.RangeQuery;
 import com.yelp.nrtsearch.server.grpc.SearchRequest;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import io.grpc.StatusRuntimeException;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -413,7 +416,43 @@ public class DateTimeFieldDefTest extends ServerTestCase {
 
   @Test
   public void testRangeQueryWithCombinationOfSpecifiedBoundsAndExclusive() {
-    String dateFieldName = "timestamp_epoch_millis";
+    rangeQueryWithCombinationOfSpecifiedBoundsAndExclusive("timestamp_epoch_millis");
+  }
+
+  @Test
+  public void testRangeQueryWithCombinationOfSpecifiedBoundsAndExclusive_docValues() {
+    rangeQueryWithCombinationOfSpecifiedBoundsAndExclusive("timestamp_epoch_millis.dv");
+  }
+
+  @Test
+  public void testRangeQueryWithCombinationOfSpecifiedBoundsAndExclusive_searchable() {
+    rangeQueryWithCombinationOfSpecifiedBoundsAndExclusive("timestamp_epoch_millis.search");
+  }
+
+  @Test
+  public void testRangeQueryWithCombinationOfSpecifiedBoundsAndExclusive_multiDocValues() {
+    rangeQueryWithCombinationOfSpecifiedBoundsAndExclusive("timestamp_epoch_millis.mv_dv");
+  }
+
+  @Test
+  public void testRangeQueryWithCombinationOfSpecifiedBoundsAndExclusive_multiSearchable() {
+    rangeQueryWithCombinationOfSpecifiedBoundsAndExclusive("timestamp_epoch_millis.mv_search");
+  }
+
+  @Test
+  public void testRangeQueryWithCombinationOfSpecifiedBoundsAndExclusive_unsupported() {
+    try {
+      rangeQueryWithCombinationOfSpecifiedBoundsAndExclusive("timestamp_epoch_millis.none");
+      fail();
+    } catch (StatusRuntimeException e) {
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "Range query requires field to be searchable or have doc values: timestamp_epoch_millis.none"));
+    }
+  }
+
+  private void rangeQueryWithCombinationOfSpecifiedBoundsAndExclusive(String dateFieldName) {
 
     // Both bounds defined
 

--- a/src/test/java/com/yelp/nrtsearch/server/field/DoubleFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/DoubleFieldDefTest.java
@@ -16,6 +16,8 @@
 package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
@@ -24,6 +26,7 @@ import com.yelp.nrtsearch.server.grpc.Query;
 import com.yelp.nrtsearch.server.grpc.RangeQuery;
 import com.yelp.nrtsearch.server.grpc.SearchRequest;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import io.grpc.StatusRuntimeException;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -180,6 +183,43 @@ public class DoubleFieldDefTest extends ServerTestCase {
 
   @Test
   public void testRangeQuery() {
+    rangeQuery("double_field");
+  }
+
+  @Test
+  public void testRangeQuery_docValues() {
+    rangeQuery("double_field.dv");
+  }
+
+  @Test
+  public void testRangeQuery_searchable() {
+    rangeQuery("double_field.search");
+  }
+
+  @Test
+  public void testRangeQuery_multiDocValues() {
+    rangeQuery("double_field.mv_dv");
+  }
+
+  @Test
+  public void testRangeQuery_multiSearchable() {
+    rangeQuery("double_field.mv_search");
+  }
+
+  @Test
+  public void testRangeQuery_unsupported() {
+    try {
+      rangeQuery("double_field.none");
+      fail();
+    } catch (StatusRuntimeException e) {
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "Range query requires field to be searchable or have doc values: double_field.none"));
+    }
+  }
+
+  private void rangeQuery(String fieldName) {
     // Both bounds defined
 
     // Both inclusive

--- a/src/test/java/com/yelp/nrtsearch/server/field/FloatFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/FloatFieldDefTest.java
@@ -16,6 +16,8 @@
 package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
@@ -24,6 +26,7 @@ import com.yelp.nrtsearch.server.grpc.Query;
 import com.yelp.nrtsearch.server.grpc.RangeQuery;
 import com.yelp.nrtsearch.server.grpc.SearchRequest;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import io.grpc.StatusRuntimeException;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -180,6 +183,43 @@ public class FloatFieldDefTest extends ServerTestCase {
 
   @Test
   public void testRangeQuery() {
+    rangeQuery("float_field");
+  }
+
+  @Test
+  public void testRangeQuery_docValues() {
+    rangeQuery("float_field.dv");
+  }
+
+  @Test
+  public void testRangeQuery_searchable() {
+    rangeQuery("float_field.search");
+  }
+
+  @Test
+  public void testRangeQuery_multiDocValues() {
+    rangeQuery("float_field.mv_dv");
+  }
+
+  @Test
+  public void testRangeQuery_multiSearchable() {
+    rangeQuery("float_field.mv_search");
+  }
+
+  @Test
+  public void testRangeQuery_unsupported() {
+    try {
+      rangeQuery("float_field.none");
+      fail();
+    } catch (StatusRuntimeException e) {
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "Range query requires field to be searchable or have doc values: float_field.none"));
+    }
+  }
+
+  private void rangeQuery(String fieldName) {
     // Both bounds defined
 
     // Both inclusive

--- a/src/test/java/com/yelp/nrtsearch/server/field/IntFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/IntFieldDefTest.java
@@ -16,6 +16,8 @@
 package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
@@ -24,6 +26,7 @@ import com.yelp.nrtsearch.server.grpc.Query;
 import com.yelp.nrtsearch.server.grpc.RangeQuery;
 import com.yelp.nrtsearch.server.grpc.SearchRequest;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import io.grpc.StatusRuntimeException;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -172,6 +175,43 @@ public class IntFieldDefTest extends ServerTestCase {
 
   @Test
   public void testRangeQuery() {
+    rangeQuery("int_field");
+  }
+
+  @Test
+  public void testRangeQuery_docValues() {
+    rangeQuery("int_field.dv");
+  }
+
+  @Test
+  public void testRangeQuery_searchable() {
+    rangeQuery("int_field.search");
+  }
+
+  @Test
+  public void testRangeQuery_multiDocValues() {
+    rangeQuery("int_field.mv_dv");
+  }
+
+  @Test
+  public void testRangeQuery_multiSearchable() {
+    rangeQuery("int_field.mv_search");
+  }
+
+  @Test
+  public void testRangeQuery_unsupported() {
+    try {
+      rangeQuery("int_field.none");
+      fail();
+    } catch (StatusRuntimeException e) {
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "Range query requires field to be searchable or have doc values: int_field.none"));
+    }
+  }
+
+  private void rangeQuery(String fieldName) {
     // Both bounds defined
 
     // Both inclusive

--- a/src/test/java/com/yelp/nrtsearch/server/field/LongFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/LongFieldDefTest.java
@@ -16,6 +16,8 @@
 package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
@@ -24,6 +26,7 @@ import com.yelp.nrtsearch.server.grpc.Query;
 import com.yelp.nrtsearch.server.grpc.RangeQuery;
 import com.yelp.nrtsearch.server.grpc.SearchRequest;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import io.grpc.StatusRuntimeException;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -167,6 +170,43 @@ public class LongFieldDefTest extends ServerTestCase {
 
   @Test
   public void testRangeQuery() {
+    rangeQuery("long_field");
+  }
+
+  @Test
+  public void testRangeQuery_docValues() {
+    rangeQuery("long_field.dv");
+  }
+
+  @Test
+  public void testRangeQuery_searchable() {
+    rangeQuery("long_field.search");
+  }
+
+  @Test
+  public void testRangeQuery_multiDocValues() {
+    rangeQuery("long_field.mv_dv");
+  }
+
+  @Test
+  public void testRangeQuery_multiSearchable() {
+    rangeQuery("long_field.mv_search");
+  }
+
+  @Test
+  public void testRangeQuery_unsupported() {
+    try {
+      rangeQuery("long_field.none");
+      fail();
+    } catch (StatusRuntimeException e) {
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "Range query requires field to be searchable or have doc values: long_field.none"));
+    }
+  }
+
+  private void rangeQuery(String fieldName) {
     // Both bounds defined
 
     // Both inclusive

--- a/src/test/resources/field/registerFieldsDateTime.json
+++ b/src/test/resources/field/registerFieldsDateTime.json
@@ -12,7 +12,40 @@
       "type": "DATE_TIME",
       "dateTimeFormat": "epoch_millis",
       "storeDocValues": true,
-      "search": true
+      "search": true,
+      "childFields": [
+        {
+          "name": "dv",
+          "type": "DATE_TIME",
+          "dateTimeFormat": "epoch_millis",
+          "storeDocValues": true
+        },
+        {
+          "name": "search",
+          "type": "DATE_TIME",
+          "dateTimeFormat": "epoch_millis",
+          "search": true
+        },
+        {
+          "name": "none",
+          "type": "DATE_TIME",
+          "dateTimeFormat": "epoch_millis"
+        },
+        {
+          "name": "mv_dv",
+          "type": "DATE_TIME",
+          "dateTimeFormat": "epoch_millis",
+          "multiValued": true,
+          "storeDocValues": true
+        },
+        {
+          "name": "mv_search",
+          "type": "DATE_TIME",
+          "dateTimeFormat": "epoch_millis",
+          "multiValued": true,
+          "search": true
+        }
+      ]
     },
     {
       "name": "timestamp_strict_date_optional_time",

--- a/src/test/resources/field/registerFieldsDouble.json
+++ b/src/test/resources/field/registerFieldsDouble.json
@@ -6,7 +6,35 @@
             "type": "DOUBLE",
             "storeDocValues": true,
             "multiValued": false,
-            "search": true
+            "search": true,
+            "childFields": [
+                {
+                    "name": "dv",
+                    "type": "DOUBLE",
+                    "storeDocValues": true
+                },
+                {
+                    "name": "search",
+                    "type": "DOUBLE",
+                    "search": true
+                },
+                {
+                    "name": "none",
+                    "type": "DOUBLE"
+                },
+                {
+                    "name": "mv_dv",
+                    "type": "DOUBLE",
+                    "multiValued": true,
+                    "storeDocValues": true
+                },
+                {
+                    "name": "mv_search",
+                    "type": "DOUBLE",
+                    "multiValued": true,
+                    "search": true
+                }
+            ]
         },
         {
             "name": "single_stored",

--- a/src/test/resources/field/registerFieldsFloat.json
+++ b/src/test/resources/field/registerFieldsFloat.json
@@ -6,7 +6,35 @@
             "type": "FLOAT",
             "storeDocValues": true,
             "multiValued": false,
-            "search": true
+            "search": true,
+            "childFields": [
+                {
+                    "name": "dv",
+                    "type": "FLOAT",
+                    "storeDocValues": true
+                },
+                {
+                    "name": "search",
+                    "type": "FLOAT",
+                    "search": true
+                },
+                {
+                    "name": "none",
+                    "type": "FLOAT"
+                },
+                {
+                    "name": "mv_dv",
+                    "type": "FLOAT",
+                    "multiValued": true,
+                    "storeDocValues": true
+                },
+                {
+                    "name": "mv_search",
+                    "type": "FLOAT",
+                    "multiValued": true,
+                    "search": true
+                }
+            ]
         },
         {
             "name": "single_stored",

--- a/src/test/resources/field/registerFieldsInt.json
+++ b/src/test/resources/field/registerFieldsInt.json
@@ -6,7 +6,35 @@
             "type": "INT",
             "storeDocValues": true,
             "multiValued": false,
-            "search": true
+            "search": true,
+            "childFields": [
+                {
+                    "name": "dv",
+                    "type": "INT",
+                    "storeDocValues": true
+                },
+                {
+                    "name": "search",
+                    "type": "INT",
+                    "search": true
+                },
+                {
+                    "name": "none",
+                    "type": "INT"
+                },
+                {
+                    "name": "mv_dv",
+                    "type": "INT",
+                    "multiValued": true,
+                    "storeDocValues": true
+                },
+                {
+                    "name": "mv_search",
+                    "type": "INT",
+                    "multiValued": true,
+                    "search": true
+                }
+            ]
         },
         {
             "name": "single_stored",

--- a/src/test/resources/field/registerFieldsLong.json
+++ b/src/test/resources/field/registerFieldsLong.json
@@ -6,7 +6,35 @@
             "type": "LONG",
             "storeDocValues": true,
             "multiValued": false,
-            "search": true
+            "search": true,
+            "childFields": [
+                {
+                    "name": "dv",
+                    "type": "LONG",
+                    "storeDocValues": true
+                },
+                {
+                    "name": "search",
+                    "type": "LONG",
+                    "search": true
+                },
+                {
+                    "name": "none",
+                    "type": "LONG"
+                },
+                {
+                    "name": "mv_dv",
+                    "type": "LONG",
+                    "multiValued": true,
+                    "storeDocValues": true
+                },
+                {
+                    "name": "mv_search",
+                    "type": "LONG",
+                    "multiValued": true,
+                    "search": true
+                }
+            ]
         },
         {
             "name": "single_stored",


### PR DESCRIPTION
Add slow range query support for fields with only doc values enabled.

Additional changes
- Verifies doc values and/or indexing is enabled on the field
- Singled float/double fields now use sorted encoding, otherwise ranges do not work correctly for negative numbers