### PR TITLE
Use freshness target for isolated replica index updates

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NRTReplicaNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NRTReplicaNode.java
@@ -91,7 +91,10 @@ public class NRTReplicaNode extends ReplicaNode {
       }
       copyJobManager =
           new RemoteCopyJobManager(
-              isolatedReplicaConfig.getPollingIntervalSeconds(), nrtDataManager, this);
+              isolatedReplicaConfig.getPollingIntervalSeconds(),
+              nrtDataManager,
+              this,
+              isolatedReplicaConfig);
     } else {
       copyJobManager =
           new GrpcCopyJobManager(indexName, indexId, primaryAddress, ackedCopy, this, id);

--- a/src/main/java/com/yelp/nrtsearch/server/remote/RemoteBackend.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/RemoteBackend.java
@@ -41,8 +41,10 @@ public interface RemoteBackend extends PluginDownloader {
    * Configuration context for update interval when downloading point state.
    *
    * @param updateIntervalSeconds update interval in seconds, or 0 to get the latest point state
+   * @param currentIndexTimestamp timestamp of the currently loaded index data, or null if no
+   *     version loaded
    */
-  record UpdateIntervalContext(int updateIntervalSeconds) {}
+  record UpdateIntervalContext(int updateIntervalSeconds, Instant currentIndexTimestamp) {}
 
   /**
    * Get if a given global resource exists in the backend.
@@ -181,13 +183,16 @@ public interface RemoteBackend extends PluginDownloader {
    * Download NRT point state from the remote backend, potentially using an update interval. When
    * the update interval is greater than zero, the backend will provide the first index version
    * within the update interval. Intervals begin at midnight UTC. If no index version is available
-   * within the last interval, the latest version is returned.
+   * within the last interval, the latest version is returned. If the current index version
+   * timestamp is within the update interval, null is returned to indicate that the current index
+   * version is still valid.
    *
    * @param service service name
    * @param indexIdentifier unique index identifier
    * @param updateIntervalContext configuration context for update interval, or null to get the
    *     latest point state
-   * @return input stream of point state data and the timestamp of the point state
+   * @return input stream of point state data and the timestamp of the point state, or null if the
+   *     current index version satisfies the update interval
    * @throws IOException on error downloading point state
    */
   InputStreamWithTimestamp downloadPointState(

--- a/src/test/java/com/yelp/nrtsearch/server/nrt/jobs/RemoteCopyJobManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/nrt/jobs/RemoteCopyJobManagerTest.java
@@ -57,7 +57,8 @@ public class RemoteCopyJobManagerTest {
 
   @Before
   public void setUp() {
-    copyJobManager = new RemoteCopyJobManager(POLLING_INTERVAL, mockDataManager, mockReplicaNode);
+    copyJobManager =
+        new RemoteCopyJobManager(POLLING_INTERVAL, mockDataManager, mockReplicaNode, null);
   }
 
   @After
@@ -93,7 +94,7 @@ public class RemoteCopyJobManagerTest {
     NrtDataManager.PointStateWithTimestamp pointStateWithTimestamp =
         new NrtDataManager.PointStateWithTimestamp(pointState, timestamp);
 
-    when(mockDataManager.getTargetPointState()).thenReturn(pointStateWithTimestamp);
+    when(mockDataManager.getTargetPointState(null)).thenReturn(pointStateWithTimestamp);
 
     // Test the method
     CopyJob copyJob = copyJobManager.newCopyJob("test_reason", null, null, true, mockOnceDone);
@@ -106,7 +107,7 @@ public class RemoteCopyJobManagerTest {
     assertEquals(pointState, remoteCopyJob.getPointState());
     assertEquals(timestamp, remoteCopyJob.getPointStateTimestamp());
 
-    verify(mockDataManager).getTargetPointState();
+    verify(mockDataManager).getTargetPointState(null);
   }
 
   @Test
@@ -179,12 +180,12 @@ public class RemoteCopyJobManagerTest {
     NrtDataManager.PointStateWithTimestamp pointStateWithTimestamp =
         new NrtDataManager.PointStateWithTimestamp(targetPointState, Instant.now());
 
-    when(mockDataManager.getTargetPointState()).thenReturn(pointStateWithTimestamp);
+    when(mockDataManager.getTargetPointState(null)).thenReturn(pointStateWithTimestamp);
     when(mockReplicaNode.getCurrentSearchingVersion()).thenReturn(0L); // Lower than target version
 
     // Create a copy job manager with very short polling interval for testing
     RemoteCopyJobManager shortIntervalManager =
-        new RemoteCopyJobManager(1, mockDataManager, mockReplicaNode);
+        new RemoteCopyJobManager(1, mockDataManager, mockReplicaNode, null);
 
     try {
       shortIntervalManager.start();
@@ -209,13 +210,13 @@ public class RemoteCopyJobManagerTest {
     NrtDataManager.PointStateWithTimestamp pointStateWithTimestamp =
         new NrtDataManager.PointStateWithTimestamp(targetPointState, Instant.now());
 
-    when(mockDataManager.getTargetPointState()).thenReturn(pointStateWithTimestamp);
+    when(mockDataManager.getTargetPointState(null)).thenReturn(pointStateWithTimestamp);
     when(mockReplicaNode.getCurrentSearchingVersion())
         .thenReturn(targetPointState.version); // Same as target
 
     // Create a copy job manager with very short polling interval for testing
     RemoteCopyJobManager shortIntervalManager =
-        new RemoteCopyJobManager(1, mockDataManager, mockReplicaNode);
+        new RemoteCopyJobManager(1, mockDataManager, mockReplicaNode, null);
 
     try {
       shortIntervalManager.start();
@@ -234,11 +235,12 @@ public class RemoteCopyJobManagerTest {
   @Test
   public void testUpdateTask_exceptionHandling() throws Exception {
     // Set up test data to throw an exception
-    when(mockDataManager.getTargetPointState()).thenThrow(new RuntimeException("Test exception"));
+    when(mockDataManager.getTargetPointState(null))
+        .thenThrow(new RuntimeException("Test exception"));
 
     // Create a copy job manager with very short polling interval for testing
     RemoteCopyJobManager shortIntervalManager =
-        new RemoteCopyJobManager(1, mockDataManager, mockReplicaNode);
+        new RemoteCopyJobManager(1, mockDataManager, mockReplicaNode, null);
 
     try {
       shortIntervalManager.start();
@@ -259,7 +261,7 @@ public class RemoteCopyJobManagerTest {
   public void testUpdateTask_interrupted() throws Exception {
     // Create a copy job manager
     RemoteCopyJobManager shortIntervalManager =
-        new RemoteCopyJobManager(1, mockDataManager, mockReplicaNode);
+        new RemoteCopyJobManager(1, mockDataManager, mockReplicaNode, null);
 
     try {
       shortIntervalManager.start();


### PR DESCRIPTION
Consider the freshness target when updating index data, while using the isolated replicas feature. The logic is similar to that used when getting the initial index data during bootstrapping. The main difference is that is also looks at the timestamp of the currently loaded index version. If the current and target versions are both within the same update interval, the update is skipped.