### PR TITLE
Add new field in config for maxClauseCount

### DIFF
--- a/docs/server_configuration.rst
+++ b/docs/server_configuration.rst
@@ -107,6 +107,11 @@ Example server configuration
      - If enabled, the primary will enable keepAlive on the replication channel with keepAliveTime 1 minute and keepAliveTimeout 10 seconds. Replicas ignore this option.
      - true
 
+   * - maxClauseCount
+     - int
+     - Maximum number of clauses in a query
+     - 1024
+
 .. list-table:: `Threadpool Configuration <https://github.com/Yelp/nrtsearch/blob/master/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java>`_ (``threadPoolConfiguration.*``)
    :widths: 25 10 50 25
    :header-rows: 1
@@ -350,3 +355,4 @@ Example server configuration
      - list
      - List of index file extensions to preload. Including '*' will preload all files.
      - ['*']
+

--- a/src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java
@@ -65,6 +65,7 @@ public class NrtsearchConfig {
   private static final String DEFAULT_SERVICE_NAME = "nrtsearch-generic";
   static final long DEFAULT_INITIAL_SYNC_PRIMARY_WAIT_MS = 30000;
   static final long DEFAULT_INITIAL_SYNC_MAX_TIME_MS = 600000; // 10m
+  private static final int DEFAULT_MAX_CLAUSE_COUNT = 1024;
   private final int port;
   private final int replicationPort;
   private final int replicaReplicationPortPingInterval;
@@ -93,6 +94,7 @@ public class NrtsearchConfig {
   private final FileCopyConfig fileCopyConfig;
   private final ScriptCacheConfig scriptCacheConfig;
   private final boolean deadlineCancellation;
+  private final int maxClauseCount;
   private final StateConfig stateConfig;
   private final IndexStartConfig indexStartConfig;
   private final int discoveryFileUpdateIntervalMs;
@@ -170,6 +172,7 @@ public class NrtsearchConfig {
     deadlineCancellation = configReader.getBoolean("deadlineCancellation", true);
     stateConfig = StateConfig.fromConfig(configReader);
     indexStartConfig = IndexStartConfig.fromConfig(configReader);
+    maxClauseCount = configReader.getInteger("maxClauseCount", DEFAULT_MAX_CLAUSE_COUNT);
     discoveryFileUpdateIntervalMs =
         configReader.getInteger(
             "discoveryFileUpdateIntervalMs", ReplicationServerClient.FILE_UPDATE_INTERVAL_MS);
@@ -329,6 +332,10 @@ public class NrtsearchConfig {
 
   public StateConfig getStateConfig() {
     return stateConfig;
+  }
+
+  public int getMaxClauseCount() {
+    return maxClauseCount;
   }
 
   public IndexStartConfig getIndexStartConfig() {

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
@@ -381,6 +381,7 @@ public class NrtsearchServer {
       ExecutorFactory.init(configuration.getThreadPoolConfiguration());
 
       initQueryCache(configuration);
+      initMaxClauseCount(configuration);
       initExtendableComponents(configuration, plugins);
 
       this.globalState = GlobalState.createState(configuration, remoteBackend);
@@ -437,6 +438,11 @@ public class NrtsearchServer {
                 cacheConfig.getSkipCacheFactor());
       }
       IndexSearcher.setDefaultQueryCache(queryCache);
+    }
+
+    @VisibleForTesting
+    static void initMaxClauseCount(NrtsearchConfig configuration) {
+      IndexSearcher.setMaxClauseCount(configuration.getMaxClauseCount());
     }
 
     private void initExtendableComponents(NrtsearchConfig configuration, List<Plugin> plugins) {

--- a/src/test/java/com/yelp/nrtsearch/server/config/NrtsearchConfigTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/NrtsearchConfigTest.java
@@ -218,4 +218,18 @@ public class NrtsearchConfigTest {
     NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals(DirectoryFactory.MMapGrouping.NONE, luceneConfig.getMMapGrouping());
   }
+
+  @Test
+  public void testDefaultMaxClauseCount() {
+    String config = "nodeName: \"server_foo\"";
+    NrtsearchConfig luceneConfig = getForConfig(config);
+    assertEquals(1024, luceneConfig.getMaxClauseCount());
+  }
+
+  @Test
+  public void testCustomMaxClauseCount() {
+    String config = "maxClauseCount: 2048";
+    NrtsearchConfig luceneConfig = getForConfig(config);
+    assertEquals(2048, luceneConfig.getMaxClauseCount());
+  }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/NrtsearchServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/NrtsearchServerTest.java
@@ -1263,6 +1263,29 @@ public class NrtsearchServerTest {
     assertTrue(queryCache instanceof NrtQueryCache);
   }
 
+  @Test
+  public void testInitMaxClauseCount() {
+    int originalMaxClauseCount = IndexSearcher.getMaxClauseCount();
+    try {
+      String defaultConfig = "nodeName: \"test_node\"";
+      NrtsearchConfig defaultConfiguration =
+          new NrtsearchConfig(new ByteArrayInputStream(defaultConfig.getBytes()));
+
+      LuceneServerImpl.initMaxClauseCount(defaultConfiguration);
+      assertEquals(1024, IndexSearcher.getMaxClauseCount()); // Default value
+
+      String customConfig = String.join("\n", "nodeName: \"test_node\"", "maxClauseCount: 2048");
+      NrtsearchConfig customConfiguration =
+          new NrtsearchConfig(new ByteArrayInputStream(customConfig.getBytes()));
+
+      LuceneServerImpl.initMaxClauseCount(customConfiguration);
+      assertEquals(2048, IndexSearcher.getMaxClauseCount());
+
+    } finally {
+      IndexSearcher.setMaxClauseCount(originalMaxClauseCount);
+    }
+  }
+
   public static List<VirtualField> getQueryVirtualFields() {
     List<VirtualField> fields = new ArrayList<>();
     fields.add(


### PR DESCRIPTION
Currently, [TooManyClauses](https://javadoc.io/doc/org.apache.lucene/lucene-core/9.4.1/org/apache/lucene/search/IndexSearcher.TooManyClauses.html) exception is thrown when running a fuzzy query on a large index. 
This pull request introduces a new configuration parameter, `maxClauseCount`, to bump the maximum number of clauses in a query. 

### Configuration Updates:
* Added `maxClauseCount` as a configurable parameter in the `NrtsearchConfig` class with a default value of `1024`. This parameter is now parsed from the configuration file and stored as a field. (`src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java`: [[1]](diffhunk://#diff-2a3baba0fdda6088abccbf7ff5c17154f481240dc3ed57fe4b4a7871473495c7R68) [[2]](diffhunk://#diff-2a3baba0fdda6088abccbf7ff5c17154f481240dc3ed57fe4b4a7871473495c7R97) [[3]](diffhunk://#diff-2a3baba0fdda6088abccbf7ff5c17154f481240dc3ed57fe4b4a7871473495c7R175) [[4]](diffhunk://#diff-2a3baba0fdda6088abccbf7ff5c17154f481240dc3ed57fe4b4a7871473495c7R337-R340)

* Updated the server configuration documentation to include the new `maxClauseCount` parameter. (`docs/server_configuration.rst`: [docs/server_configuration.rstR110-R114](diffhunk://#diff-cd37b156b0135a5e034a4fe5aeb2e0994c72457a046b8b366c15f24f9d33bed5R110-R114))

### Server Initialization:
* Added a new method, `initMaxClauseCount`, in `LuceneServerImpl` to set the `maxClauseCount` value in `IndexSearcher` during server initialization. (`src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java`: [[1]](diffhunk://#diff-3ef56a436815c3587af5cc3e5ad21d43f6f682b5a153e3d302b8f90b7a2b8328R384) [[2]](diffhunk://#diff-3ef56a436815c3587af5cc3e5ad21d43f6f682b5a153e3d302b8f90b7a2b8328R443-R447)

### Testing Enhancements:
* Added unit tests in `NrtsearchConfigTest` to verify the default and custom values of `maxClauseCount` parsed from the configuration. (`src/test/java/com/yelp/nrtsearch/server/config/NrtsearchConfigTest.java`: [src/test/java/com/yelp/nrtsearch/server/config/NrtsearchConfigTest.javaR221-R234](diffhunk://#diff-384726cf6c04938a80a2d30bd1e98fbad3fdc969dbeccef9b8e4d98bdde50924R221-R234))

* Added a test in `NrtsearchServerTest` to validate the behavior of the `initMaxClauseCount` method, ensuring that the `maxClauseCount` value is correctly applied to `IndexSearcher`. (`src/test/java/com/yelp/nrtsearch/server/grpc/NrtsearchServerTest.java`: [src/test/java/com/yelp/nrtsearch/server/grpc/NrtsearchServerTest.javaR1266-R1288](diffhunk://#diff-4945d9726d09bc17a31b9f3e097fdd81959e8803d424e7683e9defe0d96d811cR1266-R1288))

./gradlew clean installDist test   successfully builds project
Run nrtsearch locally and verified the count changes if added in config.