### PR TITLE
Allow updating child fields

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/field/AtomFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/AtomFieldDef.java
@@ -43,7 +43,24 @@ public class AtomFieldDef extends TextBaseFieldDef
 
   public AtomFieldDef(
       String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
-    super(name, requestField, context);
+    this(name, requestField, context, null);
+  }
+
+  /**
+   * Constructor for creating an instance of this field based on a previous instance. This is used
+   * when updating field properties.
+   *
+   * @param name name of the field
+   * @param requestField the field definition from the request
+   * @param context context for creating the field definition
+   * @param previousField the previous instance of this field definition, or null if there is none
+   */
+  protected AtomFieldDef(
+      String name,
+      Field requestField,
+      FieldDefCreator.FieldDefCreatorContext context,
+      AtomFieldDef previousField) {
+    super(name, requestField, context, previousField);
   }
 
   @Override
@@ -57,6 +74,12 @@ public class AtomFieldDef extends TextBaseFieldDef
   @Override
   public String getType() {
     return "ATOM";
+  }
+
+  @Override
+  public FieldDef createUpdatedFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    return new AtomFieldDef(name, requestField, context, this);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/field/BooleanFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/BooleanFieldDef.java
@@ -39,7 +39,24 @@ import org.apache.lucene.search.Query;
 public class BooleanFieldDef extends IndexableFieldDef<Boolean> implements TermQueryable {
   protected BooleanFieldDef(
       String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
-    super(name, requestField, context, Boolean.class);
+    this(name, requestField, context, null);
+  }
+
+  /**
+   * Constructor for creating an instance of this field based on a previous instance. This is used
+   * when updating field properties.
+   *
+   * @param name name of the field
+   * @param requestField the field definition from the request
+   * @param context context for creating the field definition
+   * @param previousField the previous instance of this field definition, or null if there is none
+   */
+  protected BooleanFieldDef(
+      String name,
+      Field requestField,
+      FieldDefCreator.FieldDefCreatorContext context,
+      BooleanFieldDef previousField) {
+    super(name, requestField, context, Boolean.class, previousField);
   }
 
   @Override
@@ -136,6 +153,12 @@ public class BooleanFieldDef extends IndexableFieldDef<Boolean> implements TermQ
   @Override
   public String getType() {
     return "BOOLEAN";
+  }
+
+  @Override
+  public FieldDef createUpdatedFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    return new BooleanFieldDef(name, requestField, context, this);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/field/ContextSuggestFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/ContextSuggestFieldDef.java
@@ -41,7 +41,24 @@ public class ContextSuggestFieldDef extends IndexableFieldDef<Void> {
    */
   protected ContextSuggestFieldDef(
       String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
-    super(name, requestField, context, Void.class);
+    this(name, requestField, context, null);
+  }
+
+  /**
+   * Constructor for creating an instance of this field based on a previous instance. This is used
+   * when updating field properties.
+   *
+   * @param name name of the field
+   * @param requestField the field definition from the request
+   * @param context context for creating the field definition
+   * @param previousField the previous instance of this field definition, or null if there is none
+   */
+  protected ContextSuggestFieldDef(
+      String name,
+      Field requestField,
+      FieldDefCreator.FieldDefCreatorContext context,
+      ContextSuggestFieldDef previousField) {
+    super(name, requestField, context, Void.class, previousField);
     this.indexAnalyzer = this.parseIndexAnalyzer(requestField);
     this.searchAnalyzer = this.parseSearchAnalyzer(requestField);
     this.postingsFormat =
@@ -62,6 +79,12 @@ public class ContextSuggestFieldDef extends IndexableFieldDef<Void> {
   @Override
   public String getType() {
     return "CONTEXT_SUGGEST";
+  }
+
+  @Override
+  public FieldDef createUpdatedFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    return new ContextSuggestFieldDef(name, requestField, context, this);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/field/DateTimeFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/DateTimeFieldDef.java
@@ -82,7 +82,24 @@ public class DateTimeFieldDef extends IndexableFieldDef<Instant>
 
   public DateTimeFieldDef(
       String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
-    super(name, requestField, context, Instant.class);
+    this(name, requestField, context, null);
+  }
+
+  /**
+   * Constructor for creating an instance of this field based on a previous instance. This is used
+   * when updating field properties.
+   *
+   * @param name name of the field
+   * @param requestField the field definition from the request
+   * @param context context for creating the field definition
+   * @param previousField the previous instance of this field definition, or null if there is none
+   */
+  protected DateTimeFieldDef(
+      String name,
+      Field requestField,
+      FieldDefCreator.FieldDefCreatorContext context,
+      DateTimeFieldDef previousField) {
+    super(name, requestField, context, Instant.class, previousField);
     dateTimeFormat = requestField.getDateTimeFormat();
     dateTimeFormatter = createDateTimeFormatter(dateTimeFormat);
   }
@@ -367,6 +384,12 @@ public class DateTimeFieldDef extends IndexableFieldDef<Instant>
   @Override
   public String getType() {
     return "DATE_TIME";
+  }
+
+  @Override
+  public FieldDef createUpdatedFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    return new DateTimeFieldDef(name, requestField, context, this);
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/field/DoubleFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/DoubleFieldDef.java
@@ -39,7 +39,24 @@ public class DoubleFieldDef extends NumberFieldDef<Double> {
 
   public DoubleFieldDef(
       String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
-    super(name, requestField, DOUBLE_PARSER, context, Double.class);
+    this(name, requestField, context, null);
+  }
+
+  /**
+   * Constructor for creating an instance of this field based on a previous instance. This is used
+   * when updating field properties.
+   *
+   * @param name name of the field
+   * @param requestField the field definition from the request
+   * @param context context for creating the field definition
+   * @param previousField the previous instance of this field definition, or null if there is none
+   */
+  protected DoubleFieldDef(
+      String name,
+      Field requestField,
+      FieldDefCreator.FieldDefCreatorContext context,
+      DoubleFieldDef previousField) {
+    super(name, requestField, DOUBLE_PARSER, context, Double.class, previousField);
   }
 
   @Override
@@ -99,6 +116,12 @@ public class DoubleFieldDef extends NumberFieldDef<Double> {
   @Override
   public String getType() {
     return "DOUBLE";
+  }
+
+  @Override
+  public FieldDef createUpdatedFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    return new DoubleFieldDef(name, requestField, context, this);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/field/FieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/FieldDef.java
@@ -15,6 +15,7 @@
  */
 package com.yelp.nrtsearch.server.field;
 
+import com.yelp.nrtsearch.server.grpc.Field;
 import java.io.Closeable;
 
 /** Base class for all field definition types. */
@@ -33,6 +34,22 @@ public abstract class FieldDef implements Closeable {
   /** Get the name of this field. */
   public String getName() {
     return name;
+  }
+
+  /**
+   * Create a new instance of the current {@link FieldDef} that is updated to use the provided
+   * request field definition. This method must not modify the current instance, but instead return
+   * a new instance with the updated properties.
+   *
+   * @param name name of the field
+   * @param requestField the field definition from the request
+   * @param context context for creating the field definition
+   * @return a new instance of the field definition with updated properties
+   */
+  public FieldDef createUpdatedFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    throw new UnsupportedOperationException(
+        String.format("Field %s does not support update", this.getName()));
   }
 
   /** Get String representation of the field type. */

--- a/src/main/java/com/yelp/nrtsearch/server/field/FieldDefCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/FieldDefCreator.java
@@ -98,6 +98,29 @@ public class FieldDefCreator {
   }
 
   /**
+   * Create a new {@link FieldDef} instance based on a previous {@link FieldDef}. This is typically
+   * used when updating a field definition in the index.
+   *
+   * @param name name of the field
+   * @param field grpc request field definition
+   * @param previousFieldDef previous field definition, or null if there is none
+   * @param context context for creating the field definition
+   * @return new field definition instance
+   */
+  public FieldDef createFieldDefFromPrevious(
+      String name, Field field, FieldDef previousFieldDef, FieldDefCreatorContext context) {
+    if (previousFieldDef == null) {
+      return createFieldDef(name, field, context);
+    }
+    FieldDef updatedFieldDef = previousFieldDef.createUpdatedFieldDef(name, field, context);
+    if (updatedFieldDef == null) {
+      throw new IllegalArgumentException(
+          "FieldDef " + previousFieldDef.getName() + " cannot be updated");
+    }
+    return updatedFieldDef;
+  }
+
+  /**
    * Create a new {@link FieldDefCreatorContext} instance.
    *
    * @param globalState global state

--- a/src/main/java/com/yelp/nrtsearch/server/field/FloatFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/FloatFieldDef.java
@@ -39,7 +39,24 @@ public class FloatFieldDef extends NumberFieldDef<Float> {
 
   public FloatFieldDef(
       String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
-    super(name, requestField, FLOAT_PARSER, context, Float.class);
+    this(name, requestField, context, null);
+  }
+
+  /**
+   * Constructor for creating an instance of this field based on a previous instance. This is used
+   * when updating field properties.
+   *
+   * @param name name of the field
+   * @param requestField the field definition from the request
+   * @param context context for creating the field definition
+   * @param previousField the previous instance of this field definition, or null if there is none
+   */
+  protected FloatFieldDef(
+      String name,
+      Field requestField,
+      FieldDefCreator.FieldDefCreatorContext context,
+      FloatFieldDef previousField) {
+    super(name, requestField, FLOAT_PARSER, context, Float.class, previousField);
   }
 
   @Override
@@ -97,6 +114,12 @@ public class FloatFieldDef extends NumberFieldDef<Float> {
   @Override
   public String getType() {
     return "FLOAT";
+  }
+
+  @Override
+  public FieldDef createUpdatedFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    return new FloatFieldDef(name, requestField, context, this);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/field/IdFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/IdFieldDef.java
@@ -43,7 +43,24 @@ public class IdFieldDef extends IndexableFieldDef<String> implements TermQueryab
 
   protected IdFieldDef(
       String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
-    super(name, requestField, context, String.class);
+    this(name, requestField, context, null);
+  }
+
+  /**
+   * Constructor for creating an instance of this field based on a previous instance. This is used
+   * when updating field properties.
+   *
+   * @param name name of the field
+   * @param requestField the field definition from the request
+   * @param context context for creating the field definition
+   * @param previousField the previous instance of this field definition, or null if there is none
+   */
+  protected IdFieldDef(
+      String name,
+      Field requestField,
+      FieldDefCreator.FieldDefCreatorContext context,
+      IdFieldDef previousField) {
+    super(name, requestField, context, String.class, previousField);
   }
 
   /**
@@ -140,6 +157,12 @@ public class IdFieldDef extends IndexableFieldDef<String> implements TermQueryab
   @Override
   public String getType() {
     return "_ID";
+  }
+
+  @Override
+  public FieldDef createUpdatedFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    return new IdFieldDef(name, requestField, context, this);
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/field/IntFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/IntFieldDef.java
@@ -38,7 +38,24 @@ public class IntFieldDef extends NumberFieldDef<Integer> {
 
   public IntFieldDef(
       String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
-    super(name, requestField, INT_PARSER, context, Integer.class);
+    this(name, requestField, context, null);
+  }
+
+  /**
+   * Constructor for creating an instance of this field based on a previous instance. This is used
+   * when updating field properties.
+   *
+   * @param name name of the field
+   * @param requestField the field definition from the request
+   * @param context context for creating the field definition
+   * @param previousField the previous instance of this field definition, or null if there is none
+   */
+  protected IntFieldDef(
+      String name,
+      Field requestField,
+      FieldDefCreator.FieldDefCreatorContext context,
+      IntFieldDef previousField) {
+    super(name, requestField, INT_PARSER, context, Integer.class, previousField);
   }
 
   @Override
@@ -95,6 +112,12 @@ public class IntFieldDef extends NumberFieldDef<Integer> {
   @Override
   public String getType() {
     return "INT";
+  }
+
+  @Override
+  public FieldDef createUpdatedFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    return new IntFieldDef(name, requestField, context, this);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/field/LatLonFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/LatLonFieldDef.java
@@ -49,7 +49,24 @@ import org.apache.lucene.search.SortField;
 public class LatLonFieldDef extends IndexableFieldDef<GeoPoint> implements Sortable, GeoQueryable {
   public LatLonFieldDef(
       String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
-    super(name, requestField, context, GeoPoint.class);
+    this(name, requestField, context, null);
+  }
+
+  /**
+   * Constructor for creating an instance of this field based on a previous instance. This is used
+   * when updating field properties.
+   *
+   * @param name name of the field
+   * @param requestField the field definition from the request
+   * @param context context for creating the field definition
+   * @param previousField the previous instance of this field definition, or null if there is none
+   */
+  protected LatLonFieldDef(
+      String name,
+      Field requestField,
+      FieldDefCreator.FieldDefCreatorContext context,
+      LatLonFieldDef previousField) {
+    super(name, requestField, context, GeoPoint.class, previousField);
   }
 
   @Override
@@ -117,6 +134,12 @@ public class LatLonFieldDef extends IndexableFieldDef<GeoPoint> implements Sorta
   @Override
   public String getType() {
     return "LAT_LON";
+  }
+
+  @Override
+  public FieldDef createUpdatedFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    return new LatLonFieldDef(name, requestField, context, this);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/field/LongFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/LongFieldDef.java
@@ -38,7 +38,24 @@ public class LongFieldDef extends NumberFieldDef<Long> {
 
   public LongFieldDef(
       String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
-    super(name, requestField, LONG_PARSER, context, Long.class);
+    this(name, requestField, context, null);
+  }
+
+  /**
+   * Constructor for creating an instance of this field based on a previous instance. This is used
+   * when updating field properties.
+   *
+   * @param name name of the field
+   * @param requestField the field definition from the request
+   * @param context context for creating the field definition
+   * @param previousField the previous instance of this field definition, or null if there is none
+   */
+  protected LongFieldDef(
+      String name,
+      Field requestField,
+      FieldDefCreator.FieldDefCreatorContext context,
+      LongFieldDef previousField) {
+    super(name, requestField, LONG_PARSER, context, Long.class, previousField);
   }
 
   @Override
@@ -95,6 +112,12 @@ public class LongFieldDef extends NumberFieldDef<Long> {
   @Override
   public String getType() {
     return "LONG";
+  }
+
+  @Override
+  public FieldDef createUpdatedFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    return new LongFieldDef(name, requestField, context, this);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/field/NumberFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/NumberFieldDef.java
@@ -71,8 +71,9 @@ public abstract class NumberFieldDef<T> extends IndexableFieldDef<T>
       Field requestField,
       Function<String, Number> fieldParser,
       FieldDefCreator.FieldDefCreatorContext context,
-      Class<T> docValuesClass) {
-    super(name, requestField, context, docValuesClass);
+      Class<T> docValuesClass,
+      NumberFieldDef<?> previousField) {
+    super(name, requestField, context, docValuesClass, previousField);
     this.fieldParser = fieldParser;
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/field/ObjectFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/ObjectFieldDef.java
@@ -44,19 +44,41 @@ import org.apache.lucene.util.BytesRef;
 
 public class ObjectFieldDef extends IndexableFieldDef<Struct> {
 
-  private final Gson gson;
+  private static final Gson GSON = new GsonBuilder().serializeNulls().create();
   private final boolean isNestedDoc;
 
   protected ObjectFieldDef(
       String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
-    super(name, requestField, context, Struct.class);
+    this(name, requestField, context, null);
+  }
+
+  /**
+   * Constructor for creating an instance of this field based on a previous instance. This is used
+   * when updating field properties.
+   *
+   * @param name name of the field
+   * @param requestField the field definition from the request
+   * @param context context for creating the field definition
+   * @param previousField the previous instance of this field definition, or null if there is none
+   */
+  protected ObjectFieldDef(
+      String name,
+      Field requestField,
+      FieldDefCreator.FieldDefCreatorContext context,
+      ObjectFieldDef previousField) {
+    super(name, requestField, context, Struct.class, previousField);
     this.isNestedDoc = requestField.getNestedDoc();
-    gson = new GsonBuilder().serializeNulls().create();
   }
 
   @Override
   public String getType() {
     return "OBJECT";
+  }
+
+  @Override
+  public FieldDef createUpdatedFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    return new ObjectFieldDef(name, requestField, context, this);
   }
 
   @Override
@@ -72,7 +94,7 @@ public class ObjectFieldDef extends IndexableFieldDef<Struct> {
       parseFieldWithChildren(documentsContext.getRootDocument(), fieldValues, facetHierarchyPaths);
     } else {
       List<Map<String, Object>> fieldValueMaps = new ArrayList<>();
-      fieldValues.stream().map(e -> gson.fromJson(e, Map.class)).forEach(fieldValueMaps::add);
+      fieldValues.stream().map(e -> GSON.fromJson(e, Map.class)).forEach(fieldValueMaps::add);
 
       List<Document> childDocuments =
           fieldValueMaps.stream()
@@ -102,7 +124,7 @@ public class ObjectFieldDef extends IndexableFieldDef<Struct> {
   public void parseFieldWithChildren(
       Document document, List<String> fieldValues, List<List<String>> facetHierarchyPaths) {
     List<Map<String, Object>> fieldValueMaps = new ArrayList<>();
-    fieldValues.stream().map(e -> gson.fromJson(e, Map.class)).forEach(fieldValueMaps::add);
+    fieldValues.stream().map(e -> GSON.fromJson(e, Map.class)).forEach(fieldValueMaps::add);
     if (isStored()) {
       for (String fieldValue : fieldValues) {
         document.add(new StoredField(this.getName(), jsonToStruct(fieldValue).toByteArray()));
@@ -147,7 +169,7 @@ public class ObjectFieldDef extends IndexableFieldDef<Struct> {
             if (childValue instanceof List) {
               for (Object e : (List<Object>) childValue) {
                 if (e instanceof List || e instanceof Map) {
-                  childrenValues.add(gson.toJson(e));
+                  childrenValues.add(GSON.toJson(e));
                 } else {
                   childrenValues.add(String.valueOf(e));
                 }

--- a/src/main/java/com/yelp/nrtsearch/server/field/PolygonfieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/PolygonfieldDef.java
@@ -40,7 +40,24 @@ public class PolygonfieldDef extends IndexableFieldDef<Struct> implements Polygo
 
   protected PolygonfieldDef(
       String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
-    super(name, requestField, context, Struct.class);
+    this(name, requestField, context, null);
+  }
+
+  /**
+   * Constructor for creating an instance of this field based on a previous instance. This is used
+   * when updating field properties.
+   *
+   * @param name name of the field
+   * @param requestField the field definition from the request
+   * @param context context for creating the field definition
+   * @param previousField the previous instance of this field definition, or null if there is none
+   */
+  protected PolygonfieldDef(
+      String name,
+      Field requestField,
+      FieldDefCreator.FieldDefCreatorContext context,
+      PolygonfieldDef previousField) {
+    super(name, requestField, context, Struct.class, previousField);
   }
 
   @Override
@@ -95,6 +112,12 @@ public class PolygonfieldDef extends IndexableFieldDef<Struct> implements Polygo
   @Override
   public String getType() {
     return "POLYGON";
+  }
+
+  @Override
+  public FieldDef createUpdatedFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    return new PolygonfieldDef(name, requestField, context, this);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/field/PrefixFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/PrefixFieldDef.java
@@ -38,7 +38,24 @@ public class PrefixFieldDef extends TextBaseFieldDef {
 
   public PrefixFieldDef(
       String parentName, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
-    super(parentName + INDEX_PREFIX, requestField, context);
+    this(parentName, requestField, context, null);
+  }
+
+  /**
+   * Constructor for creating an instance of this field based on a previous instance. This is used
+   * when updating field properties.
+   *
+   * @param parentName name of the parent text field
+   * @param requestField the field definition from the request
+   * @param context context for creating the field definition
+   * @param previousField the previous instance of this field definition, or null if there is none
+   */
+  protected PrefixFieldDef(
+      String parentName,
+      Field requestField,
+      FieldDefCreator.FieldDefCreatorContext context,
+      PrefixFieldDef previousField) {
+    super(parentName + INDEX_PREFIX, requestField, context, previousField);
     this.minChars = requestField.getIndexPrefixes().getMinChars();
     this.maxChars = requestField.getIndexPrefixes().getMaxChars();
     this.parentField = parentName;
@@ -89,6 +106,12 @@ public class PrefixFieldDef extends TextBaseFieldDef {
   @Override
   public String getType() {
     return "PREFIX";
+  }
+
+  @Override
+  public FieldDef createUpdatedFieldDef(
+      String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
+    return new PrefixFieldDef(name, requestField, context, this);
   }
 
   public int getMinChars() {

--- a/src/main/java/com/yelp/nrtsearch/server/index/FieldUpdateUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/FieldUpdateUtils.java
@@ -15,6 +15,7 @@
  */
 package com.yelp.nrtsearch.server.index;
 
+import com.google.protobuf.Descriptors;
 import com.yelp.nrtsearch.server.doc.DocLookup;
 import com.yelp.nrtsearch.server.field.FieldDef;
 import com.yelp.nrtsearch.server.field.FieldDefCreator;
@@ -29,6 +30,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.apache.lucene.search.DoubleValuesSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +41,9 @@ import org.slf4j.LoggerFactory;
 /** Static helper class to handle a request to add/update fields. */
 public class FieldUpdateUtils {
   private static final Logger logger = LoggerFactory.getLogger(FieldUpdateUtils.class);
+  // The name is not actually changeable, but it is allowed to be present to identify the field to
+  // update
+  private static final Set<String> ALLOWED_UPDATABLE_FIELDS = Set.of("name", "childFields");
 
   private FieldUpdateUtils() {}
 
@@ -70,7 +78,8 @@ public class FieldUpdateUtils {
       FieldDefCreator.FieldDefCreatorContext context) {
 
     Map<String, Field> newFields = new HashMap<>(currentFields);
-    FieldAndFacetState.Builder fieldStateBuilder = currentState.toBuilder();
+    FieldAndFacetState.Builder fieldStateBuilder =
+        initializeFieldStateBuilder(currentState, currentFields, updateFields);
     List<Field> nonVirtualFields = new ArrayList<>();
     List<Field> virtualFields = new ArrayList<>();
 
@@ -84,11 +93,10 @@ public class FieldUpdateUtils {
     }
 
     for (Field field : nonVirtualFields) {
-      if (newFields.containsKey(field.getName())) {
-        throw new IllegalArgumentException("Duplicate field registration: " + field.getName());
-      }
-      parseField(field, fieldStateBuilder, context);
-      newFields.put(field.getName(), field);
+      Field updatedField = getUpdatedField(field, newFields.get(field.getName()));
+      parseField(
+          updatedField, currentState.getFields().get(field.getName()), fieldStateBuilder, context);
+      newFields.put(updatedField.getName(), updatedField);
     }
 
     // Process the virtual fields after non-virtual fields, since they may depend on other
@@ -127,20 +135,134 @@ public class FieldUpdateUtils {
    * FieldAndFacetState.Builder}.
    *
    * @param field field to process
+   * @param previousFieldDef current field definition, or null if this is a new field
    * @param fieldStateBuilder builder for new field state
    * @param context creation context
    */
   public static void parseField(
       Field field,
+      FieldDef previousFieldDef,
       FieldAndFacetState.Builder fieldStateBuilder,
       FieldDefCreator.FieldDefCreatorContext context) {
-    FieldDef fieldDef =
-        FieldDefCreator.getInstance().createFieldDef(field.getName(), field, context);
+    FieldDef fieldDef;
+    if (previousFieldDef != null) {
+      fieldDef =
+          FieldDefCreator.getInstance()
+              .createFieldDefFromPrevious(field.getName(), field, previousFieldDef, context);
+    } else {
+      fieldDef = FieldDefCreator.getInstance().createFieldDef(field.getName(), field, context);
+    }
     fieldStateBuilder.addField(fieldDef, field);
     if (fieldDef instanceof IndexableFieldDef) {
       addChildFields((IndexableFieldDef<?>) fieldDef, fieldStateBuilder);
     }
     logger.info("REGISTER: " + fieldDef.getName() + " -> " + fieldDef);
+  }
+
+  /**
+   * Initialize a {@link FieldAndFacetState.Builder} with the current fields, excluding any fields
+   * that are being updated.
+   *
+   * @param currentState current state of the fields
+   * @param currentFields current fields
+   * @param updateFields fields to update
+   * @return a new {@link FieldAndFacetState.Builder} initialized with non-updated fields
+   */
+  private static FieldAndFacetState.Builder initializeFieldStateBuilder(
+      FieldAndFacetState currentState,
+      Map<String, Field> currentFields,
+      Iterable<Field> updateFields) {
+    Set<String> updateFieldNames =
+        StreamSupport.stream(updateFields.spliterator(), false)
+            .map(Field::getName)
+            .collect(Collectors.toSet());
+
+    FieldAndFacetState.Builder fieldStateBuilder = new FieldAndFacetState().toBuilder();
+    for (Map.Entry<String, Field> entry : currentFields.entrySet()) {
+      String fieldName = entry.getKey();
+      Field field = entry.getValue();
+      if (!updateFieldNames.contains(fieldName)) {
+        FieldDef fieldDef = currentState.getFields().get(fieldName);
+        fieldStateBuilder.addField(fieldDef, field);
+        if (fieldDef instanceof IndexableFieldDef) {
+          addChildFields((IndexableFieldDef<?>) fieldDef, fieldStateBuilder);
+        }
+      }
+    }
+    return fieldStateBuilder;
+  }
+
+  /**
+   * Get the updated {@link Field} based on the new field and the existing field. If the existing
+   * field is null, it returns the new field. If the new field has only updatable properties, it
+   * updates the existing field with the new properties and returns it.
+   *
+   * @param newField the new field or update
+   * @param oldField the existing field, or null if this is a new field
+   * @return fully materialized {@link Field} with updated properties
+   */
+  private static Field getUpdatedField(Field newField, Field oldField) {
+    Objects.requireNonNull(newField);
+    if (oldField == null) {
+      return newField;
+    }
+
+    if (hasOnlyUpdatableProperties(newField)) {
+      Map<String, Field> updatedChildFields = new HashMap<>();
+      for (Field childField : oldField.getChildFieldsList()) {
+        updatedChildFields.put(childField.getName(), childField);
+      }
+      List<Field> newChildFields = new ArrayList<>();
+
+      for (Field childField : newField.getChildFieldsList()) {
+        Field updatedChildField =
+            getUpdatedField(childField, updatedChildFields.get(childField.getName()));
+        if (updatedChildFields.containsKey(updatedChildField.getName())) {
+          updatedChildFields.put(updatedChildField.getName(), updatedChildField);
+        } else {
+          newChildFields.add(updatedChildField);
+        }
+      }
+
+      // Add old fields first to maintain order in rebuilt Field
+      List<Field> finalChildFields = new ArrayList<>();
+      for (Field childField : oldField.getChildFieldsList()) {
+        finalChildFields.add(updatedChildFields.get(childField.getName()));
+      }
+      finalChildFields.addAll(newChildFields);
+
+      Field.Builder fieldBuilder = oldField.toBuilder();
+      fieldBuilder.clearChildFields();
+      fieldBuilder.addAllChildFields(finalChildFields);
+
+      return fieldBuilder.build();
+    } else {
+      throw new IllegalArgumentException("Duplicate field registration: " + newField.getName());
+    }
+  }
+
+  /**
+   * Check if the field has only updatable properties.
+   *
+   * @param field the field to check
+   * @return true if the field has only updatable properties, false otherwise
+   */
+  static boolean hasOnlyUpdatableProperties(Field field) {
+    if (field.getChildFieldsCount() == 0) {
+      return false;
+    }
+    Set<String> fieldKeys =
+        field.getAllFields().keySet().stream()
+            .map(Descriptors.FieldDescriptor::getName)
+            .collect(Collectors.toSet());
+    fieldKeys.removeAll(ALLOWED_UPDATABLE_FIELDS);
+    if (fieldKeys.isEmpty()) {
+      return true;
+    } else {
+      logger.warn(
+          "Unable to update field {}: properties {} are not updatable", field.getName(), fieldKeys);
+      return false;
+    }
   }
 
   // recursively add all children to pendingFieldDefs

--- a/src/test/java/com/yelp/nrtsearch/server/field/AtomFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/AtomFieldDefTest.java
@@ -16,6 +16,10 @@
 package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
@@ -141,5 +145,25 @@ public class AtomFieldDefTest {
                 .setTextDocValuesType(TextDocValuesType.TEXT_DOC_VALUES_TYPE_BINARY)
                 .build());
     assertEquals(DocValuesType.BINARY, fieldDef.getDocValuesType());
+  }
+
+  @Test
+  public void testCreateUpdatedFieldDef() {
+    AtomFieldDef fieldDef =
+        createFieldDef(Field.newBuilder().setName("field").setStoreDocValues(true).build());
+    FieldDef updatedField =
+        fieldDef.createUpdatedFieldDef(
+            "field",
+            Field.newBuilder().setStoreDocValues(false).build(),
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
+    assertTrue(updatedField instanceof AtomFieldDef);
+    AtomFieldDef updatedFieldDef = (AtomFieldDef) updatedField;
+
+    assertNotSame(fieldDef, updatedFieldDef);
+    assertEquals("field", updatedFieldDef.getName());
+    assertTrue(fieldDef.hasDocValues());
+    assertFalse(updatedFieldDef.hasDocValues());
+    assertSame(fieldDef.ordinalLookupCache, updatedFieldDef.ordinalLookupCache);
+    assertSame(fieldDef.ordinalBuilderLock, updatedFieldDef.ordinalBuilderLock);
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/field/BooleanFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/BooleanFieldDefTest.java
@@ -15,13 +15,22 @@
  */
 package com.yelp.nrtsearch.server.field;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
+import com.yelp.nrtsearch.server.grpc.Field;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class BooleanFieldDefTest {
+
+  private BooleanFieldDef createFieldDef(Field field) {
+    return new BooleanFieldDef(
+        "test_field", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
+  }
 
   @Test
   public void testParseTrue() {
@@ -57,5 +66,23 @@ public class BooleanFieldDefTest {
     } catch (IllegalArgumentException ignored) {
 
     }
+  }
+
+  @Test
+  public void testCreateUpdatedFieldDef() {
+    BooleanFieldDef fieldDef =
+        createFieldDef(Field.newBuilder().setName("field").setStoreDocValues(true).build());
+    FieldDef updatedField =
+        fieldDef.createUpdatedFieldDef(
+            "field",
+            Field.newBuilder().setStoreDocValues(false).build(),
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
+    assertTrue(updatedField instanceof BooleanFieldDef);
+    BooleanFieldDef updatedFieldDef = (BooleanFieldDef) updatedField;
+
+    assertNotSame(fieldDef, updatedFieldDef);
+    assertEquals("field", updatedFieldDef.getName());
+    assertTrue(fieldDef.hasDocValues());
+    assertFalse(updatedFieldDef.hasDocValues());
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/field/DoubleFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/DoubleFieldDefTest.java
@@ -16,11 +16,15 @@
 package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
 import com.yelp.nrtsearch.server.grpc.Query;
 import com.yelp.nrtsearch.server.grpc.RangeQuery;
@@ -41,6 +45,11 @@ import org.junit.Test;
 public class DoubleFieldDefTest extends ServerTestCase {
 
   @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private DoubleFieldDef createFieldDef(Field field) {
+    return new DoubleFieldDef(
+        "test_field", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
+  }
 
   private static final String fieldName = "double_field";
   private static final List<String> values =
@@ -323,5 +332,23 @@ public class DoubleFieldDefTest extends ServerTestCase {
             .sorted()
             .collect(Collectors.toList());
     assertEquals(Arrays.asList(expectedValues), actualValues);
+  }
+
+  @Test
+  public void testCreateUpdatedFieldDef() {
+    DoubleFieldDef fieldDef =
+        createFieldDef(Field.newBuilder().setName("field").setStoreDocValues(true).build());
+    FieldDef updatedField =
+        fieldDef.createUpdatedFieldDef(
+            "field",
+            Field.newBuilder().setStoreDocValues(false).build(),
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
+    assertTrue(updatedField instanceof DoubleFieldDef);
+    DoubleFieldDef updatedFieldDef = (DoubleFieldDef) updatedField;
+
+    assertNotSame(fieldDef, updatedFieldDef);
+    assertEquals("field", updatedFieldDef.getName());
+    assertTrue(fieldDef.hasDocValues());
+    assertFalse(updatedFieldDef.hasDocValues());
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/field/FieldDefCreatorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/FieldDefCreatorTest.java
@@ -15,8 +15,10 @@
  */
 package com.yelp.nrtsearch.server.field;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -148,5 +150,22 @@ public class FieldDefCreatorTest {
     FieldDefCreator.FieldDefCreatorContext context = FieldDefCreator.createContext(mockGlobalState);
 
     assertSame(config, context.config());
+  }
+
+  @Test
+  public void testCreateFieldDefFromPreviousNullUpdatedField() {
+    FieldDef mockFieldDef = mock(FieldDef.class);
+    when(mockFieldDef.getName()).thenReturn("test_field");
+    try {
+      FieldDefCreator.getInstance()
+          .createFieldDefFromPrevious(
+              "field",
+              Field.newBuilder().build(),
+              mockFieldDef,
+              mock(FieldDefCreator.FieldDefCreatorContext.class));
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("FieldDef test_field cannot be updated", e.getMessage());
+    }
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/field/FloatFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/FloatFieldDefTest.java
@@ -16,11 +16,15 @@
 package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
 import com.yelp.nrtsearch.server.grpc.Query;
 import com.yelp.nrtsearch.server.grpc.RangeQuery;
@@ -41,6 +45,11 @@ import org.junit.Test;
 public class FloatFieldDefTest extends ServerTestCase {
 
   @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private FloatFieldDef createFieldDef(Field field) {
+    return new FloatFieldDef(
+        "test_field", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
+  }
 
   private static final String fieldName = "float_field";
   private static final List<String> values =
@@ -322,5 +331,23 @@ public class FloatFieldDefTest extends ServerTestCase {
             .sorted()
             .collect(Collectors.toList());
     assertEquals(Arrays.asList(expectedValues), actualValues);
+  }
+
+  @Test
+  public void testCreateUpdatedFieldDef() {
+    FloatFieldDef fieldDef =
+        createFieldDef(Field.newBuilder().setName("field").setStoreDocValues(true).build());
+    FieldDef updatedField =
+        fieldDef.createUpdatedFieldDef(
+            "field",
+            Field.newBuilder().setStoreDocValues(false).build(),
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
+    assertTrue(updatedField instanceof FloatFieldDef);
+    FloatFieldDef updatedFieldDef = (FloatFieldDef) updatedField;
+
+    assertNotSame(fieldDef, updatedFieldDef);
+    assertEquals("field", updatedFieldDef.getName());
+    assertTrue(fieldDef.hasDocValues());
+    assertFalse(updatedFieldDef.hasDocValues());
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/field/IntFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/IntFieldDefTest.java
@@ -16,11 +16,15 @@
 package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import com.yelp.nrtsearch.server.ServerTestCase;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
 import com.yelp.nrtsearch.server.grpc.Query;
 import com.yelp.nrtsearch.server.grpc.RangeQuery;
@@ -41,6 +45,10 @@ import org.junit.Test;
 public class IntFieldDefTest extends ServerTestCase {
 
   @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private IntFieldDef createFieldDef(Field field) {
+    return new IntFieldDef("test_field", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
+  }
 
   private static final String fieldName = "int_field";
   private static final List<String> values =
@@ -313,5 +321,23 @@ public class IntFieldDefTest extends ServerTestCase {
             .sorted()
             .collect(Collectors.toList());
     assertEquals(Arrays.asList(expectedValues), actualValues);
+  }
+
+  @Test
+  public void testCreateUpdatedFieldDef() {
+    IntFieldDef fieldDef =
+        createFieldDef(Field.newBuilder().setName("field").setStoreDocValues(true).build());
+    FieldDef updatedField =
+        fieldDef.createUpdatedFieldDef(
+            "field",
+            Field.newBuilder().setStoreDocValues(false).build(),
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
+    assertTrue(updatedField instanceof IntFieldDef);
+    IntFieldDef updatedFieldDef = (IntFieldDef) updatedField;
+
+    assertNotSame(fieldDef, updatedFieldDef);
+    assertEquals("field", updatedFieldDef.getName());
+    assertTrue(fieldDef.hasDocValues());
+    assertFalse(updatedFieldDef.hasDocValues());
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/field/LatLonFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/LatLonFieldDefTest.java
@@ -16,8 +16,11 @@
 package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import com.google.type.LatLng;
 import com.yelp.nrtsearch.server.ServerTestCase;
@@ -37,6 +40,11 @@ import org.junit.Test;
 public class LatLonFieldDefTest extends ServerTestCase {
 
   @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private LatLonFieldDef createFieldDef(Field field) {
+    return new LatLonFieldDef(
+        "test_field", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
+  }
 
   protected List<String> getIndices() {
     return Collections.singletonList(DEFAULT_TEST_INDEX);
@@ -513,5 +521,23 @@ public class LatLonFieldDefTest extends ServerTestCase {
     for (Hit hit : response.getHitsList()) {
       assertTrue(idList.contains(hit.getFieldsOrThrow("doc_id").getFieldValue(0).getTextValue()));
     }
+  }
+
+  @Test
+  public void testCreateUpdatedFieldDef() {
+    LatLonFieldDef fieldDef =
+        createFieldDef(Field.newBuilder().setName("field").setStoreDocValues(true).build());
+    FieldDef updatedField =
+        fieldDef.createUpdatedFieldDef(
+            "field",
+            Field.newBuilder().setStoreDocValues(false).build(),
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
+    assertTrue(updatedField instanceof LatLonFieldDef);
+    LatLonFieldDef updatedFieldDef = (LatLonFieldDef) updatedField;
+
+    assertNotSame(fieldDef, updatedFieldDef);
+    assertEquals("field", updatedFieldDef.getName());
+    assertTrue(fieldDef.hasDocValues());
+    assertFalse(updatedFieldDef.hasDocValues());
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/field/PolygonFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/PolygonFieldDefTest.java
@@ -16,6 +16,8 @@
 package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -37,6 +39,11 @@ import org.junit.Test;
 public class PolygonFieldDefTest extends ServerTestCase {
 
   @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private PolygonfieldDef createFieldDef(Field field) {
+    return new PolygonfieldDef(
+        "test_field", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
+  }
 
   protected List<String> getIndices() {
     return Collections.singletonList(DEFAULT_TEST_INDEX);
@@ -330,5 +337,23 @@ public class PolygonFieldDefTest extends ServerTestCase {
     for (SearchResponse.Hit hit : response.getHitsList()) {
       assertTrue(idList.contains(hit.getFieldsOrThrow("doc_id").getFieldValue(0).getTextValue()));
     }
+  }
+
+  @Test
+  public void testCreateUpdatedFieldDef() {
+    PolygonfieldDef fieldDef =
+        createFieldDef(Field.newBuilder().setName("field").setStoreDocValues(true).build());
+    FieldDef updatedField =
+        fieldDef.createUpdatedFieldDef(
+            "field",
+            Field.newBuilder().setStoreDocValues(false).build(),
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
+    assertTrue(updatedField instanceof PolygonfieldDef);
+    PolygonfieldDef updatedFieldDef = (PolygonfieldDef) updatedField;
+
+    assertNotSame(fieldDef, updatedFieldDef);
+    assertEquals("field", updatedFieldDef.getName());
+    assertTrue(fieldDef.hasDocValues());
+    assertFalse(updatedFieldDef.hasDocValues());
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/field/PrefixFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/PrefixFieldDefTest.java
@@ -35,6 +35,11 @@ import org.junit.Test;
 
 public class PrefixFieldDefTest {
 
+  private PrefixFieldDef createPrefixFieldDef(Field field) {
+    return new PrefixFieldDef(
+        "test_field", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
+  }
+
   @BeforeClass
   public static void init() {
     String configStr = "node: node1";
@@ -265,5 +270,24 @@ public class PrefixFieldDefTest {
     Query query =
         noPrefixFieldDef.getPrefixQuery(prefixQuery, MultiTermQuery.CONSTANT_SCORE_REWRITE, false);
     assertTrue(query instanceof org.apache.lucene.search.PrefixQuery);
+  }
+
+  @Test
+  public void testCreateUpdatedFieldDef() {
+    PrefixFieldDef fieldDef =
+        createPrefixFieldDef(
+            Field.newBuilder().setName("field").setSearch(true).setStoreDocValues(true).build());
+    FieldDef updatedField =
+        fieldDef.createUpdatedFieldDef(
+            "field",
+            Field.newBuilder().setStoreDocValues(false).setSearch(true).build(),
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
+    assertTrue(updatedField instanceof PrefixFieldDef);
+    PrefixFieldDef updatedFieldDef = (PrefixFieldDef) updatedField;
+
+    assertNotSame(fieldDef, updatedFieldDef);
+    assertEquals("field._index_prefix", updatedFieldDef.getName());
+    assertTrue(fieldDef.hasDocValues());
+    assertFalse(updatedFieldDef.hasDocValues());
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/field/TextFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/TextFieldDefTest.java
@@ -124,4 +124,24 @@ public class TextFieldDefTest {
       assertEquals("posIncGap must be >= 0", e.getMessage());
     }
   }
+
+  @Test
+  public void testCreateUpdatedFieldDef() {
+    TextFieldDef fieldDef =
+        createFieldDef(Field.newBuilder().setName("field").setStoreDocValues(true).build());
+    FieldDef updatedField =
+        fieldDef.createUpdatedFieldDef(
+            "field",
+            Field.newBuilder().setStoreDocValues(false).build(),
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
+    assertTrue(updatedField instanceof TextFieldDef);
+    TextFieldDef updatedFieldDef = (TextFieldDef) updatedField;
+
+    assertNotSame(fieldDef, updatedFieldDef);
+    assertEquals("field", updatedFieldDef.getName());
+    assertTrue(fieldDef.hasDocValues());
+    assertFalse(updatedFieldDef.hasDocValues());
+    assertSame(fieldDef.ordinalLookupCache, updatedFieldDef.ordinalLookupCache);
+    assertSame(fieldDef.ordinalBuilderLock, updatedFieldDef.ordinalBuilderLock);
+  }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/field/VectorFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/VectorFieldDefTest.java
@@ -17,7 +17,9 @@ package com.yelp.nrtsearch.server.field;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -63,6 +65,16 @@ import org.junit.Test;
 public class VectorFieldDefTest extends ServerTestCase {
 
   @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private VectorFieldDef.FloatVectorFieldDef createFloatFieldDef(Field field) {
+    return new VectorFieldDef.FloatVectorFieldDef(
+        "test_field", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
+  }
+
+  private VectorFieldDef.ByteVectorFieldDef createByteFieldDef(Field field) {
+    return new VectorFieldDef.ByteVectorFieldDef(
+        "test_field", field, mock(FieldDefCreator.FieldDefCreatorContext.class));
+  }
 
   public static final String VECTOR_SEARCH_INDEX_NAME = "vector_search_index";
   public static final String NESTED_VECTOR_SEARCH_INDEX_NAME = "nested_vector_search_index";
@@ -2228,5 +2240,53 @@ public class VectorFieldDefTest extends ServerTestCase {
           .getShard(0)
           .release(searcherAndTaxonomy);
     }
+  }
+
+  @Test
+  public void testCreateUpdatedFieldDef_float() {
+    VectorFieldDef<?> fieldDef =
+        createFloatFieldDef(
+            Field.newBuilder()
+                .setName("field")
+                .setStoreDocValues(true)
+                .setVectorDimensions(3)
+                .build());
+    FieldDef updatedField =
+        fieldDef.createUpdatedFieldDef(
+            "field",
+            Field.newBuilder().setStoreDocValues(false).setVectorDimensions(3).build(),
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
+    assertTrue(updatedField instanceof VectorFieldDef.FloatVectorFieldDef);
+    VectorFieldDef.FloatVectorFieldDef updatedFieldDef =
+        (VectorFieldDef.FloatVectorFieldDef) updatedField;
+
+    assertNotSame(fieldDef, updatedFieldDef);
+    assertEquals("field", updatedFieldDef.getName());
+    assertTrue(fieldDef.hasDocValues());
+    assertFalse(updatedFieldDef.hasDocValues());
+  }
+
+  @Test
+  public void testCreateUpdatedFieldDef_byte() {
+    VectorFieldDef<?> fieldDef =
+        createByteFieldDef(
+            Field.newBuilder()
+                .setName("field")
+                .setStoreDocValues(true)
+                .setVectorDimensions(3)
+                .build());
+    FieldDef updatedField =
+        fieldDef.createUpdatedFieldDef(
+            "field",
+            Field.newBuilder().setStoreDocValues(false).setVectorDimensions(3).build(),
+            mock(FieldDefCreator.FieldDefCreatorContext.class));
+    assertTrue(updatedField instanceof VectorFieldDef.ByteVectorFieldDef);
+    VectorFieldDef.ByteVectorFieldDef updatedFieldDef =
+        (VectorFieldDef.ByteVectorFieldDef) updatedField;
+
+    assertNotSame(fieldDef, updatedFieldDef);
+    assertEquals("field", updatedFieldDef.getName());
+    assertTrue(fieldDef.hasDocValues());
+    assertFalse(updatedFieldDef.hasDocValues());
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/CustomFieldTypeTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/CustomFieldTypeTest.java
@@ -101,7 +101,7 @@ public class CustomFieldTypeTest {
 
     public TestFieldDef(
         String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
-      super(name, requestField, context, Integer.class);
+      super(name, requestField, context, Integer.class, null);
     }
 
     @Override

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/UpdateFieldsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/UpdateFieldsTest.java
@@ -1,0 +1,504 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.grpc;
+
+import static com.yelp.nrtsearch.server.ServerTestCase.getFieldsFromResourceFile;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.yelp.nrtsearch.server.config.IndexStartConfig;
+import com.yelp.nrtsearch.server.field.AtomFieldDef;
+import com.yelp.nrtsearch.server.field.FieldDef;
+import com.yelp.nrtsearch.server.field.LongFieldDef;
+import com.yelp.nrtsearch.server.field.TextFieldDef;
+import com.yelp.nrtsearch.server.index.ImmutableIndexState;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class UpdateFieldsTest {
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  private static final Set<String> expectedFieldNames =
+      Set.of("doc_id", "text_field", "object_field", "int_field");
+
+  private static final Field idField =
+      Field.newBuilder()
+          .setName("doc_id")
+          .setType(FieldType._ID)
+          .setSearch(true)
+          .setStore(true)
+          .build();
+
+  private static final Field textField =
+      Field.newBuilder().setName("text_field").setType(FieldType.TEXT).setSearch(true).build();
+
+  private static final Field objectField =
+      Field.newBuilder()
+          .setName("object_field")
+          .setType(FieldType.OBJECT)
+          .addChildFields(
+              Field.newBuilder()
+                  .setName("child_field")
+                  .setType(FieldType.ATOM)
+                  .setSearch(true)
+                  .setStoreDocValues(true)
+                  .build())
+          .build();
+
+  private static final Field intField =
+      Field.newBuilder()
+          .setName("int_field")
+          .setType(FieldType.INT)
+          .setSearch(true)
+          .setStoreDocValues(true)
+          .build();
+
+  @After
+  public void cleanup() {
+    TestServer.cleanupAll();
+  }
+
+  private TestServer createPrimaryServer() throws Exception {
+    TestServer server =
+        TestServer.builder(folder)
+            .withAutoStartConfig(
+                true, Mode.PRIMARY, 0, IndexStartConfig.IndexDataLocationType.LOCAL)
+            .build();
+    server.createIndex("test_index");
+    server.startPrimaryIndex("test_index", -1, null);
+    server.registerFields(
+        "test_index", getFieldsFromResourceFile("/registerFieldsUpdateFields.json").getFieldList());
+    assertEquals(
+        createExpectedFieldMap(), getIndexState(server).getIndexStateInfo().getFieldsMap());
+    return server;
+  }
+
+  private Map<String, Field> createExpectedFieldMap() {
+    Map<String, Field> expectedFieldMap = new HashMap<>();
+    expectedFieldMap.put("doc_id", idField);
+    expectedFieldMap.put("text_field", textField);
+    expectedFieldMap.put("object_field", objectField);
+    expectedFieldMap.put("int_field", intField);
+    return expectedFieldMap;
+  }
+
+  private ImmutableIndexState getIndexState(TestServer server) throws Exception {
+    return (ImmutableIndexState) server.getGlobalState().getIndex("test_index");
+  }
+
+  @Test
+  public void testAddChildField() throws Exception {
+    TestServer primaryServer = createPrimaryServer();
+    primaryServer.registerFields(
+        "test_index",
+        List.of(
+            Field.newBuilder()
+                .setName("text_field")
+                .addChildFields(
+                    Field.newBuilder()
+                        .setName("new_child_field")
+                        .setSearch(true)
+                        .setStoreDocValues(true)
+                        .build())
+                .build()));
+    ImmutableIndexState indexState = getIndexState(primaryServer);
+    Map<String, Field> fieldMap = indexState.getIndexStateInfo().getFieldsMap();
+    assertEquals(expectedFieldNames, fieldMap.keySet());
+
+    Map<String, Field> expectedFieldMap = createExpectedFieldMap();
+    Field textFieldWithChild =
+        textField.toBuilder()
+            .addChildFields(
+                Field.newBuilder()
+                    .setName("new_child_field")
+                    .setSearch(true)
+                    .setStoreDocValues(true)
+                    .build())
+            .build();
+    expectedFieldMap.put("text_field", textFieldWithChild);
+    assertEquals(expectedFieldMap, indexState.getIndexStateInfo().getFieldsMap());
+
+    FieldDef newFieldDef = indexState.getFieldOrThrow("text_field.new_child_field");
+    assertTrue(newFieldDef instanceof AtomFieldDef);
+  }
+
+  @Test
+  public void testAddMultipleChildField() throws Exception {
+    TestServer primaryServer = createPrimaryServer();
+    primaryServer.registerFields(
+        "test_index",
+        List.of(
+            Field.newBuilder()
+                .setName("text_field")
+                .addChildFields(
+                    Field.newBuilder()
+                        .setName("new_child_field_1")
+                        .setSearch(true)
+                        .setStoreDocValues(true)
+                        .build())
+                .addChildFields(
+                    Field.newBuilder()
+                        .setName("new_child_field_2")
+                        .setType(FieldType.TEXT)
+                        .setAnalyzer(Analyzer.newBuilder().setPredefined("classic").build())
+                        .setSearch(true)
+                        .build())
+                .build()));
+    ImmutableIndexState indexState = getIndexState(primaryServer);
+    Map<String, Field> fieldMap = indexState.getIndexStateInfo().getFieldsMap();
+    assertEquals(expectedFieldNames, fieldMap.keySet());
+
+    Map<String, Field> expectedFieldMap = createExpectedFieldMap();
+    Field textFieldWithChild =
+        textField.toBuilder()
+            .addChildFields(
+                Field.newBuilder()
+                    .setName("new_child_field_1")
+                    .setSearch(true)
+                    .setStoreDocValues(true)
+                    .build())
+            .addChildFields(
+                Field.newBuilder()
+                    .setName("new_child_field_2")
+                    .setType(FieldType.TEXT)
+                    .setAnalyzer(Analyzer.newBuilder().setPredefined("classic").build())
+                    .setSearch(true)
+                    .build())
+            .build();
+    expectedFieldMap.put("text_field", textFieldWithChild);
+    assertEquals(expectedFieldMap, indexState.getIndexStateInfo().getFieldsMap());
+
+    FieldDef newFieldDef = indexState.getFieldOrThrow("text_field.new_child_field_1");
+    assertTrue(newFieldDef instanceof AtomFieldDef);
+    newFieldDef = indexState.getFieldOrThrow("text_field.new_child_field_2");
+    assertTrue(newFieldDef instanceof TextFieldDef);
+  }
+
+  @Test
+  public void testAddWithExistingChildren() throws Exception {
+    TestServer primaryServer = createPrimaryServer();
+    primaryServer.registerFields(
+        "test_index",
+        List.of(
+            Field.newBuilder()
+                .setName("object_field")
+                .addChildFields(
+                    Field.newBuilder()
+                        .setName("new_child_field_1")
+                        .setType(FieldType.LONG)
+                        .setSearch(true)
+                        .setStoreDocValues(true)
+                        .build())
+                .addChildFields(
+                    Field.newBuilder()
+                        .setName("new_child_field_2")
+                        .setType(FieldType.TEXT)
+                        .setAnalyzer(Analyzer.newBuilder().setPredefined("classic").build())
+                        .setSearch(true)
+                        .build())
+                .build()));
+    ImmutableIndexState indexState = getIndexState(primaryServer);
+    Map<String, Field> fieldMap = indexState.getIndexStateInfo().getFieldsMap();
+    assertEquals(expectedFieldNames, fieldMap.keySet());
+
+    Map<String, Field> expectedFieldMap = createExpectedFieldMap();
+    Field objectFieldWithChild =
+        objectField.toBuilder()
+            .addChildFields(
+                Field.newBuilder()
+                    .setName("new_child_field_1")
+                    .setType(FieldType.LONG)
+                    .setSearch(true)
+                    .setStoreDocValues(true)
+                    .build())
+            .addChildFields(
+                Field.newBuilder()
+                    .setName("new_child_field_2")
+                    .setType(FieldType.TEXT)
+                    .setAnalyzer(Analyzer.newBuilder().setPredefined("classic").build())
+                    .setSearch(true)
+                    .build())
+            .build();
+    expectedFieldMap.put("object_field", objectFieldWithChild);
+    assertEquals(expectedFieldMap, indexState.getIndexStateInfo().getFieldsMap());
+
+    FieldDef newFieldDef = indexState.getFieldOrThrow("object_field.child_field");
+    assertTrue(newFieldDef instanceof AtomFieldDef);
+    newFieldDef = indexState.getFieldOrThrow("object_field.new_child_field_1");
+    assertTrue(newFieldDef instanceof LongFieldDef);
+    newFieldDef = indexState.getFieldOrThrow("object_field.new_child_field_2");
+    assertTrue(newFieldDef instanceof TextFieldDef);
+  }
+
+  @Test
+  public void testAddChildrenToMultipleFields() throws Exception {
+    TestServer primaryServer = createPrimaryServer();
+    primaryServer.registerFields(
+        "test_index",
+        List.of(
+            Field.newBuilder()
+                .setName("text_field")
+                .addChildFields(
+                    Field.newBuilder()
+                        .setName("new_child_field_1")
+                        .setSearch(true)
+                        .setStoreDocValues(true)
+                        .build())
+                .addChildFields(
+                    Field.newBuilder()
+                        .setName("new_child_field_2")
+                        .setType(FieldType.TEXT)
+                        .setAnalyzer(Analyzer.newBuilder().setPredefined("classic").build())
+                        .setSearch(true)
+                        .build())
+                .build(),
+            Field.newBuilder()
+                .setName("object_field")
+                .addChildFields(
+                    Field.newBuilder()
+                        .setName("new_child_field_1")
+                        .setType(FieldType.LONG)
+                        .setSearch(true)
+                        .setStoreDocValues(true)
+                        .build())
+                .addChildFields(
+                    Field.newBuilder()
+                        .setName("new_child_field_2")
+                        .setType(FieldType.TEXT)
+                        .setAnalyzer(Analyzer.newBuilder().setPredefined("classic").build())
+                        .setSearch(true)
+                        .build())
+                .build()));
+    ImmutableIndexState indexState = getIndexState(primaryServer);
+    Map<String, Field> fieldMap = indexState.getIndexStateInfo().getFieldsMap();
+    assertEquals(expectedFieldNames, fieldMap.keySet());
+
+    Map<String, Field> expectedFieldMap = createExpectedFieldMap();
+    Field textFieldWithChild =
+        textField.toBuilder()
+            .addChildFields(
+                Field.newBuilder()
+                    .setName("new_child_field_1")
+                    .setSearch(true)
+                    .setStoreDocValues(true)
+                    .build())
+            .addChildFields(
+                Field.newBuilder()
+                    .setName("new_child_field_2")
+                    .setType(FieldType.TEXT)
+                    .setAnalyzer(Analyzer.newBuilder().setPredefined("classic").build())
+                    .setSearch(true)
+                    .build())
+            .build();
+    expectedFieldMap.put("text_field", textFieldWithChild);
+
+    Field objectFieldWithChild =
+        objectField.toBuilder()
+            .addChildFields(
+                Field.newBuilder()
+                    .setName("new_child_field_1")
+                    .setType(FieldType.LONG)
+                    .setSearch(true)
+                    .setStoreDocValues(true)
+                    .build())
+            .addChildFields(
+                Field.newBuilder()
+                    .setName("new_child_field_2")
+                    .setType(FieldType.TEXT)
+                    .setAnalyzer(Analyzer.newBuilder().setPredefined("classic").build())
+                    .setSearch(true)
+                    .build())
+            .build();
+    expectedFieldMap.put("object_field", objectFieldWithChild);
+    assertEquals(expectedFieldMap, indexState.getIndexStateInfo().getFieldsMap());
+
+    FieldDef newFieldDef = indexState.getFieldOrThrow("text_field.new_child_field_1");
+    assertTrue(newFieldDef instanceof AtomFieldDef);
+    newFieldDef = indexState.getFieldOrThrow("text_field.new_child_field_2");
+    assertTrue(newFieldDef instanceof TextFieldDef);
+
+    newFieldDef = indexState.getFieldOrThrow("object_field.child_field");
+    assertTrue(newFieldDef instanceof AtomFieldDef);
+    newFieldDef = indexState.getFieldOrThrow("object_field.new_child_field_1");
+    assertTrue(newFieldDef instanceof LongFieldDef);
+    newFieldDef = indexState.getFieldOrThrow("object_field.new_child_field_2");
+    assertTrue(newFieldDef instanceof TextFieldDef);
+  }
+
+  @Test
+  public void testAddChildAndTopLevelField() throws Exception {
+    TestServer primaryServer = createPrimaryServer();
+    primaryServer.registerFields(
+        "test_index",
+        List.of(
+            Field.newBuilder()
+                .setName("text_field")
+                .addChildFields(
+                    Field.newBuilder()
+                        .setName("new_child_field")
+                        .setSearch(true)
+                        .setStoreDocValues(true)
+                        .build())
+                .build(),
+            Field.newBuilder()
+                .setName("new_top_level_field")
+                .setType(FieldType.TEXT)
+                .setSearch(true)
+                .build()));
+    ImmutableIndexState indexState = getIndexState(primaryServer);
+
+    Map<String, Field> expectedFieldMap = createExpectedFieldMap();
+    Field textFieldWithChild =
+        textField.toBuilder()
+            .addChildFields(
+                Field.newBuilder()
+                    .setName("new_child_field")
+                    .setSearch(true)
+                    .setStoreDocValues(true)
+                    .build())
+            .build();
+    expectedFieldMap.put("text_field", textFieldWithChild);
+    expectedFieldMap.put(
+        "new_top_level_field",
+        Field.newBuilder()
+            .setName("new_top_level_field")
+            .setType(FieldType.TEXT)
+            .setSearch(true)
+            .build());
+    assertEquals(expectedFieldMap, indexState.getIndexStateInfo().getFieldsMap());
+
+    FieldDef newFieldDef = indexState.getFieldOrThrow("text_field.new_child_field");
+    assertTrue(newFieldDef instanceof AtomFieldDef);
+    newFieldDef = indexState.getFieldOrThrow("new_top_level_field");
+    assertTrue(newFieldDef instanceof TextFieldDef);
+  }
+
+  @Test
+  public void testAddNestedChildField() throws Exception {
+    TestServer primaryServer = createPrimaryServer();
+    primaryServer.registerFields(
+        "test_index",
+        List.of(
+            Field.newBuilder()
+                .setName("object_field")
+                .addChildFields(
+                    Field.newBuilder()
+                        .setName("child_field")
+                        .addChildFields(
+                            Field.newBuilder()
+                                .setName("nested_child_field")
+                                .setType(FieldType.TEXT)
+                                .setSearch(true)
+                                .setStoreDocValues(true)
+                                .build()))
+                .build()));
+    ImmutableIndexState indexState = getIndexState(primaryServer);
+    Map<String, Field> fieldMap = indexState.getIndexStateInfo().getFieldsMap();
+    assertEquals(expectedFieldNames, fieldMap.keySet());
+
+    Map<String, Field> expectedFieldMap = createExpectedFieldMap();
+
+    Field nestedChildField =
+        objectField.getChildFields(0).toBuilder()
+            .addChildFields(
+                Field.newBuilder()
+                    .setName("nested_child_field")
+                    .setType(FieldType.TEXT)
+                    .setSearch(true)
+                    .setStoreDocValues(true)
+                    .build())
+            .build();
+
+    Field objectFieldWithChild =
+        objectField.toBuilder().setChildFields(0, nestedChildField).build();
+    expectedFieldMap.put("object_field", objectFieldWithChild);
+    assertEquals(expectedFieldMap, indexState.getIndexStateInfo().getFieldsMap());
+
+    FieldDef newFieldDef =
+        indexState.getFieldOrThrow("object_field.child_field.nested_child_field");
+    assertTrue(newFieldDef instanceof TextFieldDef);
+  }
+
+  @Test
+  public void testAddNestedChildFieldToMultipleLevels() throws Exception {
+    TestServer primaryServer = createPrimaryServer();
+    primaryServer.registerFields(
+        "test_index",
+        List.of(
+            Field.newBuilder()
+                .setName("object_field")
+                .addChildFields(
+                    Field.newBuilder()
+                        .setName("child_field")
+                        .addChildFields(
+                            Field.newBuilder()
+                                .setName("nested_child_field")
+                                .setType(FieldType.TEXT)
+                                .setSearch(true)
+                                .setStoreDocValues(true)
+                                .build()))
+                .addChildFields(
+                    Field.newBuilder()
+                        .setName("new_child_field")
+                        .setType(FieldType.TEXT)
+                        .setSearch(true)
+                        .setStore(true)
+                        .build())
+                .build()));
+    ImmutableIndexState indexState = getIndexState(primaryServer);
+    Map<String, Field> fieldMap = indexState.getIndexStateInfo().getFieldsMap();
+    assertEquals(expectedFieldNames, fieldMap.keySet());
+
+    Map<String, Field> expectedFieldMap = createExpectedFieldMap();
+
+    Field nestedChildField =
+        objectField.getChildFields(0).toBuilder()
+            .addChildFields(
+                Field.newBuilder()
+                    .setName("nested_child_field")
+                    .setType(FieldType.TEXT)
+                    .setSearch(true)
+                    .setStoreDocValues(true)
+                    .build())
+            .build();
+
+    Field objectFieldWithChild =
+        objectField.toBuilder()
+            .setChildFields(0, nestedChildField)
+            .addChildFields(
+                Field.newBuilder()
+                    .setName("new_child_field")
+                    .setType(FieldType.TEXT)
+                    .setSearch(true)
+                    .setStore(true)
+                    .build())
+            .build();
+    expectedFieldMap.put("object_field", objectFieldWithChild);
+    assertEquals(expectedFieldMap, indexState.getIndexStateInfo().getFieldsMap());
+
+    FieldDef newFieldDef =
+        indexState.getFieldOrThrow("object_field.child_field.nested_child_field");
+    assertTrue(newFieldDef instanceof TextFieldDef);
+    newFieldDef = indexState.getFieldOrThrow("object_field.new_child_field");
+    assertTrue(newFieldDef instanceof TextFieldDef);
+  }
+}

--- a/src/test/resources/registerFieldsUpdateFields.json
+++ b/src/test/resources/registerFieldsUpdateFields.json
@@ -1,0 +1,34 @@
+{
+  "indexName": "test_index",
+  "field": [
+    {
+      "name": "doc_id",
+      "type": "_ID",
+      "search": true,
+      "store": true
+    },
+    {
+      "name": "text_field",
+      "type": "TEXT",
+      "search": true
+    },
+    {
+      "name": "object_field",
+      "type": "OBJECT",
+      "childFields": [
+        {
+          "name": "child_field",
+          "type": "ATOM",
+          "search": true,
+          "storeDocValues": true
+        }
+      ]
+    },
+    {
+      "name": "int_field",
+      "type": "INT",
+      "search": true,
+      "storeDocValues": true
+    }
+  ]
+}


### PR DESCRIPTION
Adds the ability to add child fields to existing fields.

The system currently treats `FieldDef` objects as (mostly) immutable singletons. This simplifies interactions, since we know the `FieldDef` cannot change during use. This solution aims to keep most those properties.

To add children to an existing field, invoke the registerFields/updateFields and provide a `Field` message of the form:
```
{
  "name": "exist_field",
  "childFields": [
    // Fields to add
  ]
}
```
This can be done recursively to add children to nested fields. When the schema update is processed, the new field information merged into the existing `Field` recursively.

Once you have the updated `Field`, new `FieldDef` instances are created that contain the changes. It is important that these be new objects, so that it does not affect any requests using the old objects. In this way, the old `FieldDef`s remain immutable.

For some fields, there is mutable information that should be shared between all `FieldDef` instances. The current usage is for the global ordinal cache in text type fields. For this reason, the previous `FieldDef` instance is used to create the updated version. This allows it to provide any shared resources during the `FieldDef` construction.

This update framework should be extendable to allow updating other field properties. However, it may be challenging for existing fields that are not `optional`.

This branch is being publish to get initial comments. This is a larger change and should probably be released as part of a minor version update.