### PR TITLE
Add config option to require indices have an _ID field

### DIFF
--- a/docs/server_configuration.rst
+++ b/docs/server_configuration.rst
@@ -117,6 +117,11 @@ Example server configuration
      - If enabled, the server will use a separate executor for commit operations instead of using the indexing executor.
      - false
 
+   * - requireIdField
+     - bool
+     - If enabled, all indices must contain an _ID field to be started.
+     - false
+
 .. list-table:: `Threadpool Configuration <https://github.com/Yelp/nrtsearch/blob/master/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java>`_ (``threadPoolConfiguration.*``)
    :widths: 25 10 50 25
    :header-rows: 1

--- a/src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java
@@ -113,6 +113,7 @@ public class NrtsearchConfig {
   private final boolean verifyReplicationIndexId;
   private final boolean useKeepAliveForReplication;
   private final DirectoryFactory.MMapGrouping mmapGrouping;
+  private final boolean requireIdField;
 
   @Inject
   public NrtsearchConfig(InputStream yamlStream) {
@@ -192,6 +193,7 @@ public class NrtsearchConfig {
             o -> DirectoryFactory.parseMMapGrouping(o.toString()),
             DirectoryFactory.MMapGrouping.SEGMENT);
     useSeparateCommitExecutor = configReader.getBoolean("useSeparateCommitExecutor", false);
+    requireIdField = configReader.getBoolean("requireIdField", false);
 
     List<String> indicesWithOverrides = configReader.getKeysOrEmpty("indexLiveSettingsOverrides");
     Map<String, IndexLiveSettings> liveSettingsMap = new HashMap<>();
@@ -387,6 +389,10 @@ public class NrtsearchConfig {
 
   public boolean getUseSeparateCommitExecutor() {
     return useSeparateCommitExecutor;
+  }
+
+  public boolean getRequireIdField() {
+    return requireIdField;
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/index/StartIndexProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/StartIndexProcessor.java
@@ -42,6 +42,7 @@ public class StartIndexProcessor {
   private final IndexStateManager indexStateManager;
   private final boolean remoteCommit;
   private final int discoveryFileUpdateIntervalMs;
+  private final boolean requireIdField;
   private static final Logger logger = LoggerFactory.getLogger(StartIndexProcessor.class);
 
   /**
@@ -53,6 +54,7 @@ public class StartIndexProcessor {
    * @param indexStateManager index state manager
    * @param remoteCommit whether to commit to remote state
    * @param discoveryFileUpdateIntervalMs interval to update backends from discovery file
+   * @param requireIdField whether the index must have an _ID field defined
    */
   public StartIndexProcessor(
       String serviceName,
@@ -60,13 +62,15 @@ public class StartIndexProcessor {
       RemoteBackend remoteBackend,
       IndexStateManager indexStateManager,
       boolean remoteCommit,
-      int discoveryFileUpdateIntervalMs) {
+      int discoveryFileUpdateIntervalMs,
+      boolean requireIdField) {
     this.serviceName = serviceName;
     this.ephemeralId = ephemeralId;
     this.remoteBackend = remoteBackend;
     this.indexStateManager = indexStateManager;
     this.remoteCommit = remoteCommit;
     this.discoveryFileUpdateIntervalMs = discoveryFileUpdateIntervalMs;
+    this.requireIdField = requireIdField;
   }
 
   public StartIndexResponse process(IndexState indexState, StartIndexRequest startIndexRequest)
@@ -96,6 +100,13 @@ public class StartIndexProcessor {
   private StartIndexResponse processInternal(
       IndexState indexState, StartIndexRequest startIndexRequest)
       throws StartIndexProcessorException {
+
+    if (requireIdField && indexState.getIdFieldDef().isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Index %s must have an _ID field defined to be started", indexState.getName()));
+    }
+
     final ShardState shardState = indexState.getShard(0);
     final Mode mode = startIndexRequest.getMode();
     final long primaryGen;

--- a/src/main/java/com/yelp/nrtsearch/server/state/BackendGlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/state/BackendGlobalState.java
@@ -450,7 +450,8 @@ public class BackendGlobalState extends GlobalState {
                 .getIndexStartConfig()
                 .getDataLocationType()
                 .equals(IndexDataLocationType.REMOTE),
-            getConfiguration().getDiscoveryFileUpdateIntervalMs());
+            getConfiguration().getDiscoveryFileUpdateIntervalMs(),
+            getConfiguration().getRequireIdField());
     try {
       return startIndexHandler.process(indexStateManager.getCurrent(), startIndexRequest);
     } catch (StartIndexProcessorException e) {

--- a/src/test/java/com/yelp/nrtsearch/server/config/NrtsearchConfigTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/NrtsearchConfigTest.java
@@ -232,4 +232,18 @@ public class NrtsearchConfigTest {
     NrtsearchConfig luceneConfig = getForConfig(config);
     assertEquals(2048, luceneConfig.getMaxClauseCount());
   }
+
+  @Test
+  public void testRequireIdField_default() {
+    String config = "nodeName: \"server_foo\"";
+    NrtsearchConfig luceneConfig = getForConfig(config);
+    assertFalse(luceneConfig.getRequireIdField());
+  }
+
+  @Test
+  public void testRequireIdField_set() {
+    String config = "requireIdField: true";
+    NrtsearchConfig luceneConfig = getForConfig(config);
+    assertTrue(luceneConfig.getRequireIdField());
+  }
 }


### PR DESCRIPTION
Having an `_ID` is pretty important for most all use cases. This branch adds a new config option `requireIdField`, which defaults to `false`. When set to `true`, attempting to start an index that does not contain an `_ID` field will throw an error. In the future, we can make `true` the default.