### PR TITLE
Fix mapped buffer leak when using acked copy

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/handler/RecvRawFileV2Handler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/RecvRawFileV2Handler.java
@@ -97,6 +97,7 @@ public class RecvRawFileV2Handler extends Handler<FileInfo, RawFileChunk> {
             responseObserver.onNext(rawFileChunk);
             fileOffset += chunkSize;
             if (fileOffset == fileLength) {
+              maybeCloseFile();
               responseObserver.onCompleted();
             }
           }


### PR DESCRIPTION
When using acked copy for distributing data to replicas, the primary leaks buffer mappings. It appears that `onComplete` does not get called (perhaps since it already was called on the `responseObserver`?). Because of this, the `IndexInput` is never closed.

A call has been added to close the input when the copy has finished. This method is idempotent, so an extra call should cause no harm.