### PR TITLE
feat(plugin): add ingestion plugin framework and example implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ java {
 }
 
 allprojects {
-    version = '1.0.0-beta.10'
+    version = '1.0.0-beta.11'
     group = 'com.yelp.nrtsearch'
 }
 

--- a/example-plugin/build.gradle
+++ b/example-plugin/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     testImplementation libs.grpc.testing
     testImplementation libs.junit
     testImplementation libs.protobuf.java
+    testImplementation("org.awaitility:awaitility:4.3.0")
 }
 
 distributions {

--- a/example-plugin/src/test/java/com/yelp/nrtsearch/plugins/example/ExamplePluginTest.java
+++ b/example-plugin/src/test/java/com/yelp/nrtsearch/plugins/example/ExamplePluginTest.java
@@ -15,7 +15,9 @@
  */
 package com.yelp.nrtsearch.plugins.example;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
@@ -26,6 +28,7 @@ import com.yelp.nrtsearch.server.grpc.CustomResponse;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
 import com.yelp.nrtsearch.server.grpc.MatchQuery;
 import com.yelp.nrtsearch.server.grpc.Query;
+import com.yelp.nrtsearch.server.grpc.RefreshRequest;
 import com.yelp.nrtsearch.server.grpc.SearchRequest;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import com.yelp.nrtsearch.server.plugins.Plugin;
@@ -37,41 +40,81 @@ import java.util.stream.Stream;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
 public class ExamplePluginTest extends ServerTestCase {
   @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+  private static final String INGESTION_TEST_INDEX = ExamplePlugin.INGESTION_TEST_INDEX;
 
-  private static final ExamplePlugin examplePlugin = new ExamplePlugin(getConfig());
+  private ExamplePlugin examplePlugin;
+  private static final String FIELD_1 = "field1";
+
+  @Override
+  protected List<String> getIndices() {
+    return List.of(DEFAULT_TEST_INDEX, INGESTION_TEST_INDEX);
+  }
 
   @Override
   protected List<Plugin> getPlugins(NrtsearchConfig configuration) {
+    examplePlugin = new ExamplePlugin(configuration);
     return List.of(examplePlugin);
   }
 
   @Override
   protected FieldDefRequest getIndexDef(String name) throws IOException {
-    return getFieldsFromResourceFile("/register_fields.json");
+    if (DEFAULT_TEST_INDEX.equals(name)) {
+      return getFieldsFromResourceFile("/register_fields.json");
+    } else if (INGESTION_TEST_INDEX.equals(name)) {
+      return getFieldsFromResourceFile("/register_fields_ingestion.json");
+    } else {
+      throw new IllegalArgumentException("Unknown index: " + name);
+    }
   }
 
   @Override
   protected void initIndex(String name) throws Exception {
-    AddDocumentRequest addDocumentRequest =
-        AddDocumentRequest.newBuilder()
-            .setIndexName(name)
-            .putFields(
-                "field1",
-                MultiValuedField.newBuilder().addValue("How to use Nrtsearch<br>").build())
-            .build();
-    AddDocumentRequest addDocumentRequest2 =
-        AddDocumentRequest.newBuilder()
-            .setIndexName(name)
-            .putFields(
-                "field1",
-                MultiValuedField.newBuilder().addValue("<head>How to create plugin</head>").build())
-            .build();
-    addDocuments(Stream.of(addDocumentRequest, addDocumentRequest2));
+    // Only initialize test docs for analysis test index
+    if (DEFAULT_TEST_INDEX.equals(name)) {
+      AddDocumentRequest addDocumentRequest =
+          AddDocumentRequest.newBuilder()
+              .setIndexName(name)
+              .putFields(
+                  "field1",
+                  MultiValuedField.newBuilder().addValue("How to use Nrtsearch<br>").build())
+              .build();
+      AddDocumentRequest addDocumentRequest2 =
+          AddDocumentRequest.newBuilder()
+              .setIndexName(name)
+              .putFields(
+                  "field1",
+                  MultiValuedField.newBuilder()
+                      .addValue("<head>How to create plugin</head>")
+                      .build())
+              .build();
+      addDocuments(Stream.of(addDocumentRequest, addDocumentRequest2));
+    }
+  }
+
+  @Before
+  public void ensurePluginInitialized() throws Exception {
+    if (examplePlugin == null) {
+      for (Plugin plugin : getPlugins(getConfig())) {
+        if (plugin instanceof ExamplePlugin) {
+          examplePlugin = (ExamplePlugin) plugin;
+          break;
+        }
+      }
+    }
+  }
+
+  @After
+  public void cleanupPlugin() throws Exception {
+    if (examplePlugin != null) {
+      examplePlugin.stopIngestion();
+    }
   }
 
   @Test
@@ -119,6 +162,40 @@ public class ExamplePluginTest extends ServerTestCase {
 
     SearchResponse response = getGrpcServer().getBlockingStub().search(searchRequest);
     assertThat(response.getHitsCount()).isEqualTo(1);
+  }
+
+  @Test
+  public void testPluginIngestion() throws Exception {
+    examplePlugin.startIngestion();
+
+    await()
+        .atMost(5, SECONDS)
+        .untilAsserted(
+            () -> {
+              getGrpcServer()
+                  .getBlockingStub()
+                  .refresh(RefreshRequest.newBuilder().setIndexName(INGESTION_TEST_INDEX).build());
+
+              SearchResponse response =
+                  getGrpcServer()
+                      .getBlockingStub()
+                      .search(
+                          SearchRequest.newBuilder()
+                              .setIndexName(INGESTION_TEST_INDEX)
+                              .setStartHit(0)
+                              .setTopHits(5)
+                              .setQuery(
+                                  Query.newBuilder()
+                                      .setMatchQuery(
+                                          MatchQuery.newBuilder()
+                                              .setField("field1")
+                                              .setQuery("test doc")
+                                              .build())
+                                      .build())
+                              .build());
+
+              assertThat(response.getHitsCount()).isEqualTo(2);
+            });
   }
 
   private static NrtsearchConfig getConfig() {

--- a/example-plugin/src/test/resources/register_fields_ingestion.json
+++ b/example-plugin/src/test/resources/register_fields_ingestion.json
@@ -1,0 +1,15 @@
+{
+  "indexName": "ingestion_test_index",
+  "field": [
+    {
+      "name": "field1",
+      "type": "TEXT",
+      "search": true
+    },
+    {
+      "name": "field2",
+      "type": "TEXT",
+      "search": true
+    }
+  ]
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,3 +8,4 @@ pluginManagement {
 }
 include('clientlib')
 rootProject.name = 'nrtsearch'
+include('example-plugin')

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
@@ -94,6 +94,7 @@ import com.yelp.nrtsearch.server.monitoring.QueryCacheCollector;
 import com.yelp.nrtsearch.server.monitoring.SearchResponseCollector;
 import com.yelp.nrtsearch.server.monitoring.ThreadPoolCollector;
 import com.yelp.nrtsearch.server.monitoring.ThreadPoolCollector.RejectionCounterWrapper;
+import com.yelp.nrtsearch.server.plugins.AbstractIngestionPlugin;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.plugins.PluginsService;
 import com.yelp.nrtsearch.server.remote.RemoteBackend;
@@ -157,6 +158,7 @@ public class NrtsearchServer {
     GlobalState globalState = serverImpl.getGlobalState();
 
     registerMetrics(globalState);
+    initializeIngestionPluginState(globalState, plugins);
 
     if (configuration.getMaxConcurrentCallsPerConnectionForReplication() != -1) {
       replicationServer =
@@ -219,6 +221,15 @@ public class NrtsearchServer {
             .start();
     logger.info("Server started, listening on " + configuration.getPort() + " for messages");
     BootstrapMetrics.nrtsearchBootstrapTimer.set((System.nanoTime() - startNs) / 1_000_000_000.0);
+  }
+
+  private void initializeIngestionPluginState(GlobalState globalState, List<Plugin> plugins)
+      throws IOException {
+    for (Plugin plugin : plugins) {
+      if (plugin instanceof AbstractIngestionPlugin abstractIngestionPlugin) {
+        abstractIngestionPlugin.initializeState(globalState);
+      }
+    }
   }
 
   @VisibleForTesting

--- a/src/main/java/com/yelp/nrtsearch/server/plugins/AbstractIngestionPlugin.java
+++ b/src/main/java/com/yelp/nrtsearch/server/plugins/AbstractIngestionPlugin.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.plugins;
+
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.handler.AddDocumentHandler;
+import com.yelp.nrtsearch.server.index.IndexState;
+import com.yelp.nrtsearch.server.index.ShardState;
+import com.yelp.nrtsearch.server.state.GlobalState;
+import java.io.IOException;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class for ingestion plugins that handles state management and indexing operations. Plugin
+ * implementations: 1. Must implement startIngestion/stopIngestion to handle source-specific logic
+ * 2. Should use addDocuments/commit methods to index data during ingestion
+ */
+public abstract class AbstractIngestionPlugin extends Plugin implements IngestionPlugin {
+  private static final Logger logger = LoggerFactory.getLogger(AbstractIngestionPlugin.class);
+
+  protected final NrtsearchConfig config;
+  private GlobalState globalState;
+
+  protected AbstractIngestionPlugin(NrtsearchConfig config) {
+    this.config = config;
+  }
+
+  /**
+   * Initialize plugin state with index access. Called by NrtSearchServer when index is ready.
+   *
+   * @param globalState The global server state
+   */
+  public final void initializeState(GlobalState globalState) throws IOException {
+    if (this.globalState != null) {
+      throw new IllegalStateException("Plugin already initialized");
+    }
+    this.globalState = globalState;
+  }
+
+  /**
+   * Add documents. Available for plugin implementations to call during ingestion.
+   *
+   * @param addDocRequests List of document requests to add
+   * @return The sequence number of the indexing operation
+   * @throws IOException if there are indexing errors
+   */
+  protected final long addDocuments(List<AddDocumentRequest> addDocRequests, String indexName)
+      throws Exception {
+    return new AddDocumentHandler.DocumentIndexer(globalState, addDocRequests, indexName)
+        .runIndexingJob();
+  }
+
+  /**
+   * Commit ingested documents. Available for plugin implementations to call during ingestion.
+   *
+   * @throws IOException if there are commit errors
+   */
+  protected final void commit(String indexName) throws IOException {
+    verifyInitialized(indexName);
+    IndexState indexState = globalState.getIndexOrThrow(indexName);
+    ShardState shard = indexState.getShard(0);
+    if (shard == null) {
+      throw new IllegalStateException("No shard found for index");
+    }
+    shard.commit();
+  }
+
+  private void verifyInitialized(String indexName) throws IOException {
+    IndexState indexState = globalState.getIndexOrThrow(indexName);
+    if (indexState == null) {
+      throw new IllegalStateException("Plugin not initialized");
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    stopIngestion();
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/plugins/IngestionPlugin.java
+++ b/src/main/java/com/yelp/nrtsearch/server/plugins/IngestionPlugin.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.plugins;
+
+import java.io.IOException;
+
+/** Interface for ingestion plugins. Defines lifecycle methods that plugins must implement. */
+public interface IngestionPlugin {
+
+  /**
+   * Start ingesting documents from the source. Plugin implementations can start source connections
+   * and begin processing.
+   *
+   * @throws IOException if there are startup errors
+   */
+  void startIngestion() throws IOException;
+
+  /**
+   * Stop ingesting documents from the source. Plugin implementations should cleanup source
+   * connections and stop processing.
+   *
+   * @throws IOException if there are shutdown errors
+   */
+  void stopIngestion() throws IOException;
+}

--- a/src/test/java/com/yelp/nrtsearch/server/ServerTestCase.java
+++ b/src/test/java/com/yelp/nrtsearch/server/ServerTestCase.java
@@ -33,6 +33,7 @@ import com.yelp.nrtsearch.server.grpc.NrtsearchClientBuilder;
 import com.yelp.nrtsearch.server.grpc.RefreshRequest;
 import com.yelp.nrtsearch.server.grpc.SettingsRequest;
 import com.yelp.nrtsearch.server.grpc.StartIndexRequest;
+import com.yelp.nrtsearch.server.plugins.AbstractIngestionPlugin;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.state.GlobalState;
 import com.yelp.nrtsearch.server.utils.NrtsearchTestConfigurationFactory;
@@ -235,6 +236,11 @@ public class ServerTestCase {
             null,
             getPlugins(configuration));
     globalState = server.getGlobalState();
+    for (Plugin plugin : getPlugins(configuration)) {
+      if (plugin instanceof AbstractIngestionPlugin abstractIngestionPlugin) {
+        abstractIngestionPlugin.initializeState(globalState);
+      }
+    }
     return server;
   }
 


### PR DESCRIPTION
- Introduced AbstractIngestionPlugin base class to support ingestion plugins
- Defined IngestionPlugin interface with start/stop lifecycle methods
- Updated NrtsearchServer to initialize ingestion plugin state
- Implemented ExamplePlugin as an ingestion + analysis plugin
- Added test coverage for ingestion using Awaitility for async validation
- Registered example plugin in build and settings
- Bumped version to 1.0.0-beta.11