### PR TITLE
Add option to use virtual threads in place of thread pools

### DIFF
--- a/docs/server_configuration.rst
+++ b/docs/server_configuration.rst
@@ -22,7 +22,7 @@ Example server configuration
     search:
       maxThreads: 4
     index:
-      maxThreads: 18
+      useVirtualThreads: true
   botoCfgPath: "/user/app/boto.cfg"
   bucketName: "nrtsearch-bucket"
   serviceName: "nrtsearch-service-test"
@@ -141,6 +141,11 @@ Example server configuration
      - Name prefix for threads created by searcher threadpool executor
      - LuceneSearchExecutor
 
+   * - search.useVirtualThreads
+     - bool
+     - Whether to use virtual threads instead of a traditional thread pool for search operations
+     - false
+
    * - index.maxThreads
      - int
      - Size of indexing threadpool executor
@@ -155,6 +160,11 @@ Example server configuration
      - string
      - Name prefix for threads created by indexing threadpool executor
      - LuceneIndexingExecutor
+
+   * - index.useVirtualThreads
+     - bool
+     - Whether to use virtual threads instead of a traditional thread pool for indexing operations
+     - false
 
    * - server.maxThreads
      - int
@@ -171,6 +181,11 @@ Example server configuration
      - Name prefix for threads created by NrtsearchServer threadpool executor
      - GrpcServerExecutor
 
+   * - server.useVirtualThreads
+     - bool
+     - Whether to use virtual threads instead of a traditional thread pool for server operations
+     - false
+
    * - replicationserver.maxThreads
      - int
      - Size of ReplicationServer threadpool executor
@@ -185,6 +200,11 @@ Example server configuration
      - string
      - Name prefix for threads created by ReplicationServer threadpool executor
      - GrpcReplicationServerExecutor
+
+   * - replicationserver.useVirtualThreads
+     - bool
+     - Whether to use virtual threads instead of a traditional thread pool for replication server operations
+     - false
 
    * - fetch.maxThreads
      - int
@@ -201,6 +221,11 @@ Example server configuration
      - Name prefix for threads created by fetch threadpool executor
      - LuceneFetchExecutor
 
+   * - fetch.useVirtualThreads
+     - bool
+     - Whether to use virtual threads instead of a traditional thread pool for fetch operations
+     - false
+
    * - grpc.maxThreads
      - int
      - Size of gRPC threadpool executor
@@ -215,6 +240,11 @@ Example server configuration
      - string
      - Name prefix for threads created by gRPC threadpool executor
      - GrpcExecutor
+
+   * - grpc.useVirtualThreads
+     - bool
+     - Whether to use virtual threads instead of a traditional thread pool for gRPC operations
+     - false
 
    * - metrics.maxThreads
      - int
@@ -231,6 +261,11 @@ Example server configuration
      - Name prefix for threads created by metrics threadpool executor
      - MetricsExecutor
 
+   * - metrics.useVirtualThreads
+     - bool
+     - Whether to use virtual threads instead of a traditional thread pool for metrics operations
+     - false
+
    * - vectormerge.maxThreads
      - int
      - Size of vector merge threadpool executor
@@ -246,6 +281,11 @@ Example server configuration
      - Name prefix for threads created by vector merge threadpool executor
      - VectorMergeExecutor
 
+   * - vectormerge.useVirtualThreads
+     - bool
+     - Whether to use virtual threads instead of a traditional thread pool for vector merge operations
+     - false
+
    * - commit.maxThreads
      - int
      - Size of commit threadpool executor
@@ -260,6 +300,11 @@ Example server configuration
      - string
      - Name prefix for threads created by commit threadpool executor
      - CommitExecutor
+
+   * - commit.useVirtualThreads
+     - bool
+     - Whether to use virtual threads instead of a traditional thread pool for commit operations
+     - false
 
 .. list-table:: `Alternative Max Threads Config <https://github.com/Yelp/nrtsearch/blob/master/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java>`_ (``threadPoolConfiguration.*.maxThreads.*``)
    :widths: 25 10 50 25

