### PR TITLE
Updated jackson version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 aws = "1.12.768"
 grpc = "1.66.0"
-jackson = "2.17.2"
+jackson = "2.19.1"
 log4j = "2.23.1"
 lucene = "10.1.0"
 prometheus = "1.3.1"


### PR DESCRIPTION
This is required so that it matches the version in our internal plugin.