### PR TITLE
change precision on bootstrap metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ java {
 }
 
 allprojects {
-    version = '1.0.0-beta.6'
+    version = '1.0.0-beta.7'
     group = 'com.yelp.nrtsearch'
 }
 

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
@@ -218,7 +218,7 @@ public class NrtsearchServer {
             .build()
             .start();
     logger.info("Server started, listening on " + configuration.getPort() + " for messages");
-    BootstrapMetrics.nrtsearchBootstrapTimer.set((System.nanoTime() - startNs) / 1_000_000_000);
+    BootstrapMetrics.nrtsearchBootstrapTimer.set((System.nanoTime() - startNs) / 1_000_000_000.0);
   }
 
   @VisibleForTesting

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NrtDataManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NrtDataManager.java
@@ -205,7 +205,7 @@ public class NrtDataManager implements Closeable {
         // graphing tools.
         BootstrapMetrics.dataRestoreTimer
             .labelValues(getBaseIndexName(indexIdentifier), indexIdentifier)
-            .set(timeSpentMs / 1_000);
+            .set(timeSpentMs / 1_000.0);
       }
 
       lastPointState = pointState;

--- a/src/main/java/com/yelp/nrtsearch/server/plugins/PluginsService.java
+++ b/src/main/java/com/yelp/nrtsearch/server/plugins/PluginsService.java
@@ -78,7 +78,7 @@ public class PluginsService {
       BootstrapMetrics.pluginInitializationTimer
           .labelValues(
               descriptor.getPluginMetadata().getName(), descriptor.getPluginMetadata().getVersion())
-          .set((System.nanoTime() - startNs) / 1_000_000_000);
+          .set((System.nanoTime() - startNs) / 1_000_000_000.0);
     }
     return loadedPlugins;
   }


### PR DESCRIPTION
change the precision on bootstrap metrics as some of the tasks take only dozens of MS.
verified by jshell
```
waziqi@dev374-uswest1adevc:~/nrtsearch$ jshell
|  Welcome to JShell -- Version 21.0.6
|  For an introduction type: /help intro

jshell> (123456789L - 123L)/ 1_000_000_000
$1 ==> 0

jshell> (123456789L - 123L)/ 1_000_000_000.0
$2 ==> 0.123456666

```