### PR TITLE
Add delete support for ingestion plugins

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/ingestion/AbstractIngestor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/ingestion/AbstractIngestor.java
@@ -16,12 +16,17 @@
 package com.yelp.nrtsearch.server.ingestion;
 
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
+import com.yelp.nrtsearch.server.field.IdFieldDef;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.Query;
 import com.yelp.nrtsearch.server.handler.AddDocumentHandler;
 import com.yelp.nrtsearch.server.index.IndexState;
+import com.yelp.nrtsearch.server.index.ShardState;
+import com.yelp.nrtsearch.server.query.QueryNodeMapper;
 import com.yelp.nrtsearch.server.state.GlobalState;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Abstract base class for ingestion implementations. Provides common ingestion utilities like
@@ -59,6 +64,59 @@ public abstract class AbstractIngestor implements Ingestor {
     verifyInitialized(indexName);
     return new AddDocumentHandler.DocumentIndexer(globalState, addDocRequests, indexName)
         .runIndexingJob();
+  }
+
+  /**
+   * Delete documents matching the specified queries.
+   *
+   * <p>This method deletes documents from the index that match any of the provided queries. It is
+   * designed to support deletion of documents by ID or other criteria during ingestion (e.g., for
+   * handling DELETE and UPDATE_BEFORE row kinds in change data capture scenarios).
+   *
+   * <p>The delete operation is executed directly against the IndexWriter, ensuring it is processed
+   * before any subsequent addDocuments calls. This ordering is critical for UPDATE operations where
+   * the old document must be deleted before the new version is added.
+   *
+   * @param queries list of queries to match documents for deletion
+   * @param indexName target index name
+   * @return sequence number of the delete operation
+   * @throws Exception if delete fails
+   */
+  @Override
+  public long deleteByQuery(List<Query> queries, String indexName) throws Exception {
+    verifyInitialized(indexName);
+    IndexState indexState = globalState.getIndexOrThrow(indexName);
+    ShardState shardState = indexState.getShard(0);
+    indexState.verifyStarted();
+
+    QueryNodeMapper queryNodeMapper = QueryNodeMapper.getInstance();
+    List<org.apache.lucene.search.Query> luceneQueries =
+        queries.stream().map(query -> queryNodeMapper.getQuery(query, indexState)).toList();
+
+    try {
+      shardState.writer.deleteDocuments(
+          luceneQueries.toArray(new org.apache.lucene.search.Query[] {}));
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to delete documents by query", e);
+    }
+
+    return shardState.writer.getMaxCompletedSequenceNumber();
+  }
+
+  /**
+   * Get the ID field definition for the index, if one exists.
+   *
+   * <p>This method provides access to the index's ID field metadata, which is useful for ingestion
+   * plugins that need to construct delete queries based on document IDs.
+   *
+   * @param indexName name of the index
+   * @return Optional containing the IdFieldDef, or empty if no ID field is defined
+   * @throws IOException if index state cannot be accessed
+   */
+  protected Optional<IdFieldDef> getIdFieldDef(String indexName) throws IOException {
+    verifyInitialized(indexName);
+    IndexState indexState = globalState.getIndexOrThrow(indexName);
+    return indexState.getIdFieldDef();
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/ingestion/Ingestor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/ingestion/Ingestor.java
@@ -16,6 +16,7 @@
 package com.yelp.nrtsearch.server.ingestion;
 
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.Query;
 import com.yelp.nrtsearch.server.state.GlobalState;
 import java.io.IOException;
 import java.util.List;
@@ -81,6 +82,21 @@ public interface Ingestor {
    * @throws Exception if indexing fails
    */
   long addDocuments(List<AddDocumentRequest> addDocRequests, String indexName) throws Exception;
+
+  /**
+   * Delete documents matching the specified queries.
+   *
+   * <p>This method is designed to support deletion of documents during ingestion, particularly for
+   * change data capture scenarios where DELETE and UPDATE_BEFORE operations need to be processed.
+   * The delete operation should be executed before any subsequent addDocuments calls to ensure
+   * correct ordering for UPDATE operations.
+   *
+   * @param queries list of queries to match documents for deletion
+   * @param indexName name of the target index
+   * @return sequence number of the delete operation
+   * @throws Exception if delete fails
+   */
+  long deleteByQuery(List<Query> queries, String indexName) throws Exception;
 
   /**
    * Commit any pending changes to the specified index.

--- a/src/test/java/com/yelp/nrtsearch/test_utils/AmazonS3Provider.java
+++ b/src/test/java/com/yelp/nrtsearch/test_utils/AmazonS3Provider.java
@@ -70,7 +70,7 @@ public class AmazonS3Provider extends ExternalResource {
   protected void before() throws Throwable {
     temporaryFolder.create();
     s3Path = temporaryFolder.newFolder("s3").toString();
-    api = S3Mock.create(8011, s3Path);
+    api = new S3Mock.Builder().withPort(8011).withFileBackend(s3Path).build();
     api.start();
     s3 = createTestS3Client("http://127.0.0.1:8011");
     s3.createBucket(bucketName);


### PR DESCRIPTION
- Add deleteByQuery() method to Ingestor interface and AbstractIngestor
- Add getIdFieldDef() helper to expose index ID field metadata to plugins
- Support TermInSetQuery for type-safe deletes (LONG, INT, TEXT fields)
- Fix S3Mock to use file-based backend instead of in-memory for large plugin tests

Tested this on paimon-ingestion plugin 