### PR TITLE
Add Isolated Replicas feature to download index updates from remote backend

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/IsolatedReplicaConfig.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/IsolatedReplicaConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.config;
+
+import java.util.Objects;
+
+/** Config class for the isolated replica feature that decouples replicas from the primary. */
+public class IsolatedReplicaConfig {
+  public static final String CONFIG_PREFIX = "isolatedReplicaConfig.";
+
+  private final boolean enabled;
+  private final int pollingIntervalSeconds;
+
+  /**
+   * Create instance from provided configuration reader.
+   *
+   * @param configReader config reader
+   * @return class instance
+   */
+  public static IsolatedReplicaConfig fromConfig(YamlConfigReader configReader) {
+    Objects.requireNonNull(configReader);
+    boolean enabled = configReader.getBoolean(CONFIG_PREFIX + "enabled", false);
+    int pollingIntervalSeconds =
+        configReader.getInteger(CONFIG_PREFIX + "pollingIntervalSeconds", 120);
+    return new IsolatedReplicaConfig(enabled, pollingIntervalSeconds);
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param enabled if isolated replica is enabled
+   * @param pollingIntervalSeconds interval in seconds to poll for new index versions, must be > 0
+   */
+  public IsolatedReplicaConfig(boolean enabled, int pollingIntervalSeconds) {
+    this.enabled = enabled;
+    this.pollingIntervalSeconds = pollingIntervalSeconds;
+    if (pollingIntervalSeconds <= 0) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Polling interval seconds must be positive, got: %d", pollingIntervalSeconds));
+    }
+  }
+
+  /**
+   * @return if isolated replica is enabled
+   */
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  /**
+   * @return interval in seconds to poll for new index versions
+   */
+  public int getPollingIntervalSeconds() {
+    return pollingIntervalSeconds;
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java
@@ -114,6 +114,7 @@ public class NrtsearchConfig {
   private final boolean useKeepAliveForReplication;
   private final DirectoryFactory.MMapGrouping mmapGrouping;
   private final boolean requireIdField;
+  private final IsolatedReplicaConfig isolatedReplicaConfig;
 
   @Inject
   public NrtsearchConfig(InputStream yamlStream) {
@@ -194,6 +195,7 @@ public class NrtsearchConfig {
             DirectoryFactory.MMapGrouping.SEGMENT);
     useSeparateCommitExecutor = configReader.getBoolean("useSeparateCommitExecutor", false);
     requireIdField = configReader.getBoolean("requireIdField", false);
+    isolatedReplicaConfig = IsolatedReplicaConfig.fromConfig(configReader);
 
     List<String> indicesWithOverrides = configReader.getKeysOrEmpty("indexLiveSettingsOverrides");
     Map<String, IndexLiveSettings> liveSettingsMap = new HashMap<>();
@@ -393,6 +395,10 @@ public class NrtsearchConfig {
 
   public boolean getRequireIdField() {
     return requireIdField;
+  }
+
+  public IsolatedReplicaConfig getIsolatedReplicaConfig() {
+    return isolatedReplicaConfig;
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClient.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClient.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.yelp.nrtsearch.server.grpc.ReplicationServerGrpc.ReplicationServerBlockingStub;
 import com.yelp.nrtsearch.server.grpc.discovery.PrimaryFileNameResolverProvider;
-import com.yelp.nrtsearch.server.nrt.SimpleCopyJob.FileChunkStreamingIterator;
+import com.yelp.nrtsearch.server.nrt.jobs.SimpleCopyJob.FileChunkStreamingIterator;
 import io.grpc.Deadline;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;

--- a/src/main/java/com/yelp/nrtsearch/server/handler/CopyFilesHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/CopyFilesHandler.java
@@ -15,6 +15,8 @@
  */
 package com.yelp.nrtsearch.server.handler;
 
+import static com.yelp.nrtsearch.server.nrt.NrtUtils.readFilesMetaData;
+
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.yelp.nrtsearch.server.grpc.CopyFiles;
 import com.yelp.nrtsearch.server.grpc.TransferStatus;
@@ -23,7 +25,6 @@ import com.yelp.nrtsearch.server.index.IndexState;
 import com.yelp.nrtsearch.server.index.IndexStateManager;
 import com.yelp.nrtsearch.server.index.ShardState;
 import com.yelp.nrtsearch.server.monitoring.NrtMetrics;
-import com.yelp.nrtsearch.server.nrt.NRTReplicaNode;
 import com.yelp.nrtsearch.server.state.GlobalState;
 import com.yelp.nrtsearch.server.utils.ProtoMessagePrinter;
 import io.grpc.Status;
@@ -106,8 +107,7 @@ public class CopyFilesHandler extends Handler<CopyFiles, TransferStatus> {
 
     long primaryGen = copyFilesRequest.getPrimaryGen();
     // these are the files that the remote (primary) wants us to copy
-    Map<String, FileMetaData> files =
-        NRTReplicaNode.readFilesMetaData(copyFilesRequest.getFilesMetadata());
+    Map<String, FileMetaData> files = readFilesMetaData(copyFilesRequest.getFilesMetadata());
 
     AtomicBoolean finished = new AtomicBoolean();
     CopyJob job;

--- a/src/main/java/com/yelp/nrtsearch/server/index/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/ShardState.java
@@ -962,6 +962,8 @@ public class ShardState implements Closeable {
               configuration.getNodeName(),
               indexDir,
               new ShardSearcherFactory(true, false),
+              configuration.getIsolatedReplicaConfig(),
+              nrtDataManager,
               verbose ? System.out : new PrintStream(OutputStream.nullOutputStream()),
               configuration.getFileCopyConfig().getAckedCopy(),
               configuration.getDecInitialCommit(),

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NrtCopyThread.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NrtCopyThread.java
@@ -15,6 +15,8 @@
  */
 package com.yelp.nrtsearch.server.nrt;
 
+import com.yelp.nrtsearch.server.nrt.jobs.SimpleCopyJob;
+import com.yelp.nrtsearch.server.nrt.jobs.VisitableCopyJob;
 import java.io.Closeable;
 import java.util.Locale;
 import org.apache.lucene.replicator.nrt.CopyJob;
@@ -61,7 +63,7 @@ public abstract class NrtCopyThread extends Thread implements Closeable {
    * Returns null if we are closing, else, returns the top job or waits for one to arrive if the
    * queue is empty.
    */
-  private synchronized SimpleCopyJob getNextJob() {
+  private synchronized VisitableCopyJob getNextJob() {
     while (true) {
       if (finish) {
         return null;
@@ -72,7 +74,7 @@ public abstract class NrtCopyThread extends Thread implements Closeable {
           throw new RuntimeException(ie);
         }
       } else {
-        return (SimpleCopyJob) getJob();
+        return (VisitableCopyJob) getJob();
       }
     }
   }
@@ -81,7 +83,7 @@ public abstract class NrtCopyThread extends Thread implements Closeable {
   public void run() {
     // nocommit: prioritize jobs better here, the way an OS assigns CPU to processes:
     while (true) {
-      SimpleCopyJob topJob = getNextJob();
+      VisitableCopyJob topJob = getNextJob();
       if (topJob == null) {
         assert finish;
         break;

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/CopyJobManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/CopyJobManager.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.nrt.jobs;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.lucene.replicator.nrt.CopyJob;
+import org.apache.lucene.replicator.nrt.FileMetaData;
+
+/** Manages the creation and completion of {@link CopyJob}s. */
+public interface CopyJobManager extends Closeable {
+  /**
+   * Start the copy job manager, initializing any resources needed. This is called at the end of the
+   * {@link com.yelp.nrtsearch.server.nrt.NRTReplicaNode} startup process.
+   *
+   * @throws IOException on error
+   */
+  void start() throws IOException;
+
+  /**
+   * Create a new {@link CopyJob} to copy the needed files to the replica.
+   *
+   * @param reason the reason for the copy job
+   * @param files the files to be copied
+   * @param prevFiles the previous files on the replica
+   * @param highPriority if true, the copy job should be prioritized (nrt copy)
+   * @param onceDone callback to be called once the copy job is done
+   * @return the new copy job
+   * @throws IOException on error
+   */
+  CopyJob newCopyJob(
+      String reason,
+      Map<String, FileMetaData> files,
+      Map<String, FileMetaData> prevFiles,
+      boolean highPriority,
+      CopyJob.OnceDone onceDone)
+      throws IOException;
+
+  /**
+   * Called in the {@link com.yelp.nrtsearch.server.nrt.NRTReplicaNode} finishNRTCopy method to
+   * allow the copy job manager to perform any needed finalization after an nrt copy job is
+   * completed.
+   *
+   * @param copyJob the completed copy job
+   * @throws IOException on error
+   */
+  void finishNRTCopy(CopyJob copyJob) throws IOException;
+}

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/GrpcCopyJobManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/GrpcCopyJobManager.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.nrt.jobs;
+
+import static com.yelp.nrtsearch.server.nrt.NrtUtils.readFilesMetaData;
+
+import com.yelp.nrtsearch.server.grpc.ReplicationServerClient;
+import com.yelp.nrtsearch.server.nrt.NRTReplicaNode;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.lucene.replicator.nrt.CopyJob;
+import org.apache.lucene.replicator.nrt.CopyState;
+import org.apache.lucene.replicator.nrt.FileMetaData;
+import org.apache.lucene.replicator.nrt.NodeCommunicationException;
+
+/**
+ * CopyJobManager implementation that uses gRPC to communicate with the primary to get the CopyState
+ * and files to copy.
+ */
+public class GrpcCopyJobManager implements CopyJobManager {
+  private final String indexName;
+  private final String indexId;
+  private final ReplicationServerClient primaryAddress;
+  private final boolean ackedCopy;
+  private final NRTReplicaNode replicaNode;
+  private final int replicaId;
+
+  public GrpcCopyJobManager(
+      String indexName,
+      String indexId,
+      ReplicationServerClient primaryAddress,
+      boolean ackedCopy,
+      NRTReplicaNode replicaNode,
+      int replicaId) {
+    this.indexName = indexName;
+    this.indexId = indexId;
+    this.primaryAddress = primaryAddress;
+    this.ackedCopy = ackedCopy;
+    this.replicaNode = replicaNode;
+    this.replicaId = replicaId;
+  }
+
+  @Override
+  public void start() throws IOException {}
+
+  @Override
+  public CopyJob newCopyJob(
+      String reason,
+      Map<String, FileMetaData> files,
+      Map<String, FileMetaData> prevFiles,
+      boolean highPriority,
+      CopyJob.OnceDone onceDone)
+      throws IOException {
+    if (!replicaNode.hasPrimaryConnection()) {
+      throw new IllegalStateException(
+          "Cannot create new copy job, primary connection not available");
+    }
+
+    CopyState copyState;
+
+    // sendMeFiles(?) (we dont need this, just send Index,replica, and request for copy State)
+    if (files == null) {
+      // No incoming CopyState: ask primary for latest one now
+      try {
+        // Exceptions in here mean something went wrong talking over the socket, which are fine
+        // (e.g. primary node crashed):
+        copyState = getCopyStateFromPrimary();
+      } catch (Throwable t) {
+        throw new NodeCommunicationException("exc while reading files to copy", t);
+      }
+      files = copyState.files();
+    } else {
+      copyState = null;
+    }
+    return new SimpleCopyJob(
+        reason,
+        primaryAddress,
+        copyState,
+        replicaNode,
+        files,
+        highPriority,
+        onceDone,
+        indexName,
+        indexId,
+        ackedCopy);
+  }
+
+  @Override
+  public void finishNRTCopy(CopyJob copyJob) throws IOException {}
+
+  private CopyState getCopyStateFromPrimary() throws IOException {
+    com.yelp.nrtsearch.server.grpc.CopyState copyState =
+        primaryAddress.recvCopyState(indexName, indexId, replicaId);
+    return readCopyState(copyState);
+  }
+
+  /** Pulls CopyState off the wire */
+  private static CopyState readCopyState(com.yelp.nrtsearch.server.grpc.CopyState copyState)
+      throws IOException {
+
+    // Decode a new CopyState
+    byte[] infosBytes = new byte[copyState.getInfoBytesLength()];
+    copyState.getInfoBytes().copyTo(ByteBuffer.wrap(infosBytes));
+
+    long gen = copyState.getGen();
+    long version = copyState.getVersion();
+    Map<String, FileMetaData> files = readFilesMetaData(copyState.getFilesMetadata());
+
+    Set<String> completedMergeFiles = new HashSet<>(copyState.getCompletedMergeFilesList());
+    long primaryGen = copyState.getPrimaryGen();
+
+    return new CopyState(files, version, gen, infosBytes, completedMergeFiles, primaryGen, null);
+  }
+
+  @Override
+  public void close() throws IOException {}
+}

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/RemoteCopyJobManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/RemoteCopyJobManager.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.nrt.jobs;
+
+import com.yelp.nrtsearch.server.nrt.NRTReplicaNode;
+import com.yelp.nrtsearch.server.nrt.NrtDataManager;
+import com.yelp.nrtsearch.server.nrt.state.NrtPointState;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+import org.apache.lucene.replicator.nrt.CopyJob;
+import org.apache.lucene.replicator.nrt.CopyState;
+import org.apache.lucene.replicator.nrt.FileMetaData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * CopyJobManager implementation that creates RemoteCopyJob instances to copy files from remote
+ * storage (e.g., S3) instead of from a primary node. This is useful for recovering or replicating
+ * data directly from remote storage.
+ *
+ * <p>This manager periodically polls the NrtDataManager for updates to the target point state and
+ * initiates new copy jobs as needed.
+ */
+public class RemoteCopyJobManager implements CopyJobManager {
+  private static final Logger logger = LoggerFactory.getLogger(NrtDataManager.class);
+
+  private final int pollingIntervalSecond;
+  private final NrtDataManager dataManager;
+  private final NRTReplicaNode replicaNode;
+  private final Thread updateThread;
+  private final UpdateTask updateTask;
+
+  public RemoteCopyJobManager(
+      int pollingIntervalSecond, NrtDataManager dataManager, NRTReplicaNode replicaNode) {
+    this.pollingIntervalSecond = pollingIntervalSecond;
+    this.dataManager = dataManager;
+    this.replicaNode = replicaNode;
+    logger.info(
+        "Starting RemoteCopyJobManager with polling interval of {}s", pollingIntervalSecond);
+    updateTask = new UpdateTask();
+    updateThread = new Thread(updateTask, "RemoteCopyJobManager-UpdateThread");
+    updateThread.setDaemon(true);
+  }
+
+  @Override
+  public void start() throws IOException {
+    updateThread.start();
+  }
+
+  @Override
+  public CopyJob newCopyJob(
+      String reason,
+      Map<String, FileMetaData> files,
+      Map<String, FileMetaData> prevFiles,
+      boolean highPriority,
+      CopyJob.OnceDone onceDone)
+      throws IOException {
+    if (files != null) {
+      throw new IllegalArgumentException("RemoteCopyJobManager does not support merge precopy");
+    }
+
+    NrtDataManager.PointStateWithTimestamp targetPointStateWithTimestamp =
+        dataManager.getTargetPointState();
+
+    CopyState copyState = targetPointStateWithTimestamp.pointState().toCopyState();
+    return new RemoteCopyJob(
+        reason,
+        targetPointStateWithTimestamp.pointState(),
+        targetPointStateWithTimestamp.timestamp(),
+        copyState,
+        dataManager,
+        replicaNode,
+        copyState.files(),
+        highPriority,
+        onceDone);
+  }
+
+  @Override
+  public void finishNRTCopy(CopyJob copyJob) throws IOException {
+    // If the copy job failed, we do not update the last known point state
+    if (copyJob.getFailed()) {
+      return;
+    }
+    if (copyJob instanceof RemoteCopyJob remoteCopyJob) {
+      NrtPointState pointState = remoteCopyJob.getPointState();
+      Instant pointStateTimestamp = remoteCopyJob.getPointStateTimestamp();
+      dataManager.setLastPointState(pointState, pointStateTimestamp);
+    } else {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected copyJob to be instance of RemoteCopyJob, got %s",
+              copyJob.getClass().getName()));
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    updateTask.setQuitting();
+    updateThread.interrupt();
+    try {
+      updateThread.join();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Background task that periodically polls the NrtDataManager for updates to the target point
+   * state and initiates new NRT points on the replica node as needed.
+   */
+  class UpdateTask implements Runnable {
+    private volatile boolean quitting = false;
+
+    public UpdateTask() {}
+
+    public void setQuitting() {
+      quitting = true;
+    }
+
+    @Override
+    public void run() {
+      while (!quitting) {
+        try {
+          NrtPointState targetPointState;
+          long currentIndexVersion;
+          targetPointState = dataManager.getTargetPointState().pointState();
+          currentIndexVersion = replicaNode.getCurrentSearchingVersion();
+          if (targetPointState.version > currentIndexVersion) {
+            logger.info(
+                "Advancing to new NRT point: {}, current version: {}",
+                targetPointState,
+                currentIndexVersion);
+            replicaNode.newNRTPoint(targetPointState.primaryGen, targetPointState.version);
+          }
+        } catch (Exception e) {
+          logger.error("Error when polling for new point state: {}", e.getMessage(), e);
+        }
+
+        try {
+          Thread.sleep(pollingIntervalSecond * 1000L);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/SimpleCopyJob.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/SimpleCopyJob.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.nrt.jobs;
+
+import com.yelp.nrtsearch.server.grpc.FileInfo;
+import com.yelp.nrtsearch.server.grpc.RawFileChunk;
+import com.yelp.nrtsearch.server.grpc.ReplicationServerClient;
+import com.yelp.nrtsearch.server.monitoring.NrtMetrics;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import org.apache.lucene.replicator.nrt.CopyJob;
+import org.apache.lucene.replicator.nrt.CopyOneFile;
+import org.apache.lucene.replicator.nrt.CopyState;
+import org.apache.lucene.replicator.nrt.FileMetaData;
+import org.apache.lucene.replicator.nrt.GrpcCopyOneFile;
+import org.apache.lucene.replicator.nrt.Node;
+import org.apache.lucene.replicator.nrt.NodeCommunicationException;
+import org.apache.lucene.replicator.nrt.ReplicaNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SimpleCopyJob extends VisitableCopyJob {
+  private static final Logger logger = LoggerFactory.getLogger(SimpleCopyJob.class);
+
+  private final CopyState copyState;
+  private final ReplicationServerClient primaryAddres;
+  private final String indexName;
+  private final String indexId;
+  private final boolean ackedCopy;
+  private Iterator<Map.Entry<String, FileMetaData>> iter;
+
+  public SimpleCopyJob(
+      String reason,
+      ReplicationServerClient primaryAddress,
+      CopyState copyState,
+      ReplicaNode dest,
+      Map<String, FileMetaData> files,
+      boolean highPriority,
+      OnceDone onceDone,
+      String indexName,
+      String indexId,
+      boolean ackedCopy)
+      throws IOException {
+    super(reason, files, dest, highPriority, onceDone);
+    this.copyState = copyState;
+    this.primaryAddres = primaryAddress;
+    this.indexName = indexName;
+    this.indexId = indexId;
+    this.ackedCopy = ackedCopy;
+  }
+
+  @Override
+  protected CopyOneFile newCopyOneFile(CopyOneFile prev) {
+    // no state needs to be changed when transferring to a new job
+    return prev;
+  }
+
+  @Override
+  public void start() throws IOException {
+    if (iter == null) {
+      iter = toCopy.iterator();
+      // This means we resumed an already in-progress copy; we do this one first:
+      if (current != null) {
+        totBytes += current.getFileMetaData().length();
+      }
+      for (Map.Entry<String, FileMetaData> ent : toCopy) {
+        FileMetaData metaData = ent.getValue();
+        totBytes += metaData.length();
+      }
+
+      // Send all file names / offsets up front to avoid ping-ping latency:
+      try {
+        dest.message(
+            "SimpleCopyJob.init: done start files count="
+                + toCopy.size()
+                + " totBytes="
+                + totBytes);
+      } catch (Throwable t) {
+        cancel("exc during start", t);
+        throw new NodeCommunicationException("exc during start", t);
+      }
+    } else {
+      throw new IllegalStateException("already started");
+    }
+  }
+
+  @Override
+  public void runBlocking() throws Exception {
+    while (!visit())
+      ;
+    if (getFailed()) {
+      throw new RuntimeException("copy failed: " + cancelReason, exc);
+    }
+  }
+
+  @Override
+  public boolean conflicts(CopyJob _other) {
+    Set<String> filesToCopy = new HashSet<>();
+    for (Map.Entry<String, FileMetaData> ent : toCopy) {
+      filesToCopy.add(ent.getKey());
+    }
+
+    SimpleCopyJob other = (SimpleCopyJob) _other;
+    synchronized (other) {
+      for (Map.Entry<String, FileMetaData> ent : other.toCopy) {
+        if (filesToCopy.contains(ent.getKey())) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  @Override
+  public void finish() throws IOException {
+    dest.message(
+        String.format(
+            Locale.ROOT,
+            "top: file copy done; took %.1f msec to copy %d bytes (%.2f MB/sec); now rename %d tmp files",
+            (System.nanoTime() - startNS) / 1000000.0,
+            totBytesCopied,
+            (totBytesCopied / 1024. / 1024.) / ((System.nanoTime() - startNS) / 1000000000.0),
+            copiedFiles.size()));
+
+    // NOTE: if any of the files we copied overwrote a file in the current commit point, we
+    // (ReplicaNode) removed the commit point up
+    // front so that the commit is not corrupt.  This way if we hit exc here, or if we crash here,
+    // we won't leave a corrupt commit in
+    // the index:
+    for (Map.Entry<String, String> ent : copiedFiles.entrySet()) {
+      String tmpFileName = ent.getValue();
+      String fileName = ent.getKey();
+
+      if (Node.VERBOSE_FILES) {
+        dest.message("rename file " + tmpFileName + " to " + fileName);
+      }
+
+      // NOTE: if this throws exception, then some files have been moved to their true names, and
+      // others are leftover .tmp files.  I don't
+      // think heroic exception handling is necessary (no harm will come, except some leftover
+      // files),  nor warranted here (would make the
+      // code more complex, for the exceptional cases when something is wrong w/ your IO system):
+      dest.getDirectory().rename(tmpFileName, fileName);
+    }
+
+    // nocommit syncMetaData here?
+    copiedFiles.clear();
+  }
+
+  @Override
+  public boolean getFailed() {
+    return exc != null;
+  }
+
+  @Override
+  public Set<String> getFileNamesToCopy() {
+    Set<String> fileNames = new HashSet<>();
+    for (Map.Entry<String, FileMetaData> ent : toCopy) {
+      fileNames.add(ent.getKey());
+    }
+    return fileNames;
+  }
+
+  @Override
+  public Set<String> getFileNames() {
+    return files.keySet();
+  }
+
+  @Override
+  public CopyState getCopyState() {
+    return copyState;
+  }
+
+  @Override
+  public long getTotalBytesCopied() {
+    return totBytesCopied;
+  }
+
+  /** Higher priority and then "first come first serve" order. */
+  @Override
+  public int compareTo(CopyJob _other) {
+    SimpleCopyJob other = (SimpleCopyJob) _other;
+    if (highPriority != other.highPriority) {
+      return highPriority ? -1 : 1;
+    } else if (ord < other.ord) {
+      // let earlier merges run to completion first
+      return -1;
+    } else if (ord > other.ord) {
+      // let earlier merges run to completion first
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  /** Do an iota of work; returns true if all copying is done */
+  @Override
+  public synchronized boolean visit() throws IOException {
+    if (exc != null) {
+      // We were externally cancelled:
+      return true;
+    }
+    if (current == null) {
+      if (!iter.hasNext()) {
+        return true;
+      }
+      Map.Entry<String, FileMetaData> next = iter.next();
+      FileMetaData metaData = next.getValue();
+      String fileName = next.getKey();
+      Iterator<RawFileChunk> rawFileChunkIterator;
+      try {
+        if (ackedCopy) {
+          FileChunkStreamingIterator fcsi = new FileChunkStreamingIterator(indexName);
+          primaryAddres.recvRawFileV2(fileName, 0, indexName, indexId, fcsi);
+          rawFileChunkIterator = fcsi;
+        } else {
+          rawFileChunkIterator = primaryAddres.recvRawFile(fileName, 0, indexName, indexId);
+        }
+      } catch (Throwable t) {
+        cancel("exc during start", t);
+        throw new NodeCommunicationException("exc during start", t);
+      }
+      current = new GrpcCopyOneFile(rawFileChunkIterator, dest, fileName, metaData);
+    }
+    if (current.visit()) {
+      // This file is done copying
+      copiedFiles.put(current.getFileName(), current.getFileTmpName());
+      totBytesCopied += current.getBytesCopied();
+      assert totBytesCopied <= totBytes
+          : "totBytesCopied=" + totBytesCopied + " totBytes=" + totBytes;
+      current = null;
+      return false;
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return "SimpleCopyJob(ord="
+        + ord
+        + " "
+        + reason
+        + " highPriority="
+        + highPriority
+        + " files count="
+        + files.size()
+        + " bytesCopied="
+        + totBytesCopied
+        + " (of "
+        + totBytes
+        + ") filesCopied="
+        + copiedFiles.size()
+        + ")";
+  }
+
+  /** Stream observer that also functions as a file chunk iterator. */
+  public static class FileChunkStreamingIterator
+      implements StreamObserver<RawFileChunk>, Iterator<RawFileChunk> {
+    private static final RawFileChunk TERMINAL_CHUNK = RawFileChunk.newBuilder().build();
+    private static final double BYTES_TO_MB = 1.0 / (1024 * 1024);
+    private final String indexName;
+    private StreamObserver<FileInfo> observer;
+    BlockingQueue<RawFileChunk> pendingChunks = new LinkedBlockingQueue<>();
+    RawFileChunk next = null;
+    volatile Throwable error = null;
+    boolean observerDone = false;
+
+    public FileChunkStreamingIterator(String indexName) {
+      this.indexName = indexName;
+    }
+
+    /**
+     * Set the request observer for this streaming copy.
+     *
+     * @param observer request observer
+     */
+    public void init(StreamObserver<FileInfo> observer) {
+      this.observer = observer;
+    }
+
+    @Override
+    public void onNext(RawFileChunk value) {
+      // buffer all file chunks, this is bounded by the max in flight config value
+      pendingChunks.add(value);
+      NrtMetrics.nrtAckedCopyMB.labelValues(indexName).inc(value.getSerializedSize() * BYTES_TO_MB);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      // set error and add terminal chunk, so hasNext won't block forever
+      error = t;
+      pendingChunks.add(TERMINAL_CHUNK);
+      synchronized (this) {
+        if (!observerDone) {
+          observerDone = true;
+          observer.onError(t);
+        }
+      }
+      logger.error("File streaming onError", t);
+    }
+
+    @Override
+    public void onCompleted() {
+      // add terminal chunk to signal end of file
+      pendingChunks.add(TERMINAL_CHUNK);
+      synchronized (this) {
+        if (!observerDone) {
+          observerDone = true;
+          observer.onCompleted();
+        }
+      }
+      logger.debug("File streaming onCompleted");
+    }
+
+    @Override
+    public boolean hasNext() {
+      // set next chunk
+      if (next == null) {
+        try {
+          next = pendingChunks.take();
+        } catch (InterruptedException e) {
+          synchronized (this) {
+            if (!observerDone) {
+              observerDone = true;
+              observer.onError(e);
+            }
+          }
+          throw new RuntimeException(e);
+        }
+      }
+      // handle error
+      if (error != null) {
+        throw new RuntimeException("Error getting next element", error);
+      }
+      // see if we are at the end of file
+      return next != TERMINAL_CHUNK;
+    }
+
+    @Override
+    public RawFileChunk next() {
+      if (next == null) {
+        boolean hasNext = hasNext();
+        if (!hasNext) {
+          throw new IllegalStateException("Next called on empty iterator");
+        }
+      }
+      // send an ack for this chunk, if requested by the primary
+      if (next.getAck()) {
+        synchronized (this) {
+          if (!observerDone) {
+            observer.onNext(FileInfo.newBuilder().setAckSeqNum(next.getSeqNum()).build());
+            logger.debug(String.format("File streaming acking seq: %d", next.getSeqNum()));
+          }
+        }
+      }
+      RawFileChunk result = next;
+      next = null;
+      return result;
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/VisitableCopyJob.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/VisitableCopyJob.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.nrt.jobs;
+
+import java.io.IOException;
+import java.util.Map;
+import org.apache.lucene.replicator.nrt.CopyJob;
+import org.apache.lucene.replicator.nrt.FileMetaData;
+import org.apache.lucene.replicator.nrt.ReplicaNode;
+
+/**
+ * Extension of {@link CopyJob} that supports a visit operation to run a unit of work to copy the
+ * file. This is used by {@link com.yelp.nrtsearch.server.nrt.NrtCopyThread}.
+ */
+public abstract class VisitableCopyJob extends CopyJob {
+  protected VisitableCopyJob(
+      String reason,
+      Map<String, FileMetaData> files,
+      ReplicaNode dest,
+      boolean highPriority,
+      OnceDone onceDone)
+      throws IOException {
+    super(reason, files, dest, highPriority, onceDone);
+  }
+
+  /**
+   * Perform a unit of work to copy the file.
+   *
+   * @return true if the file is fully copied, false if more work remains
+   * @throws IOException on error
+   */
+  public abstract boolean visit() throws IOException;
+}

--- a/src/main/java/com/yelp/nrtsearch/server/remote/InputStreamDataInput.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/InputStreamDataInput.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.remote;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.lucene.store.DataInput;
+
+/** A DataInput implementation that wraps an InputStream. */
+public class InputStreamDataInput extends DataInput implements Closeable {
+  private final InputStream wrapped;
+
+  public InputStreamDataInput(InputStream wrapped) {
+    this.wrapped = wrapped;
+  }
+
+  @Override
+  public byte readByte() throws IOException {
+    int value = wrapped.read();
+    if (value == -1) {
+      throw new IOException("End of stream reached");
+    }
+    return (byte) value;
+  }
+
+  @Override
+  public void readBytes(byte[] bytes, int offset, int length) throws IOException {
+    int read = 0;
+    while (read < length) {
+      int result = wrapped.read(bytes, offset + read, length - read);
+      if (result == -1) {
+        throw new IOException("End of stream reached before reading all bytes");
+      }
+      read += result;
+    }
+  }
+
+  @Override
+  public void skipBytes(long numBytes) throws IOException {
+    long skipped = 0;
+    while (skipped < numBytes) {
+      long result = wrapped.skip(numBytes - skipped);
+      if (result == 0) {
+        if (wrapped.read() == -1) {
+          throw new IOException("End of stream reached while skipping bytes");
+        }
+        skipped++;
+      } else {
+        skipped += result;
+      }
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    wrapped.close();
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/remote/RemoteBackend.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/RemoteBackend.java
@@ -20,6 +20,7 @@ import com.yelp.nrtsearch.server.nrt.state.NrtPointState;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Map;
 
 /** Interface for interacting with service resources stored in a persistent backend. */
@@ -33,6 +34,8 @@ public interface RemoteBackend extends PluginDownloader {
   enum GlobalResourceType {
     GLOBAL_STATE
   }
+
+  record InputStreamWithTimestamp(InputStream inputStream, Instant timestamp) {}
 
   /**
    * Get if a given global resource exists in the backend.
@@ -141,6 +144,20 @@ public interface RemoteBackend extends PluginDownloader {
       throws IOException;
 
   /**
+   * Download a single index file from the remote backend.
+   *
+   * @param service service name
+   * @param indexIdentifier unique index identifier
+   * @param fileName file name to download
+   * @param fileMetaData file metadata
+   * @return input stream of the index file
+   * @throws IOException on error downloading the file
+   */
+  InputStream downloadIndexFile(
+      String service, String indexIdentifier, String fileName, NrtFileMetaData fileMetaData)
+      throws IOException;
+
+  /**
    * Upload NRT point state to the remote backend.
    *
    * @param service service name
@@ -158,8 +175,9 @@ public interface RemoteBackend extends PluginDownloader {
    *
    * @param service service name
    * @param indexIdentifier unique index identifier
-   * @return input stream of point state data
+   * @return input stream of point state data with timestamp
    * @throws IOException on error downloading point state
    */
-  InputStream downloadPointState(String service, String indexIdentifier) throws IOException;
+  InputStreamWithTimestamp downloadPointState(String service, String indexIdentifier)
+      throws IOException;
 }

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/SnapshotCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/SnapshotCommand.java
@@ -164,7 +164,10 @@ public class SnapshotCommand implements Callable<Integer> {
       throw new IllegalArgumentException("No data found for index: " + resolvedIndexResource);
     }
     byte[] pointStateBytes =
-        s3Backend.downloadPointState(serviceName, resolvedIndexResource).readAllBytes();
+        s3Backend
+            .downloadPointState(serviceName, resolvedIndexResource)
+            .inputStream()
+            .readAllBytes();
     NrtPointState nrtPointState = RemoteUtils.pointStateFromUtf8(pointStateBytes);
     Set<String> indexDataFiles =
         nrtPointState.files.entrySet().stream()

--- a/src/main/java/org/apache/lucene/replicator/nrt/CopyOneFile.java
+++ b/src/main/java/org/apache/lucene/replicator/nrt/CopyOneFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Yelp Inc.
+ * Copyright 2025 Yelp Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,152 +15,54 @@
  */
 package org.apache.lucene.replicator.nrt;
 
-import com.google.protobuf.ByteString;
-import com.yelp.nrtsearch.server.grpc.RawFileChunk;
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.Iterator;
-import java.util.Locale;
-import org.apache.lucene.codecs.CodecUtil;
-import org.apache.lucene.store.IOContext;
-import org.apache.lucene.store.IndexOutput;
 
-public class CopyOneFile implements Closeable {
-  private final Iterator<RawFileChunk> rawFileChunkIterator;
-  private final IndexOutput out;
-  private final ReplicaNode dest;
-  public final String name;
-  public final String tmpName;
-  public final FileMetaData metaData;
-  public final long bytesToCopy;
-  private final long copyStartNS;
-  private final ByteBuffer checksumBuffer = ByteBuffer.allocate(Long.BYTES);
-
-  private long bytesCopied;
-  private long remoteFileChecksum;
-
-  public CopyOneFile(
-      Iterator<RawFileChunk> rawFileChunkIterator,
-      ReplicaNode dest,
-      String name,
-      FileMetaData metaData)
-      throws IOException {
-
-    this.rawFileChunkIterator = rawFileChunkIterator;
-    this.name = name;
-    this.dest = dest;
-    // TODO: pass correct IOCtx, e.g. seg total size
-    out = dest.createTempOutput(name, "copy", IOContext.DEFAULT);
-    tmpName = out.getName();
-    // last 8 bytes are checksum:
-    bytesToCopy = metaData.length() - Long.BYTES;
-    if (Node.VERBOSE_FILES) {
-      dest.message(
-          "file "
-              + name
-              + ": start copying to tmp file "
-              + tmpName
-              + " length="
-              + (8 + bytesToCopy));
-    }
-    copyStartNS = System.nanoTime();
-    this.metaData = metaData;
-    dest.startCopyFile(name);
-  }
+/**
+ * Interface to replace the Lucene CopyOneFile class, so that we can use separate implementations
+ * for gRPC vs remote (S3) replication.
+ */
+public interface CopyOneFile extends Closeable {
+  /**
+   * Get the number of bytes copied so far.
+   *
+   * @return number of bytes copied so far
+   */
+  long getBytesCopied();
 
   /**
-   * Closes this stream and releases any system resources associated with it. If the stream is
-   * already closed then invoking this method has no effect.
+   * Perform one unit of work copying the file.
    *
-   * <p>As noted in {@link AutoCloseable#close()}, cases where the close may fail require careful
-   * attention. It is strongly advised to relinquish the underlying resources and to internally
-   * <em>mark</em> the {@code Closeable} as closed, prior to throwing the {@code IOException}.
-   *
-   * @throws IOException if an I/O error occurs
+   * @return true if the file is fully copied, false otherwise
+   * @throws IOException on error
    */
-  @Override
-  public void close() throws IOException {
-    out.close();
-    dest.finishCopyFile(name);
-    // This job may have been canceled before being completed, meaning the replica no longer needs
-    // it. Drain the iterator to not leak direct memory.
-    while (rawFileChunkIterator.hasNext()) {
-      rawFileChunkIterator.next();
-    }
-  }
+  boolean visit() throws IOException;
 
-  public long getBytesCopied() {
-    return bytesCopied;
-  }
+  /**
+   * Get the file metadata.
+   *
+   * @return file metadata
+   */
+  FileMetaData getFileMetaData();
 
-  /** Copy another chunk of bytes, returning true once the copy is done */
-  public boolean visit() throws IOException {
-    if (rawFileChunkIterator.hasNext()) {
-      RawFileChunk rawFileChunk = rawFileChunkIterator.next();
-      ByteString byteString = rawFileChunk.getContent();
-      bytesCopied += byteString.size();
-      if (bytesCopied < bytesToCopy) {
-        out.writeBytes(byteString.toByteArray(), 0, byteString.size());
-      } else {
-        int checksumBytesRead = (int) (bytesCopied - bytesToCopy);
-        if (byteString.size() > checksumBytesRead) {
-          // This chunk contains some data and some checksum
-          out.writeBytes(byteString.toByteArray(), 0, byteString.size() - checksumBytesRead);
-          checksumBuffer.put(
-              byteString.toByteArray(), byteString.size() - checksumBytesRead, checksumBytesRead);
-        } else {
-          // This chunk only contains checksum
-          checksumBuffer.put(byteString.toByteArray());
-        }
-        // Only get the checksum after it has been entirely read
-        if (checksumBytesRead == Long.BYTES) {
-          checksumBuffer.rewind();
-          remoteFileChecksum = checksumBuffer.getLong();
-          bytesCopied -= Long.BYTES;
-        }
-      }
-      return false;
-    } else {
-      long checksum = out.getChecksum();
-      if (checksum != metaData.checksum()) {
-        // Bits flipped during copy!
-        dest.message(
-            "file "
-                + tmpName
-                + ": checksum mismatch after copy (bits flipped during network copy?) after-copy checksum="
-                + checksum
-                + " vs expected="
-                + metaData.checksum()
-                + "; cancel job");
-        throw new IOException("file " + name + ": checksum mismatch after file copy");
-      }
-      // Paranoia: make sure the primary node is not smoking crack, by somehow sending us an already
-      // corrupted file whose checksum (in its
-      // footer) disagrees with reality:
-      long actualChecksumIn = remoteFileChecksum;
-      if (actualChecksumIn != checksum) {
-        dest.message(
-            "file "
-                + tmpName
-                + ": checksum claimed by primary disagrees with the file's footer: claimed checksum="
-                + checksum
-                + " vs actual="
-                + actualChecksumIn);
-        throw new IOException("file " + name + ": checksum mismatch after file copy");
-      }
-      CodecUtil.writeBELong(out, checksum);
-      close();
-      if (Node.VERBOSE_FILES) {
-        dest.message(
-            String.format(
-                Locale.ROOT,
-                "file %s: done copying [%s, %.3fms]",
-                name,
-                Node.bytesToString(metaData.length()),
-                (System.nanoTime() - copyStartNS) / 1000000.0));
-      }
-      return true;
-    }
-  }
+  /**
+   * Get the file name.
+   *
+   * @return file name
+   */
+  String getFileName();
+
+  /**
+   * Get the temporary file name used during copying.
+   *
+   * @return temporary file name
+   */
+  String getFileTmpName();
+
+  /**
+   * Get the total number of bytes to copy.
+   *
+   * @return total number of bytes to copy
+   */
+  long getBytesToCopy();
 }

--- a/src/main/java/org/apache/lucene/replicator/nrt/StreamCopyOneFile.java
+++ b/src/main/java/org/apache/lucene/replicator/nrt/StreamCopyOneFile.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.replicator.nrt;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexOutput;
+
+/** Copies one file from an incoming DataInput to a dest filename in a local Directory */
+public class StreamCopyOneFile implements CopyOneFile {
+  private final DataInput in;
+  private final IndexOutput out;
+  private final ReplicaNode dest;
+  public final String name;
+  public final String tmpName;
+  public final FileMetaData metaData;
+  public final long bytesToCopy;
+  private final long copyStartNS;
+  private final byte[] buffer;
+
+  private long bytesCopied;
+
+  public StreamCopyOneFile(
+      DataInput in, ReplicaNode dest, String name, FileMetaData metaData, byte[] buffer)
+      throws IOException {
+    this.in = in;
+    this.name = name;
+    this.dest = dest;
+    this.buffer = buffer;
+    // TODO: pass correct IOCtx, e.g. seg total size
+    out = dest.createTempOutput(name, "copy", IOContext.DEFAULT);
+    tmpName = out.getName();
+
+    // last 8 bytes are checksum, which we write ourselves after copying all bytes and confirming
+    // checksum:
+    bytesToCopy = metaData.length() - Long.BYTES;
+
+    if (Node.VERBOSE_FILES) {
+      dest.message(
+          "file "
+              + name
+              + ": start copying to tmp file "
+              + tmpName
+              + " length="
+              + (8 + bytesToCopy));
+    }
+
+    copyStartNS = System.nanoTime();
+    this.metaData = metaData;
+    dest.startCopyFile(name);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (in instanceof Closeable closeable) {
+      closeable.close();
+    }
+    out.close();
+    dest.finishCopyFile(name);
+  }
+
+  /** Copy another chunk of bytes, returning true once the copy is done */
+  public boolean visit() throws IOException {
+    long bytesLeft = bytesToCopy - bytesCopied;
+    if (bytesLeft == 0) {
+      long checksum = out.getChecksum();
+      if (checksum != metaData.checksum()) {
+        // Bits flipped during copy!
+        dest.message(
+            "file "
+                + tmpName
+                + ": checksum mismatch after copy (bits flipped during network copy?) after-copy checksum="
+                + checksum
+                + " vs expected="
+                + metaData.checksum()
+                + "; cancel job");
+        throw new IOException("file " + name + ": checksum mismatch after file copy");
+      }
+
+      // Paranoia: make sure the primary node is not smoking crack, by somehow sending us an
+      // already corrupted file whose checksum (in its
+      // footer) disagrees with reality:
+      long actualChecksumIn = CodecUtil.readBELong(in);
+      if (actualChecksumIn != checksum) {
+        dest.message(
+            "file "
+                + tmpName
+                + ": checksum claimed by primary disagrees with the file's footer: claimed checksum="
+                + checksum
+                + " vs actual="
+                + actualChecksumIn);
+        throw new IOException("file " + name + ": checksum mismatch after file copy");
+      }
+      CodecUtil.writeBELong(out, checksum);
+      close();
+
+      if (Node.VERBOSE_FILES) {
+        dest.message(
+            String.format(
+                Locale.ROOT,
+                "file %s: done copying [%s, %.3fms]",
+                name,
+                Node.bytesToString(metaData.length()),
+                (System.nanoTime() - copyStartNS) / (double) TimeUnit.MILLISECONDS.toNanos(1)));
+      }
+
+      return true;
+    }
+
+    int toCopy = (int) Math.min(bytesLeft, buffer.length);
+    in.readBytes(buffer, 0, toCopy);
+    out.writeBytes(buffer, 0, toCopy);
+
+    // TODO: rsync will fsync a range of the file; maybe we should do that here for large files in
+    // case we crash/killed
+    bytesCopied += toCopy;
+
+    return false;
+  }
+
+  @Override
+  public FileMetaData getFileMetaData() {
+    return metaData;
+  }
+
+  @Override
+  public String getFileName() {
+    return name;
+  }
+
+  @Override
+  public String getFileTmpName() {
+    return tmpName;
+  }
+
+  @Override
+  public long getBytesToCopy() {
+    return bytesToCopy;
+  }
+
+  public long getBytesCopied() {
+    return bytesCopied;
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/config/IsolatedReplicaConfigTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/IsolatedReplicaConfigTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import org.junit.Test;
+
+public class IsolatedReplicaConfigTest {
+
+  private static IsolatedReplicaConfig getConfig(String configFile) {
+    return IsolatedReplicaConfig.fromConfig(
+        new YamlConfigReader(new ByteArrayInputStream(configFile.getBytes())));
+  }
+
+  @Test
+  public void testDefaultValues() {
+    String configFile = "nodeName: \"server_foo\"";
+    IsolatedReplicaConfig config = getConfig(configFile);
+
+    assertThat(config.isEnabled()).isFalse();
+    assertThat(config.getPollingIntervalSeconds()).isEqualTo(120);
+  }
+
+  @Test
+  public void testEnabledTrue() {
+    String configFile = String.join("\n", "isolatedReplicaConfig:", "  enabled: true");
+    IsolatedReplicaConfig config = getConfig(configFile);
+
+    assertThat(config.isEnabled()).isTrue();
+    assertThat(config.getPollingIntervalSeconds()).isEqualTo(120); // default value
+  }
+
+  @Test
+  public void testEnabledFalse() {
+    String configFile = String.join("\n", "isolatedReplicaConfig:", "  enabled: false");
+    IsolatedReplicaConfig config = getConfig(configFile);
+
+    assertThat(config.isEnabled()).isFalse();
+    assertThat(config.getPollingIntervalSeconds()).isEqualTo(120); // default value
+  }
+
+  @Test
+  public void testCustomPollingInterval() {
+    String configFile = String.join("\n", "isolatedReplicaConfig:", "  pollingIntervalSeconds: 60");
+    IsolatedReplicaConfig config = getConfig(configFile);
+
+    assertThat(config.isEnabled()).isFalse(); // default value
+    assertThat(config.getPollingIntervalSeconds()).isEqualTo(60);
+  }
+
+  @Test
+  public void testBothValuesSet() {
+    String configFile =
+        String.join(
+            "\n", "isolatedReplicaConfig:", "  enabled: true", "  pollingIntervalSeconds: 30");
+    IsolatedReplicaConfig config = getConfig(configFile);
+
+    assertThat(config.isEnabled()).isTrue();
+    assertThat(config.getPollingIntervalSeconds()).isEqualTo(30);
+  }
+
+  @Test
+  public void testZeroPollingInterval() {
+    String configFile = String.join("\n", "isolatedReplicaConfig:", "  pollingIntervalSeconds: 0");
+    try {
+      getConfig(configFile);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage()).isEqualTo("Polling interval seconds must be positive, got: 0");
+    }
+  }
+
+  @Test
+  public void testNegativePollingInterval() {
+    String configFile =
+        String.join("\n", "isolatedReplicaConfig:", "  pollingIntervalSeconds: -10");
+    try {
+      getConfig(configFile);
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage()).isEqualTo("Polling interval seconds must be positive, got: -10");
+    }
+  }
+
+  @Test
+  public void testLargePollingInterval() {
+    String configFile =
+        String.join("\n", "isolatedReplicaConfig:", "  pollingIntervalSeconds: 3600");
+    IsolatedReplicaConfig config = getConfig(configFile);
+
+    assertThat(config.isEnabled()).isFalse();
+    assertThat(config.getPollingIntervalSeconds()).isEqualTo(3600);
+  }
+
+  @Test
+  public void testStringBooleanEnabled() {
+    String configFile = String.join("\n", "isolatedReplicaConfig:", "  enabled: \"true\"");
+    IsolatedReplicaConfig config = getConfig(configFile);
+
+    assertThat(config.isEnabled()).isTrue();
+    assertThat(config.getPollingIntervalSeconds()).isEqualTo(120);
+  }
+
+  @Test
+  public void testStringBooleanDisabled() {
+    String configFile = String.join("\n", "isolatedReplicaConfig:", "  enabled: \"false\"");
+    IsolatedReplicaConfig config = getConfig(configFile);
+
+    assertThat(config.isEnabled()).isFalse();
+    assertThat(config.getPollingIntervalSeconds()).isEqualTo(120);
+  }
+
+  @Test
+  public void testStringPollingInterval() {
+    String configFile =
+        String.join("\n", "isolatedReplicaConfig:", "  pollingIntervalSeconds: \"90\"");
+    IsolatedReplicaConfig config = getConfig(configFile);
+
+    assertThat(config.isEnabled()).isFalse();
+    assertThat(config.getPollingIntervalSeconds()).isEqualTo(90);
+  }
+
+  @Test
+  public void testConstructorWithEnabledTrue() {
+    IsolatedReplicaConfig config = new IsolatedReplicaConfig(true, 240);
+
+    assertThat(config.isEnabled()).isTrue();
+    assertThat(config.getPollingIntervalSeconds()).isEqualTo(240);
+  }
+
+  @Test
+  public void testConstructorWithEnabledFalse() {
+    IsolatedReplicaConfig config = new IsolatedReplicaConfig(false, 15);
+
+    assertThat(config.isEnabled()).isFalse();
+    assertThat(config.getPollingIntervalSeconds()).isEqualTo(15);
+  }
+
+  @Test
+  public void testConstructorWithZeroInterval() {
+    try {
+      new IsolatedReplicaConfig(true, 0);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage()).isEqualTo("Polling interval seconds must be positive, got: 0");
+    }
+  }
+
+  @Test
+  public void testConstructorWithNegativeInterval() {
+    try {
+      new IsolatedReplicaConfig(false, -5);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage()).isEqualTo("Polling interval seconds must be positive, got: -5");
+    }
+  }
+
+  @Test
+  public void testFromConfigWithNullConfigReader() {
+    assertThatThrownBy(() -> IsolatedReplicaConfig.fromConfig(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void testFromConfigWithMockConfigReader() {
+    YamlConfigReader mockReader = mock(YamlConfigReader.class);
+    when(mockReader.getBoolean("isolatedReplicaConfig.enabled", false)).thenReturn(true);
+    when(mockReader.getInteger("isolatedReplicaConfig.pollingIntervalSeconds", 120)).thenReturn(45);
+
+    IsolatedReplicaConfig config = IsolatedReplicaConfig.fromConfig(mockReader);
+
+    assertThat(config.isEnabled()).isTrue();
+    assertThat(config.getPollingIntervalSeconds()).isEqualTo(45);
+  }
+
+  @Test
+  public void testFromConfigWithMockConfigReaderDefaults() {
+    YamlConfigReader mockReader = mock(YamlConfigReader.class);
+    when(mockReader.getBoolean("isolatedReplicaConfig.enabled", false)).thenReturn(false);
+    when(mockReader.getInteger("isolatedReplicaConfig.pollingIntervalSeconds", 120))
+        .thenReturn(120);
+
+    IsolatedReplicaConfig config = IsolatedReplicaConfig.fromConfig(mockReader);
+
+    assertThat(config.isEnabled()).isFalse();
+    assertThat(config.getPollingIntervalSeconds()).isEqualTo(120);
+  }
+
+  @Test
+  public void testConfigPrefix() {
+    assertThat(IsolatedReplicaConfig.CONFIG_PREFIX).isEqualTo("isolatedReplicaConfig.");
+  }
+
+  @Test
+  public void testEmptyConfig() {
+    String configFile = "{}";
+    IsolatedReplicaConfig config = getConfig(configFile);
+
+    assertThat(config.isEnabled()).isFalse();
+    assertThat(config.getPollingIntervalSeconds()).isEqualTo(120);
+  }
+
+  @Test
+  public void testComplexYamlWithOtherSettings() {
+    String configFile =
+        String.join(
+            "\n",
+            "nodeName: \"test_node\"",
+            "port: 9090",
+            "isolatedReplicaConfig:",
+            "  enabled: true",
+            "  pollingIntervalSeconds: 180",
+            "otherConfig:",
+            "  someValue: 42");
+    IsolatedReplicaConfig config = getConfig(configFile);
+
+    assertThat(config.isEnabled()).isTrue();
+    assertThat(config.getPollingIntervalSeconds()).isEqualTo(180);
+  }
+
+  @Test
+  public void testConfigWithComments() {
+    String configFile =
+        String.join(
+            "\n",
+            "# Node configuration",
+            "nodeName: \"test_node\"",
+            "# Isolated replica settings",
+            "isolatedReplicaConfig:",
+            "  enabled: true  # Enable isolated replica",
+            "  pollingIntervalSeconds: 300  # Poll every 5 minutes");
+    IsolatedReplicaConfig config = getConfig(configFile);
+
+    assertThat(config.isEnabled()).isTrue();
+    assertThat(config.getPollingIntervalSeconds()).isEqualTo(300);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/nrt/DefaultCopyThreadTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/nrt/DefaultCopyThreadTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.yelp.nrtsearch.server.nrt.jobs.SimpleCopyJob;
 import java.io.IOException;
 import java.util.Collections;
 import org.apache.lucene.replicator.nrt.CopyJob;

--- a/src/test/java/com/yelp/nrtsearch/server/nrt/NrtUtilsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/nrt/NrtUtilsTest.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.nrt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.ByteString;
+import com.yelp.nrtsearch.server.grpc.FileMetadata;
+import com.yelp.nrtsearch.server.grpc.FilesMetadata;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.lucene.replicator.nrt.FileMetaData;
+import org.junit.Test;
+
+public class NrtUtilsTest {
+
+  @Test
+  public void testReadFilesMetaDataEmpty() throws IOException {
+    FilesMetadata filesMetadata = FilesMetadata.newBuilder().setNumFiles(0).build();
+
+    Map<String, FileMetaData> result = NrtUtils.readFilesMetaData(filesMetadata);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void testReadFilesMetaDataSingleFile() throws IOException {
+    byte[] header = {0x01, 0x02, 0x03, 0x04};
+    byte[] footer = {(byte) 0xFF, (byte) 0xFE, (byte) 0xFD};
+
+    FileMetadata fileMetadata =
+        FileMetadata.newBuilder()
+            .setFileName("test.txt")
+            .setLen(1024L)
+            .setChecksum(123456789L)
+            .setHeaderLength(header.length)
+            .setHeader(ByteString.copyFrom(header))
+            .setFooterLength(footer.length)
+            .setFooter(ByteString.copyFrom(footer))
+            .build();
+
+    FilesMetadata filesMetadata =
+        FilesMetadata.newBuilder().setNumFiles(1).addFileMetadata(fileMetadata).build();
+
+    Map<String, FileMetaData> result = NrtUtils.readFilesMetaData(filesMetadata);
+
+    assertThat(result).hasSize(1);
+    assertThat(result).containsKey("test.txt");
+
+    FileMetaData fileMetaData = result.get("test.txt");
+    assertThat(fileMetaData.length()).isEqualTo(1024L);
+    assertThat(fileMetaData.checksum()).isEqualTo(123456789L);
+    assertThat(fileMetaData.header()).isEqualTo(header);
+    assertThat(fileMetaData.footer()).isEqualTo(footer);
+  }
+
+  @Test
+  public void testReadFilesMetaDataMultipleFiles() throws IOException {
+    byte[] header1 = {0x10, 0x20};
+    byte[] footer1 = {0x30, 0x40, 0x50};
+    byte[] header2 = {(byte) 0xAA, (byte) 0xBB, (byte) 0xCC, (byte) 0xDD, (byte) 0xEE};
+    byte[] footer2 = {(byte) 0x99};
+
+    FileMetadata file1 =
+        FileMetadata.newBuilder()
+            .setFileName("file1.dat")
+            .setLen(2048L)
+            .setChecksum(111111111L)
+            .setHeaderLength(header1.length)
+            .setHeader(ByteString.copyFrom(header1))
+            .setFooterLength(footer1.length)
+            .setFooter(ByteString.copyFrom(footer1))
+            .build();
+
+    FileMetadata file2 =
+        FileMetadata.newBuilder()
+            .setFileName("file2.idx")
+            .setLen(4096L)
+            .setChecksum(222222222L)
+            .setHeaderLength(header2.length)
+            .setHeader(ByteString.copyFrom(header2))
+            .setFooterLength(footer2.length)
+            .setFooter(ByteString.copyFrom(footer2))
+            .build();
+
+    FilesMetadata filesMetadata =
+        FilesMetadata.newBuilder()
+            .setNumFiles(2)
+            .addFileMetadata(file1)
+            .addFileMetadata(file2)
+            .build();
+
+    Map<String, FileMetaData> result = NrtUtils.readFilesMetaData(filesMetadata);
+
+    assertThat(result).hasSize(2);
+    assertThat(result).containsKeys("file1.dat", "file2.idx");
+
+    // Verify file1
+    FileMetaData fileMetaData1 = result.get("file1.dat");
+    assertThat(fileMetaData1.length()).isEqualTo(2048L);
+    assertThat(fileMetaData1.checksum()).isEqualTo(111111111L);
+    assertThat(fileMetaData1.header()).isEqualTo(header1);
+    assertThat(fileMetaData1.footer()).isEqualTo(footer1);
+
+    // Verify file2
+    FileMetaData fileMetaData2 = result.get("file2.idx");
+    assertThat(fileMetaData2.length()).isEqualTo(4096L);
+    assertThat(fileMetaData2.checksum()).isEqualTo(222222222L);
+    assertThat(fileMetaData2.header()).isEqualTo(header2);
+    assertThat(fileMetaData2.footer()).isEqualTo(footer2);
+  }
+
+  @Test
+  public void testReadFilesMetaDataWithEmptyHeaderAndFooter() throws IOException {
+    byte[] emptyHeader = new byte[0];
+    byte[] emptyFooter = new byte[0];
+
+    FileMetadata fileMetadata =
+        FileMetadata.newBuilder()
+            .setFileName("empty_metadata.txt")
+            .setLen(512L)
+            .setChecksum(987654321L)
+            .setHeaderLength(0)
+            .setHeader(ByteString.copyFrom(emptyHeader))
+            .setFooterLength(0)
+            .setFooter(ByteString.copyFrom(emptyFooter))
+            .build();
+
+    FilesMetadata filesMetadata =
+        FilesMetadata.newBuilder().setNumFiles(1).addFileMetadata(fileMetadata).build();
+
+    Map<String, FileMetaData> result = NrtUtils.readFilesMetaData(filesMetadata);
+
+    assertThat(result).hasSize(1);
+    assertThat(result).containsKey("empty_metadata.txt");
+
+    FileMetaData fileMetaData = result.get("empty_metadata.txt");
+    assertThat(fileMetaData.length()).isEqualTo(512L);
+    assertThat(fileMetaData.checksum()).isEqualTo(987654321L);
+    assertThat(fileMetaData.header()).isEqualTo(emptyHeader);
+    assertThat(fileMetaData.footer()).isEqualTo(emptyFooter);
+  }
+
+  @Test
+  public void testReadFilesMetaDataWithZeroLength() throws IOException {
+    byte[] header = {0x77, (byte) 0x88};
+    byte[] footer = {(byte) 0x99, (byte) 0xAA, (byte) 0xBB};
+
+    FileMetadata fileMetadata =
+        FileMetadata.newBuilder()
+            .setFileName("zero_length.dat")
+            .setLen(0L)
+            .setChecksum(0L)
+            .setHeaderLength(header.length)
+            .setHeader(ByteString.copyFrom(header))
+            .setFooterLength(footer.length)
+            .setFooter(ByteString.copyFrom(footer))
+            .build();
+
+    FilesMetadata filesMetadata =
+        FilesMetadata.newBuilder().setNumFiles(1).addFileMetadata(fileMetadata).build();
+
+    Map<String, FileMetaData> result = NrtUtils.readFilesMetaData(filesMetadata);
+
+    assertThat(result).hasSize(1);
+    assertThat(result).containsKey("zero_length.dat");
+
+    FileMetaData fileMetaData = result.get("zero_length.dat");
+    assertThat(fileMetaData.length()).isEqualTo(0L);
+    assertThat(fileMetaData.checksum()).isEqualTo(0L);
+    assertThat(fileMetaData.header()).isEqualTo(header);
+    assertThat(fileMetaData.footer()).isEqualTo(footer);
+  }
+
+  @Test
+  public void testReadFilesMetaDataWithNegativeChecksum() throws IOException {
+    byte[] header = {0x01};
+    byte[] footer = {0x02};
+
+    FileMetadata fileMetadata =
+        FileMetadata.newBuilder()
+            .setFileName("negative_checksum.txt")
+            .setLen(100L)
+            .setChecksum(-123456789L)
+            .setHeaderLength(header.length)
+            .setHeader(ByteString.copyFrom(header))
+            .setFooterLength(footer.length)
+            .setFooter(ByteString.copyFrom(footer))
+            .build();
+
+    FilesMetadata filesMetadata =
+        FilesMetadata.newBuilder().setNumFiles(1).addFileMetadata(fileMetadata).build();
+
+    Map<String, FileMetaData> result = NrtUtils.readFilesMetaData(filesMetadata);
+
+    assertThat(result).hasSize(1);
+    assertThat(result).containsKey("negative_checksum.txt");
+
+    FileMetaData fileMetaData = result.get("negative_checksum.txt");
+    assertThat(fileMetaData.length()).isEqualTo(100L);
+    assertThat(fileMetaData.checksum()).isEqualTo(-123456789L);
+    assertThat(fileMetaData.header()).isEqualTo(header);
+    assertThat(fileMetaData.footer()).isEqualTo(footer);
+  }
+
+  @Test
+  public void testReadFilesMetaDataWithLargeFile() throws IOException {
+    byte[] header = new byte[1024];
+    byte[] footer = new byte[512];
+
+    // Fill with some pattern
+    for (int i = 0; i < header.length; i++) {
+      header[i] = (byte) (i % 256);
+    }
+    for (int i = 0; i < footer.length; i++) {
+      footer[i] = (byte) ((i * 2) % 256);
+    }
+
+    FileMetadata fileMetadata =
+        FileMetadata.newBuilder()
+            .setFileName("large_file.bin")
+            .setLen(Long.MAX_VALUE)
+            .setChecksum(Long.MAX_VALUE)
+            .setHeaderLength(header.length)
+            .setHeader(ByteString.copyFrom(header))
+            .setFooterLength(footer.length)
+            .setFooter(ByteString.copyFrom(footer))
+            .build();
+
+    FilesMetadata filesMetadata =
+        FilesMetadata.newBuilder().setNumFiles(1).addFileMetadata(fileMetadata).build();
+
+    Map<String, FileMetaData> result = NrtUtils.readFilesMetaData(filesMetadata);
+
+    assertThat(result).hasSize(1);
+    assertThat(result).containsKey("large_file.bin");
+
+    FileMetaData fileMetaData = result.get("large_file.bin");
+    assertThat(fileMetaData.length()).isEqualTo(Long.MAX_VALUE);
+    assertThat(fileMetaData.checksum()).isEqualTo(Long.MAX_VALUE);
+    assertThat(fileMetaData.header()).isEqualTo(header);
+    assertThat(fileMetaData.footer()).isEqualTo(footer);
+  }
+
+  @Test
+  public void testReadFilesMetaDataWithSpecialCharactersInFileName() throws IOException {
+    byte[] header = {0x55};
+    byte[] footer = {0x66};
+
+    FileMetadata fileMetadata =
+        FileMetadata.newBuilder()
+            .setFileName("file with spaces & special chars!@#$%^&*()_+.txt")
+            .setLen(256L)
+            .setChecksum(555555555L)
+            .setHeaderLength(header.length)
+            .setHeader(ByteString.copyFrom(header))
+            .setFooterLength(footer.length)
+            .setFooter(ByteString.copyFrom(footer))
+            .build();
+
+    FilesMetadata filesMetadata =
+        FilesMetadata.newBuilder().setNumFiles(1).addFileMetadata(fileMetadata).build();
+
+    Map<String, FileMetaData> result = NrtUtils.readFilesMetaData(filesMetadata);
+
+    assertThat(result).hasSize(1);
+    assertThat(result).containsKey("file with spaces & special chars!@#$%^&*()_+.txt");
+
+    FileMetaData fileMetaData = result.get("file with spaces & special chars!@#$%^&*()_+.txt");
+    assertThat(fileMetaData.length()).isEqualTo(256L);
+    assertThat(fileMetaData.checksum()).isEqualTo(555555555L);
+    assertThat(fileMetaData.header()).isEqualTo(header);
+    assertThat(fileMetaData.footer()).isEqualTo(footer);
+  }
+
+  @Test
+  public void testReadFilesMetaDataConsistencyWithNumFiles() throws IOException {
+    // Test that the assertion in the method works correctly
+    byte[] header = {0x01};
+    byte[] footer = {0x02};
+
+    FileMetadata file1 =
+        FileMetadata.newBuilder()
+            .setFileName("file1.txt")
+            .setLen(100L)
+            .setChecksum(111L)
+            .setHeaderLength(header.length)
+            .setHeader(ByteString.copyFrom(header))
+            .setFooterLength(footer.length)
+            .setFooter(ByteString.copyFrom(footer))
+            .build();
+
+    FileMetadata file2 =
+        FileMetadata.newBuilder()
+            .setFileName("file2.txt")
+            .setLen(200L)
+            .setChecksum(222L)
+            .setHeaderLength(header.length)
+            .setHeader(ByteString.copyFrom(header))
+            .setFooterLength(footer.length)
+            .setFooter(ByteString.copyFrom(footer))
+            .build();
+
+    // numFiles matches actual count
+    FilesMetadata filesMetadata =
+        FilesMetadata.newBuilder()
+            .setNumFiles(2)
+            .addFileMetadata(file1)
+            .addFileMetadata(file2)
+            .build();
+
+    Map<String, FileMetaData> result = NrtUtils.readFilesMetaData(filesMetadata);
+
+    assertThat(result).hasSize(2);
+    assertThat(result).containsKeys("file1.txt", "file2.txt");
+  }
+
+  @Test
+  public void testReadFilesMetaDataPreservesOrder() throws IOException {
+    byte[] header = {0x01};
+    byte[] footer = {0x02};
+
+    // Create files with predictable ordering
+    FileMetadata[] files = new FileMetadata[5];
+    for (int i = 0; i < 5; i++) {
+      files[i] =
+          FileMetadata.newBuilder()
+              .setFileName("file_" + String.format("%02d", i) + ".txt")
+              .setLen(100L + i)
+              .setChecksum(1000L + i)
+              .setHeaderLength(header.length)
+              .setHeader(ByteString.copyFrom(header))
+              .setFooterLength(footer.length)
+              .setFooter(ByteString.copyFrom(footer))
+              .build();
+    }
+
+    FilesMetadata.Builder builder = FilesMetadata.newBuilder().setNumFiles(5);
+
+    for (FileMetadata file : files) {
+      builder.addFileMetadata(file);
+    }
+
+    Map<String, FileMetaData> result = NrtUtils.readFilesMetaData(builder.build());
+
+    assertThat(result).hasSize(5);
+
+    // Verify all files are present with correct data
+    for (int i = 0; i < 5; i++) {
+      String fileName = "file_" + String.format("%02d", i) + ".txt";
+      assertThat(result).containsKey(fileName);
+
+      FileMetaData fileMetaData = result.get(fileName);
+      assertThat(fileMetaData.length()).isEqualTo(100L + i);
+      assertThat(fileMetaData.checksum()).isEqualTo(1000L + i);
+      assertThat(fileMetaData.header()).isEqualTo(header);
+      assertThat(fileMetaData.footer()).isEqualTo(footer);
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/nrt/ProportionalCopyThreadTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/nrt/ProportionalCopyThreadTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.yelp.nrtsearch.server.nrt.jobs.SimpleCopyJob;
 import java.io.IOException;
 import java.util.Collections;
 import org.apache.lucene.replicator.nrt.CopyJob;

--- a/src/test/java/com/yelp/nrtsearch/server/nrt/SimpleCopyJobTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/nrt/SimpleCopyJobTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import com.google.protobuf.ByteString;
 import com.yelp.nrtsearch.server.grpc.FileInfo;
 import com.yelp.nrtsearch.server.grpc.RawFileChunk;
-import com.yelp.nrtsearch.server.nrt.SimpleCopyJob.FileChunkStreamingIterator;
+import com.yelp.nrtsearch.server.nrt.jobs.SimpleCopyJob.FileChunkStreamingIterator;
 import io.grpc.stub.StreamObserver;
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/java/com/yelp/nrtsearch/server/nrt/jobs/RemoteCopyJobManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/nrt/jobs/RemoteCopyJobManagerTest.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.nrt.jobs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.yelp.nrtsearch.server.nrt.NRTReplicaNode;
+import com.yelp.nrtsearch.server.nrt.NrtDataManager;
+import com.yelp.nrtsearch.server.nrt.state.NrtFileMetaData;
+import com.yelp.nrtsearch.server.nrt.state.NrtPointState;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+import org.apache.lucene.replicator.nrt.CopyJob;
+import org.apache.lucene.replicator.nrt.CopyState;
+import org.apache.lucene.replicator.nrt.FileMetaData;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RemoteCopyJobManagerTest {
+
+  @Mock private NrtDataManager mockDataManager;
+  @Mock private NRTReplicaNode mockReplicaNode;
+  @Mock private CopyJob.OnceDone mockOnceDone;
+
+  private RemoteCopyJobManager copyJobManager;
+  private static final int POLLING_INTERVAL = 1; // 1 second for fast tests
+
+  @Before
+  public void setUp() {
+    copyJobManager = new RemoteCopyJobManager(POLLING_INTERVAL, mockDataManager, mockReplicaNode);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    if (copyJobManager != null) {
+      copyJobManager.close();
+    }
+  }
+
+  @Test
+  public void testConstructor() {
+    assertNotNull(copyJobManager);
+  }
+
+  @Test
+  public void testNewCopyJob_withFiles() throws IOException {
+    Map<String, FileMetaData> files =
+        Map.of("file1", new FileMetaData(new byte[0], new byte[0], 1, 0));
+
+    try {
+      copyJobManager.newCopyJob("test", files, null, false, mockOnceDone);
+      fail("Expected IllegalArgumentException when files is not null");
+    } catch (IllegalArgumentException e) {
+      assertEquals("RemoteCopyJobManager does not support merge precopy", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testNewCopyJob_success() throws IOException {
+    // Create test data
+    NrtPointState pointState = createTestPointState();
+    Instant timestamp = Instant.now();
+    NrtDataManager.PointStateWithTimestamp pointStateWithTimestamp =
+        new NrtDataManager.PointStateWithTimestamp(pointState, timestamp);
+
+    when(mockDataManager.getTargetPointState()).thenReturn(pointStateWithTimestamp);
+
+    // Test the method
+    CopyJob copyJob = copyJobManager.newCopyJob("test_reason", null, null, true, mockOnceDone);
+
+    // Verify results
+    assertNotNull(copyJob);
+    assertTrue(copyJob instanceof RemoteCopyJob);
+
+    RemoteCopyJob remoteCopyJob = (RemoteCopyJob) copyJob;
+    assertEquals(pointState, remoteCopyJob.getPointState());
+    assertEquals(timestamp, remoteCopyJob.getPointStateTimestamp());
+
+    verify(mockDataManager).getTargetPointState();
+  }
+
+  @Test
+  public void testFinishNRTCopy_success() throws IOException {
+    // Create a mock RemoteCopyJob
+    RemoteCopyJob mockRemoteCopyJob = mock(RemoteCopyJob.class);
+    NrtPointState pointState = createTestPointState();
+    Instant timestamp = Instant.now();
+
+    when(mockRemoteCopyJob.getFailed()).thenReturn(false);
+    when(mockRemoteCopyJob.getPointState()).thenReturn(pointState);
+    when(mockRemoteCopyJob.getPointStateTimestamp()).thenReturn(timestamp);
+
+    // Test the method
+    copyJobManager.finishNRTCopy(mockRemoteCopyJob);
+
+    // Verify that setLastPointState was called
+    verify(mockDataManager).setLastPointState(pointState, timestamp);
+  }
+
+  @Test
+  public void testFinishNRTCopy_failed() throws IOException {
+    // Create a mock RemoteCopyJob that failed
+    RemoteCopyJob mockRemoteCopyJob = mock(RemoteCopyJob.class);
+    when(mockRemoteCopyJob.getFailed()).thenReturn(true);
+
+    // Test the method
+    copyJobManager.finishNRTCopy(mockRemoteCopyJob);
+
+    // Verify that setLastPointState was NOT called
+    verify(mockDataManager, never()).setLastPointState(any(), any());
+  }
+
+  @Test
+  public void testFinishNRTCopy_wrongCopyJobType() throws IOException {
+    // Create a mock CopyJob that is not a RemoteCopyJob
+    CopyJob mockCopyJob = mock(CopyJob.class);
+    when(mockCopyJob.getFailed()).thenReturn(false);
+
+    try {
+      copyJobManager.finishNRTCopy(mockCopyJob);
+      fail("Expected IllegalArgumentException for wrong copy job type");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("Expected copyJob to be instance of RemoteCopyJob"));
+    }
+  }
+
+  @Test
+  public void testStart() throws IOException {
+    copyJobManager.start();
+
+    // The thread should be started - we can't easily test the thread directly
+    // but we can verify it doesn't throw an exception
+    assertTrue(true);
+  }
+
+  @Test
+  public void testClose() throws IOException {
+    copyJobManager.start();
+    copyJobManager.close();
+
+    // Verify the manager can be closed without errors
+    assertTrue(true);
+  }
+
+  @Test
+  public void testUpdateTask_newPointAvailable() throws Exception {
+    // Set up test data
+    NrtPointState targetPointState = createTestPointState();
+    NrtDataManager.PointStateWithTimestamp pointStateWithTimestamp =
+        new NrtDataManager.PointStateWithTimestamp(targetPointState, Instant.now());
+
+    when(mockDataManager.getTargetPointState()).thenReturn(pointStateWithTimestamp);
+    when(mockReplicaNode.getCurrentSearchingVersion()).thenReturn(0L); // Lower than target version
+
+    // Create a copy job manager with very short polling interval for testing
+    RemoteCopyJobManager shortIntervalManager =
+        new RemoteCopyJobManager(1, mockDataManager, mockReplicaNode);
+
+    try {
+      shortIntervalManager.start();
+
+      // Wait a bit for the update task to run at least once
+      Thread.sleep(1200); // Wait 1.2 seconds
+
+      // Verify newNRTPoint was called at least once (it may be called multiple times due to
+      // polling)
+      verify(mockReplicaNode, atLeast(1))
+          .newNRTPoint(targetPointState.primaryGen, targetPointState.version);
+
+    } finally {
+      shortIntervalManager.close();
+    }
+  }
+
+  @Test
+  public void testUpdateTask_noNewPoint() throws Exception {
+    // Set up test data where current version is already up to date
+    NrtPointState targetPointState = createTestPointState();
+    NrtDataManager.PointStateWithTimestamp pointStateWithTimestamp =
+        new NrtDataManager.PointStateWithTimestamp(targetPointState, Instant.now());
+
+    when(mockDataManager.getTargetPointState()).thenReturn(pointStateWithTimestamp);
+    when(mockReplicaNode.getCurrentSearchingVersion())
+        .thenReturn(targetPointState.version); // Same as target
+
+    // Create a copy job manager with very short polling interval for testing
+    RemoteCopyJobManager shortIntervalManager =
+        new RemoteCopyJobManager(1, mockDataManager, mockReplicaNode);
+
+    try {
+      shortIntervalManager.start();
+
+      // Wait a bit for the update task to run
+      Thread.sleep(1500); // Wait 1.5 seconds
+
+      // Verify newNRTPoint was NOT called
+      verify(mockReplicaNode, never()).newNRTPoint(anyLong(), anyLong());
+
+    } finally {
+      shortIntervalManager.close();
+    }
+  }
+
+  @Test
+  public void testUpdateTask_exceptionHandling() throws Exception {
+    // Set up test data to throw an exception
+    when(mockDataManager.getTargetPointState()).thenThrow(new RuntimeException("Test exception"));
+
+    // Create a copy job manager with very short polling interval for testing
+    RemoteCopyJobManager shortIntervalManager =
+        new RemoteCopyJobManager(1, mockDataManager, mockReplicaNode);
+
+    try {
+      shortIntervalManager.start();
+
+      // Wait a bit for the update task to run
+      Thread.sleep(1500); // Wait 1.5 seconds
+
+      // The thread should continue running despite the exception
+      // We can't easily verify this, but at least it shouldn't crash the test
+      assertTrue(true);
+
+    } finally {
+      shortIntervalManager.close();
+    }
+  }
+
+  @Test
+  public void testUpdateTask_interrupted() throws Exception {
+    // Create a copy job manager
+    RemoteCopyJobManager shortIntervalManager =
+        new RemoteCopyJobManager(1, mockDataManager, mockReplicaNode);
+
+    try {
+      shortIntervalManager.start();
+
+      // Wait a short time then close (which interrupts the thread)
+      Thread.sleep(500);
+      shortIntervalManager.close();
+
+      // Verify it completes without hanging
+      assertTrue(true);
+
+    } catch (Exception e) {
+      // Should not throw any exceptions
+      fail("Unexpected exception: " + e.getMessage());
+    }
+  }
+
+  /** Create a test NrtPointState for testing purposes. */
+  private NrtPointState createTestPointState() {
+    long version = 1;
+    long gen = 3;
+    byte[] infosBytes = new byte[] {1, 2, 3, 4, 5};
+    long primaryGen = 5;
+    Set<String> completedMergeFiles = Set.of("file1");
+    String primaryId = "testPrimaryId";
+
+    FileMetaData fileMetaData =
+        new FileMetaData(new byte[] {6, 7, 8}, new byte[] {0, 10, 11}, 10, 25);
+    NrtFileMetaData nrtFileMetaData =
+        new NrtFileMetaData(
+            new byte[] {6, 7, 8}, new byte[] {0, 10, 11}, 10, 25, "primaryId2", "timeString");
+
+    CopyState copyState =
+        new CopyState(
+            Map.of("file3", fileMetaData),
+            version,
+            gen,
+            infosBytes,
+            completedMergeFiles,
+            primaryGen,
+            null);
+
+    return new NrtPointState(copyState, Map.of("file3", nrtFileMetaData), primaryId);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/nrt/jobs/RemoteCopyJobTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/nrt/jobs/RemoteCopyJobTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.nrt.jobs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import com.yelp.nrtsearch.server.nrt.NrtDataManager;
+import com.yelp.nrtsearch.server.nrt.state.NrtFileMetaData;
+import com.yelp.nrtsearch.server.nrt.state.NrtPointState;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.lucene.replicator.nrt.CopyJob;
+import org.apache.lucene.replicator.nrt.CopyState;
+import org.apache.lucene.replicator.nrt.FileMetaData;
+import org.apache.lucene.replicator.nrt.ReplicaNode;
+import org.apache.lucene.store.Directory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RemoteCopyJobTest {
+
+  @Mock private NrtDataManager mockDataManager;
+  @Mock private ReplicaNode mockReplicaNode;
+  @Mock private Directory mockDirectory;
+  @Mock private CopyJob.OnceDone mockOnceDone;
+
+  private NrtPointState testPointState;
+  private Instant testTimestamp;
+  private CopyState testCopyState;
+  private Map<String, FileMetaData> testFiles;
+
+  @Before
+  public void setUp() {
+    testPointState = createTestPointState();
+    testTimestamp = Instant.now();
+    testCopyState = testPointState.toCopyState();
+    testFiles = createTestFiles();
+  }
+
+  @Test
+  public void testConstructor() throws IOException {
+    RemoteCopyJob copyJob = createRemoteCopyJob();
+
+    assertNotNull(copyJob);
+    assertEquals(testPointState, copyJob.getPointState());
+    assertEquals(testTimestamp, copyJob.getPointStateTimestamp());
+    assertEquals(testCopyState, copyJob.getCopyState());
+  }
+
+  @Test
+  public void testGetPointState() throws IOException {
+    RemoteCopyJob copyJob = createRemoteCopyJob();
+    assertEquals(testPointState, copyJob.getPointState());
+  }
+
+  @Test
+  public void testGetPointStateTimestamp() throws IOException {
+    RemoteCopyJob copyJob = createRemoteCopyJob();
+    assertEquals(testTimestamp, copyJob.getPointStateTimestamp());
+  }
+
+  @Test
+  public void testGetCopyState() throws IOException {
+    RemoteCopyJob copyJob = createRemoteCopyJob();
+    assertEquals(testCopyState, copyJob.getCopyState());
+  }
+
+  @Test
+  public void testGetFileNames() throws IOException {
+    RemoteCopyJob copyJob = createRemoteCopyJob();
+    Set<String> fileNames = copyJob.getFileNames();
+
+    // The method should return a set (may be empty depending on how the parent class works)
+    assertNotNull(fileNames);
+  }
+
+  @Test
+  public void testGetFileNamesToCopy() throws IOException {
+    RemoteCopyJob copyJob = createRemoteCopyJob();
+    Set<String> fileNamesToCopy = copyJob.getFileNamesToCopy();
+
+    // The method should return a set (may be empty depending on how the parent class works)
+    assertNotNull(fileNamesToCopy);
+  }
+
+  @Test
+  public void testGetTotalBytesCopied_initial() throws IOException {
+    RemoteCopyJob copyJob = createRemoteCopyJob();
+    assertEquals(0L, copyJob.getTotalBytesCopied());
+  }
+
+  @Test
+  public void testGetFailed_initial() throws IOException {
+    RemoteCopyJob copyJob = createRemoteCopyJob();
+    assertFalse(copyJob.getFailed());
+  }
+
+  @Test
+  public void testStart_success() throws IOException {
+    RemoteCopyJob copyJob = createRemoteCopyJob();
+
+    copyJob.start();
+
+    // Verify that the replica node received the initialization message
+    verify(mockReplicaNode).message(anyString());
+  }
+
+  @Test
+  public void testStart_alreadyStarted() throws IOException {
+    RemoteCopyJob copyJob = createRemoteCopyJob();
+
+    copyJob.start();
+
+    try {
+      copyJob.start();
+      fail("Expected IllegalStateException when starting already started job");
+    } catch (IllegalStateException e) {
+      assertEquals("already started", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testStart_replicaNodeThrowsException() throws IOException {
+    RemoteCopyJob copyJob = createRemoteCopyJob();
+
+    doThrow(new RuntimeException("Test exception")).when(mockReplicaNode).message(anyString());
+
+    try {
+      copyJob.start();
+      fail("Expected exception when replica node throws");
+    } catch (Exception e) {
+      // Some exception should be thrown when the replica node fails
+      assertNotNull(e);
+    }
+  }
+
+  @Test
+  public void testCompareTo_samePriority() throws IOException {
+    RemoteCopyJob copyJob1 = createRemoteCopyJob("reason1", false);
+    RemoteCopyJob copyJob2 = createRemoteCopyJob("reason2", false);
+
+    // Both jobs have same priority, so comparison should be based on order
+    int comparison = copyJob1.compareTo(copyJob2);
+    assertTrue(comparison < 0); // copyJob1 was created first
+  }
+
+  @Test
+  public void testCompareTo_differentPriority() throws IOException {
+    RemoteCopyJob highPriorityJob = createRemoteCopyJob("high", true);
+    RemoteCopyJob lowPriorityJob = createRemoteCopyJob("low", false);
+
+    assertTrue(highPriorityJob.compareTo(lowPriorityJob) < 0); // high priority comes first
+    assertTrue(lowPriorityJob.compareTo(highPriorityJob) > 0); // low priority comes later
+  }
+
+  @Test
+  public void testConflicts_noConflict() throws IOException {
+    Map<String, FileMetaData> files1 =
+        Map.of("file1.dat", new FileMetaData(new byte[0], new byte[0], 100, 0));
+    Map<String, FileMetaData> files2 =
+        Map.of("file2.dat", new FileMetaData(new byte[0], new byte[0], 200, 0));
+
+    RemoteCopyJob copyJob1 = createRemoteCopyJobWithFiles("reason1", files1);
+    RemoteCopyJob copyJob2 = createRemoteCopyJobWithFiles("reason2", files2);
+
+    assertFalse(copyJob1.conflicts(copyJob2));
+    assertFalse(copyJob2.conflicts(copyJob1));
+  }
+
+  @Test
+  public void testConflicts_hasConflict() throws IOException {
+    Map<String, FileMetaData> files1 =
+        Map.of(
+            "file1.dat", new FileMetaData(new byte[0], new byte[0], 100, 0),
+            "shared.dat", new FileMetaData(new byte[0], new byte[0], 50, 0));
+    Map<String, FileMetaData> files2 =
+        Map.of(
+            "file2.dat", new FileMetaData(new byte[0], new byte[0], 200, 0),
+            "shared.dat", new FileMetaData(new byte[0], new byte[0], 50, 0));
+
+    RemoteCopyJob copyJob1 = createRemoteCopyJobWithFiles("reason1", files1);
+    RemoteCopyJob copyJob2 = createRemoteCopyJobWithFiles("reason2", files2);
+
+    // Test the conflicts method - the result depends on internal toCopy field setup
+    // Just verify the method can be called without exception
+    boolean conflicts = copyJob1.conflicts(copyJob2);
+    // The actual result depends on how the parent class sets up toCopy
+    assertNotNull(conflicts);
+  }
+
+  @Test
+  public void testVisit_noFiles() throws IOException {
+    Map<String, FileMetaData> emptyFiles = Map.of();
+    RemoteCopyJob copyJob = createRemoteCopyJobWithFiles("empty", emptyFiles);
+
+    copyJob.start();
+
+    // With no files to copy, visit should return true (done)
+    assertTrue(copyJob.visit());
+  }
+
+  @Test
+  public void testVisit_simple() throws IOException {
+    RemoteCopyJob copyJob = createRemoteCopyJob();
+
+    copyJob.start();
+
+    // Test that visit can be called without exception
+    boolean result = copyJob.visit();
+    // We just verify the method can be called without throwing
+    assertNotNull(result);
+  }
+
+  @Test
+  public void testRunBlocking_success() throws Exception {
+    Map<String, FileMetaData> emptyFiles = Map.of();
+    RemoteCopyJob copyJob = createRemoteCopyJobWithFiles("blocking", emptyFiles);
+
+    copyJob.start();
+    copyJob.runBlocking();
+
+    // Should complete without exception
+    assertTrue(true);
+  }
+
+  @Test
+  public void testFinish_success() throws IOException {
+    RemoteCopyJob copyJob = createRemoteCopyJob();
+
+    copyJob.start();
+    copyJob.finish();
+
+    // Verify that message was called at least twice (once for start, once for finish)
+    verify(mockReplicaNode, atLeast(2)).message(anyString());
+  }
+
+  @Test
+  public void testToString() throws IOException {
+    RemoteCopyJob copyJob = createRemoteCopyJob();
+    String result = copyJob.toString();
+
+    assertNotNull(result);
+    assertTrue(result.contains("RemoteCopyJob"));
+    assertTrue(result.contains("test_reason"));
+  }
+
+  @Test
+  public void testNewCopyOneFile() throws IOException {
+    RemoteCopyJob copyJob = createRemoteCopyJob();
+
+    // This method should return the same instance that was passed in
+    // (no state changes when transferring to a new job)
+    Object result = copyJob.newCopyOneFile(null);
+
+    // The method should return the input (null in this case)
+    assertEquals(null, result);
+  }
+
+  // Helper methods
+
+  private RemoteCopyJob createRemoteCopyJob() throws IOException {
+    return createRemoteCopyJob("test_reason", false);
+  }
+
+  private RemoteCopyJob createRemoteCopyJob(String reason, boolean highPriority)
+      throws IOException {
+    return createRemoteCopyJobWithFiles(reason, testFiles, highPriority);
+  }
+
+  private RemoteCopyJob createRemoteCopyJobWithFiles(String reason, Map<String, FileMetaData> files)
+      throws IOException {
+    return createRemoteCopyJobWithFiles(reason, files, false);
+  }
+
+  private RemoteCopyJob createRemoteCopyJobWithFiles(
+      String reason, Map<String, FileMetaData> files, boolean highPriority) throws IOException {
+    return createRemoteCopyJobWithPointStateAndFiles(testPointState, files, reason, highPriority);
+  }
+
+  private RemoteCopyJob createRemoteCopyJobWithPointStateAndFiles(
+      NrtPointState pointState,
+      Map<String, FileMetaData> files,
+      String reason,
+      boolean highPriority)
+      throws IOException {
+    CopyState copyState = pointState.toCopyState();
+    return new RemoteCopyJob(
+        reason,
+        pointState,
+        testTimestamp,
+        copyState,
+        mockDataManager,
+        mockReplicaNode,
+        files,
+        highPriority,
+        mockOnceDone);
+  }
+
+  private NrtPointState createTestPointState() {
+    long version = 1;
+    long gen = 3;
+    byte[] infosBytes = new byte[] {1, 2, 3, 4, 5};
+    long primaryGen = 5;
+    Set<String> completedMergeFiles = Set.of("file1");
+    String primaryId = "testPrimaryId";
+
+    FileMetaData fileMetaData =
+        new FileMetaData(new byte[] {6, 7, 8}, new byte[] {0, 10, 11}, 10, 25);
+    NrtFileMetaData nrtFileMetaData =
+        new NrtFileMetaData(
+            new byte[] {6, 7, 8}, new byte[] {0, 10, 11}, 10, 25, "primaryId2", "timeString");
+
+    CopyState copyState =
+        new CopyState(
+            Map.of("file3", fileMetaData),
+            version,
+            gen,
+            infosBytes,
+            completedMergeFiles,
+            primaryGen,
+            null);
+
+    return new NrtPointState(copyState, Map.of("file3", nrtFileMetaData), primaryId);
+  }
+
+  private Map<String, FileMetaData> createTestFiles() {
+    Map<String, FileMetaData> files = new HashMap<>();
+    files.put("file1.dat", new FileMetaData(new byte[] {1, 2}, new byte[] {3, 4}, 100, 12345));
+    files.put("file2.idx", new FileMetaData(new byte[] {5, 6}, new byte[] {7, 8}, 200, 67890));
+    return files;
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/remote/InputStreamDataInputTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/remote/InputStreamDataInputTest.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.remote;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Test;
+
+public class InputStreamDataInputTest {
+
+  @Test
+  public void testReadByte() throws IOException {
+    byte[] data = {0x01, 0x02, (byte) 0xFF, 0x7F, (byte) 0x80};
+    InputStream inputStream = new ByteArrayInputStream(data);
+    try (InputStreamDataInput dataInput = new InputStreamDataInput(inputStream)) {
+      assertThat(dataInput.readByte()).isEqualTo((byte) 0x01);
+      assertThat(dataInput.readByte()).isEqualTo((byte) 0x02);
+      assertThat(dataInput.readByte()).isEqualTo((byte) 0xFF);
+      assertThat(dataInput.readByte()).isEqualTo((byte) 0x7F);
+      assertThat(dataInput.readByte()).isEqualTo((byte) 0x80);
+    }
+  }
+
+  @Test
+  public void testReadByteFromEmptyStream() throws IOException {
+    InputStream inputStream = new ByteArrayInputStream(new byte[0]);
+    try (InputStreamDataInput dataInput = new InputStreamDataInput(inputStream)) {
+      assertThatThrownBy(() -> dataInput.readByte())
+          .isInstanceOf(IOException.class)
+          .hasMessage("End of stream reached");
+    }
+  }
+
+  @Test
+  public void testReadByteAtEndOfStream() throws IOException {
+    byte[] data = {0x01};
+    InputStream inputStream = new ByteArrayInputStream(data);
+    try (InputStreamDataInput dataInput = new InputStreamDataInput(inputStream)) {
+      // Read the only byte
+      assertThat(dataInput.readByte()).isEqualTo((byte) 0x01);
+
+      // Next read should throw exception
+      assertThatThrownBy(() -> dataInput.readByte())
+          .isInstanceOf(IOException.class)
+          .hasMessage("End of stream reached");
+    }
+  }
+
+  @Test
+  public void testReadBytes() throws IOException {
+    byte[] data = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    InputStream inputStream = new ByteArrayInputStream(data);
+    try (InputStreamDataInput dataInput = new InputStreamDataInput(inputStream)) {
+      byte[] buffer = new byte[4];
+      dataInput.readBytes(buffer, 0, 4);
+      assertThat(buffer).containsExactly(0x01, 0x02, 0x03, 0x04);
+
+      buffer = new byte[4];
+      dataInput.readBytes(buffer, 0, 4);
+      assertThat(buffer).containsExactly(0x05, 0x06, 0x07, 0x08);
+    }
+  }
+
+  @Test
+  public void testReadBytesWithOffset() throws IOException {
+    byte[] data = {0x01, 0x02, 0x03, 0x04, 0x05};
+    InputStream inputStream = new ByteArrayInputStream(data);
+    try (InputStreamDataInput dataInput = new InputStreamDataInput(inputStream)) {
+      byte[] buffer = new byte[10];
+      dataInput.readBytes(buffer, 3, 5);
+
+      // Check that only the specified range was filled
+      assertThat(buffer[0]).isEqualTo((byte) 0x00); // untouched
+      assertThat(buffer[1]).isEqualTo((byte) 0x00); // untouched
+      assertThat(buffer[2]).isEqualTo((byte) 0x00); // untouched
+      assertThat(buffer[3]).isEqualTo((byte) 0x01); // start of data
+      assertThat(buffer[4]).isEqualTo((byte) 0x02);
+      assertThat(buffer[5]).isEqualTo((byte) 0x03);
+      assertThat(buffer[6]).isEqualTo((byte) 0x04);
+      assertThat(buffer[7]).isEqualTo((byte) 0x05); // end of data
+      assertThat(buffer[8]).isEqualTo((byte) 0x00); // untouched
+      assertThat(buffer[9]).isEqualTo((byte) 0x00); // untouched
+    }
+  }
+
+  @Test
+  public void testReadBytesPartialRead() throws IOException {
+    // Create a mock InputStream that returns partial reads
+    InputStream mockStream = mock(InputStream.class);
+    when(mockStream.read(any(byte[].class), anyInt(), anyInt()))
+        .thenReturn(2) // First call returns 2 bytes
+        .thenReturn(3) // Second call returns 3 bytes
+        .thenReturn(-1); // Third call returns EOF
+
+    try (InputStreamDataInput dataInput = new InputStreamDataInput(mockStream)) {
+      byte[] buffer = new byte[10];
+
+      dataInput.readBytes(buffer, 0, 5);
+
+      // Verify that read was called twice to get all 5 bytes
+      verify(mockStream, times(2)).read(any(byte[].class), anyInt(), anyInt());
+    }
+  }
+
+  @Test
+  public void testReadBytesEndOfStream() throws IOException {
+    byte[] data = {0x01, 0x02, 0x03};
+    InputStream inputStream = new ByteArrayInputStream(data);
+    try (InputStreamDataInput dataInput = new InputStreamDataInput(inputStream)) {
+      byte[] buffer = new byte[5];
+      assertThatThrownBy(() -> dataInput.readBytes(buffer, 0, 5))
+          .isInstanceOf(IOException.class)
+          .hasMessage("End of stream reached before reading all bytes");
+    }
+  }
+
+  @Test
+  public void testReadBytesZeroLength() throws IOException {
+    byte[] data = {0x01, 0x02, 0x03};
+    InputStream inputStream = new ByteArrayInputStream(data);
+    try (InputStreamDataInput dataInput = new InputStreamDataInput(inputStream)) {
+      byte[] buffer = new byte[5];
+      // Reading zero bytes should not throw and should not consume any data
+      dataInput.readBytes(buffer, 0, 0);
+
+      // Verify we can still read the first byte
+      assertThat(dataInput.readByte()).isEqualTo((byte) 0x01);
+    }
+  }
+
+  @Test
+  public void testSkipBytes() throws IOException {
+    byte[] data = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    InputStream inputStream = new ByteArrayInputStream(data);
+    try (InputStreamDataInput dataInput = new InputStreamDataInput(inputStream)) {
+      // Skip 3 bytes
+      dataInput.skipBytes(3);
+
+      // Next read should return the 4th byte
+      assertThat(dataInput.readByte()).isEqualTo((byte) 0x04);
+
+      // Skip 2 more bytes
+      dataInput.skipBytes(2);
+
+      // Next read should return the 7th byte
+      assertThat(dataInput.readByte()).isEqualTo((byte) 0x07);
+    }
+  }
+
+  @Test
+  public void testSkipBytesZero() throws IOException {
+    byte[] data = {0x01, 0x02, 0x03};
+    InputStream inputStream = new ByteArrayInputStream(data);
+    try (InputStreamDataInput dataInput = new InputStreamDataInput(inputStream)) {
+      // Skipping zero bytes should be a no-op
+      dataInput.skipBytes(0);
+
+      // Should still be able to read the first byte
+      assertThat(dataInput.readByte()).isEqualTo((byte) 0x01);
+    }
+  }
+
+  @Test
+  public void testSkipBytesWithPartialSkips() throws IOException {
+    // Create a mock InputStream that returns partial skips
+    InputStream mockStream = mock(InputStream.class);
+    when(mockStream.skip(anyLong()))
+        .thenReturn(2L) // First skip call returns 2
+        .thenReturn(3L) // Second skip call returns 3
+        .thenReturn(0L); // Third skip call returns 0 (no more skips possible)
+    when(mockStream.read())
+        .thenReturn(0x01) // When skip returns 0, try to read
+        .thenReturn(-1); // Then EOF
+
+    try (InputStreamDataInput dataInput = new InputStreamDataInput(mockStream)) {
+      dataInput.skipBytes(6); // Should require multiple skip calls
+
+      verify(mockStream, times(3)).skip(anyLong());
+      verify(mockStream, times(1)).read(); // Should call read once when skip returns 0
+    }
+  }
+
+  @Test
+  public void testSkipBytesEndOfStream() throws IOException {
+    byte[] data = {0x01, 0x02, 0x03};
+    InputStream inputStream = new ByteArrayInputStream(data);
+    try (InputStreamDataInput dataInput = new InputStreamDataInput(inputStream)) {
+      assertThatThrownBy(() -> dataInput.skipBytes(5))
+          .isInstanceOf(IOException.class)
+          .hasMessage("End of stream reached while skipping bytes");
+    }
+  }
+
+  @Test
+  public void testSkipBytesWithReadFallback() throws IOException {
+    // Create a mock that can't skip but can read
+    InputStream mockStream = mock(InputStream.class);
+    when(mockStream.skip(anyLong())).thenReturn(0L); // Always returns 0 (can't skip)
+    when(mockStream.read())
+        .thenReturn(0x01) // Return some bytes when read
+        .thenReturn(0x02)
+        .thenReturn(0x03)
+        .thenReturn(-1); // Then EOF
+
+    try (InputStreamDataInput dataInput = new InputStreamDataInput(mockStream)) {
+      dataInput.skipBytes(3);
+
+      // Should have called read 3 times since skip always returns 0
+      verify(mockStream, times(3)).read();
+    }
+  }
+
+  @Test
+  public void testSkipBytesWithReadFallbackEndOfStream() throws IOException {
+    // Create a mock that can't skip and hits EOF during read
+    InputStream mockStream = mock(InputStream.class);
+    when(mockStream.skip(anyLong())).thenReturn(0L); // Always returns 0 (can't skip)
+    when(mockStream.read())
+        .thenReturn(0x01) // Return one byte
+        .thenReturn(-1); // Then EOF
+
+    try (InputStreamDataInput dataInput = new InputStreamDataInput(mockStream)) {
+      assertThatThrownBy(() -> dataInput.skipBytes(3))
+          .isInstanceOf(IOException.class)
+          .hasMessage("End of stream reached while skipping bytes");
+    }
+  }
+
+  @Test
+  public void testClose() throws IOException {
+    InputStream mockStream = mock(InputStream.class);
+    try (InputStreamDataInput dataInput = new InputStreamDataInput(mockStream)) {
+      // The close will be called automatically by try-with-resources
+    }
+    verify(mockStream, times(1)).close();
+  }
+
+  @Test
+  public void testCloseWithIOException() throws IOException {
+    InputStream mockStream = mock(InputStream.class);
+    IOException expectedException = new IOException("Close failed");
+    doThrow(expectedException).when(mockStream).close();
+
+    InputStreamDataInput dataInput = new InputStreamDataInput(mockStream);
+
+    assertThatThrownBy(() -> dataInput.close()).isEqualTo(expectedException);
+  }
+
+  @Test
+  public void testIntegrationWithRealData() throws IOException {
+    // Test with a larger dataset to ensure everything works together
+    byte[] data = new byte[1000];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = (byte) (i % 256);
+    }
+
+    InputStream inputStream = new ByteArrayInputStream(data);
+    try (InputStreamDataInput dataInput = new InputStreamDataInput(inputStream)) {
+      // Read some individual bytes
+      assertThat(dataInput.readByte()).isEqualTo((byte) 0);
+      assertThat(dataInput.readByte()).isEqualTo((byte) 1);
+      assertThat(dataInput.readByte()).isEqualTo((byte) 2);
+
+      // Skip some bytes
+      dataInput.skipBytes(10);
+
+      // Read a chunk
+      byte[] buffer = new byte[5];
+      dataInput.readBytes(buffer, 0, 5);
+      assertThat(buffer).containsExactly((byte) 13, (byte) 14, (byte) 15, (byte) 16, (byte) 17);
+
+      // Skip to near the end
+      dataInput.skipBytes(975);
+
+      // Read the last few bytes
+      assertThat(dataInput.readByte()).isEqualTo((byte) (993 % 256));
+      assertThat(dataInput.readByte()).isEqualTo((byte) (994 % 256));
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/backup/SnapshotRestoreCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/backup/SnapshotRestoreCommandTest.java
@@ -373,7 +373,7 @@ public class SnapshotRestoreCommandTest {
     S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, s3Client);
     NrtPointState pointState =
         RemoteUtils.pointStateFromUtf8(
-            s3Backend.downloadPointState(SERVICE_NAME, indexResource).readAllBytes());
+            s3Backend.downloadPointState(SERVICE_NAME, indexResource).inputStream().readAllBytes());
     assertEquals(Set.of("_0.cfe", "_0.si", "_0.cfs"), pointState.files.keySet());
     Set<String> pointBackendFiles =
         pointState.files.entrySet().stream()
@@ -414,7 +414,7 @@ public class SnapshotRestoreCommandTest {
 
     NrtPointState pointState =
         RemoteUtils.pointStateFromUtf8(
-            s3Backend.downloadPointState(serviceName, indexResource).readAllBytes());
+            s3Backend.downloadPointState(serviceName, indexResource).inputStream().readAllBytes());
     assertEquals(expectedIndexFiles, pointState.files.keySet());
     Set<String> localPointFiles =
         pointState.files.entrySet().stream().map(Map.Entry::getKey).collect(Collectors.toSet());

--- a/src/test/java/org/apache/lucene/replicator/nrt/CopyOneFileTest.java
+++ b/src/test/java/org/apache/lucene/replicator/nrt/CopyOneFileTest.java
@@ -84,8 +84,8 @@ public class CopyOneFileTest {
     when(mockNode.createTempOutput("test_copy", "copy", IOContext.DEFAULT)).thenReturn(mockOutput);
     // copy does not use header or footer
     FileMetaData fileMetaData = new FileMetaData(new byte[0], new byte[0], length, checksum);
-    CopyOneFile copyOneFile =
-        new CopyOneFile(chunks.listIterator(), mockNode, "test_copy", fileMetaData);
+    GrpcCopyOneFile copyOneFile =
+        new GrpcCopyOneFile(chunks.listIterator(), mockNode, "test_copy", fileMetaData);
 
     for (int i = 0; i < chunks.size(); ++i) {
       assertFalse(copyOneFile.visit());

--- a/src/test/java/org/apache/lucene/replicator/nrt/StreamCopyOneFileTest.java
+++ b/src/test/java/org/apache/lucene/replicator/nrt/StreamCopyOneFileTest.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.replicator.nrt;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Random;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexOutput;
+import org.junit.Test;
+
+public class StreamCopyOneFileTest {
+  private static final int CHUNK_SIZE = 1024;
+  private static final Random rand = new Random();
+
+  @Test
+  public void testCopySmallFile() throws IOException {
+    copyAndVerify(100);
+  }
+
+  @Test
+  public void testCopyFullChunk() throws IOException {
+    copyAndVerify(CHUNK_SIZE);
+  }
+
+  @Test
+  public void testCopyMultiChunks() throws IOException {
+    copyAndVerify(CHUNK_SIZE + 100);
+  }
+
+  @Test
+  public void testCopyFileWithChecksumOnly() throws IOException {
+    copyAndVerify(Long.BYTES);
+  }
+
+  @Test
+  public void testCopyFileWithMinimalData() throws IOException {
+    copyAndVerify(Long.BYTES + 1);
+  }
+
+  @Test
+  public void testChecksumsMatch() throws IOException {
+    long checksum = rand.nextLong();
+    int fileLength = 100;
+
+    MockDataInput mockDataInput = createMockDataInput(fileLength, checksum);
+    IndexOutput mockOutput = mock(IndexOutput.class);
+    ReplicaNode mockNode = mock(ReplicaNode.class);
+
+    when(mockOutput.getChecksum()).thenReturn(checksum);
+    when(mockOutput.getName()).thenReturn("test_file.tmp");
+    when(mockNode.createTempOutput(eq("test_file"), eq("copy"), any(IOContext.class)))
+        .thenReturn(mockOutput);
+
+    FileMetaData fileMetaData = new FileMetaData(new byte[0], new byte[0], fileLength, checksum);
+    byte[] buffer = new byte[CHUNK_SIZE];
+
+    try (StreamCopyOneFile copyOneFile =
+        new StreamCopyOneFile(mockDataInput, mockNode, "test_file", fileMetaData, buffer)) {
+
+      // Copy all data
+      boolean done = false;
+      while (!done) {
+        done = copyOneFile.visit();
+      }
+
+      // Verify the file was copied correctly
+      verify(mockNode).startCopyFile("test_file");
+      verify(mockNode).finishCopyFile("test_file");
+      verify(mockOutput).close();
+    }
+  }
+
+  @Test
+  public void testChecksumMismatchThrowsException() throws IOException {
+    long correctChecksum = rand.nextLong();
+    long wrongChecksum = correctChecksum + 1; // Different checksum
+    int fileLength = 100;
+
+    MockDataInput mockDataInput = createMockDataInput(fileLength, correctChecksum);
+    IndexOutput mockOutput = mock(IndexOutput.class);
+    ReplicaNode mockNode = mock(ReplicaNode.class);
+
+    when(mockOutput.getChecksum()).thenReturn(wrongChecksum); // Wrong checksum
+    when(mockOutput.getName()).thenReturn("test_file.tmp");
+    when(mockNode.createTempOutput(eq("test_file"), eq("copy"), any(IOContext.class)))
+        .thenReturn(mockOutput);
+
+    FileMetaData fileMetaData =
+        new FileMetaData(new byte[0], new byte[0], fileLength, correctChecksum);
+    byte[] buffer = new byte[CHUNK_SIZE];
+
+    try (StreamCopyOneFile copyOneFile =
+        new StreamCopyOneFile(mockDataInput, mockNode, "test_file", fileMetaData, buffer)) {
+
+      // Copy all data - should throw on final visit
+      assertThrows(
+          IOException.class,
+          () -> {
+            boolean done = false;
+            while (!done) {
+              done = copyOneFile.visit();
+            }
+          });
+    }
+  }
+
+  @Test
+  public void testRemoteChecksumMismatchThrowsException() throws IOException {
+    long correctChecksum = rand.nextLong();
+    long wrongRemoteChecksum = correctChecksum + 1;
+    int fileLength = 100;
+
+    MockDataInput mockDataInput = createMockDataInput(fileLength, wrongRemoteChecksum);
+    IndexOutput mockOutput = mock(IndexOutput.class);
+    ReplicaNode mockNode = mock(ReplicaNode.class);
+
+    when(mockOutput.getChecksum()).thenReturn(correctChecksum);
+    when(mockOutput.getName()).thenReturn("test_file.tmp");
+    when(mockNode.createTempOutput(eq("test_file"), eq("copy"), any(IOContext.class)))
+        .thenReturn(mockOutput);
+
+    FileMetaData fileMetaData =
+        new FileMetaData(new byte[0], new byte[0], fileLength, correctChecksum);
+    byte[] buffer = new byte[CHUNK_SIZE];
+
+    // Copy all data - should throw on final visit due to remote checksum mismatch
+    assertThrows(
+        IOException.class,
+        () -> {
+          try (StreamCopyOneFile copyOneFile =
+              new StreamCopyOneFile(mockDataInput, mockNode, "test_file", fileMetaData, buffer)) {
+            boolean done = false;
+            while (!done) {
+              done = copyOneFile.visit();
+            }
+          }
+        });
+  }
+
+  @Test
+  public void testGetters() throws IOException {
+    long checksum = rand.nextLong();
+    int fileLength = 100;
+
+    MockDataInput mockDataInput = createMockDataInput(fileLength, checksum);
+    IndexOutput mockOutput = mock(IndexOutput.class);
+    ReplicaNode mockNode = mock(ReplicaNode.class);
+
+    when(mockOutput.getChecksum()).thenReturn(checksum);
+    when(mockOutput.getName()).thenReturn("test_file.tmp");
+    when(mockNode.createTempOutput(eq("test_file"), eq("copy"), any(IOContext.class)))
+        .thenReturn(mockOutput);
+
+    FileMetaData fileMetaData = new FileMetaData(new byte[0], new byte[0], fileLength, checksum);
+    byte[] buffer = new byte[CHUNK_SIZE];
+
+    try (StreamCopyOneFile copyOneFile =
+        new StreamCopyOneFile(mockDataInput, mockNode, "test_file", fileMetaData, buffer)) {
+
+      // Test getters
+      assertEquals("test_file", copyOneFile.getFileName());
+      assertEquals("test_file.tmp", copyOneFile.getFileTmpName());
+      assertEquals(fileMetaData, copyOneFile.getFileMetaData());
+      assertEquals(fileLength - Long.BYTES, copyOneFile.getBytesToCopy());
+      assertEquals(0, copyOneFile.getBytesCopied()); // Initially 0
+
+      // Copy some data and check bytes copied
+      copyOneFile.visit();
+      assertTrue(copyOneFile.getBytesCopied() > 0);
+    }
+  }
+
+  @Test
+  public void testCloseWithCloseableDataInput() throws IOException {
+    long checksum = rand.nextLong();
+    int fileLength = 100;
+
+    MockCloseableDataInput mockDataInput = new MockCloseableDataInput(fileLength, checksum);
+    IndexOutput mockOutput = mock(IndexOutput.class);
+    ReplicaNode mockNode = mock(ReplicaNode.class);
+
+    when(mockOutput.getChecksum()).thenReturn(checksum);
+    when(mockOutput.getName()).thenReturn("test_file.tmp");
+    when(mockNode.createTempOutput(eq("test_file"), eq("copy"), any(IOContext.class)))
+        .thenReturn(mockOutput);
+
+    FileMetaData fileMetaData = new FileMetaData(new byte[0], new byte[0], fileLength, checksum);
+    byte[] buffer = new byte[CHUNK_SIZE];
+
+    StreamCopyOneFile copyOneFile =
+        new StreamCopyOneFile(mockDataInput, mockNode, "test_file", fileMetaData, buffer);
+
+    copyOneFile.close();
+
+    // Verify that the closeable data input was closed
+    assertTrue(mockDataInput.isClosed());
+    verify(mockOutput).close();
+    verify(mockNode).finishCopyFile("test_file");
+  }
+
+  private void copyAndVerify(int length) throws IOException {
+    long checksum = rand.nextLong();
+
+    MockDataInput mockDataInput = createMockDataInput(length, checksum);
+    IndexOutput mockOutput = mock(IndexOutput.class);
+    ReplicaNode mockNode = mock(ReplicaNode.class);
+
+    when(mockOutput.getChecksum()).thenReturn(checksum);
+    when(mockOutput.getName()).thenReturn("test_file.tmp");
+    when(mockNode.createTempOutput(eq("test_file"), eq("copy"), any(IOContext.class)))
+        .thenReturn(mockOutput);
+
+    FileMetaData fileMetaData = new FileMetaData(new byte[0], new byte[0], length, checksum);
+    byte[] buffer = new byte[CHUNK_SIZE];
+
+    try (StreamCopyOneFile copyOneFile =
+        new StreamCopyOneFile(mockDataInput, mockNode, "test_file", fileMetaData, buffer)) {
+
+      // Verify initial state
+      assertEquals(0, copyOneFile.getBytesCopied());
+      assertEquals(length - Long.BYTES, copyOneFile.getBytesToCopy());
+
+      // Copy the file
+      boolean done = false;
+      int iterations = 0;
+      while (!done && iterations < 1000) { // Safety guard against infinite loops
+        done = copyOneFile.visit();
+        iterations++;
+      }
+
+      assertTrue("File copy should complete", done);
+
+      // Verify final state
+      assertEquals(length - Long.BYTES, copyOneFile.getBytesCopied());
+
+      // Verify mocks were called appropriately
+      verify(mockNode).startCopyFile("test_file");
+      verify(mockNode).finishCopyFile("test_file");
+      verify(mockOutput).close();
+
+      // Verify data was written
+      if (length > Long.BYTES) {
+        // Calculate expected number of writeBytes calls based on chunk size
+        int dataLength = length - (int) Long.BYTES;
+        int expectedCalls = (dataLength + CHUNK_SIZE - 1) / CHUNK_SIZE; // Ceiling division
+        verify(mockOutput, times(expectedCalls))
+            .writeBytes(any(byte[].class), eq(0), any(Integer.class));
+      }
+    }
+  }
+
+  private MockDataInput createMockDataInput(int totalLength, long checksum) {
+    int dataLength = totalLength - Long.BYTES;
+    byte[] data = new byte[dataLength];
+    rand.nextBytes(data);
+
+    return new MockDataInput(data, checksum);
+  }
+
+  // Mock DataInput implementation for testing
+  private static class MockDataInput extends DataInput {
+    private final byte[] data;
+    private final long checksum;
+    private int position = 0;
+
+    public MockDataInput(byte[] data, long checksum) {
+      this.data = data;
+      this.checksum = checksum;
+    }
+
+    @Override
+    public byte readByte() throws IOException {
+      if (position < data.length) {
+        return data[position++];
+      } else if (position < data.length + Long.BYTES) {
+        // Return checksum bytes
+        int checksumByteIndex = position - data.length;
+        position++;
+        return (byte) (checksum >>> (8 * (Long.BYTES - 1 - checksumByteIndex)));
+      } else {
+        throw new IOException("End of input");
+      }
+    }
+
+    @Override
+    public void readBytes(byte[] b, int offset, int len) throws IOException {
+      for (int i = 0; i < len; i++) {
+        b[offset + i] = readByte();
+      }
+    }
+
+    @Override
+    public void skipBytes(long count) throws IOException {
+      for (long i = 0; i < count; i++) {
+        readByte(); // Simple implementation for testing
+      }
+    }
+  }
+
+  // Mock Closeable DataInput for testing close functionality
+  private static class MockCloseableDataInput extends MockDataInput implements Closeable {
+    private boolean closed = false;
+
+    public MockCloseableDataInput(byte[] data, long checksum) {
+      super(data, checksum);
+    }
+
+    public MockCloseableDataInput(int totalLength, long checksum) {
+      super(new byte[totalLength - Long.BYTES], checksum);
+      rand.nextBytes(super.data);
+    }
+
+    @Override
+    public void close() throws IOException {
+      closed = true;
+    }
+
+    public boolean isClosed() {
+      return closed;
+    }
+  }
+}


### PR DESCRIPTION
Adds the isolated replicas feature. When enabled, the replica downloads index updates directly from the remote backend (S3). This feature is only usable if the index is started without a connection to the primary.

## Config
```
isolatedReplicaConfig:
  enabled: true
  pollingIntervalSeconds: 30
```
- `enabled`: if the feature is enabled, default: false
- `pollingIntervalSeconds`: how long to wait before checking for a new index version, default: 120

## CopyJobManager
The `CopyJobManager` interface was added to extract the gRPC specific logic out of the `NrtReplicaNode`. The existing logic was moved into the `GrpcCopyJobManager` and the `RemoteCopyJobManager` was created for copying from the remote backend. Methods:
- `start`: called at the end of `NrtReplicaNode` start
- `newCopyJob`: create copy job for use by Lucene nrt replication system
- `finishNRTCopy`: called after a copy job finishes

## NrtDataManager
This class now manages starting a file download from the remote backend. It also keeps track of the currently active nrt point and point timestamp. When a copy job finishes successfully, the point state and timestamp are updated.

## InputStreamDataInput
The base Lucene file copy api uses the `DataInput` interface. The `InputStreamDataInput` wraps the file `InputStream` so it can be used directly.

## RemoteBackend
The remote backend is now able to download an index file directly, presenting it as an `InputStream`. Getting the point state from the backend now also returns the timestamp associated with that point.

## CopyOneFile
This is a Lucene class that we are redefining and shadowing with the classpath. Since the definition was specific to gRPC, I changed this class into an interface. The previous implementation is now `GrpcCopyOneFile`. A new implementation has been added called `StreamCopyOneFile`. This is closer to the stock implementation and hopefully we can unhack this code at some point.

Note: many of the tests were generated by AI