--- a/src/main/java/com/yelp/nrtsearch/server/concurrent/ExecutorServiceStatsWrapper.java
+++ b/src/main/java/com/yelp/nrtsearch/server/concurrent/ExecutorServiceStatsWrapper.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.concurrent;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * {@link ExecutorService} implementation that wraps another {@link ExecutorService} and tracks
+ * stats. Currently, only tracks the total number of tasks submitted to the executor.
+ */
+public class ExecutorServiceStatsWrapper implements ExecutorService {
+  private final ExecutorService delegate;
+  private final AtomicLong totalTasks = new AtomicLong(0);
+
+  public ExecutorServiceStatsWrapper(ExecutorService delegate) {
+    this.delegate = delegate;
+  }
+
+  /**
+   * Returns the total number of tasks submitted to this executor.
+   *
+   * @return total number of tasks
+   */
+  public long getTotalTasks() {
+    return totalTasks.get();
+  }
+
+  @Override
+  public void shutdown() {
+    delegate.shutdown();
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    return delegate.shutdownNow();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return delegate.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return delegate.isTerminated();
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return delegate.awaitTermination(timeout, unit);
+  }
+
+  @Override
+  public <T> Future<T> submit(Callable<T> task) {
+    totalTasks.incrementAndGet();
+    return delegate.submit(task);
+  }
+
+  @Override
+  public <T> Future<T> submit(Runnable task, T result) {
+    totalTasks.incrementAndGet();
+    return delegate.submit(task, result);
+  }
+
+  @Override
+  public Future<?> submit(Runnable task) {
+    totalTasks.incrementAndGet();
+    return delegate.submit(task);
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+      throws InterruptedException {
+    totalTasks.addAndGet(tasks.size());
+    return delegate.invokeAll(tasks);
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(
+      Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+      throws InterruptedException {
+    totalTasks.addAndGet(tasks.size());
+    return delegate.invokeAll(tasks, timeout, unit);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+      throws InterruptedException, ExecutionException {
+    totalTasks.addAndGet(tasks.size());
+    return delegate.invokeAny(tasks);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    totalTasks.addAndGet(tasks.size());
+    return delegate.invokeAny(tasks, timeout, unit);
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    totalTasks.incrementAndGet();
+    delegate.execute(command);
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java
@@ -63,47 +63,62 @@ public class ThreadPoolConfiguration {
    * @param maxThreads max number of threads
    * @param maxBufferedItems max number of buffered items
    * @param threadNamePrefix prefix for thread names
+   * @param useVirtualThreads whether to use virtual threads, instead of a thread pool
    */
-  public record ThreadPoolSettings(int maxThreads, int maxBufferedItems, String threadNamePrefix) {}
+  public record ThreadPoolSettings(
+      int maxThreads, int maxBufferedItems, String threadNamePrefix, boolean useVirtualThreads) {}
 
   private static final Map<ExecutorFactory.ExecutorType, ThreadPoolSettings>
       defaultThreadPoolSettings =
           Map.of(
               ExecutorFactory.ExecutorType.SEARCH,
               new ThreadPoolSettings(
-                  DEFAULT_SEARCHING_THREADS, DEFAULT_SEARCH_BUFFERED_ITEMS, "LuceneSearchExecutor"),
+                  DEFAULT_SEARCHING_THREADS,
+                  DEFAULT_SEARCH_BUFFERED_ITEMS,
+                  "LuceneSearchExecutor",
+                  false),
               ExecutorFactory.ExecutorType.INDEX,
               new ThreadPoolSettings(
                   DEFAULT_INDEXING_THREADS,
                   DEFAULT_INDEXING_BUFFERED_ITEMS,
-                  "LuceneIndexingExecutor"),
+                  "LuceneIndexingExecutor",
+                  false),
               ExecutorFactory.ExecutorType.SERVER,
               new ThreadPoolSettings(
                   DEFAULT_GRPC_SERVER_THREADS,
                   DEFAULT_GRPC_SERVER_BUFFERED_ITEMS,
-                  "GrpcServerExecutor"),
+                  "GrpcServerExecutor",
+                  false),
               ExecutorFactory.ExecutorType.REPLICATIONSERVER,
               new ThreadPoolSettings(
                   DEFAULT_GRPC_REPLICATIONSERVER_THREADS,
                   DEFAULT_GRPC_REPLICATIONSERVER_BUFFERED_ITEMS,
-                  "GrpcReplicationServerExecutor"),
+                  "GrpcReplicationServerExecutor",
+                  false),
               ExecutorFactory.ExecutorType.FETCH,
               new ThreadPoolSettings(
-                  DEFAULT_FETCH_THREADS, DEFAULT_FETCH_BUFFERED_ITEMS, "LuceneFetchExecutor"),
+                  DEFAULT_FETCH_THREADS,
+                  DEFAULT_FETCH_BUFFERED_ITEMS,
+                  "LuceneFetchExecutor",
+                  false),
               ExecutorFactory.ExecutorType.GRPC,
               new ThreadPoolSettings(
-                  DEFAULT_GRPC_THREADS, DEFAULT_GRPC_BUFFERED_ITEMS, "GrpcExecutor"),
+                  DEFAULT_GRPC_THREADS, DEFAULT_GRPC_BUFFERED_ITEMS, "GrpcExecutor", false),
               ExecutorFactory.ExecutorType.METRICS,
               new ThreadPoolSettings(
-                  DEFAULT_METRICS_THREADS, DEFAULT_METRICS_BUFFERED_ITEMS, "MetricsExecutor"),
+                  DEFAULT_METRICS_THREADS,
+                  DEFAULT_METRICS_BUFFERED_ITEMS,
+                  "MetricsExecutor",
+                  false),
               ExecutorFactory.ExecutorType.VECTORMERGE,
               new ThreadPoolSettings(
                   DEFAULT_VECTOR_MERGE_THREADS,
                   DEFAULT_VECTOR_MERGE_BUFFERED_ITEMS,
-                  "VectorMergeExecutor"),
+                  "VectorMergeExecutor",
+                  false),
               ExecutorFactory.ExecutorType.COMMIT,
               new ThreadPoolSettings(
-                  DEFAULT_COMMIT_THREADS, DEFAULT_COMMIT_BUFFERED_ITEMS, "CommitExecutor"));
+                  DEFAULT_COMMIT_THREADS, DEFAULT_COMMIT_BUFFERED_ITEMS, "CommitExecutor", false));
 
   private final Map<ExecutorFactory.ExecutorType, ThreadPoolSettings> threadPoolSettings;
 
