### PR TITLE
Add option to use separate executor to process commit tasks

### DIFF
--- a/docs/server_configuration.rst
+++ b/docs/server_configuration.rst
@@ -111,6 +111,11 @@ Example server configuration
      - int
      - Maximum number of clauses in a query
      - 1024
+   
+   * - useSeparateCommitExecutor
+     - bool
+     - If enabled, the server will use a separate executor for commit operations instead of using the indexing executor.
+     - false
 
 .. list-table:: `Threadpool Configuration <https://github.com/Yelp/nrtsearch/blob/master/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java>`_ (``threadPoolConfiguration.*``)
    :widths: 25 10 50 25
@@ -240,6 +245,21 @@ Example server configuration
      - string
      - Name prefix for threads created by vector merge threadpool executor
      - VectorMergeExecutor
+
+   * - commit.maxThreads
+     - int
+     - Size of commit threadpool executor
+     - 5
+
+   * - commit.maxBufferedItems
+     - int
+     - Max tasks that can be queued by commit threadpool executor
+     - 5
+
+   * - commit.threadNamePrefix
+     - string
+     - Name prefix for threads created by commit threadpool executor
+     - CommitExecutor
 
 .. list-table:: `Alternative Max Threads Config <https://github.com/Yelp/nrtsearch/blob/master/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java>`_ (``threadPoolConfiguration.*.maxThreads.*``)
    :widths: 25 10 50 25

--- a/src/main/java/com/yelp/nrtsearch/server/concurrent/ExecutorFactory.java
+++ b/src/main/java/com/yelp/nrtsearch/server/concurrent/ExecutorFactory.java
@@ -41,7 +41,8 @@ public class ExecutorFactory {
     FETCH,
     GRPC,
     METRICS,
-    VECTORMERGE
+    VECTORMERGE,
+    COMMIT
   }
 
   private static final Logger logger = LoggerFactory.getLogger(ExecutorFactory.class);

