### PR TITLE
Add remote executor for S3 operations

### DIFF
--- a/docs/server_configuration.rst
+++ b/docs/server_configuration.rst
@@ -311,6 +311,26 @@ Example server configuration
      - Whether to use virtual threads instead of a traditional thread pool for commit operations
      - false
 
+   * - remote.maxThreads
+     - int
+     - Size of remote threadpool executor
+     - 20
+
+   * - remote.maxBufferedItems
+     - int
+     - Max tasks that can be queued by remote threadpool executor
+     - INT_MAX
+
+   * - remote.threadNamePrefix
+     - string
+     - Name prefix for threads created by remote threadpool executor
+     - RemoteExecutor
+
+   * - remote.useVirtualThreads
+     - bool
+     - Whether to use virtual threads instead of a traditional thread pool for remote operations
+     - false
+
 .. list-table:: `Alternative Max Threads Config <https://github.com/Yelp/nrtsearch/blob/master/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java>`_ (``threadPoolConfiguration.*.maxThreads.*``)
    :widths: 25 10 50 25
    :header-rows: 1

--- a/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/ThreadPoolConfiguration.java
@@ -57,6 +57,9 @@ public class ThreadPoolConfiguration {
   public static final int DEFAULT_COMMIT_THREADS = 5;
   public static final int DEFAULT_COMMIT_BUFFERED_ITEMS = DEFAULT_COMMIT_THREADS;
 
+  public static final int DEFAULT_REMOTE_THREADS = 20;
+  public static final int DEFAULT_REMOTE_BUFFERED_ITEMS = Integer.MAX_VALUE;
+
   /**
    * Settings for a {@link ExecutorFactory.ExecutorType}.
    *
@@ -118,7 +121,10 @@ public class ThreadPoolConfiguration {
                   false),
               ExecutorFactory.ExecutorType.COMMIT,
               new ThreadPoolSettings(
-                  DEFAULT_COMMIT_THREADS, DEFAULT_COMMIT_BUFFERED_ITEMS, "CommitExecutor", false));
+                  DEFAULT_COMMIT_THREADS, DEFAULT_COMMIT_BUFFERED_ITEMS, "CommitExecutor", false),
+              ExecutorFactory.ExecutorType.REMOTE,
+              new ThreadPoolSettings(
+                  DEFAULT_REMOTE_THREADS, DEFAULT_REMOTE_BUFFERED_ITEMS, "RemoteExecutor", false));
 
   private final Map<ExecutorFactory.ExecutorType, ThreadPoolSettings> threadPoolSettings;
 

--- a/src/main/java/com/yelp/nrtsearch/server/field/FieldDefCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/FieldDefCreator.java
@@ -15,6 +15,7 @@
  */
 package com.yelp.nrtsearch.server.field;
 
+import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.FieldType;
@@ -39,8 +40,9 @@ public class FieldDefCreator {
    * Addition context for field definition creation.
    *
    * @param config service configuration
+   * @param executorFactory executor factory
    */
-  public record FieldDefCreatorContext(NrtsearchConfig config) {}
+  public record FieldDefCreatorContext(NrtsearchConfig config, ExecutorFactory executorFactory) {}
 
   public FieldDefCreator(NrtsearchConfig configuration) {
     register("ATOM", AtomFieldDef::new);
@@ -104,7 +106,8 @@ public class FieldDefCreator {
    * @return new context instance
    */
   public static FieldDefCreatorContext createContext(GlobalState globalState) {
-    return new FieldDefCreatorContext(globalState.getConfiguration());
+    return new FieldDefCreatorContext(
+        globalState.getConfiguration(), globalState.getExecutorFactory());
   }
 
   private void register(Map<String, FieldDefProvider<? extends FieldDef>> fieldDefs) {

--- a/src/main/java/com/yelp/nrtsearch/server/field/VectorFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/VectorFieldDef.java
@@ -158,7 +158,9 @@ public abstract class VectorFieldDef<T> extends IndexableFieldDef<T> implements 
   }
 
   private static KnnVectorsFormat createVectorsFormat(
-      VectorSearchType vectorSearchType, VectorIndexingOptions vectorIndexingOptions) {
+      VectorSearchType vectorSearchType,
+      VectorIndexingOptions vectorIndexingOptions,
+      FieldDefCreator.FieldDefCreatorContext fieldDefCreatorContext) {
     int m =
         vectorIndexingOptions.hasHnswM()
             ? vectorIndexingOptions.getHnswM()
@@ -171,7 +173,9 @@ public abstract class VectorFieldDef<T> extends IndexableFieldDef<T> implements 
         vectorIndexingOptions.hasMergeWorkers() ? vectorIndexingOptions.getMergeWorkers() : 1;
     ExecutorService executorService =
         mergeWorkers > 1
-            ? ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.VECTORMERGE)
+            ? fieldDefCreatorContext
+                .executorFactory()
+                .getExecutor(ExecutorFactory.ExecutorType.VECTORMERGE)
             : null;
     KnnVectorsFormat vectorsFormat =
         switch (vectorSearchType) {
@@ -267,7 +271,7 @@ public abstract class VectorFieldDef<T> extends IndexableFieldDef<T> implements 
       this.similarityFunction = getSimilarityFunction(requestField.getVectorSimilarity());
       setupNormalizedVectorField(requestField.getVectorSimilarity(), context);
       this.vectorsFormat =
-          createVectorsFormat(vectorSearchType, requestField.getVectorIndexingOptions());
+          createVectorsFormat(vectorSearchType, requestField.getVectorIndexingOptions(), context);
     } else {
       this.similarityFunction = null;
       this.vectorsFormat = null;

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/GrpcServerExecutorSupplier.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/GrpcServerExecutorSupplier.java
@@ -42,11 +42,15 @@ public class GrpcServerExecutorSupplier implements ServerCallExecutorSupplier {
   private final ExecutorService metricsExecutor;
   private final ExecutorService grpcExecutor;
 
-  public GrpcServerExecutorSupplier() {
-    serverExecutor = ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.SERVER);
-    metricsExecutor =
-        ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.METRICS);
-    grpcExecutor = ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.GRPC);
+  /**
+   * Constructor for GrpcServerExecutorSupplier.
+   *
+   * @param executorFactory the ExecutorFactory to get executors from
+   */
+  public GrpcServerExecutorSupplier(ExecutorFactory executorFactory) {
+    serverExecutor = executorFactory.getExecutor(ExecutorFactory.ExecutorType.SERVER);
+    metricsExecutor = executorFactory.getExecutor(ExecutorFactory.ExecutorType.METRICS);
+    grpcExecutor = executorFactory.getExecutor(ExecutorFactory.ExecutorType.GRPC);
   }
 
   public ExecutorService getServerExecutor() {

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
@@ -135,6 +135,7 @@ public class NrtsearchServer {
   private final RemoteBackend remoteBackend;
   private final PrometheusRegistry prometheusRegistry;
   private final PluginsService pluginsService;
+  private final ExecutorFactory executorFactory;
 
   private Server server;
   private Server replicationServer;
@@ -144,10 +145,12 @@ public class NrtsearchServer {
   public NrtsearchServer(
       NrtsearchConfig configuration,
       RemoteBackend remoteBackend,
-      PrometheusRegistry prometheusRegistry) {
+      PrometheusRegistry prometheusRegistry,
+      ExecutorFactory executorFactory) {
     this.configuration = configuration;
     this.remoteBackend = remoteBackend;
     this.prometheusRegistry = prometheusRegistry;
+    this.executorFactory = executorFactory;
     this.pluginsService = new PluginsService(configuration, remoteBackend, prometheusRegistry);
   }
 
@@ -157,7 +160,8 @@ public class NrtsearchServer {
     List<Plugin> plugins = pluginsService.loadPlugins();
 
     LuceneServerImpl serverImpl =
-        new LuceneServerImpl(configuration, remoteBackend, prometheusRegistry, plugins);
+        new LuceneServerImpl(
+            configuration, remoteBackend, prometheusRegistry, executorFactory, plugins);
     GlobalState globalState = serverImpl.getGlobalState();
 
     registerMetrics(globalState);
@@ -168,9 +172,7 @@ public class NrtsearchServer {
               .addService(
                   new ReplicationServerImpl(
                       globalState, configuration.getVerifyReplicationIndexId()))
-              .executor(
-                  ExecutorFactory.getInstance()
-                      .getExecutor(ExecutorFactory.ExecutorType.REPLICATIONSERVER))
+              .executor(executorFactory.getExecutor(ExecutorFactory.ExecutorType.REPLICATIONSERVER))
               .maxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
               .maxConcurrentCallsPerConnection(
                   configuration.getMaxConcurrentCallsPerConnectionForReplication())
@@ -185,9 +187,7 @@ public class NrtsearchServer {
               .addService(
                   new ReplicationServerImpl(
                       globalState, configuration.getVerifyReplicationIndexId()))
-              .executor(
-                  ExecutorFactory.getInstance()
-                      .getExecutor(ExecutorFactory.ExecutorType.REPLICATIONSERVER))
+              .executor(executorFactory.getExecutor(ExecutorFactory.ExecutorType.REPLICATIONSERVER))
               .maxInboundMessageSize(MAX_MESSAGE_BYTES_SIZE)
               .build()
               .start();
@@ -206,7 +206,7 @@ public class NrtsearchServer {
                 .withLatencyBuckets(configuration.getMetricsBuckets())
                 .withPrometheusRegistry(prometheusRegistry));
     /* The port on which the server should run */
-    GrpcServerExecutorSupplier executorSupplier = new GrpcServerExecutorSupplier();
+    GrpcServerExecutorSupplier executorSupplier = new GrpcServerExecutorSupplier(executorFactory);
     server =
         ServerBuilder.forPort(configuration.getPort())
             // The last interceptor is invoked first
@@ -374,6 +374,7 @@ public class NrtsearchServer {
      * @param configuration server configuration
      * @param remoteBackend backend for persistent remote storage
      * @param prometheusRegistry metrics collector registry
+     * @param executorFactory executor factory
      * @param plugins loaded plugins
      * @throws IOException
      */
@@ -381,17 +382,17 @@ public class NrtsearchServer {
         NrtsearchConfig configuration,
         RemoteBackend remoteBackend,
         PrometheusRegistry prometheusRegistry,
+        ExecutorFactory executorFactory,
         List<Plugin> plugins)
         throws IOException {
 
       DeadlineUtils.setCancellationEnabled(configuration.getDeadlineCancellation());
-      ExecutorFactory.init(configuration.getThreadPoolConfiguration());
 
       initQueryCache(configuration);
       initMaxClauseCount(configuration);
       initExtendableComponents(configuration, plugins);
 
-      this.globalState = GlobalState.createState(configuration, remoteBackend);
+      this.globalState = GlobalState.createState(configuration, remoteBackend, executorFactory);
 
       // Initialize handlers
       initIngestionPlugin(globalState, plugins);

--- a/src/main/java/com/yelp/nrtsearch/server/modules/BackendModule.java
+++ b/src/main/java/com/yelp/nrtsearch/server/modules/BackendModule.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.server.modules;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.google.inject.*;
+import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.remote.RemoteBackend;
 import com.yelp.nrtsearch.server.remote.s3.S3Backend;
@@ -26,7 +27,8 @@ public class BackendModule extends AbstractModule {
   @Inject
   @Singleton
   @Provides
-  protected RemoteBackend providesRemoteBackend(NrtsearchConfig configuration, AmazonS3 s3) {
-    return new S3Backend(configuration, s3);
+  protected RemoteBackend providesRemoteBackend(
+      NrtsearchConfig configuration, AmazonS3 s3, ExecutorFactory executorFactory) {
+    return new S3Backend(configuration, s3, executorFactory);
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/modules/NrtsearchModule.java
+++ b/src/main/java/com/yelp/nrtsearch/server/modules/NrtsearchModule.java
@@ -19,6 +19,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.NrtsearchServer;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
@@ -46,6 +47,13 @@ public class NrtsearchModule extends AbstractModule {
   @Provides
   public PrometheusRegistry providesPrometheusRegistry() {
     return new PrometheusRegistry();
+  }
+
+  @Inject
+  @Singleton
+  @Provides
+  public ExecutorFactory providesExecutorFactory(NrtsearchConfig configuration) {
+    return new ExecutorFactory(configuration.getThreadPoolConfiguration());
   }
 
   @Inject

--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
@@ -33,7 +33,9 @@ import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.google.common.annotations.VisibleForTesting;
+import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
+import com.yelp.nrtsearch.server.config.ThreadPoolConfiguration;
 import com.yelp.nrtsearch.server.monitoring.S3DownloadStreamWrapper;
 import com.yelp.nrtsearch.server.nrt.state.NrtFileMetaData;
 import com.yelp.nrtsearch.server.nrt.state.NrtPointState;
@@ -56,9 +58,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
@@ -83,9 +85,9 @@ public class S3Backend implements RemoteBackend {
   private static final Logger logger = LoggerFactory.getLogger(S3Backend.class);
   private static final String ZIP_EXTENSION = ".zip";
 
-  public static final int NUM_S3_THREADS = 20;
-
-  private final ThreadPoolExecutor executor;
+  private final ExecutorService executor;
+  private final int maxExecutorParallelism;
+  private final boolean shutdownExecutor;
   private final boolean saveBeforeUnzip;
   private final AmazonS3 s3;
   private final String serviceBucket;
@@ -105,13 +107,20 @@ public class S3Backend implements RemoteBackend {
    *
    * @param configuration configuration
    * @param s3 s3 client
+   * @param executorFactory executor factory
    */
-  public S3Backend(NrtsearchConfig configuration, AmazonS3 s3) {
+  public S3Backend(NrtsearchConfig configuration, AmazonS3 s3, ExecutorFactory executorFactory) {
     this(
         configuration.getBucketName(),
         configuration.getSavePluginBeforeUnzip(),
         configuration.getS3Metrics(),
-        s3);
+        s3,
+        executorFactory.getExecutor(ExecutorFactory.ExecutorType.REMOTE),
+        configuration
+            .getThreadPoolConfiguration()
+            .getThreadPoolSettings(ExecutorFactory.ExecutorType.REMOTE)
+            .maxThreads(),
+        false);
   }
 
   /**
@@ -124,8 +133,28 @@ public class S3Backend implements RemoteBackend {
    */
   public S3Backend(
       String serviceBucket, boolean savePluginBeforeUnzip, boolean s3Metrics, AmazonS3 s3) {
+    this(
+        serviceBucket,
+        savePluginBeforeUnzip,
+        s3Metrics,
+        s3,
+        Executors.newFixedThreadPool(ThreadPoolConfiguration.DEFAULT_REMOTE_THREADS),
+        ThreadPoolConfiguration.DEFAULT_REMOTE_THREADS,
+        true);
+  }
+
+  private S3Backend(
+      String serviceBucket,
+      boolean savePluginBeforeUnzip,
+      boolean s3Metrics,
+      AmazonS3 s3,
+      ExecutorService executor,
+      int maxExecutorParallelism,
+      boolean shutdownExecutor) {
     this.s3 = s3;
-    this.executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(NUM_S3_THREADS);
+    this.executor = executor;
+    this.maxExecutorParallelism = maxExecutorParallelism;
+    this.shutdownExecutor = shutdownExecutor;
     this.saveBeforeUnzip = savePluginBeforeUnzip;
     this.serviceBucket = serviceBucket;
     this.transferManager =
@@ -139,6 +168,11 @@ public class S3Backend implements RemoteBackend {
 
   public AmazonS3 getS3() {
     return s3;
+  }
+
+  @VisibleForTesting
+  ExecutorService getExecutor() {
+    return executor;
   }
 
   @Override
@@ -236,7 +270,7 @@ public class S3Backend implements RemoteBackend {
       @Override
       public InputStream nextElement() {
         // top off the work queue so parts can download in parallel
-        while (pendingParts.size() < NUM_S3_THREADS && queuedPart <= numParts) {
+        while (pendingParts.size() < maxExecutorParallelism && queuedPart <= numParts) {
           // set to final variable for use in lambda
           final int finalPart = queuedPart;
           pendingParts.add(
@@ -273,11 +307,13 @@ public class S3Backend implements RemoteBackend {
   @Override
   public void close() {
     transferManager.shutdownNow(false);
-    try {
-      executor.shutdown();
-      executor.awaitTermination(1, TimeUnit.SECONDS);
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
+    if (shutdownExecutor) {
+      try {
+        executor.shutdown();
+        executor.awaitTermination(1, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
     }
     s3.shutdown();
   }

--- a/src/main/java/com/yelp/nrtsearch/server/state/BackendGlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/state/BackendGlobalState.java
@@ -18,6 +18,7 @@ package com.yelp.nrtsearch.server.state;
 import static com.yelp.nrtsearch.server.utils.TimeStringUtils.generateTimeStringMs;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
 import com.yelp.nrtsearch.server.config.IndexStartConfig;
 import com.yelp.nrtsearch.server.config.IndexStartConfig.IndexDataLocationType;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
@@ -116,11 +117,13 @@ public class BackendGlobalState extends GlobalState {
    *
    * @param configuration server config
    * @param remoteBackend backend for persistent remote storage
+   * @param executorFactory executor factory
    * @throws IOException on filesystem error
    */
-  public BackendGlobalState(NrtsearchConfig configuration, RemoteBackend remoteBackend)
+  public BackendGlobalState(
+      NrtsearchConfig configuration, RemoteBackend remoteBackend, ExecutorFactory executorFactory)
       throws IOException {
-    super(configuration, remoteBackend);
+    super(configuration, remoteBackend, executorFactory);
     stateBackend = createStateBackend();
     GlobalStateInfo globalStateInfo = stateBackend.loadOrCreateGlobalState();
     // init index state managers

--- a/src/test/java/com/yelp/nrtsearch/module/TestNrtsearchModule.java
+++ b/src/test/java/com/yelp/nrtsearch/module/TestNrtsearchModule.java
@@ -20,6 +20,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.NrtsearchServer;
 import com.yelp.nrtsearch.server.modules.BackendModule;
@@ -29,10 +30,13 @@ public class TestNrtsearchModule extends AbstractModule {
 
   private final NrtsearchConfig nrtsearchConfig;
   private final AmazonS3 amazonS3;
+  private final ExecutorFactory executorFactory;
 
-  public TestNrtsearchModule(NrtsearchConfig nrtsearchConfig, AmazonS3 amazonS3) {
+  public TestNrtsearchModule(
+      NrtsearchConfig nrtsearchConfig, AmazonS3 amazonS3, ExecutorFactory executorFactory) {
     this.nrtsearchConfig = nrtsearchConfig;
     this.amazonS3 = amazonS3;
+    this.executorFactory = executorFactory;
   }
 
   protected void configure() {
@@ -51,5 +55,12 @@ public class TestNrtsearchModule extends AbstractModule {
   @Provides
   protected AmazonS3 providesAmazonS3() {
     return amazonS3;
+  }
+
+  @Inject
+  @Singleton
+  @Provides
+  protected ExecutorFactory providesExecutorFactory() {
+    return executorFactory;
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/concurrent/ExecutorFactoryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/concurrent/ExecutorFactoryTest.java
@@ -24,9 +24,11 @@ import com.yelp.nrtsearch.server.config.ThreadPoolConfiguration;
 import java.io.ByteArrayInputStream;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
+import org.junit.After;
 import org.junit.Test;
 
 public class ExecutorFactoryTest {
+  ExecutorFactory executorFactory;
 
   private void init() {
     init("nodeName: node1");
@@ -35,16 +37,22 @@ public class ExecutorFactoryTest {
   private void init(String config) {
     NrtsearchConfig serverConfiguration =
         new NrtsearchConfig(new ByteArrayInputStream(config.getBytes()));
-    ExecutorFactory.init(serverConfiguration.getThreadPoolConfiguration());
+    executorFactory = new ExecutorFactory(serverConfiguration.getThreadPoolConfiguration());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (executorFactory != null) {
+      executorFactory.close();
+    }
+    executorFactory = null;
   }
 
   @Test
   public void testCachesThreadPoolExecutor() {
     init();
-    ExecutorService executor1 =
-        ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.SEARCH);
-    ExecutorService executor2 =
-        ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.SEARCH);
+    ExecutorService executor1 = executorFactory.getExecutor(ExecutorFactory.ExecutorType.SEARCH);
+    ExecutorService executor2 = executorFactory.getExecutor(ExecutorFactory.ExecutorType.SEARCH);
     assertSame(executor1, executor2);
   }
 
@@ -52,8 +60,7 @@ public class ExecutorFactoryTest {
   public void testSearchThreadPool_default() {
     init();
     ThreadPoolExecutor executor =
-        (ThreadPoolExecutor)
-            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.SEARCH);
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.SEARCH);
     assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_SEARCHING_THREADS);
     assertEquals(
         executor.getQueue().remainingCapacity(),
@@ -70,8 +77,7 @@ public class ExecutorFactoryTest {
             "    maxThreads: 5",
             "    maxBufferedItems: 10"));
     ThreadPoolExecutor executor =
-        (ThreadPoolExecutor)
-            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.SEARCH);
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.SEARCH);
     assertEquals(executor.getCorePoolSize(), 5);
     assertEquals(executor.getQueue().remainingCapacity(), 10);
   }
@@ -80,8 +86,7 @@ public class ExecutorFactoryTest {
   public void testIndexThreadPool_default() {
     init();
     ThreadPoolExecutor executor =
-        (ThreadPoolExecutor)
-            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.INDEX);
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.INDEX);
     assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_INDEXING_THREADS);
     assertEquals(
         executor.getQueue().remainingCapacity(),
@@ -98,8 +103,7 @@ public class ExecutorFactoryTest {
             "    maxThreads: 5",
             "    maxBufferedItems: 10"));
     ThreadPoolExecutor executor =
-        (ThreadPoolExecutor)
-            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.INDEX);
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.INDEX);
     assertEquals(executor.getCorePoolSize(), 5);
     assertEquals(executor.getQueue().remainingCapacity(), 10);
   }
@@ -108,8 +112,7 @@ public class ExecutorFactoryTest {
   public void testServerThreadPool_default() {
     init();
     ThreadPoolExecutor executor =
-        (ThreadPoolExecutor)
-            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.SERVER);
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.SERVER);
     assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_GRPC_SERVER_THREADS);
     assertEquals(
         executor.getQueue().remainingCapacity(),
@@ -126,8 +129,7 @@ public class ExecutorFactoryTest {
             "    maxThreads: 5",
             "    maxBufferedItems: 10"));
     ThreadPoolExecutor executor =
-        (ThreadPoolExecutor)
-            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.SERVER);
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.SERVER);
     assertEquals(executor.getCorePoolSize(), 5);
     assertEquals(executor.getQueue().remainingCapacity(), 10);
   }
@@ -137,8 +139,7 @@ public class ExecutorFactoryTest {
     init();
     ThreadPoolExecutor executor =
         (ThreadPoolExecutor)
-            ExecutorFactory.getInstance()
-                .getExecutor(ExecutorFactory.ExecutorType.REPLICATIONSERVER);
+            executorFactory.getExecutor(ExecutorFactory.ExecutorType.REPLICATIONSERVER);
     assertEquals(
         executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_GRPC_REPLICATIONSERVER_THREADS);
     assertEquals(
@@ -157,8 +158,7 @@ public class ExecutorFactoryTest {
             "    maxBufferedItems: 10"));
     ThreadPoolExecutor executor =
         (ThreadPoolExecutor)
-            ExecutorFactory.getInstance()
-                .getExecutor(ExecutorFactory.ExecutorType.REPLICATIONSERVER);
+            executorFactory.getExecutor(ExecutorFactory.ExecutorType.REPLICATIONSERVER);
     assertEquals(executor.getCorePoolSize(), 5);
     assertEquals(executor.getQueue().remainingCapacity(), 10);
   }
@@ -167,8 +167,7 @@ public class ExecutorFactoryTest {
   public void testFetchThreadPool_default() {
     init();
     ThreadPoolExecutor executor =
-        (ThreadPoolExecutor)
-            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.FETCH);
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.FETCH);
     assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_FETCH_THREADS);
     assertEquals(
         executor.getQueue().remainingCapacity(),
@@ -185,8 +184,7 @@ public class ExecutorFactoryTest {
             "    maxThreads: 5",
             "    maxBufferedItems: 10"));
     ThreadPoolExecutor executor =
-        (ThreadPoolExecutor)
-            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.FETCH);
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.FETCH);
     assertEquals(executor.getCorePoolSize(), 5);
     assertEquals(executor.getQueue().remainingCapacity(), 10);
   }
@@ -195,8 +193,7 @@ public class ExecutorFactoryTest {
   public void testGrpcThreadPool_default() {
     init();
     ThreadPoolExecutor executor =
-        (ThreadPoolExecutor)
-            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.GRPC);
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.GRPC);
     assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_GRPC_THREADS);
     assertEquals(
         executor.getQueue().remainingCapacity(),
@@ -213,8 +210,7 @@ public class ExecutorFactoryTest {
             "    maxThreads: 5",
             "    maxBufferedItems: 10"));
     ThreadPoolExecutor executor =
-        (ThreadPoolExecutor)
-            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.GRPC);
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.GRPC);
     assertEquals(executor.getCorePoolSize(), 5);
     assertEquals(executor.getQueue().remainingCapacity(), 10);
   }
@@ -223,8 +219,7 @@ public class ExecutorFactoryTest {
   public void testMetricsThreadPool_default() {
     init();
     ThreadPoolExecutor executor =
-        (ThreadPoolExecutor)
-            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.METRICS);
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.METRICS);
     assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_METRICS_THREADS);
     assertEquals(
         executor.getQueue().remainingCapacity(),
@@ -241,8 +236,7 @@ public class ExecutorFactoryTest {
             "    maxThreads: 5",
             "    maxBufferedItems: 10"));
     ThreadPoolExecutor executor =
-        (ThreadPoolExecutor)
-            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.METRICS);
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.METRICS);
     assertEquals(executor.getCorePoolSize(), 5);
     assertEquals(executor.getQueue().remainingCapacity(), 10);
   }
@@ -251,8 +245,7 @@ public class ExecutorFactoryTest {
   public void testVectorMergeThreadPool_default() {
     init();
     ThreadPoolExecutor executor =
-        (ThreadPoolExecutor)
-            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.VECTORMERGE);
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.VECTORMERGE);
     assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_VECTOR_MERGE_THREADS);
     assertEquals(
         executor.getQueue().remainingCapacity(),
@@ -269,8 +262,7 @@ public class ExecutorFactoryTest {
             "    maxThreads: 5",
             "    maxBufferedItems: 10"));
     ThreadPoolExecutor executor =
-        (ThreadPoolExecutor)
-            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.VECTORMERGE);
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.VECTORMERGE);
     assertEquals(executor.getCorePoolSize(), 5);
     assertEquals(executor.getQueue().remainingCapacity(), 10);
   }
@@ -279,8 +271,7 @@ public class ExecutorFactoryTest {
   public void testCommitThreadPool_default() {
     init();
     ThreadPoolExecutor executor =
-        (ThreadPoolExecutor)
-            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.COMMIT);
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.COMMIT);
     assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_COMMIT_THREADS);
     assertEquals(
         executor.getQueue().remainingCapacity(),
@@ -297,17 +288,41 @@ public class ExecutorFactoryTest {
             "    maxThreads: 3",
             "    maxBufferedItems: 25"));
     ThreadPoolExecutor executor =
-        (ThreadPoolExecutor)
-            ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.COMMIT);
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.COMMIT);
     assertEquals(executor.getCorePoolSize(), 3);
     assertEquals(executor.getQueue().remainingCapacity(), 25);
   }
 
   @Test
+  public void testRemoteThreadPool_default() {
+    init();
+    ThreadPoolExecutor executor =
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.REMOTE);
+    assertEquals(executor.getCorePoolSize(), ThreadPoolConfiguration.DEFAULT_REMOTE_THREADS);
+    assertEquals(
+        executor.getQueue().remainingCapacity(),
+        ThreadPoolConfiguration.DEFAULT_REMOTE_BUFFERED_ITEMS);
+  }
+
+  @Test
+  public void testRemoteThreadPool_set() {
+    init(
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  remote:",
+            "    maxThreads: 5",
+            "    maxBufferedItems: 10"));
+    ThreadPoolExecutor executor =
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.REMOTE);
+    assertEquals(executor.getCorePoolSize(), 5);
+    assertEquals(executor.getQueue().remainingCapacity(), 10);
+  }
+
+  @Test
   public void testVirtualThreadExecutor() {
     init(String.join("\n", "threadPoolConfiguration:", "  search:", "    useVirtualThreads: true"));
-    ExecutorService executor =
-        ExecutorFactory.getInstance().getExecutor(ExecutorFactory.ExecutorType.SEARCH);
+    ExecutorService executor = executorFactory.getExecutor(ExecutorFactory.ExecutorType.SEARCH);
     assertTrue(executor instanceof ExecutorServiceStatsWrapper);
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/config/ThreadPoolConfigurationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/ThreadPoolConfigurationTest.java
@@ -372,6 +372,39 @@ public class ThreadPoolConfigurationTest {
   }
 
   @Test
+  public void testRemoteThreadPool_default() {
+    String config = "nodeName: node1";
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.REMOTE);
+    assertEquals(threadPoolSettings.maxThreads(), ThreadPoolConfiguration.DEFAULT_REMOTE_THREADS);
+    assertEquals(
+        threadPoolSettings.maxBufferedItems(),
+        ThreadPoolConfiguration.DEFAULT_REMOTE_BUFFERED_ITEMS);
+    assertEquals("RemoteExecutor", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
+  public void testRemoteThreadPool_set() {
+    String config =
+        String.join(
+            "\n",
+            "threadPoolConfiguration:",
+            "  remote:",
+            "    maxThreads: 5",
+            "    maxBufferedItems: 10",
+            "    threadNamePrefix: customName");
+    ThreadPoolConfiguration threadPoolConfiguration =
+        new ThreadPoolConfiguration(getReaderForConfig(config));
+    ThreadPoolConfiguration.ThreadPoolSettings threadPoolSettings =
+        threadPoolConfiguration.getThreadPoolSettings(ExecutorFactory.ExecutorType.REMOTE);
+    assertEquals(threadPoolSettings.maxThreads(), 5);
+    assertEquals(threadPoolSettings.maxBufferedItems(), 10);
+    assertEquals("customName", threadPoolSettings.threadNamePrefix());
+  }
+
+  @Test
   public void partialOverride() {
     String config =
         String.join(

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/GrpcServerExecutorSupplierTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/GrpcServerExecutorSupplierTest.java
@@ -26,6 +26,7 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerCall;
 import java.io.ByteArrayInputStream;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,6 +35,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class GrpcServerExecutorSupplierTest {
 
+  static ExecutorFactory executorFactory;
+
   @BeforeClass
   public static void setUp() {
     ThreadPoolConfiguration threadPoolConfiguration =
@@ -41,13 +44,19 @@ public class GrpcServerExecutorSupplierTest {
             new YamlConfigReader(
                 new ByteArrayInputStream(
                     "threadPoolConfiguration:\n  search:\n    maxThreads: 1".getBytes())));
-    ExecutorFactory.init(threadPoolConfiguration);
+    executorFactory = new ExecutorFactory(threadPoolConfiguration);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    executorFactory.close();
   }
 
   @Test
   public void testGetExecutor() {
 
-    GrpcServerExecutorSupplier grpcServerExecutorSupplier = new GrpcServerExecutorSupplier();
+    GrpcServerExecutorSupplier grpcServerExecutorSupplier =
+        new GrpcServerExecutorSupplier(executorFactory);
 
     ServerCall metricsServerCall = getMockServerCall("metrics");
     ServerCall searchServerCall = getMockServerCall("search");

--- a/src/test/java/com/yelp/nrtsearch/server/index/BackendStateManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/index/BackendStateManagerTest.java
@@ -146,6 +146,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
 
     verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState);
   }
@@ -174,6 +175,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
 
     verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState);
   }
@@ -202,6 +204,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
 
     verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState);
   }
@@ -335,6 +338,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
     verify(mockState, times(1)).getMergedSettings();
 
     verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState);
@@ -401,6 +405,7 @@ public class BackendStateManagerTest {
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
     verify(mockState, times(1)).isStarted();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
@@ -464,6 +469,7 @@ public class BackendStateManagerTest {
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
     verify(mockState, times(1)).isStarted();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
@@ -545,6 +551,7 @@ public class BackendStateManagerTest {
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
     verify(mockState, times(1)).isStarted();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
@@ -629,6 +636,7 @@ public class BackendStateManagerTest {
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
     verify(mockState, times(1)).isStarted();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
@@ -721,6 +729,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
     verify(mockState, times(1)).getMergedLiveSettings(false);
 
     verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState);
@@ -769,6 +778,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
     verify(mockState, times(1)).getMergedLiveSettings(false);
     verify(mockState, times(1)).getMergedLiveSettings(true);
 
@@ -840,6 +850,7 @@ public class BackendStateManagerTest {
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
     verify(mockState2, times(1)).getMergedLiveSettings(false);
@@ -907,6 +918,7 @@ public class BackendStateManagerTest {
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
     verify(mockState2, times(1)).getMergedLiveSettings(false);
@@ -989,6 +1001,7 @@ public class BackendStateManagerTest {
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
     verify(mockState2, times(1)).getMergedLiveSettings(false);
@@ -1074,6 +1087,7 @@ public class BackendStateManagerTest {
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedStateInfo);
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
     verify(mockState2, times(1)).getMergedLiveSettings(false);
@@ -1163,6 +1177,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
     verify(mockState2, times(1)).getMergedLiveSettings(true);
@@ -1240,6 +1255,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
     verify(mockState2, times(1)).getMergedLiveSettings(true);
@@ -1314,6 +1330,7 @@ public class BackendStateManagerTest {
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedState);
     verify(mockGlobalState, times(2)).getConfiguration();
+    verify(mockGlobalState, times(2)).getExecutorFactory();
     verify(mockState, times(2)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
     verify(mockState2, times(1)).getAllFieldsJSON();
@@ -1389,6 +1406,7 @@ public class BackendStateManagerTest {
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedState);
     verify(mockGlobalState, times(2)).getConfiguration();
+    verify(mockGlobalState, times(2)).getExecutorFactory();
     verify(mockState, times(2)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
     verify(mockState2, times(1)).getAllFieldsJSON();
@@ -1489,6 +1507,7 @@ public class BackendStateManagerTest {
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), expectedState);
     verify(mockGlobalState, times(2)).getConfiguration();
+    verify(mockGlobalState, times(2)).getExecutorFactory();
     verify(mockState, times(2)).getIndexStateInfo();
     verify(mockState, times(1)).getFieldAndFacetState();
     verify(mockState2, times(1)).getAllFieldsJSON();
@@ -1548,6 +1567,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
 
     verifyNoMoreInteractions(mockBackend, mockGlobalState, mockState);
   }
@@ -1599,6 +1619,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).isStarted();
     verify(mockState, times(1)).start(Mode.PRIMARY, mockDataManager, 1, mockReplicationClient);
@@ -1636,6 +1657,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
     verify(mockState, times(1)).getIndexStateInfo();
     verify(mockState, times(1)).isStarted();
     verify(mockState, times(1)).start(Mode.PRIMARY, mockDataManager, 1, mockReplicationClient);
@@ -1670,6 +1692,7 @@ public class BackendStateManagerTest {
     verify(mockBackend, times(1))
         .loadIndexState(BackendGlobalState.getUniqueIndexName("test_index", "test_id"));
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
     verify(mockState, times(1)).isStarted();
     verify(mockState, times(1)).start(Mode.REPLICA, mockDataManager, 1, mockReplicationClient);
 
@@ -1714,6 +1737,7 @@ public class BackendStateManagerTest {
         .commitIndexState(
             BackendGlobalState.getUniqueIndexName("test_index", "test_id"), updatedState);
     verify(mockGlobalState, times(1)).getConfiguration();
+    verify(mockGlobalState, times(1)).getExecutorFactory();
     verify(mockState, times(3)).getIndexStateInfo();
     verify(mockState, times(1)).isStarted();
     verify(mockState, times(1)).start(Mode.PRIMARY, mockDataManager, 1, mockReplicationClient);

--- a/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendTest.java
@@ -17,8 +17,11 @@ package com.yelp.nrtsearch.server.remote.s3;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
@@ -27,7 +30,9 @@ import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
 import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
+import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
+import com.yelp.nrtsearch.server.config.ThreadPoolConfiguration;
 import com.yelp.nrtsearch.server.nrt.state.NrtFileMetaData;
 import com.yelp.nrtsearch.server.nrt.state.NrtPointState;
 import com.yelp.nrtsearch.server.remote.RemoteBackend;
@@ -48,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ThreadPoolExecutor;
 import org.apache.commons.io.IOUtils;
 import org.apache.lucene.replicator.nrt.CopyState;
 import org.apache.lucene.replicator.nrt.FileMetaData;
@@ -69,13 +75,15 @@ public class S3BackendTest {
 
   private static AmazonS3 s3;
   private static S3Backend s3Backend;
+  private static ExecutorFactory executorFactory;
 
   @BeforeClass
   public static void setup() throws IOException {
     String configStr = "bucketName: " + BUCKET_NAME;
     NrtsearchConfig config = new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
+    executorFactory = new ExecutorFactory(config.getThreadPoolConfiguration());
     s3 = S3_PROVIDER.getAmazonS3();
-    s3Backend = new S3Backend(config, s3);
+    s3Backend = new S3Backend(config, s3, executorFactory);
     s3.putObject(BUCKET_NAME, KEY, CONTENT);
   }
 
@@ -116,6 +124,24 @@ public class S3BackendTest {
     } catch (IllegalArgumentException e) {
       assertEquals(
           String.format("Object s3://%s/%s not found", "bucket_not_exist", KEY), e.getMessage());
+    }
+  }
+
+  @Test
+  public void testUsesRemoteExecutor() {
+    assertSame(
+        executorFactory.getExecutor(ExecutorFactory.ExecutorType.REMOTE), s3Backend.getExecutor());
+  }
+
+  @Test
+  public void testDefaultExecutor() {
+    try (S3Backend s3Backend = new S3Backend(BUCKET_NAME, false, false, mock(AmazonS3.class))) {
+      ThreadPoolExecutor executor = (ThreadPoolExecutor) s3Backend.getExecutor();
+      assertNotSame(executorFactory.getExecutor(ExecutorFactory.ExecutorType.REMOTE), executor);
+      assertEquals(ThreadPoolConfiguration.DEFAULT_REMOTE_THREADS, executor.getCorePoolSize());
+      assertEquals(
+          ThreadPoolConfiguration.DEFAULT_REMOTE_BUFFERED_ITEMS,
+          executor.getQueue().remainingCapacity());
     }
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendUpdateIntervalTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendUpdateIntervalTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.nrt.state.NrtFileMetaData;
 import com.yelp.nrtsearch.server.nrt.state.NrtPointState;
@@ -75,18 +76,21 @@ public class S3BackendUpdateIntervalTest {
 
   private static AmazonS3 s3;
   private static S3Backend s3Backend;
+  private static ExecutorFactory executorFactory;
 
   @BeforeClass
   public static void setup() throws IOException {
     String configStr = "bucketName: " + BUCKET_NAME;
     NrtsearchConfig config = new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
+    executorFactory = new ExecutorFactory(config.getThreadPoolConfiguration());
     s3 = S3_PROVIDER.getAmazonS3();
-    s3Backend = new S3Backend(config, s3);
+    s3Backend = new S3Backend(config, s3, executorFactory);
   }
 
   @AfterClass
-  public static void cleanUp() {
+  public static void cleanUp() throws IOException {
     s3Backend.close();
+    executorFactory.close();
   }
 
   /**

--- a/src/test/java/com/yelp/nrtsearch/test_utils/TestNrtsearchServer.java
+++ b/src/test/java/com/yelp/nrtsearch/test_utils/TestNrtsearchServer.java
@@ -19,6 +19,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.yelp.nrtsearch.module.TestNrtsearchModule;
+import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.NrtsearchClient;
 import com.yelp.nrtsearch.server.grpc.NrtsearchServer;
@@ -33,12 +34,14 @@ public class TestNrtsearchServer extends ExternalResource {
 
   private final NrtsearchConfig configuration;
   private final AmazonS3 amazonS3;
+  private final ExecutorFactory executorFactory;
   private NrtsearchServer server;
   private NrtsearchClient client;
 
   public TestNrtsearchServer(NrtsearchConfig configuration, AmazonS3 amazonS3) {
     this.configuration = configuration;
     this.amazonS3 = amazonS3;
+    this.executorFactory = new ExecutorFactory(configuration.getThreadPoolConfiguration());
   }
 
   @Override
@@ -52,6 +55,11 @@ public class TestNrtsearchServer extends ExternalResource {
     deleteIndexData();
     client.close();
     server.stop();
+    try {
+      executorFactory.close();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   protected NrtsearchClient getClient() {
@@ -59,7 +67,8 @@ public class TestNrtsearchServer extends ExternalResource {
   }
 
   private NrtsearchServer createTestServer() throws IOException {
-    Injector injector = Guice.createInjector(new TestNrtsearchModule(configuration, amazonS3));
+    Injector injector =
+        Guice.createInjector(new TestNrtsearchModule(configuration, amazonS3, executorFactory));
     NrtsearchServer server = injector.getInstance(NrtsearchServer.class);
     server.start();
     return server;

--- a/src/test/java/com/yelp/nrtsearch/tools/cli/ReadyCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/cli/ReadyCommandTest.java
@@ -38,7 +38,7 @@ public class ReadyCommandTest {
   @Rule public final TemporaryFolder folder = new TemporaryFolder();
 
   @After
-  public void cleanup() {
+  public void cleanup() throws IOException {
     if (server != null) {
       server.shutdown();
       server = null;


### PR DESCRIPTION
Add a new executor type `REMOTE` to use for operations such as downloading from S3. This will allow the executor to be configured and produce metrics.

I had to do some refactoring to make this work. Initialization of the `ExecutorFactory` was moved from the server creation, to during injection. This is required, since plugins may need to be downloaded before the server starts. The `ExecutorFactory` is no longer a static singleton, but is passed to where it is needed.