### PR TITLE
Bump up NRTSearch version to v1.0.0-beta.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ java {
 }
 
 allprojects {
-    version = '1.0.0-beta.3'
+    version = '1.0.0-beta.4'
     group = 'com.yelp.nrtsearch'
 }
 


### PR DESCRIPTION
Bumping version to include [816](https://github.com/Yelp/nrtsearch/pull/816)