@@ -121,8 +136,13 @@ public class ThreadPoolConfiguration {
       String threadNamePrefix =
           configReader.getString(
               poolConfigPrefix + "threadNamePrefix", defaultSettings.threadNamePrefix());
+      boolean useVirtualThreads =
+          configReader.getBoolean(
+              poolConfigPrefix + "useVirtualThreads", defaultSettings.useVirtualThreads());
       threadPoolSettings.put(
-          executorType, new ThreadPoolSettings(maxThreads, maxBufferedItems, threadNamePrefix));
+          executorType,
+          new ThreadPoolSettings(
+              maxThreads, maxBufferedItems, threadNamePrefix, useVirtualThreads));
     }
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/concurrent/ExecutorFactoryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/concurrent/ExecutorFactoryTest.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.server.concurrent;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.config.ThreadPoolConfiguration;
@@ -300,5 +301,13 @@ public class ExecutorFactoryTest {
             ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.COMMIT);
     assertEquals(executor.getCorePoolSize(), 3);
     assertEquals(executor.getQueue().remainingCapacity(), 25);
+  }
+
+  @Test
+  public void testVirtualThreadExecutor() {
+    init(String.join("\n", "threadPoolConfiguration:", "  search:", "    useVirtualThreads: true"));
+    ExecutorService executor =
+        ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.SEARCH);
+    assertTrue(executor instanceof ExecutorServiceStatsWrapper);
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/concurrent/ExecutorServiceStatsWrapperTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/concurrent/ExecutorServiceStatsWrapperTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.concurrent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class ExecutorServiceStatsWrapperTest {
+
+  @Mock private ExecutorService mockExecutorService;
+  @Mock private Future<String> mockFuture;
+  @Mock private Future<Object> mockObjectFuture;
+
+  private ExecutorServiceStatsWrapper wrapper;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    wrapper = new ExecutorServiceStatsWrapper(mockExecutorService);
+  }
+
+  @Test
+  public void testConstructor() {
+    ExecutorService executorService = mock(ExecutorService.class);
+    @SuppressWarnings("resource")
+    ExecutorServiceStatsWrapper statsWrapper = new ExecutorServiceStatsWrapper(executorService);
+    assertThat(statsWrapper.getTotalTasks()).isEqualTo(0);
+  }
+
+  @Test
+  public void testGetTotalTasksInitiallyZero() {
+    assertThat(wrapper.getTotalTasks()).isEqualTo(0);
+  }
+
+  @Test
+  public void testSubmitCallableIncrementsTaskCount() {
+    Callable<String> task = () -> "test";
+    when(mockExecutorService.submit(task)).thenReturn(mockFuture);
+
+    Future<String> result = wrapper.submit(task);
+
+    assertThat(wrapper.getTotalTasks()).isEqualTo(1);
+    assertThat(result).isEqualTo(mockFuture);
+    verify(mockExecutorService).submit(task);
+  }
+
+  @Test
+  public void testSubmitRunnableWithResultIncrementsTaskCount() {
+    Runnable task = () -> {};
+    String result = "result";
+    when(mockExecutorService.submit(task, result)).thenReturn(mockFuture);
+
+    Future<String> actualResult = wrapper.submit(task, result);
+
+    assertThat(wrapper.getTotalTasks()).isEqualTo(1);
+    assertThat(actualResult).isEqualTo(mockFuture);
+    verify(mockExecutorService).submit(task, result);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testSubmitRunnableIncrementsTaskCount() {
+    Runnable task = () -> {};
+    Future<Object> expectedFuture = mock(Future.class);
+    doReturn(expectedFuture).when(mockExecutorService).submit(task);
+
+    Future<?> result = wrapper.submit(task);
+
+    assertThat(wrapper.getTotalTasks()).isEqualTo(1);
+    assertThat(result).isEqualTo(expectedFuture);
+    verify(mockExecutorService).submit(task);
+  }
+
+  @Test
+  public void testExecuteIncrementsTaskCount() {
+    Runnable command = () -> {};
+
+    wrapper.execute(command);
+
+    assertThat(wrapper.getTotalTasks()).isEqualTo(1);
+    verify(mockExecutorService).execute(command);
+  }
+
+  @Test
+  public void testInvokeAllIncrementsTaskCountByCollectionSize() throws InterruptedException {
+    Callable<String> task1 = () -> "task1";
+    Callable<String> task2 = () -> "task2";
+    Callable<String> task3 = () -> "task3";
+    Collection<Callable<String>> tasks = Arrays.asList(task1, task2, task3);
+
+    @SuppressWarnings("unchecked")
+    List<Future<String>> expectedFutures = mock(List.class);
+    when(mockExecutorService.invokeAll(tasks)).thenReturn(expectedFutures);
+
+    List<Future<String>> result = wrapper.invokeAll(tasks);
+
+    assertThat(wrapper.getTotalTasks()).isEqualTo(3);
+    assertThat(result).isEqualTo(expectedFutures);
+    verify(mockExecutorService).invokeAll(tasks);
+  }
+
+  @Test
+  public void testInvokeAllWithTimeoutIncrementsTaskCountByCollectionSize()
+      throws InterruptedException {
+    Callable<String> task1 = () -> "task1";
+    Callable<String> task2 = () -> "task2";
+    Collection<Callable<String>> tasks = Arrays.asList(task1, task2);
+
+    @SuppressWarnings("unchecked")
+    List<Future<String>> expectedFutures = mock(List.class);
+    when(mockExecutorService.invokeAll(tasks, 10, TimeUnit.SECONDS)).thenReturn(expectedFutures);
+
+    List<Future<String>> result = wrapper.invokeAll(tasks, 10, TimeUnit.SECONDS);
+
+    assertThat(wrapper.getTotalTasks()).isEqualTo(2);
+    assertThat(result).isEqualTo(expectedFutures);
+    verify(mockExecutorService).invokeAll(tasks, 10, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void testInvokeAnyIncrementsTaskCountByCollectionSize()
+      throws InterruptedException, ExecutionException {
+    Callable<String> task1 = () -> "task1";
+    Callable<String> task2 = () -> "task2";
+    Collection<Callable<String>> tasks = Arrays.asList(task1, task2);
+
+    when(mockExecutorService.invokeAny(tasks)).thenReturn("task1");
+
+    String result = wrapper.invokeAny(tasks);
+
+    assertThat(wrapper.getTotalTasks()).isEqualTo(2);
+    assertThat(result).isEqualTo("task1");
+    verify(mockExecutorService).invokeAny(tasks);
+  }
+
+  @Test
+  public void testInvokeAnyWithTimeoutIncrementsTaskCountByCollectionSize()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    Callable<String> task1 = () -> "task1";
+    Callable<String> task2 = () -> "task2";
+    Collection<Callable<String>> tasks = Arrays.asList(task1, task2);
+
+    when(mockExecutorService.invokeAny(tasks, 10, TimeUnit.SECONDS)).thenReturn("task1");
+
+    String result = wrapper.invokeAny(tasks, 10, TimeUnit.SECONDS);
+
+    assertThat(wrapper.getTotalTasks()).isEqualTo(2);
+    assertThat(result).isEqualTo("task1");
+    verify(mockExecutorService).invokeAny(tasks, 10, TimeUnit.SECONDS);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testMultipleOperationsAccumulateTaskCount() {
+    Runnable runnable = () -> {};
+    Callable<String> callable = () -> "test";
+
+    doReturn(mockObjectFuture).when(mockExecutorService).submit(any(Runnable.class));
+    doReturn(mockFuture).when(mockExecutorService).submit(any(Callable.class));
+
+    wrapper.submit(runnable);
+    wrapper.submit(callable);
+    wrapper.execute(runnable);
+
+    assertThat(wrapper.getTotalTasks()).isEqualTo(3);
+  }
+
+  @Test
+  public void testShutdownDelegatesToUnderlyingExecutor() {
+    wrapper.shutdown();
+    verify(mockExecutorService).shutdown();
+  }
+
+  @Test
+  public void testShutdownNowDelegatesToUnderlyingExecutor() {
+    List<Runnable> expectedTasks = Arrays.asList(() -> {}, () -> {});
+    when(mockExecutorService.shutdownNow()).thenReturn(expectedTasks);
+
+    List<Runnable> result = wrapper.shutdownNow();
+
+    assertThat(result).isEqualTo(expectedTasks);
+    verify(mockExecutorService).shutdownNow();
+  }
+
+  @Test
+  public void testIsShutdownDelegatesToUnderlyingExecutor() {
+    when(mockExecutorService.isShutdown()).thenReturn(true);
+
+    boolean result = wrapper.isShutdown();
+
+    assertThat(result).isTrue();
+    verify(mockExecutorService).isShutdown();
+  }
+
+  @Test
+  public void testIsTerminatedDelegatesToUnderlyingExecutor() {
+    when(mockExecutorService.isTerminated()).thenReturn(true);
+
+    boolean result = wrapper.isTerminated();
+
+    assertThat(result).isTrue();
+    verify(mockExecutorService).isTerminated();
+  }
+
+  @Test
+  public void testAwaitTerminationDelegatesToUnderlyingExecutor() throws InterruptedException {
+    when(mockExecutorService.awaitTermination(10, TimeUnit.SECONDS)).thenReturn(true);
+
+    boolean result = wrapper.awaitTermination(10, TimeUnit.SECONDS);
+
+    assertThat(result).isTrue();
+    verify(mockExecutorService).awaitTermination(10, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void testEmptyCollectionDoesNotIncrementTaskCount() throws InterruptedException {
+    Collection<Callable<String>> emptyTasks = Arrays.asList();
+    @SuppressWarnings("unchecked")
+    List<Future<String>> emptyFutures = mock(List.class);
+    when(mockExecutorService.invokeAll(emptyTasks)).thenReturn(emptyFutures);
+
+    wrapper.invokeAll(emptyTasks);
+
+    assertThat(wrapper.getTotalTasks()).isEqualTo(0);
+    verify(mockExecutorService).invokeAll(emptyTasks);
+  }
+
+  @Test
+  public void testTaskCountThreadSafety() throws InterruptedException {
+    // Test concurrent access to task counter
+    int numThreads = 10;
+    int tasksPerThread = 100;
+    Thread[] threads = new Thread[numThreads];
+
+    doReturn(mockObjectFuture).when(mockExecutorService).submit(any(Runnable.class));
+
+    for (int i = 0; i < numThreads; i++) {
+      threads[i] =
+          new Thread(
+              () -> {
+                for (int j = 0; j < tasksPerThread; j++) {
+                  wrapper.submit(() -> {});
+                }
+              });
+    }
+
+    for (Thread thread : threads) {
+      thread.start();
+    }
+
+    for (Thread thread : threads) {
+      thread.join();
+    }
+
+    assertThat(wrapper.getTotalTasks()).isEqualTo(numThreads * tasksPerThread);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/config/ThreadPoolConfigurationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/ThreadPoolConfigurationTest.java
@@ -47,6 +47,7 @@ public class ThreadPoolConfigurationTest {
             .getThreadPoolSettings(ExecutorFactory.ExecutorType.SEARCH);
     assertEquals(threadPoolSettings.maxThreads(), 16);
     assertEquals(threadPoolSettings.maxBufferedItems(), 100);
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -62,6 +63,7 @@ public class ThreadPoolConfigurationTest {
         threadPoolSettings.maxBufferedItems(),
         ThreadPoolConfiguration.DEFAULT_SEARCH_BUFFERED_ITEMS);
     assertEquals("LuceneSearchExecutor", threadPoolSettings.threadNamePrefix());
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -81,6 +83,7 @@ public class ThreadPoolConfigurationTest {
     assertEquals(threadPoolSettings.maxThreads(), 5);
     assertEquals(threadPoolSettings.maxBufferedItems(), 10);
     assertEquals("customName", threadPoolSettings.threadNamePrefix());
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -95,6 +98,7 @@ public class ThreadPoolConfigurationTest {
         threadPoolSettings.maxBufferedItems(),
         ThreadPoolConfiguration.DEFAULT_INDEXING_BUFFERED_ITEMS);
     assertEquals("LuceneIndexingExecutor", threadPoolSettings.threadNamePrefix());
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -114,6 +118,7 @@ public class ThreadPoolConfigurationTest {
     assertEquals(threadPoolSettings.maxThreads(), 5);
     assertEquals(threadPoolSettings.maxBufferedItems(), 10);
     assertEquals("customName", threadPoolSettings.threadNamePrefix());
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -129,6 +134,7 @@ public class ThreadPoolConfigurationTest {
         threadPoolSettings.maxBufferedItems(),
         ThreadPoolConfiguration.DEFAULT_GRPC_SERVER_BUFFERED_ITEMS);
     assertEquals("GrpcServerExecutor", threadPoolSettings.threadNamePrefix());
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -148,6 +154,7 @@ public class ThreadPoolConfigurationTest {
     assertEquals(threadPoolSettings.maxThreads(), 5);
     assertEquals(threadPoolSettings.maxBufferedItems(), 10);
     assertEquals("customName", threadPoolSettings.threadNamePrefix());
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -165,6 +172,7 @@ public class ThreadPoolConfigurationTest {
         threadPoolSettings.maxBufferedItems(),
         ThreadPoolConfiguration.DEFAULT_GRPC_REPLICATIONSERVER_BUFFERED_ITEMS);
     assertEquals("GrpcReplicationServerExecutor", threadPoolSettings.threadNamePrefix());
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -185,6 +193,7 @@ public class ThreadPoolConfigurationTest {
     assertEquals(threadPoolSettings.maxThreads(), 5);
     assertEquals(threadPoolSettings.maxBufferedItems(), 10);
     assertEquals("customName", threadPoolSettings.threadNamePrefix());
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -199,6 +208,7 @@ public class ThreadPoolConfigurationTest {
         threadPoolSettings.maxBufferedItems(),
         ThreadPoolConfiguration.DEFAULT_FETCH_BUFFERED_ITEMS);
     assertEquals("LuceneFetchExecutor", threadPoolSettings.threadNamePrefix());
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -218,6 +228,7 @@ public class ThreadPoolConfigurationTest {
     assertEquals(threadPoolSettings.maxThreads(), 5);
     assertEquals(threadPoolSettings.maxBufferedItems(), 10);
     assertEquals("customName", threadPoolSettings.threadNamePrefix());
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -231,6 +242,7 @@ public class ThreadPoolConfigurationTest {
     assertEquals(
         threadPoolSettings.maxBufferedItems(), ThreadPoolConfiguration.DEFAULT_GRPC_BUFFERED_ITEMS);
     assertEquals("GrpcExecutor", threadPoolSettings.threadNamePrefix());
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -250,6 +262,7 @@ public class ThreadPoolConfigurationTest {
     assertEquals(threadPoolSettings.maxThreads(), 5);
     assertEquals(threadPoolSettings.maxBufferedItems(), 10);
     assertEquals("customName", threadPoolSettings.threadNamePrefix());
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -264,6 +277,7 @@ public class ThreadPoolConfigurationTest {
         threadPoolSettings.maxBufferedItems(),
         ThreadPoolConfiguration.DEFAULT_METRICS_BUFFERED_ITEMS);
     assertEquals("MetricsExecutor", threadPoolSettings.threadNamePrefix());
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -283,6 +297,7 @@ public class ThreadPoolConfigurationTest {
     assertEquals(threadPoolSettings.maxThreads(), 5);
     assertEquals(threadPoolSettings.maxBufferedItems(), 10);
     assertEquals("customName", threadPoolSettings.threadNamePrefix());
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -298,6 +313,7 @@ public class ThreadPoolConfigurationTest {
         threadPoolSettings.maxBufferedItems(),
         ThreadPoolConfiguration.DEFAULT_VECTOR_MERGE_BUFFERED_ITEMS);
     assertEquals("VectorMergeExecutor", threadPoolSettings.threadNamePrefix());
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -317,6 +333,7 @@ public class ThreadPoolConfigurationTest {
     assertEquals(threadPoolSettings.maxThreads(), 5);
     assertEquals(threadPoolSettings.maxBufferedItems(), 10);
     assertEquals("customName", threadPoolSettings.threadNamePrefix());
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -331,6 +348,7 @@ public class ThreadPoolConfigurationTest {
         threadPoolSettings.maxBufferedItems(),
         ThreadPoolConfiguration.DEFAULT_COMMIT_BUFFERED_ITEMS);
     assertEquals("CommitExecutor", threadPoolSettings.threadNamePrefix());
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -350,6 +368,7 @@ public class ThreadPoolConfigurationTest {
     assertEquals(threadPoolSettings.maxThreads(), 3);
     assertEquals(threadPoolSettings.maxBufferedItems(), 25);
     assertEquals("customCommitExecutor", threadPoolSettings.threadNamePrefix());
+    assertFalse(threadPoolSettings.useVirtualThreads());
   }
 
   @Test
@@ -372,12 +391,25 @@ public class ThreadPoolConfigurationTest {
         searchThreadPoolSettings.maxBufferedItems(),
         ThreadPoolConfiguration.DEFAULT_SEARCH_BUFFERED_ITEMS);
     assertEquals("customName", searchThreadPoolSettings.threadNamePrefix());
+    assertFalse(searchThreadPoolSettings.useVirtualThreads());
     ThreadPoolConfiguration.ThreadPoolSettings indexThreadPoolSettings =
         threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.INDEX);
     assertEquals(
         indexThreadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_INDEXING_THREADS);
     assertEquals(indexThreadPoolSettings.maxBufferedItems(), 14);
     assertEquals("LuceneIndexingExecutor", indexThreadPoolSettings.threadNamePrefix());
+    assertFalse(indexThreadPoolSettings.useVirtualThreads());
+  }
+
+  @Test
+  public void testUseVirtualThreads() {
+    String config =
+        String.join("\n", "threadPoolConfiguration:", "  search:", "    useVirtualThreads: true");
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.SEARCH);
+    assertTrue(threadPoolSettings.useVirtualThreads());
   }
 
   @Test


### PR DESCRIPTION
Give the options for any thread pool to be configured with the `useVirtualThreads` option (default: `false`). When this is set to `true`, all other thread pool configuration is ignored, and the `ExecutorService` is created using `Executors.newVirtualThreadPerTaskExecutor()`.

The implementation is package private, so it is hard to extract out metics. I have wrapped the service for metric collection. Currently, only the total task count is exposed.

Some of the tests were generated with AI.