### PR TITLE
Support null for sort field values

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,5 +18,6 @@ A high performance gRPC server, with optional REST APIs on top of `Apache Lucene
    index_live_settings
    docker_compose
    server_configuration
+   reserved_values
    development
    vector_search

--- a/docs/reserved_values.rst
+++ b/docs/reserved_values.rst
@@ -1,0 +1,6 @@
+Reserved Values
+=================
+This section contains values that are reserved for internal use. These values should be avoided to prevent
+unexpected behavior. The reserved values are:
+
+- **%NULL_SORT_VALUE%**: Used to denote a null value for a sort field in LastHitInfo. Use of this value in your documents may cause queries that use searchAfter to behave incorrectly.

--- a/src/main/java/com/yelp/nrtsearch/server/search/collectors/SortFieldCollector.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/collectors/SortFieldCollector.java
@@ -91,7 +91,9 @@ public class SortFieldCollector extends DocCollector {
     lastHitBuilder.setLastDocId(lastHit.doc);
     for (Object fv : fd.fields) {
       String fvstr;
-      if (fv instanceof BytesRef) {
+      if (fv == null) {
+        fvstr = SortParser.NULL_SORT_VALUE;
+      } else if (fv instanceof BytesRef) {
         fvstr = ((BytesRef) fv).utf8ToString();
       } else {
         fvstr = fv.toString();

--- a/src/main/java/com/yelp/nrtsearch/server/search/sort/SortParser.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/sort/SortParser.java
@@ -39,7 +39,7 @@ import org.apache.lucene.util.BytesRef;
 public class SortParser {
   public static final BiFunction<SortField, Object, CompositeFieldValue>
       DEFAULT_SORT_VALUE_EXTRACTOR = (sortField, value) -> getValueForSortField(sortField, value);
-  public static final String NULL_SORT_VALUE = "NULL_SORT_VALUE";
+  public static final String NULL_SORT_VALUE = "%NULL_SORT_VALUE%";
   private static final String DOCID = "docid";
   private static final String SCORE = "score";
 

--- a/src/main/java/com/yelp/nrtsearch/server/search/sort/SortParser.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/sort/SortParser.java
@@ -39,6 +39,7 @@ import org.apache.lucene.util.BytesRef;
 public class SortParser {
   public static final BiFunction<SortField, Object, CompositeFieldValue>
       DEFAULT_SORT_VALUE_EXTRACTOR = (sortField, value) -> getValueForSortField(sortField, value);
+  public static final String NULL_SORT_VALUE = "NULL_SORT_VALUE";
   private static final String DOCID = "docid";
   private static final String SCORE = "score";
 
@@ -165,7 +166,12 @@ public class SortParser {
       throw new IllegalArgumentException(
           String.format("field: %s does not support sorting", field.getFieldName()));
     }
-    return ((Sortable) fd).parseLastValue(stringValue);
+
+    if (NULL_SORT_VALUE.equals(stringValue)) {
+      return null;
+    } else {
+      return ((Sortable) fd).parseLastValue(stringValue);
+    }
   }
 
   /**
@@ -178,6 +184,10 @@ public class SortParser {
    */
   private static SearchResponse.Hit.CompositeFieldValue getValueForSortField(
       SortField sortField, Object sortValue) {
+    if (sortValue == null) {
+      return SearchResponse.Hit.CompositeFieldValue.newBuilder().build();
+    }
+
     var fieldValue = SearchResponse.Hit.FieldValue.newBuilder();
     switch (sortField.getType()) {
       case DOC:

--- a/src/test/resources/search/SortWithMissingRegisterFields.json
+++ b/src/test/resources/search/SortWithMissingRegisterFields.json
@@ -1,0 +1,22 @@
+{
+  "indexName": "sort_with_missing",
+  "field": [
+    {
+      "name": "doc_id",
+      "type": "_ID",
+      "storeDocValues": true
+    },
+    {
+      "name": "int_field",
+      "type": "INT",
+      "search": true,
+      "storeDocValues": true
+    },
+    {
+      "name": "string_field",
+      "type": "ATOM",
+      "search": true,
+      "storeDocValues": true
+    }
+  ]
+}


### PR DESCRIPTION
For certain field types (like `TEXT`), sort values will be `null` when a document has no value. This causes issues for our sort processing.

For the `LastHitInfo`, the gRPC interface does not make it easy to express `null` for sort field values. I propose using the string `NULL_SORT_VALUE`. This seems specific enough to avoid collision with actual data.

When populating the sort values in each `Hit`, an empty `CompositeFieldValue` is used. This is what you would see if you tried to retrieve the field.

The `searchAfter` parsing has been updated to accept the `NULL_SORT_VALUE` string value.