### PR TITLE
Add hnsw binary quantized option for float vector search

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
@@ -696,7 +696,7 @@ enum VectorElementType {
 
 // Options for indexing a VECTOR field for search
 message VectorIndexingOptions {
-    // The vector indexing type, supports 'hnsw' and 'hnsw_scalar_quantized', default: hnsw
+    // The vector indexing type, supports 'hnsw', 'hnsw_binary_quantized', and 'hnsw_scalar_quantized', default: hnsw
     optional string type = 1;
     // The number of neighbors each node will be connected to in the HNSW graph, default: 16
     optional int32 hnsw_m = 2;
@@ -709,11 +709,11 @@ message VectorIndexingOptions {
     // determining the most accurate pair. Otherwise, the value must be between 0.9 and 1.0 (both inclusive).
     // default: unset
     optional float quantized_confidence_interval = 5;
-    // The number of bits to use for quantizing the vectors. It can have the following values:
+    // The number of bits to use for scalar quantizing the vectors. It can have the following values:
     //      4 - half byte
     //      7 - signed byte (default)
     optional int32 quantized_bits = 6;
-    // Whether to compress the vectors, if true, the vectors that are quantized with <= 4 bits will be compressed into
+    // Whether to compress the vectors, if true, the vectors that are (scalar) quantized with <= 4 bits will be compressed into
     // a single byte. If false, the vectors will be stored as is. This provides a trade-off of memory usage and speed.
     // default: false
     optional bool quantized_compress = 7;

--- a/grpc-gateway/luceneserver.pb.go
+++ b/grpc-gateway/luceneserver.pb.go
@@ -1645,7 +1645,7 @@ type VectorIndexingOptions struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The vector indexing type, supports 'hnsw' and 'hnsw_scalar_quantized', default: hnsw
+	// The vector indexing type, supports 'hnsw', 'hnsw_binary_quantized', and 'hnsw_scalar_quantized', default: hnsw
 	Type *string `protobuf:"bytes,1,opt,name=type,proto3,oneof" json:"type,omitempty"`
 	// The number of neighbors each node will be connected to in the HNSW graph, default: 16
 	HnswM *int32 `protobuf:"varint,2,opt,name=hnsw_m,json=hnswM,proto3,oneof" json:"hnsw_m,omitempty"`
@@ -1658,12 +1658,12 @@ type VectorIndexingOptions struct {
 	// determining the most accurate pair. Otherwise, the value must be between 0.9 and 1.0 (both inclusive).
 	// default: unset
 	QuantizedConfidenceInterval *float32 `protobuf:"fixed32,5,opt,name=quantized_confidence_interval,json=quantizedConfidenceInterval,proto3,oneof" json:"quantized_confidence_interval,omitempty"`
-	// The number of bits to use for quantizing the vectors. It can have the following values:
+	// The number of bits to use for scalar quantizing the vectors. It can have the following values:
 	//
 	//	4 - half byte
 	//	7 - signed byte (default)
 	QuantizedBits *int32 `protobuf:"varint,6,opt,name=quantized_bits,json=quantizedBits,proto3,oneof" json:"quantized_bits,omitempty"`
-	// Whether to compress the vectors, if true, the vectors that are quantized with <= 4 bits will be compressed into
+	// Whether to compress the vectors, if true, the vectors that are (scalar) quantized with <= 4 bits will be compressed into
 	// a single byte. If false, the vectors will be stored as is. This provides a trade-off of memory usage and speed.
 	// default: false
 	QuantizedCompress *bool `protobuf:"varint,7,opt,name=quantized_compress,json=quantizedCompress,proto3,oneof" json:"quantized_compress,omitempty"`

--- a/grpc-gateway/luceneserver.swagger.json
+++ b/grpc-gateway/luceneserver.swagger.json
@@ -6181,7 +6181,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "title": "The vector indexing type, supports 'hnsw' and 'hnsw_scalar_quantized', default: hnsw"
+          "title": "The vector indexing type, supports 'hnsw', 'hnsw_binary_quantized', and 'hnsw_scalar_quantized', default: hnsw"
         },
         "hnswM": {
           "type": "integer",
@@ -6206,11 +6206,11 @@
         "quantizedBits": {
           "type": "integer",
           "format": "int32",
-          "title": "The number of bits to use for quantizing the vectors. It can have the following values:\n     4 - half byte\n     7 - signed byte (default)"
+          "title": "The number of bits to use for scalar quantizing the vectors. It can have the following values:\n     4 - half byte\n     7 - signed byte (default)"
         },
         "quantizedCompress": {
           "type": "boolean",
-          "title": "Whether to compress the vectors, if true, the vectors that are quantized with \u003c= 4 bits will be compressed into\na single byte. If false, the vectors will be stored as is. This provides a trade-off of memory usage and speed.\ndefault: false"
+          "title": "Whether to compress the vectors, if true, the vectors that are (scalar) quantized with \u003c= 4 bits will be compressed into\na single byte. If false, the vectors will be stored as is. This provides a trade-off of memory usage and speed.\ndefault: false"
         }
       },
       "title": "Options for indexing a VECTOR field for search"

--- a/src/test/resources/field/registerFieldsVectorSearch.json
+++ b/src/test/resources/field/registerFieldsVectorSearch.json
@@ -141,6 +141,16 @@
       ]
     },
     {
+      "name": "binary_quantized_vector",
+      "type": "VECTOR",
+      "search": true,
+      "vectorDimensions": 3,
+      "vectorSimilarity": "cosine",
+      "vectorIndexingOptions": {
+        "type": "hnsw_binary_quantized"
+      }
+    },
+    {
       "name": "filter",
       "type": "ATOM",
       "search": true,


### PR DESCRIPTION
Allow use of the `Lucene102HnswBinaryQuantizedVectorsFormat` for float vector search on the `development` branch. This option is enabled by setting the type to `hnsw_binary_quantized`.