### PR TITLE
Backport: Add Term/TermInSet query support for DATE_TIME field

### DIFF
--- a/src/test/resources/field/registerFieldsDateTime.json
+++ b/src/test/resources/field/registerFieldsDateTime.json
@@ -26,6 +26,27 @@
       "dateTimeFormat": "yyyy-MM-dd HH:mm:ss",
       "storeDocValues": true,
       "search": true
+    },
+    {
+      "name": "single_stored",
+      "type": "DATE_TIME",
+      "dateTimeFormat": "epoch_millis",
+      "search": true,
+      "store": true
+    },
+    {
+      "name": "multi_stored",
+      "type": "DATE_TIME",
+      "dateTimeFormat": "epoch_millis",
+      "search": true,
+      "multiValued": true,
+      "store": true
+    },
+    {
+      "name": "stored_only",
+      "type": "DATE_TIME",
+      "dateTimeFormat": "epoch_millis",
+      "store": true
     }
   ]
 }


### PR DESCRIPTION
Partial backport of https://github.com/Yelp/nrtsearch/pull/797

This version of Lucene does not have the same support for doc value based term queries, so term queries are only available when the field is configured as `searchable`.