### PR TITLE
fix sort by string when the value is null

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/search/sort/SortParser.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/sort/SortParser.java
@@ -196,7 +196,9 @@ public class SortParser {
         break;
       case STRING:
       case STRING_VAL:
-        if (sortValue instanceof BytesRef) {
+        if (sortValue == null) {
+          fieldValue.setTextValue("");
+        } else if (sortValue instanceof BytesRef) {
           fieldValue.setTextValue(((BytesRef) sortValue).utf8ToString());
         } else {
           fieldValue.setTextValue((String) sortValue);


### PR DESCRIPTION
Fix
java.lang.NullPointerException
at com.yelp.nrtsearch.server.grpc.SearchResponse$Hit$FieldValue$Builder.setTextValue(SearchResponse.java:4685)
at com.yelp.nrtsearch.server.luceneserver.search.sort.SortParser.getValueForSortField(SortParser.java:202)
at com.yelp.nrtsearch.server.luceneserver.search.sort.SortParser.lambda$static$0(SortParser.java:41)
at com.yelp.nrtsearch.server.luceneserver.search.sort.SortParser.getAllSortedValues(SortParser.java:125)
at com.yelp.nrtsearch.server.luceneserver.search.collectors.SortFieldCollector.fillHitRanking(SortFieldCollector.java:84)
at com.yelp.nrtsearch.server.luceneserver.SearchHandler.setResponseHits(SearchHandler.java:516)
at com.yelp.nrtsearch.server.luceneserver.SearchHandler.handle(SearchHandler.java:233)
at com.yelp.nrtsearch.server.grpc.LuceneServer$LuceneServerImpl.search(LuceneServer.java:1076)
at com.yelp.nrtsearch.server.grpc.LuceneServerGrpc$MethodHandlers.invoke(LuceneServerGrpc.java:3376)
at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:340)
at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:866)
at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
at java.base/java.lang.Thread.run(Thread.java:1583)}

Need to backport to v0.x for deployment