### PR TITLE
Fix POLYGON field when indexing no values

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/field/PolygonfieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/PolygonfieldDef.java
@@ -85,7 +85,7 @@ public class PolygonfieldDef extends IndexableFieldDef<Struct> implements Polygo
             new StoredField(this.getName(), ObjectFieldDef.jsonToStruct(fieldValue).toByteArray()));
       }
     }
-    if (hasDocValues()) {
+    if (hasDocValues() && !fieldValues.isEmpty()) {
       document.add(
           new BinaryDocValuesField(
               getName(), new BytesRef(ObjectFieldDef.jsonToStructList(fieldValues).toByteArray())));

--- a/src/test/java/com/yelp/nrtsearch/server/field/PolygonFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/PolygonFieldDefTest.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import com.google.gson.Gson;
 import com.google.protobuf.ListValue;
@@ -29,6 +30,7 @@ import com.yelp.nrtsearch.server.grpc.AddDocumentRequest.MultiValuedField;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.IOException;
 import java.util.*;
+import org.apache.lucene.document.Document;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -293,6 +295,18 @@ public class PolygonFieldDefTest extends ServerTestCase {
       Struct struct = hit.getFieldsOrThrow("polygon").getFieldValue(0).getStructValue();
       assertEquals("Polygon", struct.getFieldsOrThrow("type").getStringValue());
     }
+  }
+
+  @Test
+  public void testEmptyIndexing() {
+    PolygonfieldDef polygonfieldDef =
+        new PolygonfieldDef(
+            "polygon",
+            Field.newBuilder().setStore(true).setStoreDocValues(true).build(),
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
+    Document document = new Document();
+    polygonfieldDef.parseDocumentField(document, Collections.emptyList(), Collections.emptyList());
+    assertEquals(0, document.getFields().size());
   }
 
   private SearchResponse doQuery(Query query, String retrieveFields) {


### PR DESCRIPTION
When a `POLYGON` is in an `OBJECT` field, it can be passed an empty list of `fieldValues`. When doc values are enabled, the empty values will still be added to the document. This causes a problem because the search field data is not present.

This fix makes it so no data is added to the document when the input list is empty.