--- a/src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java
@@ -101,6 +101,7 @@ public class NrtsearchConfig {
   private final FSTLoadMode completionCodecLoadMode;
   private final boolean filterIncompatibleSegmentReaders;
   private final Map<String, IndexLiveSettings> indexLiveSettingsOverrides;
+  private final boolean useSeparateCommitExecutor;
 
   private final YamlConfigReader configReader;
   private final long maxConnectionAgeForReplication;
@@ -190,6 +191,7 @@ public class NrtsearchConfig {
             "mmapGrouping",
             o -> DirectoryFactory.parseMMapGrouping(o.toString()),
             DirectoryFactory.MMapGrouping.SEGMENT);
+    useSeparateCommitExecutor = configReader.getBoolean("useSeparateCommitExecutor", false);
 
     List<String> indicesWithOverrides = configReader.getKeysOrEmpty("indexLiveSettingsOverrides");
     Map<String, IndexLiveSettings> liveSettingsMap = new HashMap<>();
@@ -381,6 +383,10 @@ public class NrtsearchConfig {
   public IndexLiveSettings getLiveSettingsOverride(String indexName) {
     return indexLiveSettingsOverrides.getOrDefault(
         indexName, IndexLiveSettings.newBuilder().build());
+  }
+
+  public boolean getUseSeparateCommitExecutor() {
+    return useSeparateCommitExecutor;
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java
@@ -54,6 +54,9 @@ public class ThreadPoolConfiguration {
   public static final int DEFAULT_VECTOR_MERGE_BUFFERED_ITEMS =
       Math.max(100, 2 * DEFAULT_VECTOR_MERGE_THREADS);
 
+  public static final int DEFAULT_COMMIT_THREADS = 5;
+  public static final int DEFAULT_COMMIT_BUFFERED_ITEMS = DEFAULT_COMMIT_THREADS;
+
   /**
    * Settings for a {@link ExecutorFactory.ExecutorType}.
    *
@@ -97,7 +100,10 @@ public class ThreadPoolConfiguration {
               new ThreadPoolSettings(
                   DEFAULT_VECTOR_MERGE_THREADS,
                   DEFAULT_VECTOR_MERGE_BUFFERED_ITEMS,
-                  "VectorMergeExecutor"));
+                  "VectorMergeExecutor"),
+              ExecutorFactory.ExecutorType.COMMIT,
+              new ThreadPoolSettings(
+                  DEFAULT_COMMIT_THREADS, DEFAULT_COMMIT_BUFFERED_ITEMS, "CommitExecutor"));
 
   private final Map<ExecutorFactory.ExecutorType, ThreadPoolSettings> threadPoolSettings;
 

--- a/src/main/java/com/yelp/nrtsearch/server/handler/CommitHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/CommitHandler.java
@@ -40,7 +40,7 @@ public class CommitHandler extends Handler<CommitRequest, CommitResponse> {
   public void handle(CommitRequest commitRequest, StreamObserver<CommitResponse> responseObserver) {
     try {
       getGlobalState()
-          .submitIndexingTask(
+          .submitCommitTask(
               Context.current()
                   .wrap(
                       () -> {
@@ -82,7 +82,6 @@ public class CommitHandler extends Handler<CommitRequest, CommitResponse> {
                                     .asRuntimeException());
                           }
                         }
-                        return null;
                       }));
     } catch (RejectedExecutionException e) {
       logger.error(

--- a/src/test/java/com/yelp/nrtsearch/server/concurrent/ExecutorFactoryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/concurrent/ExecutorFactoryTest.java
@@ -273,4 +273,32 @@ public class ExecutorFactoryTest {
     assertEquals(executor.getCorePoolSize(), 5);
     assertEquals(executor.getQueue().remainingCapacity(), 10);
   }
+
+  @Test
+  public void testCommitThreadPool_default() {
+    init();
+    ThreadPoolExecutor executor =
+        (ThreadPoolExecutor)
+            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.COMMIT);
+    assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_COMMIT_THREADS);
+    assertEquals(
+        executor.getQueue().remainingCapacity(),
+        ThreadPoolConfiguration.DEFAULT_COMMIT_BUFFERED_ITEMS);
+  }
+
+  @Test
+  public void testCommitThreadPool_set() {
+    init(
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  commit:",
+            "    maxThreads: 3",
+            "    maxBufferedItems: 25"));
+    ThreadPoolExecutor executor =
+        (ThreadPoolExecutor)
+            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.COMMIT);
+    assertEquals(executor.getCorePoolSize(), 3);
+    assertEquals(executor.getQueue().remainingCapacity(), 25);
+  }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/config/ThreadPoolConfigurationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/ThreadPoolConfigurationTest.java
@@ -320,6 +320,39 @@ public class ThreadPoolConfigurationTest {
   }
 
   @Test
+  public void testCommitThreadPool_default() {
+    String config = "nodeName: node1";
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.COMMIT);
+    assertEquals(threadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_COMMIT_THREADS);
+    assertEquals(
+        threadPoolSettings.maxBufferedItems(),
+        ThreadPoolConfiguration.DEFAULT_COMMIT_BUFFERED_ITEMS);
+    assertEquals("CommitExecutor", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
+  public void testCommitThreadPool_set() {
+    String config =
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  commit:",
+            "    maxThreads: 3",
+            "    maxBufferedItems: 25",
+            "    threadNamePrefix: customCommitExecutor");
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.COMMIT);
+    assertEquals(threadPoolSettings.maxThreads(), 3);
+    assertEquals(threadPoolSettings.maxBufferedItems(), 25);
+    assertEquals("customCommitExecutor", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
   public void partialOverride() {
     String config =
         String.join(

--- a/src/test/java/com/yelp/nrtsearch/server/handler/CommitHandlerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/handler/CommitHandlerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.handler;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.yelp.nrtsearch.server.grpc.CommitRequest;
+import com.yelp.nrtsearch.server.grpc.CommitResponse;
+import com.yelp.nrtsearch.server.index.IndexState;
+import com.yelp.nrtsearch.server.state.GlobalState;
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.Future;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class CommitHandlerTest {
+
+  @Test
+  public void testHandle_usesCommitExecutor() throws Exception {
+    // Setup
+    GlobalState mockGlobalState = mock(GlobalState.class);
+    IndexState mockIndexState = mock(IndexState.class);
+    StreamObserver<CommitResponse> mockResponseObserver = mock(StreamObserver.class);
+
+    // Create a spy of CommitHandler so we can mock the getIndexState method
+    CommitHandler handler = spy(new CommitHandler(mockGlobalState));
+
+    // Configure mocks
+    doReturn(mockIndexState).when(handler).getIndexState(anyString());
+    when(mockIndexState.commit()).thenReturn(42L);
+    when(mockGlobalState.getEphemeralId()).thenReturn("test_id");
+    when(mockGlobalState.getConfiguration()).thenReturn(null); // Not used in this test
+
+    // Mock submitCommitTask to execute the runnable immediately
+    when(mockGlobalState.submitCommitTask(any(Runnable.class)))
+        .thenAnswer(
+            new Answer<Future<?>>() {
+              @Override
+              public Future<?> answer(InvocationOnMock invocation) {
+                Runnable runnable = invocation.getArgument(0);
+                runnable.run();
+                return mock(Future.class);
+              }
+            });
+
+    // Execute
+    CommitRequest request = CommitRequest.newBuilder().setIndexName("test_index").build();
+    handler.handle(request, mockResponseObserver);
+
+    // Verify interactions
+    verify(mockGlobalState).submitCommitTask(any(Runnable.class));
+    verify(mockIndexState).commit();
+
+    // Capture and verify response
+    ArgumentCaptor<CommitResponse> responseCaptor = ArgumentCaptor.forClass(CommitResponse.class);
+    verify(mockResponseObserver).onNext(responseCaptor.capture());
+    verify(mockResponseObserver).onCompleted();
+
+    CommitResponse response = responseCaptor.getValue();
+    assertEquals(42L, response.getGen());
+    assertEquals("test_id", response.getPrimaryId());
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/state/GlobalStateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/state/GlobalStateTest.java
@@ -18,9 +18,12 @@ package com.yelp.nrtsearch.server.state;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
+import com.yelp.nrtsearch.server.config.ThreadPoolConfiguration;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -28,6 +31,13 @@ import org.junit.rules.TemporaryFolder;
 public class GlobalStateTest {
 
   @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  @Before
+  public void setUp() {
+    // Initialize ExecutorFactory with default configuration
+    NrtsearchConfig defaultConfig = getConfig("nodeName: test");
+    ExecutorFactory.init(defaultConfig.getThreadPoolConfiguration());
+  }
 
   private NrtsearchConfig getConfig(String config) {
     return new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
@@ -61,5 +71,93 @@ public class GlobalStateTest {
     }
     GlobalState globalState2 = GlobalState.createState(configuration, null);
     assertTrue(globalState2.getGeneration() > gen);
+  }
+
+  @Test
+  public void testSubmitCommitTask_executesTask() throws IOException, InterruptedException {
+    String configFile = String.join("\n", "stateConfig:", "  backendType: LOCAL");
+    NrtsearchConfig configuration = getConfig(configFile);
+    GlobalState globalState = GlobalState.createState(configuration, null);
+
+    // Create a task that will modify this array when executed
+    boolean[] taskExecuted = {false};
+    globalState.submitCommitTask(() -> taskExecuted[0] = true);
+
+    // Wait a short time for the task to be executed
+    Thread.sleep(100);
+
+    // Verify the task was executed
+    assertTrue("Commit task was not executed", taskExecuted[0]);
+  }
+
+  @Test
+  public void testSubmitCommitTask_usesCorrectExecutor() throws IOException {
+    String configFile =
+        String.join(
+            "\n",
+            "stateConfig:",
+            "  backendType: LOCAL",
+            "threadPoolConfiguration:",
+            "  commit:",
+            "    maxThreads: 3",
+            "    maxBufferedItems: 25",
+            "    threadNamePrefix: TestCommitExecutor");
+    NrtsearchConfig configuration = getConfig(configFile);
+
+    // Initialize ExecutorFactory with our custom configuration
+    ExecutorFactory.init(configuration.getThreadPoolConfiguration());
+
+    GlobalState globalState = GlobalState.createState(configuration, null);
+
+    // Execute a simple task to ensure the executor is created
+    globalState.submitCommitTask(() -> {});
+
+    // The executor should now use the custom configuration
+    ThreadPoolConfiguration.ThreadPoolSettings settings =
+        globalState
+            .getThreadPoolConfiguration()
+            .getThreadPoolSettings(ExecutorFactory.ExecutorType.COMMIT);
+
+    assertEquals(3, settings.maxThreads());
+    assertEquals(25, settings.maxBufferedItems());
+    assertEquals("TestCommitExecutor", settings.threadNamePrefix());
+  }
+
+  @Test
+  public void testSubmitCommitTask_withToggleDisabled() throws IOException, InterruptedException {
+    // Create configuration with useSeparateCommitExecutor = false
+    String configFile =
+        String.join(
+            "\n", "stateConfig:", "  backendType: LOCAL", "useSeparateCommitExecutor: false");
+    NrtsearchConfig configuration = getConfig(configFile);
+    GlobalState globalState = GlobalState.createState(configuration, null);
+
+    boolean[] taskExecuted = {false};
+    globalState.submitCommitTask(() -> taskExecuted[0] = true);
+
+    // Wait a short time for the task to be executed
+    Thread.sleep(100);
+
+    // Verify the task was executed by the indexing executor
+    assertTrue("Commit task was not executed", taskExecuted[0]);
+  }
+
+  @Test
+  public void testSubmitCommitTask_withToggleEnabled() throws IOException, InterruptedException {
+    // Create configuration with useSeparateCommitExecutor = true
+    String configFile =
+        String.join(
+            "\n", "stateConfig:", "  backendType: LOCAL", "useSeparateCommitExecutor: true");
+    NrtsearchConfig configuration = getConfig(configFile);
+    GlobalState globalState = GlobalState.createState(configuration, null);
+
+    boolean[] taskExecuted = {false};
+    globalState.submitCommitTask(() -> taskExecuted[0] = true);
+
+    // Wait a short time for the task to be executed
+    Thread.sleep(100);
+
+    // Verify the task was executed by the commit executor
+    assertTrue("Commit task was not executed", taskExecuted[0]);
   }
 }


### PR DESCRIPTION
Adds the option `useSeparateCommitExecutor` to the nrtsearch config file, default false. When true, commit tasks use a separate executor for processing.

We sometimes see issues where commit tasks get backed up behind indexing tasks in the indexing executor queue. This can lead to commit requests timing out before they are processed, which keeps indexers from making progress. Using a separate pool would let the commit operation start regardless of what other indexing tasks are in progress. This should be safe, since the indexer only intends to commit completed indexing operations.

I set the default thread count/queue size for the executor to 5. In practice, there should be very few commits sent concurrently.

This code was written mostly by AI.