### PR TITLE
Fix FilteredSSDVFacetCounts NPE when there are no hits

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/facet/FilteredSSDVFacetCounts.java
+++ b/src/main/java/com/yelp/nrtsearch/server/facet/FilteredSSDVFacetCounts.java
@@ -370,6 +370,9 @@ public class FilteredSSDVFacetCounts extends Facets {
     if (path.length > 0) {
       throw new IllegalArgumentException("path should be 0 length");
     }
+    if (counts == null) {
+      return null;
+    }
     return getDim(dim, topN);
   }
 


### PR DESCRIPTION
When `FilteredSSDVFacetCounts` was updated to lucene 10, initializing the count array changed to being lazy. We need to add a check to avoid a NPE when there are no hits.