### PR TITLE
fix unit in bootstrap metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ java {
 }
 
 allprojects {
-    version = '1.0.0-beta.5'
+    version = '1.0.0-beta.6'
     group = 'com.yelp.nrtsearch'
 }
 

--- a/src/main/java/com/yelp/nrtsearch/server/plugins/PluginsService.java
+++ b/src/main/java/com/yelp/nrtsearch/server/plugins/PluginsService.java
@@ -78,7 +78,7 @@ public class PluginsService {
       BootstrapMetrics.pluginInitializationTimer
           .labelValues(
               descriptor.getPluginMetadata().getName(), descriptor.getPluginMetadata().getVersion())
-          .set((System.nanoTime() - startNs) / 1000000.0);
+          .set((System.nanoTime() - startNs) / 1_000_000_000);
     }
     return loadedPlugins;
   }


### PR DESCRIPTION
There are a unit conversion bug in bootstrap metrics when I creating the dashboards.
https://grafana.yelpcorp.com/goto/nragcMpHR?orgId=1