### PR TITLE
Add maxFullFlushMergeWaitMillis to index settings

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
@@ -1421,7 +1421,8 @@ message IndexSettings {
     // implementation that has a public constructor taking a single File argument default: FSDirectory.
     // This implementation will be wrapped by NRTCachingDirectory, if enabled and not using MMappedDirectory.
     google.protobuf.StringValue directory = 7;
-
+    // Maximum time in milliseconds to wait for merges when doing a full flush
+    google.protobuf.UInt64Value maxFullFlushMergeWaitMillis = 8;
 }
 
 // Index live settings

--- a/docs/index_settings.rst
+++ b/docs/index_settings.rst
@@ -67,3 +67,10 @@ nrtCachingDirectoryMaxMergeSizeMB
 When both this and nrtCachingDirectoryMaxSizeMB are > 0 and the index directory is not an MMapDirectory, adds an `NRTCachingDirectory <https://lucene.apache.org/core/8_4_0/core/org/apache/lucene/store/NRTCachingDirectory.html>`_ wrapper. Specifies the maximum size of merges that can be cached.
 
 Default: 5.0
+
+maxFullFlushMergeWaitMillis
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Maximum time in milliseconds to wait for background merges to complete when performing a full flush. If background merges are still running after this time, the flush will continue without waiting for them to finish, which may result in more segments in the index.
+
+Default: 500

--- a/src/main/java/com/yelp/nrtsearch/server/index/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/IndexState.java
@@ -532,6 +532,9 @@ public abstract class IndexState implements Closeable {
   /** Get if additional index metrics should be collected and published. */
   public abstract boolean getVerboseMetrics();
 
+  /** Maximum time in milliseconds to wait for merges when doing a full flush. */
+  public abstract long getMaxFullFlushMergeWaitMillis();
+
   @Override
   public void close() throws IOException {}
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/StateBackendServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/StateBackendServerTest.java
@@ -1586,6 +1586,7 @@ public class StateBackendServerTest {
                     .build())
             .setIndexMergeSchedulerAutoThrottle(BoolValue.newBuilder().setValue(true).build())
             .setDirectory(StringValue.newBuilder().setValue("MMapDirectory").build())
+            .setMaxFullFlushMergeWaitMillis(UInt64Value.newBuilder().setValue(500).build())
             .build();
 
     IndexSettings.Builder builder = IndexSettings.newBuilder();


### PR DESCRIPTION
Add `maxFullFlushMergeWaitMillis` to `IndexSettings`.

This parameter is used by the Lucene `IndexWriter` to control the merge on flush feature. The value controls how long to wait for small segment merges to complete during an index flush. A value of 0 skips triggering the merges at all.

This code was mostly written by AI.