### PR TITLE
Add index timestamp metric for isolated replicas

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/NrtMetrics.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/NrtMetrics.java
@@ -119,6 +119,13 @@ public class NrtMetrics {
           .labelNames("index")
           .build();
 
+  public static final Gauge indexTimestampSec =
+      Gauge.builder()
+          .name("nrt_index_timestamp_sec")
+          .help("Timestamp (epoch seconds) of the current index version.")
+          .labelNames("index")
+          .build();
+
   /**
    * Add all nrt metrics to the collector registry.
    *
@@ -137,5 +144,6 @@ public class NrtMetrics {
     registry.register(nrtMergeCopyStartCount);
     registry.register(nrtMergeCopyEndCount);
     registry.register(nrtAckedCopyMB);
+    registry.register(indexTimestampSec);
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NrtDataManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NrtDataManager.java
@@ -20,6 +20,7 @@ import static com.yelp.nrtsearch.server.state.BackendGlobalState.getBaseIndexNam
 import com.google.common.annotations.VisibleForTesting;
 import com.yelp.nrtsearch.server.grpc.RestoreIndex;
 import com.yelp.nrtsearch.server.monitoring.BootstrapMetrics;
+import com.yelp.nrtsearch.server.monitoring.NrtMetrics;
 import com.yelp.nrtsearch.server.nrt.state.NrtFileMetaData;
 import com.yelp.nrtsearch.server.nrt.state.NrtPointState;
 import com.yelp.nrtsearch.server.remote.RemoteBackend;
@@ -233,6 +234,9 @@ public class NrtDataManager implements Closeable {
 
       lastPointState = pointState;
       lastPointTimestamp = pointStateWithTimestamp.timestamp();
+      NrtMetrics.indexTimestampSec
+          .labelValues(getBaseIndexName(indexIdentifier))
+          .set(lastPointTimestamp.getEpochSecond());
     }
   }
 
@@ -313,6 +317,9 @@ public class NrtDataManager implements Closeable {
     if (lastPointState == null || (pointState.version > lastPointState.version)) {
       this.lastPointState = pointState;
       this.lastPointTimestamp = timestamp;
+      NrtMetrics.indexTimestampSec
+          .labelValues(getBaseIndexName(indexIdentifier))
+          .set(lastPointTimestamp.getEpochSecond());
     } else {
       logger.info(
           "Not setting last point state, existing version is later. Existing version: {}, new version: {}",


### PR DESCRIPTION
Add a metric to track the index version age when using the isolated replicas feature.