### PR TITLE
Add rate limiting option for s3 downloading

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java
@@ -115,7 +115,6 @@ public class NrtsearchConfig {
   private final DirectoryFactory.MMapGrouping mmapGrouping;
   private final boolean requireIdField;
   private final IsolatedReplicaConfig isolatedReplicaConfig;
-  private final boolean s3Metrics;
 
   @Inject
   public NrtsearchConfig(InputStream yamlStream) {
@@ -197,7 +196,6 @@ public class NrtsearchConfig {
     useSeparateCommitExecutor = configReader.getBoolean("useSeparateCommitExecutor", false);
     requireIdField = configReader.getBoolean("requireIdField", false);
     isolatedReplicaConfig = IsolatedReplicaConfig.fromConfig(configReader);
-    s3Metrics = configReader.getBoolean("s3Metrics", false);
 
     List<String> indicesWithOverrides = configReader.getKeysOrEmpty("indexLiveSettingsOverrides");
     Map<String, IndexLiveSettings> liveSettingsMap = new HashMap<>();
@@ -401,10 +399,6 @@ public class NrtsearchConfig {
 
   public IsolatedReplicaConfig getIsolatedReplicaConfig() {
     return isolatedReplicaConfig;
-  }
-
-  public boolean getS3Metrics() {
-    return s3Metrics;
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/utils/GlobalThrottledInputStream.java
+++ b/src/main/java/com/yelp/nrtsearch/server/utils/GlobalThrottledInputStream.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.utils;
+
+import java.io.InputStream;
+import org.apache.commons.io.input.ProxyInputStream;
+
+/**
+ * InputStream wrapper that uses a GlobalWindowRateLimiter to throttle read bytes. It acquires
+ * permits from the rate limiter after each read operation.
+ */
+public class GlobalThrottledInputStream extends ProxyInputStream {
+  private final GlobalWindowRateLimiter limiter;
+
+  /**
+   * Constructs a GlobalThrottledInputStream that wraps the given InputStream and uses the provided
+   * GlobalWindowRateLimiter for throttling.
+   *
+   * @param in the InputStream to be wrapped
+   * @param limiter the GlobalWindowRateLimiter to use for throttling
+   */
+  public GlobalThrottledInputStream(InputStream in, GlobalWindowRateLimiter limiter) {
+    super(in);
+    this.limiter = limiter;
+  }
+
+  @Override
+  protected void afterRead(int n) {
+    if (n != -1) {
+      limiter.acquire(n);
+    }
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/utils/GlobalWindowRateLimiter.java
+++ b/src/main/java/com/yelp/nrtsearch/server/utils/GlobalWindowRateLimiter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.utils;
+
+/**
+ * Limit the number of bytes read in a time window. If the limit is exceeded, the thread will sleep
+ * until the next window. The rate limiter is synchronized to be thread safe.
+ */
+public class GlobalWindowRateLimiter {
+  private final long bytesPerWindow;
+  private final long windowMillis;
+
+  private long windowStartTime;
+  private long bytesReadInWindow;
+
+  /**
+   * Constructor for GlobalWindowRateLimiter.
+   *
+   * @param bytesPerSecond maximum bytes per second
+   * @param windowSeconds size of the time window in seconds
+   */
+  public GlobalWindowRateLimiter(long bytesPerSecond, int windowSeconds) {
+    this.bytesPerWindow = bytesPerSecond * windowSeconds;
+    this.windowMillis = windowSeconds * 1000L;
+    this.windowStartTime = System.currentTimeMillis();
+    this.bytesReadInWindow = 0;
+  }
+
+  /**
+   * Acquire permission to read numBytes. If the limit is exceeded, the thread will sleep until the
+   * next window.
+   *
+   * @param numBytes number of bytes to read
+   */
+  public synchronized void acquire(int numBytes) {
+    long now = System.currentTimeMillis();
+
+    // Start new window if needed
+    if (now - windowStartTime >= windowMillis) {
+      windowStartTime = now;
+      bytesReadInWindow = 0;
+    }
+
+    bytesReadInWindow += numBytes;
+
+    // If over limit, sleep until window reset
+    if (bytesReadInWindow > bytesPerWindow) {
+      long sleepMillis = windowMillis - (now - windowStartTime);
+      if (sleepMillis > 0) {
+        try {
+          Thread.sleep(sleepMillis);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      windowStartTime = System.currentTimeMillis();
+      bytesReadInWindow = numBytes;
+    }
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/CleanupSnapshotsCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/CleanupSnapshotsCommand.java
@@ -123,7 +123,7 @@ public class CleanupSnapshotsCommand implements Callable<Integer> {
       s3Client =
           StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
     }
-    S3Backend s3Backend = new S3Backend(bucketName, false, false, s3Client);
+    S3Backend s3Backend = new S3Backend(bucketName, false, S3Backend.DEFAULT_CONFIG, s3Client);
 
     long deleteAfterMs = BackupCommandUtils.getTimeIntervalMs(deleteAfter);
     long minTimestampMs = System.currentTimeMillis() - deleteAfterMs;

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/RestoreCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/RestoreCommand.java
@@ -147,7 +147,7 @@ public class RestoreCommand implements Callable<Integer> {
       s3Client =
           StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
     }
-    S3Backend s3Backend = new S3Backend(bucketName, false, false, s3Client);
+    S3Backend s3Backend = new S3Backend(bucketName, false, S3Backend.DEFAULT_CONFIG, s3Client);
 
     String resolvedSnapshotRoot =
         BackupCommandUtils.getSnapshotRoot(snapshotRoot, snapshotServiceName);

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/SnapshotCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/SnapshotCommand.java
@@ -121,7 +121,7 @@ public class SnapshotCommand implements Callable<Integer> {
       s3Client =
           StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
     }
-    S3Backend s3Backend = new S3Backend(bucketName, false, false, s3Client);
+    S3Backend s3Backend = new S3Backend(bucketName, false, S3Backend.DEFAULT_CONFIG, s3Client);
 
     String resolvedIndexResource =
         StateCommandUtils.getResourceName(s3Backend, serviceName, indexName, exactResourceName);

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/cleanup/CleanupDataCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/cleanup/CleanupDataCommand.java
@@ -128,7 +128,7 @@ public class CleanupDataCommand implements Callable<Integer> {
       s3Client =
           StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
     }
-    S3Backend s3Backend = new S3Backend(bucketName, false, false, s3Client);
+    S3Backend s3Backend = new S3Backend(bucketName, false, S3Backend.DEFAULT_CONFIG, s3Client);
 
     String resolvedIndexResource =
         StateCommandUtils.getResourceName(s3Backend, serviceName, indexName, exactResourceName);

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetRemoteStateCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetRemoteStateCommand.java
@@ -96,7 +96,7 @@ public class GetRemoteStateCommand implements Callable<Integer> {
       s3Client =
           StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
     }
-    S3Backend s3Backend = new S3Backend(bucketName, false, false, s3Client);
+    S3Backend s3Backend = new S3Backend(bucketName, false, S3Backend.DEFAULT_CONFIG, s3Client);
     String resolvedResourceName =
         StateCommandUtils.getResourceName(s3Backend, serviceName, resourceName, exactResourceName);
 

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetResourceVersionCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetResourceVersionCommand.java
@@ -99,7 +99,7 @@ public class GetResourceVersionCommand implements Callable<Integer> {
       s3Client =
           StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
     }
-    S3Backend s3Backend = new S3Backend(bucketName, false, false, s3Client);
+    S3Backend s3Backend = new S3Backend(bucketName, false, S3Backend.DEFAULT_CONFIG, s3Client);
     String resolvedResourceName =
         StateCommandUtils.getResourceName(s3Backend, serviceName, resourceName, exactResourceName);
 

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/ListResourceVersions.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/ListResourceVersions.java
@@ -107,7 +107,7 @@ public class ListResourceVersions implements Callable<Integer> {
       s3Client =
           StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
     }
-    S3Backend s3Backend = new S3Backend(bucketName, false, false, s3Client);
+    S3Backend s3Backend = new S3Backend(bucketName, false, S3Backend.DEFAULT_CONFIG, s3Client);
     String resolvedResourceName =
         StateCommandUtils.getResourceName(s3Backend, serviceName, resourceName, exactResourceName);
 

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/PutRemoteStateCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/PutRemoteStateCommand.java
@@ -107,7 +107,7 @@ public class PutRemoteStateCommand implements Callable<Integer> {
       s3Client =
           StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
     }
-    S3Backend s3Backend = new S3Backend(bucketName, false, false, s3Client);
+    S3Backend s3Backend = new S3Backend(bucketName, false, S3Backend.DEFAULT_CONFIG, s3Client);
 
     String resolvedResourceName =
         StateCommandUtils.getResourceName(s3Backend, serviceName, resourceName, exactResourceName);

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/SetResourceVersionCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/SetResourceVersionCommand.java
@@ -105,7 +105,7 @@ public class SetResourceVersionCommand implements Callable<Integer> {
       s3Client =
           StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
     }
-    S3Backend s3Backend = new S3Backend(bucketName, false, false, s3Client);
+    S3Backend s3Backend = new S3Backend(bucketName, false, S3Backend.DEFAULT_CONFIG, s3Client);
     String resolvedResourceName =
         StateCommandUtils.getResourceName(s3Backend, serviceName, resourceName, exactResourceName);
 

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/UpdateGlobalIndexStateCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/UpdateGlobalIndexStateCommand.java
@@ -120,7 +120,7 @@ public class UpdateGlobalIndexStateCommand implements Callable<Integer> {
       s3Client =
           StateCommandUtils.createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
     }
-    S3Backend s3Backend = new S3Backend(bucketName, false, false, s3Client);
+    S3Backend s3Backend = new S3Backend(bucketName, false, S3Backend.DEFAULT_CONFIG, s3Client);
 
     String stateFileContents = StateCommandUtils.getGlobalStateFileContents(s3Backend, serviceName);
     if (stateFileContents == null) {

--- a/src/test/java/com/yelp/nrtsearch/server/config/NrtsearchConfigTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/NrtsearchConfigTest.java
@@ -291,18 +291,4 @@ public class NrtsearchConfigTest {
     NrtsearchConfig luceneConfig = getForConfig(config);
     luceneConfig.getIngestionPluginConfigs(); // should throw
   }
-
-  @Test
-  public void testS3Metrics_default() {
-    String config = "nodeName: \"server_foo\"";
-    NrtsearchConfig luceneConfig = getForConfig(config);
-    assertFalse(luceneConfig.getS3Metrics());
-  }
-
-  @Test
-  public void testS3Metrics_set() {
-    String config = "s3Metrics: true";
-    NrtsearchConfig luceneConfig = getForConfig(config);
-    assertTrue(luceneConfig.getS3Metrics());
-  }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/StateBackendServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/StateBackendServerTest.java
@@ -152,8 +152,8 @@ public class StateBackendServerTest {
     Files.createDirectories(getReplicaIndexDir());
 
     AmazonS3 s3 = s3Provider.getAmazonS3();
-    remoteBackendPrimary = new S3Backend(TEST_BUCKET, false, false, s3);
-    remoteBackendReplica = new S3Backend(TEST_BUCKET, false, false, s3);
+    remoteBackendPrimary = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, s3);
+    remoteBackendReplica = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, s3);
   }
 
   private NrtsearchConfig getPrimaryConfig() {

--- a/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendConfigTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendConfigTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.remote.s3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
+import com.yelp.nrtsearch.server.remote.s3.S3Backend.S3BackendConfig;
+import java.io.ByteArrayInputStream;
+import org.junit.Test;
+
+public class S3BackendConfigTest {
+
+  @Test
+  public void testConstructorAndGetters() {
+    // Test constructor with rate limit values and metrics flag
+    long bytesPerSecond = 1024 * 1024; // 1MB
+    int windowSeconds = 5;
+    boolean metrics = true;
+    S3BackendConfig config = new S3BackendConfig(metrics, bytesPerSecond, windowSeconds);
+
+    // Verify getters return expected values
+    assertEquals(bytesPerSecond, config.getRateLimitBytes());
+    assertEquals(windowSeconds, config.getRateLimitWindowSeconds());
+    assertEquals(metrics, config.getMetrics());
+  }
+
+  @Test
+  public void testFromConfig_NoRateLimit() {
+    // Create config with no rate limit settings
+    String configStr = "bucketName: test-bucket";
+    NrtsearchConfig nrtsearchConfig =
+        new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
+
+    // Create S3BackendConfig from NrtsearchConfig
+    S3BackendConfig config = S3BackendConfig.fromConfig(nrtsearchConfig);
+
+    // Verify no rate limit is set (0 bytes, but default window of 1 second)
+    assertEquals(0, config.getRateLimitBytes());
+    assertEquals(1, config.getRateLimitWindowSeconds()); // Default is 1, not 0
+    assertEquals(false, config.getMetrics()); // Default metrics is false
+  }
+
+  @Test
+  public void testFromConfig_WithRateLimit() {
+    // Create config with rate limit settings
+    String configStr =
+        "bucketName: test-bucket\n"
+            + "remoteConfig:\n"
+            + "  s3:\n"
+            + "    rateLimitPerSecond: 1MB\n"
+            + "    rateLimitWindowSeconds: 5";
+    NrtsearchConfig nrtsearchConfig =
+        new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
+
+    // Create S3BackendConfig from NrtsearchConfig
+    S3BackendConfig config = S3BackendConfig.fromConfig(nrtsearchConfig);
+
+    // Verify rate limit is set correctly
+    assertEquals(1024 * 1024, config.getRateLimitBytes());
+    assertEquals(5, config.getRateLimitWindowSeconds());
+    assertEquals(false, config.getMetrics()); // Default metrics is false when not specified
+  }
+
+  @Test
+  public void testFromConfig_WithMetrics() {
+    // Create config with metrics setting
+    String configStr =
+        "bucketName: test-bucket\n" + "remoteConfig:\n" + "  s3:\n" + "    metrics: true";
+    NrtsearchConfig nrtsearchConfig =
+        new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
+
+    // Create S3BackendConfig from NrtsearchConfig
+    S3BackendConfig config = S3BackendConfig.fromConfig(nrtsearchConfig);
+
+    // Verify metrics is set correctly
+    assertEquals(true, config.getMetrics());
+    assertEquals(0, config.getRateLimitBytes()); // Default rate limit is 0
+    assertEquals(1, config.getRateLimitWindowSeconds()); // Default window is 1
+  }
+
+  @Test
+  public void testRateLimitStringToBytes_KB() {
+    // Test KB conversion
+    assertEquals(1024, S3BackendConfig.rateLimitStringToBytes("1KB"));
+    assertEquals(1024 * 5, S3BackendConfig.rateLimitStringToBytes("5KB"));
+  }
+
+  @Test
+  public void testRateLimitStringToBytes_MB() {
+    // Test MB conversion
+    assertEquals(1024 * 1024, S3BackendConfig.rateLimitStringToBytes("1MB"));
+    assertEquals(1024 * 1024 * 10, S3BackendConfig.rateLimitStringToBytes("10MB"));
+  }
+
+  @Test
+  public void testRateLimitStringToBytes_GB() {
+    // Test GB conversion - use long literals to avoid integer overflow
+    assertEquals(1024L * 1024L * 1024L, S3BackendConfig.rateLimitStringToBytes("1GB"));
+    assertEquals(1024L * 1024L * 1024L * 2L, S3BackendConfig.rateLimitStringToBytes("2GB"));
+  }
+
+  @Test
+  public void testRateLimitStringToBytes_NumericOnly() {
+    // Test numeric only (bytes)
+    assertEquals(1000, S3BackendConfig.rateLimitStringToBytes("1000"));
+  }
+
+  @Test
+  public void testRateLimitStringToBytes_Invalid() {
+    // Test invalid format throws NumberFormatException
+    try {
+      S3BackendConfig.rateLimitStringToBytes("invalid");
+      fail("Expected NumberFormatException");
+    } catch (NumberFormatException e) {
+      // Expected
+    }
+
+    try {
+      S3BackendConfig.rateLimitStringToBytes("1XB");
+      fail("Expected NumberFormatException");
+    } catch (NumberFormatException e) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void testRateLimitStringToBytes_Null() {
+    // Test null throws NullPointerException
+    try {
+      S3BackendConfig.rateLimitStringToBytes(null);
+      fail("Expected NullPointerException");
+    } catch (NullPointerException e) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void testRateLimitStringToBytes_Empty() {
+    // Test empty string throws IllegalArgumentException
+    try {
+      S3BackendConfig.rateLimitStringToBytes("");
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // Expected
+      assertEquals("Cannot convert rate limit string: ", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testInvalidRateLimit() {
+    // Test negative rate limit throws IllegalArgumentException
+    try {
+      new S3BackendConfig(true, -1024, 5);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // Expected
+      assertEquals("rateLimitBytes must be >= 0", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testZeroRateLimit() {
+    // Test zero rate limit is valid
+    assertEquals(0, S3BackendConfig.rateLimitStringToBytes("0"));
+  }
+
+  @Test
+  public void testInvalidWindowSeconds() {
+    // Test zero or negative window seconds throws IllegalArgumentException
+    try {
+      new S3BackendConfig(true, 1024, 0);
+      fail("Expected IllegalArgumentException for zero window seconds");
+    } catch (IllegalArgumentException e) {
+      // Expected
+      assertEquals("rateLimitWindowSeconds must be > 0", e.getMessage());
+    }
+
+    try {
+      new S3BackendConfig(true, 1024, -5);
+      fail("Expected IllegalArgumentException for negative window seconds");
+    } catch (IllegalArgumentException e) {
+      // Expected
+      assertEquals("rateLimitWindowSeconds must be > 0", e.getMessage());
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendRateLimitTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendRateLimitTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.remote.s3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
+import com.yelp.nrtsearch.server.remote.s3.S3Backend.S3BackendConfig;
+import com.yelp.nrtsearch.server.utils.GlobalWindowRateLimiter;
+import com.yelp.nrtsearch.test_utils.AmazonS3Provider;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class S3BackendRateLimitTest {
+  private static final String BUCKET_NAME = "s3-backend-rate-limit-test";
+  private static final String KEY = "test_key";
+  private static final String CONTENT = "test_content";
+
+  @ClassRule public static final AmazonS3Provider S3_PROVIDER = new AmazonS3Provider(BUCKET_NAME);
+
+  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+
+  private static AmazonS3 s3;
+
+  @BeforeClass
+  public static void setup() {
+    s3 = S3_PROVIDER.getAmazonS3();
+    s3.putObject(BUCKET_NAME, KEY, CONTENT);
+  }
+
+  @AfterClass
+  public static void cleanUp() {
+    // Don't shut down the S3 client here as it's shared across tests
+    // The AmazonS3Provider will handle cleanup
+  }
+
+  @Test
+  public void testRateLimiterInitialization_NoRateLimit() throws Exception {
+    // Create S3Backend with default config (no rate limiting)
+    String configStr = "bucketName: " + BUCKET_NAME;
+    NrtsearchConfig nrtsearchConfig =
+        new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
+    S3Backend s3Backend = new S3Backend(nrtsearchConfig, s3);
+
+    // Use reflection to access the private rateLimiter field
+    Field rateLimiterField = S3Backend.class.getDeclaredField("rateLimiter");
+    rateLimiterField.setAccessible(true);
+    GlobalWindowRateLimiter rateLimiter = (GlobalWindowRateLimiter) rateLimiterField.get(s3Backend);
+
+    // Verify rateLimiter is null when rate limit is 0
+    assertNull("RateLimiter should be null when rate limit is 0", rateLimiter);
+  }
+
+  @Test
+  public void testRateLimiterInitialization_WithRateLimit() throws Exception {
+    // Create S3Backend with rate limiting config
+    String configStr =
+        "bucketName: "
+            + BUCKET_NAME
+            + "\n"
+            + "remoteConfig:\n"
+            + "  s3:\n"
+            + "    rateLimitPerSecond: 1MB\n"
+            + "    rateLimitWindowSeconds: 5";
+    NrtsearchConfig nrtsearchConfig =
+        new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
+    S3Backend s3Backend = new S3Backend(nrtsearchConfig, s3);
+
+    // Use reflection to access the private rateLimiter field
+    Field rateLimiterField = S3Backend.class.getDeclaredField("rateLimiter");
+    rateLimiterField.setAccessible(true);
+    GlobalWindowRateLimiter rateLimiter = (GlobalWindowRateLimiter) rateLimiterField.get(s3Backend);
+
+    // Verify rateLimiter is not null when rate limit is > 0
+    assertNotNull("RateLimiter should not be null when rate limit is > 0", rateLimiter);
+
+    // Verify rateLimiter is initialized with correct values
+    // Access private fields of GlobalWindowRateLimiter using reflection
+    Field bytesPerWindowField = GlobalWindowRateLimiter.class.getDeclaredField("bytesPerWindow");
+    bytesPerWindowField.setAccessible(true);
+    long bytesPerWindow = (long) bytesPerWindowField.get(rateLimiter);
+
+    Field windowMillisField = GlobalWindowRateLimiter.class.getDeclaredField("windowMillis");
+    windowMillisField.setAccessible(true);
+    long windowMillis = (long) windowMillisField.get(rateLimiter);
+
+    // Verify the values match what we configured
+    assertEquals(1024 * 1024 * 5, bytesPerWindow); // 1MB * 5 seconds
+    assertEquals(5000, windowMillis); // 5 seconds in milliseconds
+  }
+
+  @Test
+  public void testDownloadWithRateLimit() throws IOException {
+    // Create S3Backend with rate limiting config
+    String configStr =
+        "bucketName: "
+            + BUCKET_NAME
+            + "\n"
+            + "remoteConfig:\n"
+            + "  s3:\n"
+            + "    rateLimitPerSecond: 1MB\n"
+            + "    rateLimitWindowSeconds: 5";
+    NrtsearchConfig nrtsearchConfig =
+        new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
+    S3Backend s3Backend = new S3Backend(nrtsearchConfig, s3);
+
+    // Download a file - this should work normally since our test file is small
+    // and the rate limit is high enough
+    InputStream inputStream =
+        s3Backend.downloadFromS3Path(String.format("s3://%s/%s", BUCKET_NAME, KEY));
+    try {
+      String contentFromS3 = convertToString(inputStream);
+      assertEquals(CONTENT, contentFromS3);
+    } finally {
+      if (inputStream != null) {
+        inputStream.close();
+      }
+    }
+  }
+
+  @Test
+  public void testCustomRateLimitConfig() throws Exception {
+    // Create a custom S3BackendConfig
+    S3BackendConfig customConfig =
+        new S3BackendConfig(
+            false, 2 * 1024 * 1024, 10); // 2MB/s, 10 second window, metrics disabled
+
+    // Create S3Backend with custom config
+    S3Backend s3Backend = new S3Backend(BUCKET_NAME, false, customConfig, s3);
+
+    // Use reflection to access the private rateLimiter field
+    Field rateLimiterField = S3Backend.class.getDeclaredField("rateLimiter");
+    rateLimiterField.setAccessible(true);
+    GlobalWindowRateLimiter rateLimiter = (GlobalWindowRateLimiter) rateLimiterField.get(s3Backend);
+
+    // Verify rateLimiter is not null
+    assertNotNull("RateLimiter should not be null with custom config", rateLimiter);
+
+    // Verify rateLimiter is initialized with correct values
+    Field bytesPerWindowField = GlobalWindowRateLimiter.class.getDeclaredField("bytesPerWindow");
+    bytesPerWindowField.setAccessible(true);
+    long bytesPerWindow = (long) bytesPerWindowField.get(rateLimiter);
+
+    Field windowMillisField = GlobalWindowRateLimiter.class.getDeclaredField("windowMillis");
+    windowMillisField.setAccessible(true);
+    long windowMillis = (long) windowMillisField.get(rateLimiter);
+
+    // Verify the values match what we configured
+    assertEquals(2 * 1024 * 1024 * 10, bytesPerWindow); // 2MB * 10 seconds
+    assertEquals(10000, windowMillis); // 10 seconds in milliseconds
+  }
+
+  @Test
+  public void testMetricsConfig() throws Exception {
+    // Create a custom S3BackendConfig with metrics enabled
+    S3BackendConfig customConfig =
+        new S3BackendConfig(true, 0, 1); // No rate limit, metrics enabled
+
+    // Create S3Backend with custom config
+    S3Backend s3Backend = new S3Backend(BUCKET_NAME, false, customConfig, s3);
+
+    // Use reflection to access the private s3Metrics field
+    Field s3MetricsField = S3Backend.class.getDeclaredField("s3Metrics");
+    s3MetricsField.setAccessible(true);
+    boolean s3Metrics = (boolean) s3MetricsField.get(s3Backend);
+
+    // Verify s3Metrics is true
+    assertEquals(true, s3Metrics);
+
+    // Download a file and verify metrics wrapper is used
+    InputStream inputStream =
+        s3Backend.downloadFromS3Path(String.format("s3://%s/%s", BUCKET_NAME, KEY));
+    try {
+      // Verify the stream is wrapped with S3DownloadStreamWrapper
+      assertEquals(
+          "com.yelp.nrtsearch.server.monitoring.S3DownloadStreamWrapper",
+          inputStream.getClass().getName());
+
+      String contentFromS3 = convertToString(inputStream);
+      assertEquals(CONTENT, contentFromS3);
+    } finally {
+      if (inputStream != null) {
+        inputStream.close();
+      }
+    }
+  }
+
+  private String convertToString(InputStream inputStream) throws IOException {
+    StringWriter writer = new StringWriter();
+    IOUtils.copy(inputStream, writer, StandardCharsets.UTF_8);
+    return writer.toString();
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Yelp Inc.
+ * Copyright 2025 Yelp Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
@@ -28,11 +29,14 @@ import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
+import com.yelp.nrtsearch.server.monitoring.S3DownloadStreamWrapper;
 import com.yelp.nrtsearch.server.nrt.state.NrtFileMetaData;
 import com.yelp.nrtsearch.server.nrt.state.NrtPointState;
 import com.yelp.nrtsearch.server.remote.RemoteBackend;
 import com.yelp.nrtsearch.server.remote.RemoteBackend.IndexResourceType;
 import com.yelp.nrtsearch.server.remote.RemoteUtils;
+import com.yelp.nrtsearch.server.utils.GlobalThrottledInputStream;
+import com.yelp.nrtsearch.server.utils.GlobalWindowRateLimiter;
 import com.yelp.nrtsearch.server.utils.TimeStringUtils;
 import com.yelp.nrtsearch.test_utils.AmazonS3Provider;
 import java.io.ByteArrayInputStream;
@@ -976,7 +980,94 @@ public class S3BackendTest {
         "Filename should start with time string", fileName.startsWith(extractedTimeString + "-"));
   }
 
-  // ...existing helper methods...
+  @Test
+  public void testWrapDownloadStream_withMetricsNoRateLimiter() {
+    // Create a mock InputStream
+    InputStream mockInputStream = mock(InputStream.class);
+    String indexIdentifier = "test_index";
+
+    // Call wrapDownloadStream with metrics enabled but no rate limiter
+    InputStream result = S3Backend.wrapDownloadStream(mockInputStream, true, indexIdentifier, null);
+
+    // Verify the result is an S3DownloadStreamWrapper
+    assertTrue(
+        "Result should be an S3DownloadStreamWrapper", result instanceof S3DownloadStreamWrapper);
+
+    // Verify it's not a GlobalThrottledInputStream
+    assertFalse(
+        "Result should not be a GlobalThrottledInputStream",
+        result instanceof GlobalThrottledInputStream);
+  }
+
+  @Test
+  public void testWrapDownloadStream_withRateLimiterNoMetrics() {
+    // Create a mock InputStream
+    InputStream mockInputStream = mock(InputStream.class);
+    String indexIdentifier = "test_index";
+
+    // Create a rate limiter
+    GlobalWindowRateLimiter rateLimiter = new GlobalWindowRateLimiter(1024, 1);
+
+    // Call wrapDownloadStream with rate limiter enabled but no metrics
+    InputStream result =
+        S3Backend.wrapDownloadStream(mockInputStream, false, indexIdentifier, rateLimiter);
+
+    // Verify the result is a GlobalThrottledInputStream
+    assertTrue(
+        "Result should be a GlobalThrottledInputStream",
+        result instanceof GlobalThrottledInputStream);
+
+    // Verify it's not an S3DownloadStreamWrapper
+    assertFalse(
+        "Result should not be an S3DownloadStreamWrapper",
+        result instanceof S3DownloadStreamWrapper);
+  }
+
+  @Test
+  public void testWrapDownloadStream_withBothMetricsAndRateLimiter() {
+    // Create a mock InputStream
+    InputStream mockInputStream = mock(InputStream.class);
+    String indexIdentifier = "test_index";
+
+    // Create a rate limiter
+    GlobalWindowRateLimiter rateLimiter = new GlobalWindowRateLimiter(1024, 1);
+
+    // Call wrapDownloadStream with both metrics and rate limiter enabled
+    InputStream result =
+        S3Backend.wrapDownloadStream(mockInputStream, true, indexIdentifier, rateLimiter);
+
+    // The result should be a GlobalThrottledInputStream wrapping an S3DownloadStreamWrapper
+    assertTrue(
+        "Result should be a GlobalThrottledInputStream",
+        result instanceof GlobalThrottledInputStream);
+
+    // We can't directly check the wrapped stream type without reflection or exposing it,
+    // but we can verify the behavior is as expected by checking the class name
+    String className = result.getClass().getName();
+    assertEquals("com.yelp.nrtsearch.server.utils.GlobalThrottledInputStream", className);
+  }
+
+  @Test
+  public void testWrapDownloadStream_withNeitherMetricsNorRateLimiter() {
+    // Create a mock InputStream
+    InputStream mockInputStream = mock(InputStream.class);
+    String indexIdentifier = "test_index";
+
+    // Call wrapDownloadStream with neither metrics nor rate limiter enabled
+    InputStream result =
+        S3Backend.wrapDownloadStream(mockInputStream, false, indexIdentifier, null);
+
+    // The result should be the original input stream
+    assertEquals("Result should be the original input stream", mockInputStream, result);
+
+    // Verify it's not an S3DownloadStreamWrapper or GlobalThrottledInputStream
+    assertFalse(
+        "Result should not be an S3DownloadStreamWrapper",
+        result instanceof S3DownloadStreamWrapper);
+    assertFalse(
+        "Result should not be a GlobalThrottledInputStream",
+        result instanceof GlobalThrottledInputStream);
+  }
 
   private void putMultiPart(String key, List<String> partsData) {
     InitiateMultipartUploadRequest initRequest =

--- a/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendWrapDownloadStreamTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendWrapDownloadStreamTest.java
@@ -49,7 +49,7 @@ public class S3BackendWrapDownloadStreamTest {
 
       // Act
       InputStream result =
-          S3Backend.wrapDownloadStream(inputStream, s3Metrics, TEST_INDEX_IDENTIFIER);
+          S3Backend.wrapDownloadStream(inputStream, s3Metrics, TEST_INDEX_IDENTIFIER, null);
 
       // Assert
       assertTrue(
@@ -75,7 +75,7 @@ public class S3BackendWrapDownloadStreamTest {
 
     // Act
     InputStream result =
-        S3Backend.wrapDownloadStream(inputStream, s3Metrics, TEST_INDEX_IDENTIFIER);
+        S3Backend.wrapDownloadStream(inputStream, s3Metrics, TEST_INDEX_IDENTIFIER, null);
 
     // Assert
     assertSame(
@@ -106,7 +106,7 @@ public class S3BackendWrapDownloadStreamTest {
 
       // Act
       InputStream result =
-          S3Backend.wrapDownloadStream(inputStream, s3Metrics, nullIndexIdentifier);
+          S3Backend.wrapDownloadStream(inputStream, s3Metrics, nullIndexIdentifier, null);
 
       // Assert
       assertTrue(
@@ -139,7 +139,7 @@ public class S3BackendWrapDownloadStreamTest {
 
       // Act
       InputStream result =
-          S3Backend.wrapDownloadStream(emptyStream, s3Metrics, TEST_INDEX_IDENTIFIER);
+          S3Backend.wrapDownloadStream(emptyStream, s3Metrics, TEST_INDEX_IDENTIFIER, null);
 
       // Assert
       assertTrue(

--- a/src/test/java/com/yelp/nrtsearch/server/state/backend/RemoteStateBackendTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/state/backend/RemoteStateBackendTest.java
@@ -64,7 +64,8 @@ public class RemoteStateBackendTest {
 
   @Before
   public void setup() throws IOException {
-    remoteBackend = new S3Backend(TEST_BUCKET, false, false, s3Provider.getAmazonS3());
+    remoteBackend =
+        new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, s3Provider.getAmazonS3());
   }
 
   private NrtsearchConfig getConfig(boolean readOnly) throws IOException {

--- a/src/test/java/com/yelp/nrtsearch/server/utils/GlobalThrottledInputStreamTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/utils/GlobalThrottledInputStreamTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Test;
+
+public class GlobalThrottledInputStreamTest {
+
+  @Test
+  public void testBasicReadFunctionality() throws IOException {
+    // Arrange
+    byte[] data = {0x01, 0x02, 0x03, 0x04, 0x05};
+    InputStream inputStream = new ByteArrayInputStream(data);
+    GlobalWindowRateLimiter mockLimiter = mock(GlobalWindowRateLimiter.class);
+
+    // Act
+    try (GlobalThrottledInputStream throttledStream =
+        new GlobalThrottledInputStream(inputStream, mockLimiter)) {
+      // Assert
+      assertThat(throttledStream.read()).isEqualTo(0x01);
+      assertThat(throttledStream.read()).isEqualTo(0x02);
+      assertThat(throttledStream.read()).isEqualTo(0x03);
+      assertThat(throttledStream.read()).isEqualTo(0x04);
+      assertThat(throttledStream.read()).isEqualTo(0x05);
+      assertThat(throttledStream.read()).isEqualTo(-1); // End of stream
+    }
+
+    // Verify limiter was called for each byte read
+    verify(mockLimiter, times(5)).acquire(1);
+    verifyNoMoreInteractions(mockLimiter);
+  }
+
+  @Test
+  public void testReadByteArray() throws IOException {
+    // Arrange
+    byte[] data = {0x01, 0x02, 0x03, 0x04, 0x05};
+    InputStream inputStream = new ByteArrayInputStream(data);
+    GlobalWindowRateLimiter mockLimiter = mock(GlobalWindowRateLimiter.class);
+
+    // Act
+    try (GlobalThrottledInputStream throttledStream =
+        new GlobalThrottledInputStream(inputStream, mockLimiter)) {
+      byte[] buffer = new byte[5];
+      int bytesRead = throttledStream.read(buffer);
+
+      // Assert
+      assertThat(bytesRead).isEqualTo(5);
+      assertThat(buffer).containsExactly(0x01, 0x02, 0x03, 0x04, 0x05);
+
+      // Verify end of stream
+      assertThat(throttledStream.read()).isEqualTo(-1);
+    }
+
+    // Verify limiter was called once with the total bytes read
+    verify(mockLimiter, times(1)).acquire(5);
+    verifyNoMoreInteractions(mockLimiter);
+  }
+
+  @Test
+  public void testReadByteArrayWithOffsetAndLength() throws IOException {
+    // Arrange
+    byte[] data = {0x01, 0x02, 0x03, 0x04, 0x05};
+    InputStream inputStream = new ByteArrayInputStream(data);
+    GlobalWindowRateLimiter mockLimiter = mock(GlobalWindowRateLimiter.class);
+
+    // Act
+    try (GlobalThrottledInputStream throttledStream =
+        new GlobalThrottledInputStream(inputStream, mockLimiter)) {
+      byte[] buffer = new byte[10]; // Larger buffer than needed
+      int bytesRead = throttledStream.read(buffer, 2, 3); // Read 3 bytes starting at offset 2
+
+      // Assert
+      assertThat(bytesRead).isEqualTo(3);
+
+      // Check that only the specified range was filled
+      assertThat(buffer[0]).isEqualTo((byte) 0x00); // untouched
+      assertThat(buffer[1]).isEqualTo((byte) 0x00); // untouched
+      assertThat(buffer[2]).isEqualTo((byte) 0x01); // start of data
+      assertThat(buffer[3]).isEqualTo((byte) 0x02);
+      assertThat(buffer[4]).isEqualTo((byte) 0x03); // end of data
+      assertThat(buffer[5]).isEqualTo((byte) 0x00); // untouched
+
+      // Read the remaining bytes
+      bytesRead = throttledStream.read(buffer, 5, 2);
+      assertThat(bytesRead).isEqualTo(2);
+      assertThat(buffer[5]).isEqualTo((byte) 0x04);
+      assertThat(buffer[6]).isEqualTo((byte) 0x05);
+
+      // Verify end of stream
+      assertThat(throttledStream.read()).isEqualTo(-1);
+    }
+
+    // Verify limiter was called twice with the correct number of bytes
+    verify(mockLimiter, times(1)).acquire(3);
+    verify(mockLimiter, times(1)).acquire(2);
+    verifyNoMoreInteractions(mockLimiter);
+  }
+
+  @Test
+  public void testEmptyStream() throws IOException {
+    // Arrange
+    byte[] data = new byte[0];
+    InputStream inputStream = new ByteArrayInputStream(data);
+    GlobalWindowRateLimiter mockLimiter = mock(GlobalWindowRateLimiter.class);
+
+    // Act
+    try (GlobalThrottledInputStream throttledStream =
+        new GlobalThrottledInputStream(inputStream, mockLimiter)) {
+      // Assert
+      assertThat(throttledStream.read()).isEqualTo(-1); // End of stream
+
+      // Try to read into a buffer
+      byte[] buffer = new byte[5];
+      assertThat(throttledStream.read(buffer)).isEqualTo(-1);
+
+      // Try to read into a buffer with offset and length
+      assertThat(throttledStream.read(buffer, 1, 3)).isEqualTo(-1);
+    }
+
+    // Verify limiter was never called since no bytes were read
+    verifyNoMoreInteractions(mockLimiter);
+  }
+
+  @Test
+  public void testPartialRead() throws IOException {
+    // Arrange - create a stream that will return fewer bytes than requested
+    byte[] data = {0x01, 0x02, 0x03};
+    InputStream inputStream = new ByteArrayInputStream(data);
+    GlobalWindowRateLimiter mockLimiter = mock(GlobalWindowRateLimiter.class);
+
+    // Act
+    try (GlobalThrottledInputStream throttledStream =
+        new GlobalThrottledInputStream(inputStream, mockLimiter)) {
+      byte[] buffer = new byte[5];
+      int bytesRead = throttledStream.read(buffer);
+
+      // Assert
+      assertThat(bytesRead).isEqualTo(3); // Only 3 bytes available
+      assertThat(buffer[0]).isEqualTo((byte) 0x01);
+      assertThat(buffer[1]).isEqualTo((byte) 0x02);
+      assertThat(buffer[2]).isEqualTo((byte) 0x03);
+
+      // Next read should return EOF
+      assertThat(throttledStream.read()).isEqualTo(-1);
+    }
+
+    // Verify limiter was called with the actual number of bytes read
+    verify(mockLimiter, times(1)).acquire(3);
+    verifyNoMoreInteractions(mockLimiter);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/utils/GlobalWindowRateLimiterTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/utils/GlobalWindowRateLimiterTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+public class GlobalWindowRateLimiterTest {
+
+  @Test
+  public void testConstructorInitialization() throws Exception {
+    // Arrange
+    long bytesPerSecond = 1024;
+    int windowSeconds = 5;
+
+    // Act
+    GlobalWindowRateLimiter rateLimiter =
+        new GlobalWindowRateLimiter(bytesPerSecond, windowSeconds);
+
+    // Assert - using reflection to access private fields
+    Field bytesPerWindowField = GlobalWindowRateLimiter.class.getDeclaredField("bytesPerWindow");
+    bytesPerWindowField.setAccessible(true);
+    long actualBytesPerWindow = (long) bytesPerWindowField.get(rateLimiter);
+
+    Field windowMillisField = GlobalWindowRateLimiter.class.getDeclaredField("windowMillis");
+    windowMillisField.setAccessible(true);
+    long actualWindowMillis = (long) windowMillisField.get(rateLimiter);
+
+    Field bytesReadInWindowField =
+        GlobalWindowRateLimiter.class.getDeclaredField("bytesReadInWindow");
+    bytesReadInWindowField.setAccessible(true);
+    long actualBytesReadInWindow = (long) bytesReadInWindowField.get(rateLimiter);
+
+    // Verify the fields were initialized correctly
+    assertThat(actualBytesPerWindow).isEqualTo(bytesPerSecond * windowSeconds);
+    assertThat(actualWindowMillis).isEqualTo(windowSeconds * 1000L);
+    assertThat(actualBytesReadInWindow).isEqualTo(0);
+
+    // We don't test windowStartTime exactly since it depends on the current time,
+    // but we can verify it's been set to a reasonable value (not 0)
+    Field windowStartTimeField = GlobalWindowRateLimiter.class.getDeclaredField("windowStartTime");
+    windowStartTimeField.setAccessible(true);
+    long actualWindowStartTime = (long) windowStartTimeField.get(rateLimiter);
+
+    assertThat(actualWindowStartTime).isGreaterThan(0);
+  }
+
+  @Test
+  public void testBasicAcquireFunctionality() throws Exception {
+    // Arrange
+    long bytesPerSecond = 10000; // High enough to not trigger rate limiting
+    int windowSeconds = 5;
+    GlobalWindowRateLimiter rateLimiter =
+        new GlobalWindowRateLimiter(bytesPerSecond, windowSeconds);
+
+    // Get access to the private field
+    Field bytesReadInWindowField =
+        GlobalWindowRateLimiter.class.getDeclaredField("bytesReadInWindow");
+    bytesReadInWindowField.setAccessible(true);
+
+    // Act & Assert
+
+    // Initial state
+    assertThat((long) bytesReadInWindowField.get(rateLimiter)).isEqualTo(0);
+
+    // First acquire
+    rateLimiter.acquire(100);
+    assertThat((long) bytesReadInWindowField.get(rateLimiter)).isEqualTo(100);
+
+    // Second acquire
+    rateLimiter.acquire(200);
+    assertThat((long) bytesReadInWindowField.get(rateLimiter)).isEqualTo(300);
+
+    // Third acquire
+    rateLimiter.acquire(50);
+    assertThat((long) bytesReadInWindowField.get(rateLimiter)).isEqualTo(350);
+  }
+
+  @Test
+  public void testWindowResetBehavior() throws Exception {
+    // Arrange
+    long bytesPerSecond = 1000;
+    int windowSeconds = 5;
+    GlobalWindowRateLimiter rateLimiter =
+        new GlobalWindowRateLimiter(bytesPerSecond, windowSeconds);
+
+    // Get access to the private fields
+    Field windowStartTimeField = GlobalWindowRateLimiter.class.getDeclaredField("windowStartTime");
+    windowStartTimeField.setAccessible(true);
+
+    Field bytesReadInWindowField =
+        GlobalWindowRateLimiter.class.getDeclaredField("bytesReadInWindow");
+    bytesReadInWindowField.setAccessible(true);
+
+    // Act & Assert
+
+    // Initial state
+    long initialWindowStartTime = (long) windowStartTimeField.get(rateLimiter);
+
+    // Add some bytes
+    rateLimiter.acquire(500);
+    assertThat((long) bytesReadInWindowField.get(rateLimiter)).isEqualTo(500);
+
+    // Simulate time passing by setting windowStartTime to a value in the past
+    // that exceeds the window duration
+    long pastTime = initialWindowStartTime - (windowSeconds * 1000 + 100);
+    windowStartTimeField.set(rateLimiter, pastTime);
+
+    // Acquire more bytes, which should trigger a window reset
+    rateLimiter.acquire(200);
+
+    // Verify window was reset
+    long newWindowStartTime = (long) windowStartTimeField.get(rateLimiter);
+    assertThat(newWindowStartTime).isNotEqualTo(pastTime);
+    assertThat((long) bytesReadInWindowField.get(rateLimiter)).isEqualTo(200); // Only the new bytes
+  }
+
+  @Test
+  public void testRateLimitingBehavior() throws Exception {
+    // Arrange
+    long bytesPerSecond = 100;
+    int windowSeconds = 1;
+    long bytesPerWindow = bytesPerSecond * windowSeconds;
+    GlobalWindowRateLimiter rateLimiter =
+        new GlobalWindowRateLimiter(bytesPerSecond, windowSeconds);
+
+    // Get access to the private fields
+    Field bytesReadInWindowField =
+        GlobalWindowRateLimiter.class.getDeclaredField("bytesReadInWindow");
+    bytesReadInWindowField.setAccessible(true);
+
+    Field windowStartTimeField = GlobalWindowRateLimiter.class.getDeclaredField("windowStartTime");
+    windowStartTimeField.setAccessible(true);
+
+    // Act & Assert
+
+    // First, fill up the window to just below the limit
+    rateLimiter.acquire((int) (bytesPerWindow - 10));
+    assertThat((long) bytesReadInWindowField.get(rateLimiter)).isEqualTo(bytesPerWindow - 10);
+
+    // Store the current window start time
+    long initialWindowStartTime = (long) windowStartTimeField.get(rateLimiter);
+
+    // Now exceed the limit, which should trigger a window reset
+    int excessBytes = 20;
+    rateLimiter.acquire(excessBytes);
+
+    // Verify that bytesReadInWindow was reset and now contains only the excess bytes
+    assertThat((long) bytesReadInWindowField.get(rateLimiter)).isEqualTo(excessBytes);
+
+    // Verify that the window start time was updated
+    long newWindowStartTime = (long) windowStartTimeField.get(rateLimiter);
+    assertThat(newWindowStartTime).isGreaterThan(initialWindowStartTime);
+  }
+
+  @Test
+  public void testThreadSafety() throws Exception {
+    // Arrange
+    long bytesPerSecond = 10000; // High enough to not trigger rate limiting
+    int windowSeconds = 5;
+    GlobalWindowRateLimiter rateLimiter =
+        new GlobalWindowRateLimiter(bytesPerSecond, windowSeconds);
+
+    // Get access to the private field
+    Field bytesReadInWindowField =
+        GlobalWindowRateLimiter.class.getDeclaredField("bytesReadInWindow");
+    bytesReadInWindowField.setAccessible(true);
+
+    int numThreads = 10;
+    int bytesPerThread = 100;
+    int totalBytes = numThreads * bytesPerThread;
+
+    ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch finishLatch = new CountDownLatch(numThreads);
+    AtomicInteger successCount = new AtomicInteger(0);
+
+    // Act - Create and start threads that will all call acquire concurrently
+    for (int i = 0; i < numThreads; i++) {
+      executorService.submit(
+          () -> {
+            try {
+              startLatch.await(); // Wait for all threads to be ready
+              rateLimiter.acquire(bytesPerThread);
+              successCount.incrementAndGet();
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            } finally {
+              finishLatch.countDown();
+            }
+          });
+    }
+
+    // Release all threads at once
+    startLatch.countDown();
+
+    // Wait for all threads to finish
+    finishLatch.await(5, TimeUnit.SECONDS);
+    executorService.shutdown();
+
+    // Assert
+    // All threads should have successfully called acquire
+    assertThat(successCount.get()).isEqualTo(numThreads);
+
+    // The total bytes read should be the sum of all thread acquisitions
+    assertThat((long) bytesReadInWindowField.get(rateLimiter)).isEqualTo(totalBytes);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/backup/SnapshotRestoreCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/backup/SnapshotRestoreCommandTest.java
@@ -370,7 +370,7 @@ public class SnapshotRestoreCommandTest {
     assertEquals(1, timeStrings.size());
     String snapshotTimeString = timeStrings.get(0);
 
-    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, false, s3Client);
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, s3Client);
     NrtPointState pointState =
         RemoteUtils.pointStateFromUtf8(
             s3Backend
@@ -412,7 +412,7 @@ public class SnapshotRestoreCommandTest {
   private void assertRestoreFiles(
       AmazonS3 s3Client, String serviceName, String indexResource, boolean withWarming)
       throws IOException {
-    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, false, s3Client);
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, s3Client);
     Set<String> expectedIndexFiles = Set.of("_0.cfe", "_0.si", "_0.cfs");
 
     NrtPointState pointState =

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/cleanup/CleanupDataCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/cleanup/CleanupDataCommandTest.java
@@ -110,7 +110,7 @@ public class CleanupDataCommandTest {
   @Test
   public void testKeepsRecentVersions() throws IOException {
     TestServer server = getTestServer();
-    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     List<String> versions = initIndex(server, s3Backend);
     CommandLine cmd = getInjectedCommand();
 
@@ -130,7 +130,7 @@ public class CleanupDataCommandTest {
   @Test
   public void testDeletesUnneededVersions() throws IOException {
     TestServer server = getTestServer();
-    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     List<String> versions = initIndex(server, s3Backend);
     CommandLine cmd = getInjectedCommand();
 
@@ -149,7 +149,7 @@ public class CleanupDataCommandTest {
   @Test
   public void testKeepsFutureVersions() throws IOException {
     TestServer server = getTestServer();
-    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     List<String> versions = initIndex(server, s3Backend);
     CommandLine cmd = getInjectedCommand();
 
@@ -171,7 +171,7 @@ public class CleanupDataCommandTest {
   @Test
   public void testGracePeriod() throws IOException {
     TestServer server = getTestServer();
-    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     List<String> versions = initIndex(server, s3Backend);
     CommandLine cmd = getInjectedCommand();
     AmazonS3 s3Client = getS3();

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetResourceVersionCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/GetResourceVersionCommandTest.java
@@ -150,7 +150,7 @@ public class GetResourceVersionCommandTest {
   @Test
   public void testSet_globalState() throws IOException {
     TestServer.initS3(folder);
-    S3Backend backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     String prefix = S3Backend.getGlobalStateResourcePrefix(SERVICE_NAME);
     backend.setCurrentResource(prefix, "version1");
 
@@ -168,7 +168,7 @@ public class GetResourceVersionCommandTest {
   @Test
   public void testSet_indexState() throws IOException {
     TestServer.initS3(folder);
-    S3Backend backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     String prefix =
         S3Backend.getIndexResourcePrefix(
             SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.INDEX_STATE);
@@ -190,7 +190,7 @@ public class GetResourceVersionCommandTest {
   @Test
   public void testSet_pointState() throws IOException {
     TestServer.initS3(folder);
-    S3Backend backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     String prefix =
         S3Backend.getIndexResourcePrefix(
             SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.POINT_STATE);
@@ -212,7 +212,7 @@ public class GetResourceVersionCommandTest {
   @Test
   public void testSet_warmingQueries() throws IOException {
     TestServer.initS3(folder);
-    S3Backend backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     String prefix =
         S3Backend.getIndexResourcePrefix(
             SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.WARMING_QUERIES);
@@ -235,7 +235,7 @@ public class GetResourceVersionCommandTest {
   public void testGetResourceFromGlobalState() throws IOException {
     TestServer server = getTestServer();
     server.startPrimaryIndex("test_index", -1, null);
-    S3Backend backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     String indexId = server.getGlobalState().getIndexStateManagerOrThrow("test_index").getIndexId();
     String prefix =
         S3Backend.getIndexResourcePrefix(
@@ -259,7 +259,7 @@ public class GetResourceVersionCommandTest {
   @Test
   public void testGetResourceFromGlobalState_notFound() throws IOException {
     TestServer.initS3(folder);
-    S3Backend backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     String prefix =
         S3Backend.getIndexResourcePrefix(
             SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.INDEX_STATE);

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/ListResourceVersionsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/ListResourceVersionsTest.java
@@ -200,7 +200,7 @@ public class ListResourceVersionsTest {
   public void testListResourceVersionsFromGlobalState() throws IOException {
     TestServer server = getTestServer();
     server.startPrimaryIndex("test_index", -1, null);
-    S3Backend backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     String indexId = server.getGlobalState().getIndexStateManagerOrThrow("test_index").getIndexId();
     String prefix =
         S3Backend.getIndexResourcePrefix(

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/PutRemoteStateCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/PutRemoteStateCommandTest.java
@@ -80,7 +80,7 @@ public class PutRemoteStateCommandTest {
   }
 
   private S3Backend getRemoteBackend() {
-    return new S3Backend(TEST_BUCKET, false, false, getS3());
+    return new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/SetResourceVersionCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/SetResourceVersionCommandTest.java
@@ -88,7 +88,7 @@ public class SetResourceVersionCommandTest {
   @Test
   public void testSetResourceVersion_globalState() throws IOException {
     TestServer.initS3(folder);
-    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     String prefix = S3Backend.getGlobalStateResourcePrefix(SERVICE_NAME);
     getS3().putObject(TEST_BUCKET, prefix + "version1", "version_data");
 
@@ -108,7 +108,7 @@ public class SetResourceVersionCommandTest {
   @Test
   public void testSetResourceVersion_indexState() throws IOException {
     TestServer.initS3(folder);
-    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     String prefix =
         S3Backend.getIndexResourcePrefix(
             SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.INDEX_STATE);
@@ -132,7 +132,7 @@ public class SetResourceVersionCommandTest {
   @Test
   public void testSetResourceVersion_pointState() throws IOException {
     TestServer.initS3(folder);
-    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     String prefix =
         S3Backend.getIndexResourcePrefix(
             SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.POINT_STATE);
@@ -156,7 +156,7 @@ public class SetResourceVersionCommandTest {
   @Test
   public void testSetResourceVersion_warmingQueries() throws IOException {
     TestServer.initS3(folder);
-    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     String prefix =
         S3Backend.getIndexResourcePrefix(
             SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.WARMING_QUERIES);
@@ -180,7 +180,7 @@ public class SetResourceVersionCommandTest {
   @Test
   public void testUpdateResourceVersion_globalState() throws IOException {
     TestServer.initS3(folder);
-    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     String prefix = S3Backend.getGlobalStateResourcePrefix(SERVICE_NAME);
     s3Backend.setCurrentResource(prefix, "version0");
     getS3().putObject(TEST_BUCKET, prefix + "version1", "version_data");
@@ -201,7 +201,7 @@ public class SetResourceVersionCommandTest {
   @Test
   public void testUpdateResourceVersion_indexState() throws IOException {
     TestServer.initS3(folder);
-    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     String prefix =
         S3Backend.getIndexResourcePrefix(
             SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.INDEX_STATE);
@@ -226,7 +226,7 @@ public class SetResourceVersionCommandTest {
   @Test
   public void testUpdateResourceVersion_pointState() throws IOException {
     TestServer.initS3(folder);
-    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     String prefix =
         S3Backend.getIndexResourcePrefix(
             SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.POINT_STATE);
@@ -251,7 +251,7 @@ public class SetResourceVersionCommandTest {
   @Test
   public void testUpdateResourceVersion_warmingQueries() throws IOException {
     TestServer.initS3(folder);
-    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     String prefix =
         S3Backend.getIndexResourcePrefix(
             SERVICE_NAME, "test_index-id", RemoteBackend.IndexResourceType.WARMING_QUERIES);
@@ -296,7 +296,7 @@ public class SetResourceVersionCommandTest {
   public void testSetResourceFromGlobalState() throws IOException {
     TestServer server = getTestServer();
     server.startPrimaryIndex("test_index", -1, null);
-    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, false, getS3());
+    S3Backend s3Backend = new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
     String indexId = server.getGlobalState().getIndexStateManagerOrThrow("test_index").getIndexId();
     String prefix =
         S3Backend.getIndexResourcePrefix(

--- a/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/StateCommandUtilsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/nrt_utils/state/StateCommandUtilsTest.java
@@ -72,7 +72,7 @@ public class StateCommandUtilsTest {
   }
 
   private S3Backend getRemoteBackend() {
-    return new S3Backend(TEST_BUCKET, false, false, getS3());
+    return new S3Backend(TEST_BUCKET, false, S3Backend.DEFAULT_CONFIG, getS3());
   }
 
   private TestServer getTestServer() throws IOException {


### PR DESCRIPTION
Adds the ability to throttle S3 downloading to a target rate. This is done by wrapping the `InputStream` and using a global rate limiter that looks at the amount of data read within a given time window.

I have restructured the configuration, and moved the 's3Metrics' options. The s3 backend options are new defined like:
```
remoteConfig:
  s3:
    metrics: true
    rateLimitPerSecond: 10MB
    rateLimitWindowSeconds: 5
``` 

`rateLimitPerSecond`: may be an absolute value of bytes, or use a kb/mb/gb suffix (default: 0, no limit)
`rateLimitWindowSeconds`: size of the window to enforce the limit over (default: 1)