### PR TITLE
Update Lucene to v10.3.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ aws = "1.12.768"
 grpc = "1.66.0"
 jackson = "2.19.1"
 log4j = "2.23.1"
-lucene = "10.2.2"
+lucene = "10.3.0"
 prometheus = "1.3.1"
 protobuf = "3.25.3"
 

--- a/src/main/java/com/yelp/nrtsearch/server/codec/ServerCodec.java
+++ b/src/main/java/com/yelp/nrtsearch/server/codec/ServerCodec.java
@@ -24,10 +24,10 @@ import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.PostingsFormat;
-import org.apache.lucene.codecs.lucene101.Lucene101Codec;
+import org.apache.lucene.codecs.lucene103.Lucene103Codec;
 
 /** Implements per-index {@link Codec}. */
-public class ServerCodec extends Lucene101Codec {
+public class ServerCodec extends Lucene103Codec {
   private final IndexStateManager stateManager;
 
   // nocommit expose compression control

--- a/src/test/java/com/yelp/nrtsearch/server/codec/ServerCodecTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/codec/ServerCodecTest.java
@@ -32,7 +32,7 @@ import java.util.Set;
 import org.apache.lucene.backward_codecs.lucene80.Lucene80DocValuesFormat;
 import org.apache.lucene.backward_codecs.lucene90.Lucene90HnswVectorsFormat;
 import org.apache.lucene.backward_codecs.lucene90.Lucene90PostingsFormat;
-import org.apache.lucene.codecs.lucene101.Lucene101PostingsFormat;
+import org.apache.lucene.codecs.lucene103.Lucene103PostingsFormat;
 import org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
 import org.junit.BeforeClass;
@@ -61,7 +61,7 @@ public class ServerCodecTest {
     when(mockFieldDef.getPostingsFormat()).thenReturn(null);
     IndexStateManager mockStateManager = getManager(mockFieldDef);
     ServerCodec serverCodec = new ServerCodec(mockStateManager);
-    assertTrue(serverCodec.getPostingsFormatForField("field") instanceof Lucene101PostingsFormat);
+    assertTrue(serverCodec.getPostingsFormatForField("field") instanceof Lucene103PostingsFormat);
     verify(mockFieldDef, times(1)).getPostingsFormat();
     verifyNoMoreInteractions(mockFieldDef);
   }
@@ -97,7 +97,7 @@ public class ServerCodecTest {
     IndexStateManager mockStateManager = getManager(mockFieldDef);
     ServerCodec serverCodec = new ServerCodec(mockStateManager);
     assertTrue(
-        serverCodec.getPostingsFormatForField("internal_field") instanceof Lucene101PostingsFormat);
+        serverCodec.getPostingsFormatForField("internal_field") instanceof Lucene103PostingsFormat);
     verifyNoInteractions(mockFieldDef);
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/MultiSegmentTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/MultiSegmentTest.java
@@ -200,7 +200,7 @@ public class MultiSegmentTest extends ServerTestCase {
                                                 RangeQuery.newBuilder()
                                                     .setField("int_field")
                                                     .setLower(String.valueOf(0))
-                                                    .setUpper(String.valueOf(NUM_DOCS))
+                                                    .setUpper(String.valueOf(NUM_DOCS / 2))
                                                     .build())
                                             .build())
                                     .build())
@@ -214,7 +214,7 @@ public class MultiSegmentTest extends ServerTestCase {
       var explain = hit.getExplain();
       var expectedExplain =
           String.format(
-              "%d.0 = weight(FunctionScoreQuery(IndexOrDocValuesQuery(indexQuery=int_field:[0 TO 100], dvQuery=int_field:[0 TO 100]), scored by expr(int_score))), result of:\n"
+              "%d.0 = weight(FunctionScoreQuery(IndexOrDocValuesQuery(indexQuery=int_field:[0 TO 50], dvQuery=int_field:[0 TO 50]), scored by expr(int_score))), result of:\n"
                   + "  %<d.0 = int_score, computed from:\n"
                   + "    %<d.0 = double(int_score)",
               NUM_DOCS - i);


### PR DESCRIPTION
Update Lucene in the development branch to latest minor version `v10.3.0`

I had to slightly modify an explain test because new optimizations were rewriting the inner query to a match all.