### PR TITLE
Add sum aggregation support

### DIFF
--- a/clientlib/src/main/java/com/yelp/nrtsearch/server/collectors/BucketOrder.java
+++ b/clientlib/src/main/java/com/yelp/nrtsearch/server/collectors/BucketOrder.java
@@ -121,7 +121,7 @@ public class BucketOrder {
     if (nestedCollector == null) {
       throw new IllegalArgumentException("Nested collector not found: " + grpcBucketOrder.getKey());
     }
-    // collectors that can be used for ordering: max, min, and now sum
+    // collectors that can be used for ordering: max, min, and sum
     if (nestedCollector.getCollectorsCase() == CollectorsCase.MAX
         || nestedCollector.getCollectorsCase() == CollectorsCase.MIN
         || nestedCollector.getCollectorsCase() == CollectorsCase.SUM) {

--- a/clientlib/src/main/java/com/yelp/nrtsearch/server/collectors/BucketOrder.java
+++ b/clientlib/src/main/java/com/yelp/nrtsearch/server/collectors/BucketOrder.java
@@ -121,9 +121,10 @@ public class BucketOrder {
     if (nestedCollector == null) {
       throw new IllegalArgumentException("Nested collector not found: " + grpcBucketOrder.getKey());
     }
-    // currently, max and min are the only aggregations that can be used for ordering
+    // collectors that can be used for ordering: max, min, and now sum
     if (nestedCollector.getCollectorsCase() == CollectorsCase.MAX
-        || nestedCollector.getCollectorsCase() == CollectorsCase.MIN) {
+        || nestedCollector.getCollectorsCase() == CollectorsCase.MIN
+        || nestedCollector.getCollectorsCase() == CollectorsCase.SUM) {
       return new NestedCollectorOrder(
           ValueType.NESTED_COLLECTOR,
           grpcBucketOrder.getOrder(),

--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -1103,6 +1103,15 @@ message NumericRangeType {
     bool maxInclusive = 5;
 }
 
+// Definition of collector to find a sum of double values over documents. Currently only allows for script based
+// value production.
+message SumCollector {
+    oneof ValueSource {
+        // Script to produce a double value
+        Script script = 1;
+    }
+}
+
 // Facet request definition
 message Facet {
     // Dimension (field)
@@ -1258,7 +1267,8 @@ message Collector {
         MaxCollector max = 6;
         // Collector for finding a min double value from collected documents
         MinCollector min = 7;
-
+        // Collector for finding a sum of double values from collected documents
+        SumCollector sum = 8;
     }
     // Nested collectors that define sub-aggregations per bucket, supported by bucket based collectors
     map<string, Collector> nestedCollectors = 3;

--- a/docs/additional_collectors.rst
+++ b/docs/additional_collectors.rst
@@ -19,6 +19,8 @@ The SearchRequest can define a mapping of additional collectors to compute aggre
             MaxCollector max = 6;
             //Collector for finding a min double value from collected documents.
             MinCollector min = 7;
+            //Collector for summing double values from collected documents.
+            SumCollector sum = 8;
         }
         //Nested collectors that define sub-aggregations per bucket, supported by bucket based collectors.
         map<string, Collector> nestedCollectors = 3;
@@ -141,6 +143,22 @@ Collect a minimum double value across all aggregated documents. This value is pr
 
     //Definition of collector to find a min double value over documents. Currently only allows for script based value production.
     message MinCollector {
+        oneof ValueSource {
+            //Script to produce a double value
+            Script script = 1;
+        }
+    }
+
+This aggregation is usable for sorting buckets as a nested collector.
+
+Sum Collector
+-----------------------------
+Collect a sum of double values across all aggregated documents. This value is produced by execution of a score script per document.
+
+.. code-block::
+
+    //Definition of collector to find a sum of double values over documents. Currently only allows for script based value production.
+    message SumCollector {
         oneof ValueSource {
             //Script to produce a double value
             Script script = 1;

--- a/src/main/java/com/yelp/nrtsearch/server/search/collectors/CollectorCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/collectors/CollectorCreator.java
@@ -25,6 +25,7 @@ import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.search.collectors.additional.FilterCollectorManager;
 import com.yelp.nrtsearch.server.search.collectors.additional.MaxCollectorManager;
 import com.yelp.nrtsearch.server.search.collectors.additional.MinCollectorManager;
+import com.yelp.nrtsearch.server.search.collectors.additional.SumCollectorManager;
 import com.yelp.nrtsearch.server.search.collectors.additional.TermsCollectorManager;
 import com.yelp.nrtsearch.server.search.collectors.additional.TopHitsCollectorManager;
 import com.yelp.nrtsearch.server.utils.StructValueTransformer;
@@ -120,6 +121,11 @@ public class CollectorCreator {
           throw new IllegalArgumentException("MinCollector cannot have nested collectors");
         }
         return () -> new MinCollectorManager(name, collector.getMin(), context);
+      case SUM:
+        if (!nestedCollectorSuppliers.isEmpty()) {
+          throw new IllegalArgumentException("SumCollector cannot have nested collectors");
+        }
+        return () -> new SumCollectorManager(name, collector.getSum(), context);
       default:
         throw new IllegalArgumentException(
             "Unknown Collector type: " + collector.getCollectorsCase());

--- a/src/main/java/com/yelp/nrtsearch/server/search/collectors/additional/SumCollectorManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/collectors/additional/SumCollectorManager.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.collectors.additional;
+
+import com.google.protobuf.DoubleValue;
+import com.yelp.nrtsearch.server.grpc.CollectorResult;
+import com.yelp.nrtsearch.server.script.ScoreScript;
+import com.yelp.nrtsearch.server.search.collectors.AdditionalCollectorManager;
+import com.yelp.nrtsearch.server.search.collectors.CollectorCreatorContext;
+import com.yelp.nrtsearch.server.search.collectors.additional.SumCollectorManager.SumCollector;
+import java.io.IOException;
+import java.util.Collection;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.ScoreMode;
+
+/**
+ * Collector to find a sum of double values of a collection of documents. Currently, supports values
+ * based on a {@link ScoreScript} definition.
+ */
+public class SumCollectorManager
+    implements AdditionalCollectorManager<SumCollector, CollectorResult> {
+  static final double INITIAL_VALUE = 0.0;
+
+  private final String name;
+  private final ValueProvider valueProvider;
+
+  /**
+   * Constructor.
+   *
+   * @param name collector name
+   * @param grpcSumCollector sum collector definition message
+   * @param context collector creation context
+   */
+  public SumCollectorManager(
+      String name,
+      com.yelp.nrtsearch.server.grpc.SumCollector grpcSumCollector,
+      CollectorCreatorContext context) {
+    this.name = name;
+
+    if (grpcSumCollector.getValueSourceCase()
+        == com.yelp.nrtsearch.server.grpc.SumCollector.ValueSourceCase.SCRIPT) {
+      valueProvider =
+          new ScriptValueProvider(
+              grpcSumCollector.getScript(), context.getIndexState().docLookup, 0.0);
+    } else {
+      throw new IllegalArgumentException(
+          "Unknown value source: " + grpcSumCollector.getValueSourceCase());
+    }
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public SumCollector newCollector() throws IOException {
+    return new SumCollector();
+  }
+
+  @Override
+  public CollectorResult reduce(Collection<SumCollector> collectors) throws IOException {
+    CollectorResult.Builder resultBuilder = CollectorResult.newBuilder();
+    double sumValue = INITIAL_VALUE;
+    for (SumCollector collector : collectors) {
+      sumValue += collector.sumValue;
+    }
+    resultBuilder.setDoubleResult(DoubleValue.newBuilder().setValue(sumValue).build());
+
+    return resultBuilder.build();
+  }
+
+  public class SumCollector implements Collector {
+    double sumValue = INITIAL_VALUE;
+
+    @Override
+    public LeafCollector getLeafCollector(LeafReaderContext leafContext) throws IOException {
+      return new SumLeafCollector(leafContext);
+    }
+
+    @Override
+    public ScoreMode scoreMode() {
+      return valueProvider.needsScore() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+    }
+
+    public class SumLeafCollector implements LeafCollector {
+      final LeafValueProvider leafValueProvider;
+
+      public SumLeafCollector(LeafReaderContext leafContext) throws IOException {
+        leafValueProvider = valueProvider.getLeafValueProvider(leafContext);
+      }
+
+      @Override
+      public void setScorer(Scorable scorer) throws IOException {
+        leafValueProvider.setScorer(scorer);
+      }
+
+      @Override
+      public void collect(int doc) throws IOException {
+        double value = leafValueProvider.getValue(doc);
+        sumValue += value;
+      }
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/MinCollectorManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/collectors/additional/MinCollectorManagerTest.java
@@ -18,12 +18,12 @@ package com.yelp.nrtsearch.server.search.collectors.additional;
 import static org.junit.Assert.*;
 
 import com.yelp.nrtsearch.server.grpc.*;
-import com.yelp.nrtsearch.server.utils.MinMaxUtilTest;
+import com.yelp.nrtsearch.server.utils.CollectorUtilTest;
 import io.grpc.StatusRuntimeException;
 import java.util.*;
 import org.junit.Test;
 
-public class MinCollectorManagerTest extends MinMaxUtilTest {
+public class MinCollectorManagerTest extends CollectorUtilTest {
   @Test
   public void testMinCollectorAllDocs() {
     minCollectorAllDocs(MATCH_ALL_QUERY, FIELD_SCRIPT);

--- a/src/test/java/com/yelp/nrtsearch/server/utils/CollectorUtilTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/utils/CollectorUtilTest.java
@@ -28,7 +28,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.NoMergePolicy;
 import org.junit.ClassRule;
 
-public class MinMaxUtilTest extends ServerTestCase {
+public class CollectorUtilTest extends ServerTestCase {
   @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
   protected static final Script FIELD_SCRIPT =
       Script.newBuilder().setLang(JsScriptEngine.LANG).setSource("value_field").build();


### PR DESCRIPTION
I was giving the vscode agent mode a try, so this was written entirely by AI.

This adds support for sum aggregations of double values produced by a script. This aggregation also supports being used to order parent buckets.