### PR TITLE
Fix sorting of single valued numeric fields

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/field/NumberFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/NumberFieldDef.java
@@ -263,17 +263,12 @@ public abstract class NumberFieldDef<T> extends IndexableFieldDef<T>
   @Override
   public SortField getSortField(SortType type) {
     verifyDocValues("Sort field");
-    SortField sortField;
-    if (isMultiValue()) {
-      sortField =
-          new SortedNumericSortField(
-              getName(),
-              getSortFieldType(),
-              type.getReverse(),
-              NUMERIC_TYPE_PARSER.apply(type.getSelector()));
-    } else {
-      sortField = new SortField(getName(), getSortFieldType(), type.getReverse());
-    }
+    SortField sortField =
+        new SortedNumericSortField(
+            getName(),
+            getSortFieldType(),
+            type.getReverse(),
+            NUMERIC_TYPE_PARSER.apply(type.getSelector()));
 
     boolean missingLast = type.getMissingLast();
     sortField.setMissingValue(getSortMissingValue(missingLast));

--- a/src/main/java/com/yelp/nrtsearch/server/index/ImmutableIndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/ImmutableIndexState.java
@@ -46,7 +46,6 @@ import com.yelp.nrtsearch.server.search.sort.SortParser;
 import com.yelp.nrtsearch.server.state.GlobalState;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -63,7 +62,6 @@ import org.apache.lucene.index.SimpleMergedSegmentWarmer;
 import org.apache.lucene.index.TieredMergePolicy;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
-import org.apache.lucene.search.SortField.Type;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.PrintStreamInfoStream;
 import org.slf4j.Logger;
@@ -72,13 +70,6 @@ import org.slf4j.LoggerFactory;
 /** Implementation of index state which is immutable. */
 public class ImmutableIndexState extends IndexState {
   private static final Logger logger = LoggerFactory.getLogger(ImmutableIndexState.class);
-  private static final EnumSet<Type> ALLOWED_INDEX_SORT_TYPES =
-      EnumSet.of(
-          SortField.Type.STRING,
-          SortField.Type.LONG,
-          SortField.Type.INT,
-          SortField.Type.DOUBLE,
-          SortField.Type.FLOAT);
 
   public static final double DEFAULT_NRT_CACHING_MAX_MERGE_SIZE_MB = 5.0;
   public static final double DEFAULT_NRT_CACHING_MAX_SIZE_MB = 60.0;
@@ -831,14 +822,9 @@ public class ImmutableIndexState extends IndexState {
 
   private static void validateIndexSort(Sort sort) {
     for (SortField sortField : sort.getSort()) {
-      if (!ALLOWED_INDEX_SORT_TYPES.contains(sortField.getType())) {
+      if (sortField.getIndexSorter() == null) {
         throw new IllegalArgumentException(
-            "Sort field: "
-                + sortField.getField()
-                + ", type: "
-                + sortField.getType()
-                + " is not in allowed types: "
-                + ALLOWED_INDEX_SORT_TYPES);
+            "Sort field: \"" + sortField.getField() + "\" does not support index sorting");
       }
     }
   }

--- a/src/test/java/com/yelp/nrtsearch/server/index/ImmutableIndexStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/index/ImmutableIndexStateTest.java
@@ -417,9 +417,7 @@ public class ImmutableIndexStateTest {
                   .build()));
       fail();
     } catch (IllegalArgumentException e) {
-      assertEquals(
-          "Sort field: null, type: DOC is not in allowed types: [STRING, INT, FLOAT, LONG, DOUBLE]",
-          e.getMessage());
+      assertEquals("Sort field: \"null\" does not support index sorting", e.getMessage());
     }
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/search/MyIndexSearcherVirtualShardsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/MyIndexSearcherVirtualShardsTest.java
@@ -110,7 +110,7 @@ public class MyIndexSearcherVirtualShardsTest extends ServerTestCase {
   @Test
   public void testHasVirtualShards() throws Exception {
     setLiveSettings(111, 10000, 2);
-    addSegments(Collections.emptyList());
+    addSegments(List.of(10));
     SearcherAndTaxonomy s = null;
     ShardState shardState = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX).getShard(0);
     try {

--- a/src/test/resources/search/SortFieldRegisterFields.json
+++ b/src/test/resources/search/SortFieldRegisterFields.json
@@ -14,8 +14,21 @@
       "storeDocValues": true
     },
     {
+      "name": "multi_int_field",
+      "type": "INT",
+      "search": true,
+      "multiValued": true,
+      "storeDocValues": true
+    },
+    {
       "name": "long_field",
       "type": "LONG",
+      "storeDocValues": true
+    },
+    {
+      "name": "multi_long_field",
+      "type": "LONG",
+      "multiValued": true,
       "storeDocValues": true
     },
     {
@@ -24,8 +37,20 @@
       "storeDocValues": true
     },
     {
+      "name": "multi_float_field",
+      "type": "FLOAT",
+      "multiValued": true,
+      "storeDocValues": true
+    },
+    {
       "name": "double_field",
       "type": "DOUBLE",
+      "storeDocValues": true
+    },
+    {
+      "name": "multi_double_field",
+      "type": "DOUBLE",
+      "multiValued": true,
       "storeDocValues": true
     },
     {

--- a/src/test/resources/search/registerFieldsHitsThreshold.json
+++ b/src/test/resources/search/registerFieldsHitsThreshold.json
@@ -10,6 +10,7 @@
     {
       "name": "int_field",
       "type": "INT",
+      "multiValued": true,
       "storeDocValues": true
     },
     {


### PR DESCRIPTION
To make doc value range queries work correctly with single valued `FLOAT` and `DOUBLE` fields, the encoding was changed to be sortable. This causes a problem, since the standard `SortField` will assume they are encoded as raw bits. This change uses `SortedNumericSortField` for single and multi valued fields.

This issue was missed because the current sort field tests did not include negative numbers. The tests have been modified to correct this. Additionally, tests have been added for multi valued numeric fields.

This does seem to cause an issue when trying to use a singled valued numeric field for index sorting, but I think we can fix this later and add better test coverage around this feature.

I'm starting to wonder if there is really a benefit to supporting single valued fields at all.