### PR TITLE
Add output size for logging hits in diagnostics

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -988,6 +988,8 @@ message SearchResponse {
         double initialDeadlineMs = 14;
         // Time for logging hits
         double loggingHitsTimeMs = 15;
+        // The size of the data logged in bytes
+        int64 loggingHitsOutputSizeBytes = 16;
     }
 
     // Message for query document hit

--- a/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
@@ -315,6 +315,8 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
       if (searchContext.getFetchTasks().getHitsLoggerFetchTask() != null) {
         diagnostics.setLoggingHitsTimeMs(
             searchContext.getFetchTasks().getHitsLoggerFetchTask().getTimeTakenMs());
+        diagnostics.setLoggingHitsOutputSizeBytes(
+            searchContext.getFetchTasks().getHitsLoggerFetchTask().getOutputSize());
       }
       if (searchContext.getFetchTasks().getInnerHitFetchTaskList() != null) {
         diagnostics.putAllInnerHitsDiagnostics(

--- a/src/main/java/com/yelp/nrtsearch/server/logging/HitsLogger.java
+++ b/src/main/java/com/yelp/nrtsearch/server/logging/HitsLogger.java
@@ -30,6 +30,7 @@ public interface HitsLogger {
    *
    * @param context the {@link SearchContext} to keep the contexts for this search request
    * @param hits query hits
+   * @return the size in bytes of the logged data
    */
-  void log(SearchContext context, List<SearchResponse.Hit.Builder> hits);
+  int log(SearchContext context, List<SearchResponse.Hit.Builder> hits);
 }

--- a/src/main/java/com/yelp/nrtsearch/server/logging/HitsLoggerFetchTask.java
+++ b/src/main/java/com/yelp/nrtsearch/server/logging/HitsLoggerFetchTask.java
@@ -33,6 +33,8 @@ public class HitsLoggerFetchTask implements FetchTask {
   private final int hitsToLog;
   private final DoubleAdder timeTakenMs = new DoubleAdder();
 
+  private int outputSize;
+
   public HitsLoggerFetchTask(LoggingHits loggingHits) {
     this.hitsLogger = HitsLoggerCreator.getInstance().createHitsLogger(loggingHits);
     this.hitsToLog = loggingHits.getHitsToLog();
@@ -52,12 +54,16 @@ public class HitsLoggerFetchTask implements FetchTask {
     // hits list can contain extra hits that don't need to be logged, otherwise, pass all hits that
     // can be logged
     if (searchContext.getHitsToLog() < hits.size()) {
-      hitsLogger.log(searchContext, hits.subList(0, searchContext.getHitsToLog()));
+      outputSize = hitsLogger.log(searchContext, hits.subList(0, searchContext.getHitsToLog()));
     } else {
-      hitsLogger.log(searchContext, hits);
+      outputSize = hitsLogger.log(searchContext, hits);
     }
 
     timeTakenMs.add(((System.nanoTime() - startTime) / TEN_TO_THE_POWER_SIX));
+  }
+
+  public int getOutputSize() {
+    return outputSize;
   }
 
   /**

--- a/src/test/java/com/yelp/nrtsearch/server/logging/HitsLoggerCreatorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/logging/HitsLoggerCreatorTest.java
@@ -58,14 +58,18 @@ public class HitsLoggerCreatorTest {
       }
 
       @Override
-      public void log(SearchContext context, List<SearchResponse.Hit.Builder> hits) {}
+      public int log(SearchContext context, List<SearchResponse.Hit.Builder> hits) {
+        return 0;
+      }
     }
 
     static class CustomHitsLogger2 implements HitsLogger {
       public CustomHitsLogger2(Map<String, Object> params) {}
 
       @Override
-      public void log(SearchContext context, List<SearchResponse.Hit.Builder> hits) {}
+      public int log(SearchContext context, List<SearchResponse.Hit.Builder> hits) {
+        return 0;
+      }
     }
 
     @Override


### PR DESCRIPTION
Adding the size of the data that was logged to help with debugging sudden changes in logging as well as making sure nrtsearch has the proper resources