### PR TITLE
Add cross index query

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -642,6 +642,44 @@ message ExactVectorQuery {
     bytes query_byte_vector = 3;
 }
 
+// Filters the primary index to documents whose join key matches documents
+// in a secondary index. The query runs on the secondary index; matching
+// values of secondary_field are collected and used to build a TermsQuery on
+// the primary_field in the primary index.
+message CrossIndexQuery {
+    // How to aggregate scores from secondary index matches.
+    enum JoinScoreMode {
+        // Unset — treated as JOIN_SCORE_NONE (filter only)
+        JOIN_SCORE_UNSET = 0;
+        // No scoring — filter only
+        JOIN_SCORE_NONE = 1;
+        // Average score of matching secondary documents
+        JOIN_SCORE_AVG = 2;
+        // Maximum score of matching secondary documents
+        JOIN_SCORE_MAX = 3;
+        // Minimum score of matching secondary documents
+        JOIN_SCORE_MIN = 4;
+        // Sum of scores of matching secondary documents
+        JOIN_SCORE_TOTAL = 5;
+    }
+
+    // Name of the secondary index (must be on the same nrtsearch node)
+    string index = 1;
+    // Field in the primary index containing the join key
+    string primary_field = 2;
+    // Field in the secondary index containing the join key
+    string secondary_field = 3;
+    // Query to execute on the secondary index
+    Query query = 4;
+    // Score aggregation mode from secondary matches (default: JOIN_SCORE_NONE = filter only)
+    JoinScoreMode score_mode = 5;
+    // Maximum number of matching secondary documents allowed (default: 0 = unlimited).
+    // If the inner query matches more documents than this limit, an error is returned.
+    // Use this to guard against excessive memory usage from large secondary result sets.
+    // Note: this counts matching documents, not unique join-key values.
+    uint32 max_terms = 6;
+}
+
 // Deprecated: Defines different types of QueryNodes
 enum QueryType {
     NONE = 0;
@@ -704,6 +742,7 @@ message Query {
         SpanQuery spanQuery = 25;
         MatchAllQuery matchAllQuery = 26;
         ExactVectorQuery exactVectorQuery = 27;
+        CrossIndexQuery crossIndexQuery = 28;
     }
 }
 

--- a/docs/queries/cross_index.rst
+++ b/docs/queries/cross_index.rst
@@ -1,0 +1,54 @@
+Cross Index Query
+==========================
+
+A query that filters the primary index to documents whose join key matches documents in a secondary index. Uses Lucene's ``JoinUtil`` internally. The ``query`` runs on the secondary index; matching values of ``secondary_field`` are collected eagerly and used to build a TermsQuery on ``primary_field`` in the primary index. The secondary index searcher is acquired only during query construction and released immediately afterward — it is **not** held open during primary search execution.
+
+Both ``primary_field`` and ``secondary_field`` must exist in their respective indices. The secondary index must be on the same nrtsearch node. The ``query`` field is required. If any of these are missing or invalid, an error is returned.
+
+Nested cross-index queries are supported: the inner ``query`` may itself contain a ``CrossIndexQuery`` referencing a third index.
+
+The ``score_mode`` controls how scores from matching secondary documents are aggregated and propagated to the primary index results:
+
+  * ``JOIN_SCORE_NONE`` - No scoring; acts as a pure filter (default)
+
+  * ``JOIN_SCORE_AVG`` - Average score of matching secondary documents
+
+  * ``JOIN_SCORE_MAX`` - Maximum score of matching secondary documents
+
+  * ``JOIN_SCORE_MIN`` - Minimum score of matching secondary documents
+
+  * ``JOIN_SCORE_TOTAL`` - Sum of scores of matching secondary documents
+
+When used inside a BooleanQuery ``FILTER`` clause, the cross-index query filters without contributing to the score regardless of ``score_mode``.
+
+Memory considerations
+---------------------
+
+``JoinUtil`` collects all unique join-key values from matching secondary documents into an in-memory hash set. For large secondary result sets this can consume significant memory. Use the ``max_terms`` field to set an upper bound on the number of matching secondary documents allowed. If the inner query matches more documents than this limit, an error is returned instead of risking excessive memory usage.
+
+Multi-valued join fields
+------------------------
+
+If the secondary join field is registered with ``multiValued: true``, this is automatically detected from the field definition and handled correctly by ``JoinUtil``. No additional configuration is needed.
+
+Proto definition:
+
+.. code-block::
+
+   message CrossIndexQuery {
+       enum JoinScoreMode {
+           JOIN_SCORE_UNSET = 0; // Unset — treated as JOIN_SCORE_NONE (filter only)
+           JOIN_SCORE_NONE = 1;  // No scoring - filter only
+           JOIN_SCORE_AVG = 2;   // Average score of matching secondary documents
+           JOIN_SCORE_MAX = 3;   // Maximum score of matching secondary documents
+           JOIN_SCORE_MIN = 4;   // Minimum score of matching secondary documents
+           JOIN_SCORE_TOTAL = 5; // Sum of scores of matching secondary documents
+       }
+
+       string index = 1;           // Name of the secondary index (must be on the same nrtsearch node)
+       string primary_field = 2;   // Field in the primary index containing the join key
+       string secondary_field = 3; // Field in the secondary index containing the join key
+       Query query = 4;            // Query to execute on the secondary index (required)
+       JoinScoreMode score_mode = 5; // Score aggregation mode (default: JOIN_SCORE_NONE)
+       uint32 max_terms = 6;       // Max matching secondary docs allowed; 0 = unlimited (default: 0)
+   }

--- a/src/main/java/com/yelp/nrtsearch/server/query/QueryContext.java
+++ b/src/main/java/com/yelp/nrtsearch/server/query/QueryContext.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.query;
+
+import com.yelp.nrtsearch.server.doc.DocLookup;
+import com.yelp.nrtsearch.server.state.GlobalState;
+import javax.annotation.Nullable;
+
+/**
+ * Context for query building. Bundles {@link DocLookup} (for field resolution and doc values) with
+ * optional {@link GlobalState} (needed for cross-index queries like {@link
+ * com.yelp.nrtsearch.server.grpc.CrossIndexQuery}).
+ */
+public record QueryContext(DocLookup docLookup, @Nullable GlobalState globalState) {}

--- a/src/main/java/com/yelp/nrtsearch/server/query/QueryNodeMapper.java
+++ b/src/main/java/com/yelp/nrtsearch/server/query/QueryNodeMapper.java
@@ -20,8 +20,11 @@ import static com.yelp.nrtsearch.server.analysis.AnalyzerCreator.isAnalyzerDefin
 import com.yelp.nrtsearch.server.analysis.AnalyzerCreator;
 import com.yelp.nrtsearch.server.doc.DocLookup;
 import com.yelp.nrtsearch.server.field.FieldDef;
+import com.yelp.nrtsearch.server.field.IndexableFieldDef;
 import com.yelp.nrtsearch.server.field.TextBaseFieldDef;
 import com.yelp.nrtsearch.server.field.properties.*;
+import com.yelp.nrtsearch.server.grpc.CrossIndexQuery;
+import com.yelp.nrtsearch.server.grpc.CrossIndexQuery.JoinScoreMode;
 import com.yelp.nrtsearch.server.grpc.ExistsQuery;
 import com.yelp.nrtsearch.server.grpc.FunctionFilterQuery;
 import com.yelp.nrtsearch.server.grpc.GeoBoundingBoxQuery;
@@ -33,14 +36,17 @@ import com.yelp.nrtsearch.server.grpc.MatchPhraseQuery;
 import com.yelp.nrtsearch.server.grpc.MatchQuery;
 import com.yelp.nrtsearch.server.grpc.MultiMatchQuery;
 import com.yelp.nrtsearch.server.grpc.MultiMatchQuery.MatchType;
+import com.yelp.nrtsearch.server.grpc.NestedQuery;
 import com.yelp.nrtsearch.server.grpc.PrefixQuery;
 import com.yelp.nrtsearch.server.grpc.RangeQuery;
 import com.yelp.nrtsearch.server.grpc.RewriteMethod;
 import com.yelp.nrtsearch.server.index.IndexState;
+import com.yelp.nrtsearch.server.index.ShardState;
 import com.yelp.nrtsearch.server.query.multifunction.MultiFunctionScoreQuery;
 import com.yelp.nrtsearch.server.script.ScoreScript;
 import com.yelp.nrtsearch.server.script.ScriptService;
 import com.yelp.nrtsearch.server.utils.ScriptParamsUtils;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -50,6 +56,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.function.FunctionMatchQuery;
 import org.apache.lucene.queries.function.FunctionScoreQuery;
@@ -72,6 +79,7 @@ import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.search.join.JoinUtil;
 import org.apache.lucene.search.join.QueryBitSetProducer;
 import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.search.join.ToParentBlockJoinQuery;
@@ -83,10 +91,13 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.QueryBuilder;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** This class maps our GRPC Query object to a Lucene Query object. */
 public class QueryNodeMapper {
 
+  private static final Logger logger = LoggerFactory.getLogger(QueryNodeMapper.class);
   private static final QueryNodeMapper INSTANCE = new QueryNodeMapper();
 
   public static QueryNodeMapper getInstance() {
@@ -102,11 +113,15 @@ public class QueryNodeMapper {
               MatchOperator.MUST, BooleanClause.Occur.MUST));
 
   public Query getQuery(com.yelp.nrtsearch.server.grpc.Query query, IndexState state) {
-    return getQuery(query, state.docLookup);
+    return getQuery(query, new QueryContext(state.docLookup, state.getGlobalState()));
   }
 
   public Query getQuery(com.yelp.nrtsearch.server.grpc.Query query, DocLookup docLookup) {
-    Query queryNode = getQueryNode(query, docLookup);
+    return getQuery(query, new QueryContext(docLookup, null));
+  }
+
+  public Query getQuery(com.yelp.nrtsearch.server.grpc.Query query, QueryContext context) {
+    Query queryNode = getQueryNode(query, context);
 
     if (query.getBoost() < 0) {
       throw new IllegalArgumentException("Boost must be a positive number");
@@ -149,21 +164,22 @@ public class QueryNodeMapper {
         new Term(IndexState.NESTED_PATH, IndexState.resolveQueryNestedPath(path, docLookup)));
   }
 
-  private Query getQueryNode(com.yelp.nrtsearch.server.grpc.Query query, DocLookup docLookup) {
+  private Query getQueryNode(com.yelp.nrtsearch.server.grpc.Query query, QueryContext context) {
+    DocLookup docLookup = context.docLookup();
     return switch (query.getQueryNodeCase()) {
-      case BOOLEANQUERY -> getBooleanQuery(query.getBooleanQuery(), docLookup);
+      case BOOLEANQUERY -> getBooleanQuery(query.getBooleanQuery(), context);
       case PHRASEQUERY -> getPhraseQuery(query.getPhraseQuery());
-      case FUNCTIONSCOREQUERY -> getFunctionScoreQuery(query.getFunctionScoreQuery(), docLookup);
+      case FUNCTIONSCOREQUERY -> getFunctionScoreQuery(query.getFunctionScoreQuery(), context);
       case TERMQUERY -> getTermQuery(query.getTermQuery(), docLookup);
       case TERMINSETQUERY -> getTermInSetQuery(query.getTermInSetQuery(), docLookup);
-      case DISJUNCTIONMAXQUERY -> getDisjunctionMaxQuery(query.getDisjunctionMaxQuery(), docLookup);
+      case DISJUNCTIONMAXQUERY -> getDisjunctionMaxQuery(query.getDisjunctionMaxQuery(), context);
       case MATCHQUERY -> getMatchQuery(query.getMatchQuery(), docLookup);
       case MATCHPHRASEQUERY -> getMatchPhraseQuery(query.getMatchPhraseQuery(), docLookup);
       case MULTIMATCHQUERY -> getMultiMatchQuery(query.getMultiMatchQuery(), docLookup);
       case RANGEQUERY -> getRangeQuery(query.getRangeQuery(), docLookup);
       case GEOBOUNDINGBOXQUERY -> getGeoBoundingBoxQuery(query.getGeoBoundingBoxQuery(), docLookup);
       case GEOPOINTQUERY -> getGeoPointQuery(query.getGeoPointQuery(), docLookup);
-      case NESTEDQUERY -> getNestedQuery(query.getNestedQuery(), docLookup);
+      case NESTEDQUERY -> getNestedQuery(query.getNestedQuery(), context);
       case EXISTSQUERY -> getExistsQuery(query.getExistsQuery());
       case GEORADIUSQUERY -> getGeoRadiusQuery(query.getGeoRadiusQuery(), docLookup);
       case FUNCTIONFILTERQUERY -> getFunctionFilterQuery(query.getFunctionFilterQuery(), docLookup);
@@ -173,10 +189,11 @@ public class QueryNodeMapper {
       case MATCHPHRASEPREFIXQUERY ->
           MatchPhrasePrefixQuery.build(query.getMatchPhrasePrefixQuery(), docLookup);
       case PREFIXQUERY -> getPrefixQuery(query.getPrefixQuery(), docLookup, false);
-      case CONSTANTSCOREQUERY -> getConstantScoreQuery(query.getConstantScoreQuery(), docLookup);
+      case CONSTANTSCOREQUERY -> getConstantScoreQuery(query.getConstantScoreQuery(), context);
       case SPANQUERY -> getSpanQuery(query.getSpanQuery(), docLookup);
       case GEOPOLYGONQUERY -> getGeoPolygonQuery(query.getGeoPolygonQuery(), docLookup);
       case EXACTVECTORQUERY -> getExactVectorQuery(query.getExactVectorQuery(), docLookup);
+      case CROSSINDEXQUERY -> getCrossIndexQuery(query.getCrossIndexQuery(), context);
       case MATCHALLQUERY, QUERYNODE_NOT_SET -> new MatchAllDocsQuery();
       default ->
           throw new UnsupportedOperationException(
@@ -207,20 +224,21 @@ public class QueryNodeMapper {
     return contextQuery;
   }
 
-  private Query getNestedQuery(
-      com.yelp.nrtsearch.server.grpc.NestedQuery nestedQuery, DocLookup docLookup) {
-    Query childRawQuery = getQuery(nestedQuery.getQuery(), docLookup);
+  private Query getNestedQuery(NestedQuery nestedQuery, QueryContext queryContext) {
+    Query childRawQuery = getQuery(nestedQuery.getQuery(), queryContext);
     Query childQuery =
         new BooleanQuery.Builder()
-            .add(getNestedPathQuery(docLookup, nestedQuery.getPath()), BooleanClause.Occur.FILTER)
+            .add(
+                getNestedPathQuery(queryContext.docLookup(), nestedQuery.getPath()),
+                BooleanClause.Occur.FILTER)
             .add(childRawQuery, BooleanClause.Occur.MUST)
             .build();
-    Query parentQuery = getNestedPathQuery(docLookup, IndexState.ROOT);
+    Query parentQuery = getNestedPathQuery(queryContext.docLookup(), IndexState.ROOT);
     return new ToParentBlockJoinQuery(
         childQuery, new QueryBitSetProducer(parentQuery), getScoreMode(nestedQuery));
   }
 
-  private ScoreMode getScoreMode(com.yelp.nrtsearch.server.grpc.NestedQuery nestedQuery) {
+  private ScoreMode getScoreMode(NestedQuery nestedQuery) {
     return switch (nestedQuery.getScoreMode()) {
       case NONE -> ScoreMode.None;
       case AVG -> ScoreMode.Avg;
@@ -234,7 +252,7 @@ public class QueryNodeMapper {
   }
 
   private BooleanQuery getBooleanQuery(
-      com.yelp.nrtsearch.server.grpc.BooleanQuery booleanQuery, DocLookup docLookup) {
+      com.yelp.nrtsearch.server.grpc.BooleanQuery booleanQuery, QueryContext context) {
     BooleanQuery.Builder builder =
         new BooleanQuery.Builder()
             .setMinimumNumberShouldMatch(booleanQuery.getMinimumNumberShouldMatch());
@@ -249,7 +267,7 @@ public class QueryNodeMapper {
         .forEach(
             clause -> {
               com.yelp.nrtsearch.server.grpc.BooleanClause.Occur occur = clause.getOccur();
-              builder.add(getQuery(clause.getQuery(), docLookup), occurMapping.get(occur));
+              builder.add(getQuery(clause.getQuery(), context), occurMapping.get(occur));
               if (occur != com.yelp.nrtsearch.server.grpc.BooleanClause.Occur.MUST_NOT) {
                 allMustNot.set(false);
               }
@@ -270,15 +288,15 @@ public class QueryNodeMapper {
   }
 
   private FunctionScoreQuery getFunctionScoreQuery(
-      com.yelp.nrtsearch.server.grpc.FunctionScoreQuery functionScoreQuery, DocLookup docLookup) {
+      com.yelp.nrtsearch.server.grpc.FunctionScoreQuery functionScoreQuery, QueryContext context) {
     ScoreScript.Factory scriptFactory =
         ScriptService.getInstance().compile(functionScoreQuery.getScript(), ScoreScript.CONTEXT);
 
     Map<String, Object> params =
         ScriptParamsUtils.decodeParams(functionScoreQuery.getScript().getParamsMap());
     return new FunctionScoreQuery(
-        getQuery(functionScoreQuery.getQuery(), docLookup),
-        scriptFactory.newFactory(params, docLookup));
+        getQuery(functionScoreQuery.getQuery(), context),
+        scriptFactory.newFactory(params, context.docLookup()));
   }
 
   private FunctionMatchQuery getFunctionFilterQuery(
@@ -319,10 +337,11 @@ public class QueryNodeMapper {
   }
 
   private DisjunctionMaxQuery getDisjunctionMaxQuery(
-      com.yelp.nrtsearch.server.grpc.DisjunctionMaxQuery disjunctionMaxQuery, DocLookup docLookup) {
+      com.yelp.nrtsearch.server.grpc.DisjunctionMaxQuery disjunctionMaxQuery,
+      QueryContext context) {
     List<Query> disjuncts =
         disjunctionMaxQuery.getDisjunctsList().stream()
-            .map(query -> getQuery(query, docLookup))
+            .map(query -> getQuery(query, context))
             .collect(Collectors.toList());
     return new DisjunctionMaxQuery(disjuncts, disjunctionMaxQuery.getTieBreakerMultiplier());
   }
@@ -604,8 +623,8 @@ public class QueryNodeMapper {
 
   private Query getConstantScoreQuery(
       com.yelp.nrtsearch.server.grpc.ConstantScoreQuery constantScoreQueryGrpc,
-      DocLookup docLookup) {
-    Query filterQuery = getQuery(constantScoreQueryGrpc.getFilter(), docLookup);
+      QueryContext context) {
+    Query filterQuery = getQuery(constantScoreQueryGrpc.getFilter(), context);
     return new ConstantScoreQuery(filterQuery);
   }
 
@@ -776,5 +795,103 @@ public class QueryNodeMapper {
     }
     throw new IllegalArgumentException(
         "Field: " + fieldName + " does not support ExactVectorQuery");
+  }
+
+  private Query getCrossIndexQuery(CrossIndexQuery crossIndexQuery, QueryContext context) {
+    if (context.globalState() == null) {
+      throw new IllegalStateException(
+          "GlobalState is required for CrossIndexQuery but was not provided");
+    }
+
+    String index = crossIndexQuery.getIndex();
+    if (index.isEmpty()) {
+      throw new IllegalArgumentException("CrossIndexQuery.index must not be empty");
+    }
+    String primaryField = crossIndexQuery.getPrimaryField();
+    if (primaryField.isEmpty()) {
+      throw new IllegalArgumentException("CrossIndexQuery.primary_field must not be empty");
+    }
+    String secondaryField = crossIndexQuery.getSecondaryField();
+    if (secondaryField.isEmpty()) {
+      throw new IllegalArgumentException("CrossIndexQuery.secondary_field must not be empty");
+    }
+    if (!crossIndexQuery.hasQuery()) {
+      throw new IllegalArgumentException("CrossIndexQuery.query must be set");
+    }
+
+    IndexState secondaryIndex;
+    try {
+      secondaryIndex = context.globalState().getIndexOrThrow(index);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          "CrossIndexQuery: secondary index \"" + index + "\" not found", e);
+    }
+
+    // Validate that fields exist and determine if secondary field is multi-valued
+    FieldDef secondaryFieldDef = secondaryIndex.docLookup.getFieldDefOrThrow(secondaryField);
+    context.docLookup().getFieldDefOrThrow(primaryField);
+    boolean multipleValuesPerDocument =
+        secondaryFieldDef instanceof IndexableFieldDef<?> indexable && indexable.isMultiValue();
+
+    ShardState secondaryShard = secondaryIndex.getShard(0);
+    SearcherTaxonomyManager.SearcherAndTaxonomy secondarySearcher;
+    try {
+      secondarySearcher = secondaryShard.acquire();
+    } catch (Exception e) {
+      throw new IllegalStateException(
+          "CrossIndexQuery: failed to acquire searcher for index \"" + index + "\"", e);
+    }
+
+    try {
+      // Build the query against the secondary index's field definitions,
+      // propagating GlobalState so nested cross-index queries are supported.
+      Query innerQuery =
+          getQuery(
+              crossIndexQuery.getQuery(),
+              new QueryContext(secondaryIndex.docLookup, context.globalState()));
+
+      int maxTerms = crossIndexQuery.getMaxTerms();
+      if (maxTerms > 0) {
+        int matchCount = secondarySearcher.searcher().count(innerQuery);
+        if (matchCount > maxTerms) {
+          throw new IllegalStateException(
+              "CrossIndexQuery: inner query matched "
+                  + matchCount
+                  + " secondary documents, exceeding max_terms limit of "
+                  + maxTerms);
+        }
+      }
+
+      ScoreMode scoreMode = mapJoinScoreMode(crossIndexQuery.getScoreMode());
+
+      // JoinUtil collects matching values eagerly at construction time, building a TermsQuery.
+      // The secondary searcher is NOT held open during primary search execution.
+      return JoinUtil.createJoinQuery(
+          secondaryField,
+          multipleValuesPerDocument,
+          primaryField,
+          innerQuery,
+          secondarySearcher.searcher(),
+          scoreMode);
+    } catch (IOException e) {
+      throw new RuntimeException("CrossIndexQuery: failed to create join query", e);
+    } finally {
+      try {
+        secondaryShard.release(secondarySearcher);
+      } catch (Exception releaseEx) {
+        logger.error("CrossIndexQuery: failed to release secondary searcher", releaseEx);
+      }
+    }
+  }
+
+  private static ScoreMode mapJoinScoreMode(JoinScoreMode mode) {
+    return switch (mode) {
+      case JOIN_SCORE_UNSET, JOIN_SCORE_NONE -> ScoreMode.None;
+      case JOIN_SCORE_AVG -> ScoreMode.Avg;
+      case JOIN_SCORE_MAX -> ScoreMode.Max;
+      case JOIN_SCORE_MIN -> ScoreMode.Min;
+      case JOIN_SCORE_TOTAL -> ScoreMode.Total;
+      default -> throw new IllegalArgumentException("Unsupported JoinScoreMode: " + mode);
+    };
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
@@ -44,6 +44,7 @@ import com.yelp.nrtsearch.server.innerhit.InnerHitContext;
 import com.yelp.nrtsearch.server.innerhit.InnerHitContext.InnerHitContextBuilder;
 import com.yelp.nrtsearch.server.innerhit.InnerHitFetchTask;
 import com.yelp.nrtsearch.server.logging.HitsLoggerFetchTask;
+import com.yelp.nrtsearch.server.query.QueryContext;
 import com.yelp.nrtsearch.server.query.QueryNodeMapper;
 import com.yelp.nrtsearch.server.rescore.QueryRescore;
 import com.yelp.nrtsearch.server.rescore.RescoreOperation;
@@ -485,7 +486,8 @@ public class SearchRequestProcessor {
             String.format("could not parse queryText: %s", queryText));
       }
     } else {
-      q = QUERY_NODE_MAPPER.getQuery(query, docLookup);
+      QueryContext queryContext = new QueryContext(docLookup, state.getGlobalState());
+      q = QUERY_NODE_MAPPER.getQuery(query, queryContext);
     }
 
     if (state.hasNestedChildFields()) {

--- a/src/test/java/com/yelp/nrtsearch/server/query/CrossIndexQueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/query/CrossIndexQueryTest.java
@@ -1,0 +1,695 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.query;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.yelp.nrtsearch.server.ServerTestCase;
+import com.yelp.nrtsearch.server.grpc.*;
+import io.grpc.StatusRuntimeException;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * Tests for {@link CrossIndexQuery} support in {@link QueryNodeMapper}. Sets up two indices:
+ * primary_index (biz_id_primary, name, rating) and secondary_index (biz_id_secondary, time_slot,
+ * covers). Tests join filtering, empty matches, score modes, boolean composition, and error cases.
+ */
+public class CrossIndexQueryTest extends ServerTestCase {
+  private static final String PRIMARY_INDEX = "primary_index";
+  private static final String SECONDARY_INDEX = "secondary_index";
+
+  @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  @Override
+  public List<String> getIndices() {
+    return Arrays.asList(PRIMARY_INDEX, SECONDARY_INDEX);
+  }
+
+  @Override
+  public FieldDefRequest getIndexDef(String name) throws IOException {
+    if (name.equals(PRIMARY_INDEX)) {
+      return FieldDefRequest.newBuilder(
+              getFieldsFromResourceFile("/registerFieldsCrossIndexPrimary.json"))
+          .setIndexName(name)
+          .build();
+    } else {
+      return FieldDefRequest.newBuilder(
+              getFieldsFromResourceFile("/registerFieldsCrossIndexSecondary.json"))
+          .setIndexName(name)
+          .build();
+    }
+  }
+
+  @Override
+  public void initIndex(String name) throws Exception {
+    if (name.equals(PRIMARY_INDEX)) {
+      initPrimaryIndex();
+    } else if (name.equals(SECONDARY_INDEX)) {
+      initSecondaryIndex();
+    }
+  }
+
+  /**
+   * Primary index: 5 businesses (biz_1 through biz_5).
+   *
+   * <ul>
+   *   <li>biz_1: "Pizza Palace", rating=5
+   *   <li>biz_2: "Sushi Spot", rating=4
+   *   <li>biz_3: "Taco Town", rating=3
+   *   <li>biz_4: "Burger Bar", rating=2
+   *   <li>biz_5: "Noodle Nook", rating=1
+   * </ul>
+   */
+  private void initPrimaryIndex() throws Exception {
+    String[][] docs = {
+      {"biz_1", "Pizza Palace", "5"},
+      {"biz_2", "Sushi Spot", "4"},
+      {"biz_3", "Taco Town", "3"},
+      {"biz_4", "Burger Bar", "2"},
+      {"biz_5", "Noodle Nook", "1"},
+    };
+    for (String[] doc : docs) {
+      addDocuments(
+          java.util.stream.Stream.of(
+              AddDocumentRequest.newBuilder()
+                  .setIndexName(PRIMARY_INDEX)
+                  .putFields(
+                      "biz_id_primary",
+                      AddDocumentRequest.MultiValuedField.newBuilder().addValue(doc[0]).build())
+                  .putFields(
+                      "name",
+                      AddDocumentRequest.MultiValuedField.newBuilder().addValue(doc[1]).build())
+                  .putFields(
+                      "rating",
+                      AddDocumentRequest.MultiValuedField.newBuilder().addValue(doc[2]).build())
+                  .build()));
+    }
+  }
+
+  /**
+   * Secondary index: reservations for some businesses.
+   *
+   * <ul>
+   *   <li>biz_1: time_slot=1200, covers=2
+   *   <li>biz_1: time_slot=1800, covers=4
+   *   <li>biz_2: time_slot=1300, covers=2
+   *   <li>biz_3: time_slot=1900, covers=6
+   * </ul>
+   *
+   * Note: biz_4 and biz_5 have NO reservations.
+   */
+  private void initSecondaryIndex() throws Exception {
+    String[][] docs = {
+      {"biz_1", "1200", "2"},
+      {"biz_1", "1800", "4"},
+      {"biz_2", "1300", "2"},
+      {"biz_3", "1900", "6"},
+    };
+    for (String[] doc : docs) {
+      addDocuments(
+          java.util.stream.Stream.of(
+              AddDocumentRequest.newBuilder()
+                  .setIndexName(SECONDARY_INDEX)
+                  .putFields(
+                      "biz_id_secondary",
+                      AddDocumentRequest.MultiValuedField.newBuilder().addValue(doc[0]).build())
+                  .putFields(
+                      "time_slot",
+                      AddDocumentRequest.MultiValuedField.newBuilder().addValue(doc[1]).build())
+                  .putFields(
+                      "covers",
+                      AddDocumentRequest.MultiValuedField.newBuilder().addValue(doc[2]).build())
+                  .build()));
+    }
+  }
+
+  /** Basic join: match all secondary docs → only businesses with reservations returned. */
+  @Test
+  public void testBasicJoinFilter() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(PRIMARY_INDEX)
+                    .setTopHits(10)
+                    .addRetrieveFields("biz_id_primary")
+                    .setQuery(
+                        Query.newBuilder()
+                            .setCrossIndexQuery(
+                                CrossIndexQuery.newBuilder()
+                                    .setIndex(SECONDARY_INDEX)
+                                    .setSecondaryField("biz_id_secondary")
+                                    .setPrimaryField("biz_id_primary")
+                                    .setQuery(
+                                        Query.newBuilder()
+                                            .setMatchAllQuery(MatchAllQuery.newBuilder()))
+                                    .setScoreMode(CrossIndexQuery.JoinScoreMode.JOIN_SCORE_NONE))
+                            .build())
+                    .build());
+
+    Set<String> returnedBizIds = extractBizIds(response);
+    // Only biz_1, biz_2, biz_3 have reservations in the secondary index
+    assertEquals(Set.of("biz_1", "biz_2", "biz_3"), returnedBizIds);
+  }
+
+  /** Inner query with filter: only reservations with covers >= 4. */
+  @Test
+  public void testJoinWithInnerFilter() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(PRIMARY_INDEX)
+                    .setTopHits(10)
+                    .addRetrieveFields("biz_id_primary")
+                    .setQuery(
+                        Query.newBuilder()
+                            .setCrossIndexQuery(
+                                CrossIndexQuery.newBuilder()
+                                    .setIndex(SECONDARY_INDEX)
+                                    .setSecondaryField("biz_id_secondary")
+                                    .setPrimaryField("biz_id_primary")
+                                    .setQuery(
+                                        Query.newBuilder()
+                                            .setRangeQuery(
+                                                RangeQuery.newBuilder()
+                                                    .setField("covers")
+                                                    .setLower("4")
+                                                    .setUpper("100")))
+                                    .setScoreMode(CrossIndexQuery.JoinScoreMode.JOIN_SCORE_NONE))
+                            .build())
+                    .build());
+
+    Set<String> returnedBizIds = extractBizIds(response);
+    // biz_1 has covers=4, biz_3 has covers=6
+    assertEquals(Set.of("biz_1", "biz_3"), returnedBizIds);
+  }
+
+  /** Inner query matches nothing → primary returns no results. */
+  @Test
+  public void testEmptySecondaryMatch() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(PRIMARY_INDEX)
+                    .setTopHits(10)
+                    .addRetrieveFields("biz_id_primary")
+                    .setQuery(
+                        Query.newBuilder()
+                            .setCrossIndexQuery(
+                                CrossIndexQuery.newBuilder()
+                                    .setIndex(SECONDARY_INDEX)
+                                    .setSecondaryField("biz_id_secondary")
+                                    .setPrimaryField("biz_id_primary")
+                                    .setQuery(
+                                        Query.newBuilder()
+                                            .setTermQuery(
+                                                TermQuery.newBuilder()
+                                                    .setField("biz_id_secondary")
+                                                    .setTextValue("nonexistent")))
+                                    .setScoreMode(CrossIndexQuery.JoinScoreMode.JOIN_SCORE_NONE))
+                            .build())
+                    .build());
+
+    assertEquals(0, response.getHitsCount());
+  }
+
+  /** Non-existent secondary index → error. */
+  @Test
+  public void testInvalidSecondaryIndex() {
+    try {
+      getGrpcServer()
+          .getBlockingStub()
+          .search(
+              SearchRequest.newBuilder()
+                  .setIndexName(PRIMARY_INDEX)
+                  .setTopHits(10)
+                  .setQuery(
+                      Query.newBuilder()
+                          .setCrossIndexQuery(
+                              CrossIndexQuery.newBuilder()
+                                  .setIndex("no_such_index")
+                                  .setSecondaryField("biz_id_secondary")
+                                  .setPrimaryField("biz_id_primary")
+                                  .setQuery(
+                                      Query.newBuilder()
+                                          .setMatchAllQuery(MatchAllQuery.newBuilder()))
+                                  .setScoreMode(CrossIndexQuery.JoinScoreMode.JOIN_SCORE_NONE))
+                          .build())
+                  .build());
+      fail("Expected exception for non-existent secondary index");
+    } catch (StatusRuntimeException e) {
+      assertTrue(e.getMessage().contains("not found"));
+    }
+  }
+
+  /** secondary_field does not exist in secondary index → error. */
+  @Test
+  public void testNonExistentSecondaryField() {
+    try {
+      getGrpcServer()
+          .getBlockingStub()
+          .search(
+              SearchRequest.newBuilder()
+                  .setIndexName(PRIMARY_INDEX)
+                  .setTopHits(10)
+                  .setQuery(
+                      Query.newBuilder()
+                          .setCrossIndexQuery(
+                              CrossIndexQuery.newBuilder()
+                                  .setIndex(SECONDARY_INDEX)
+                                  .setSecondaryField("no_such_field")
+                                  .setPrimaryField("biz_id_primary")
+                                  .setQuery(
+                                      Query.newBuilder()
+                                          .setMatchAllQuery(MatchAllQuery.newBuilder()))
+                                  .setScoreMode(CrossIndexQuery.JoinScoreMode.JOIN_SCORE_NONE))
+                          .build())
+                  .build());
+      fail("Expected exception for non-existent secondary_field in secondary index");
+    } catch (StatusRuntimeException e) {
+      assertTrue(
+          "Error should mention the missing field: " + e.getMessage(),
+          e.getMessage().contains("no_such_field") && e.getMessage().contains("unknown"));
+    }
+  }
+
+  /** primary_field does not exist in primary index → error. */
+  @Test
+  public void testNonExistentPrimaryField() {
+    try {
+      getGrpcServer()
+          .getBlockingStub()
+          .search(
+              SearchRequest.newBuilder()
+                  .setIndexName(PRIMARY_INDEX)
+                  .setTopHits(10)
+                  .setQuery(
+                      Query.newBuilder()
+                          .setCrossIndexQuery(
+                              CrossIndexQuery.newBuilder()
+                                  .setIndex(SECONDARY_INDEX)
+                                  .setSecondaryField("biz_id_secondary")
+                                  .setPrimaryField("no_such_field")
+                                  .setQuery(
+                                      Query.newBuilder()
+                                          .setMatchAllQuery(MatchAllQuery.newBuilder()))
+                                  .setScoreMode(CrossIndexQuery.JoinScoreMode.JOIN_SCORE_NONE))
+                          .build())
+                  .build());
+      fail("Expected exception for non-existent primary_field in primary index");
+    } catch (StatusRuntimeException e) {
+      assertTrue(
+          "Error should mention the missing field: " + e.getMessage(),
+          e.getMessage().contains("no_such_field") && e.getMessage().contains("unknown"));
+    }
+  }
+
+  /** CrossIndexQuery used as a FILTER clause in a BooleanQuery alongside a primary query. */
+  @Test
+  public void testBooleanCompositionWithFilter() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(PRIMARY_INDEX)
+                    .setTopHits(10)
+                    .addRetrieveFields("biz_id_primary")
+                    .setQuery(
+                        Query.newBuilder()
+                            .setBooleanQuery(
+                                BooleanQuery.newBuilder()
+                                    // MUST: rating >= 4
+                                    .addClauses(
+                                        BooleanClause.newBuilder()
+                                            .setOccur(BooleanClause.Occur.MUST)
+                                            .setQuery(
+                                                Query.newBuilder()
+                                                    .setRangeQuery(
+                                                        RangeQuery.newBuilder()
+                                                            .setField("rating")
+                                                            .setLower("4")
+                                                            .setUpper("5"))))
+                                    // FILTER: must have reservation
+                                    .addClauses(
+                                        BooleanClause.newBuilder()
+                                            .setOccur(BooleanClause.Occur.FILTER)
+                                            .setQuery(
+                                                Query.newBuilder()
+                                                    .setCrossIndexQuery(
+                                                        CrossIndexQuery.newBuilder()
+                                                            .setIndex(SECONDARY_INDEX)
+                                                            .setSecondaryField("biz_id_secondary")
+                                                            .setPrimaryField("biz_id_primary")
+                                                            .setQuery(
+                                                                Query.newBuilder()
+                                                                    .setMatchAllQuery(
+                                                                        MatchAllQuery.newBuilder()))
+                                                            .setScoreMode(
+                                                                CrossIndexQuery.JoinScoreMode
+                                                                    .JOIN_SCORE_NONE))))))
+                    .build());
+
+    Set<String> returnedBizIds = extractBizIds(response);
+    // rating >= 4: biz_1 (5), biz_2 (4)
+    // has reservation: biz_1, biz_2, biz_3
+    // intersection: biz_1, biz_2
+    assertEquals(Set.of("biz_1", "biz_2"), returnedBizIds);
+  }
+
+  /**
+   * Helper to build a FunctionScoreQuery that scores each secondary doc by its covers value. This
+   * produces varying scores so that MAX, MIN, AVG, and TOTAL are distinguishable.
+   *
+   * <p>Secondary data: biz_1 has covers=2 (score 2.0) and covers=4 (score 4.0), biz_2 has covers=2
+   * (score 2.0), biz_3 has covers=6 (score 6.0).
+   */
+  private Query coversScoreQuery() {
+    return Query.newBuilder()
+        .setFunctionScoreQuery(
+            FunctionScoreQuery.newBuilder()
+                .setQuery(Query.newBuilder().setMatchAllQuery(MatchAllQuery.newBuilder()))
+                .setScript(
+                    Script.newBuilder().setLang("js").setSource("doc['covers'].value").build()))
+        .build();
+  }
+
+  /**
+   * Test with JOIN_SCORE_MAX using varying scores. biz_1: max(2.0, 4.0) = 4.0, biz_2: max(2.0) =
+   * 2.0, biz_3: max(6.0) = 6.0.
+   */
+  @Test
+  public void testScoreModeMax() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(PRIMARY_INDEX)
+                    .setTopHits(10)
+                    .addRetrieveFields("biz_id_primary")
+                    .setQuery(
+                        Query.newBuilder()
+                            .setCrossIndexQuery(
+                                CrossIndexQuery.newBuilder()
+                                    .setIndex(SECONDARY_INDEX)
+                                    .setSecondaryField("biz_id_secondary")
+                                    .setPrimaryField("biz_id_primary")
+                                    .setQuery(coversScoreQuery())
+                                    .setScoreMode(CrossIndexQuery.JoinScoreMode.JOIN_SCORE_MAX))
+                            .build())
+                    .build());
+
+    Set<String> returnedBizIds = extractBizIds(response);
+    assertEquals(Set.of("biz_1", "biz_2", "biz_3"), returnedBizIds);
+
+    Map<String, Double> scores = extractBizIdScores(response);
+    assertEquals(4.0, scores.get("biz_1"), 0.001);
+    assertEquals(2.0, scores.get("biz_2"), 0.001);
+    assertEquals(6.0, scores.get("biz_3"), 0.001);
+  }
+
+  /**
+   * Test with JOIN_SCORE_TOTAL using varying scores. biz_1: 2.0 + 4.0 = 6.0, biz_2: 2.0, biz_3:
+   * 6.0.
+   */
+  @Test
+  public void testScoreModeTotal() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(PRIMARY_INDEX)
+                    .setTopHits(10)
+                    .addRetrieveFields("biz_id_primary")
+                    .setQuery(
+                        Query.newBuilder()
+                            .setCrossIndexQuery(
+                                CrossIndexQuery.newBuilder()
+                                    .setIndex(SECONDARY_INDEX)
+                                    .setSecondaryField("biz_id_secondary")
+                                    .setPrimaryField("biz_id_primary")
+                                    .setQuery(coversScoreQuery())
+                                    .setScoreMode(CrossIndexQuery.JoinScoreMode.JOIN_SCORE_TOTAL))
+                            .build())
+                    .build());
+
+    Set<String> returnedBizIds = extractBizIds(response);
+    assertEquals(Set.of("biz_1", "biz_2", "biz_3"), returnedBizIds);
+
+    Map<String, Double> scores = extractBizIdScores(response);
+    assertEquals(6.0, scores.get("biz_1"), 0.001);
+    assertEquals(2.0, scores.get("biz_2"), 0.001);
+    assertEquals(6.0, scores.get("biz_3"), 0.001);
+  }
+
+  /**
+   * Test with JOIN_SCORE_AVG using varying scores. biz_1: (2.0 + 4.0) / 2 = 3.0, biz_2: 2.0 / 1 =
+   * 2.0, biz_3: 6.0 / 1 = 6.0.
+   */
+  @Test
+  public void testScoreModeAvg() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(PRIMARY_INDEX)
+                    .setTopHits(10)
+                    .addRetrieveFields("biz_id_primary")
+                    .setQuery(
+                        Query.newBuilder()
+                            .setCrossIndexQuery(
+                                CrossIndexQuery.newBuilder()
+                                    .setIndex(SECONDARY_INDEX)
+                                    .setSecondaryField("biz_id_secondary")
+                                    .setPrimaryField("biz_id_primary")
+                                    .setQuery(coversScoreQuery())
+                                    .setScoreMode(CrossIndexQuery.JoinScoreMode.JOIN_SCORE_AVG))
+                            .build())
+                    .build());
+
+    Set<String> returnedBizIds = extractBizIds(response);
+    assertEquals(Set.of("biz_1", "biz_2", "biz_3"), returnedBizIds);
+
+    Map<String, Double> scores = extractBizIdScores(response);
+    assertEquals(3.0, scores.get("biz_1"), 0.001);
+    assertEquals(2.0, scores.get("biz_2"), 0.001);
+    assertEquals(6.0, scores.get("biz_3"), 0.001);
+  }
+
+  /**
+   * Test with JOIN_SCORE_MIN using varying scores. biz_1: min(2.0, 4.0) = 2.0, biz_2: min(2.0) =
+   * 2.0, biz_3: min(6.0) = 6.0.
+   */
+  @Test
+  public void testScoreModeMin() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(PRIMARY_INDEX)
+                    .setTopHits(10)
+                    .addRetrieveFields("biz_id_primary")
+                    .setQuery(
+                        Query.newBuilder()
+                            .setCrossIndexQuery(
+                                CrossIndexQuery.newBuilder()
+                                    .setIndex(SECONDARY_INDEX)
+                                    .setSecondaryField("biz_id_secondary")
+                                    .setPrimaryField("biz_id_primary")
+                                    .setQuery(coversScoreQuery())
+                                    .setScoreMode(CrossIndexQuery.JoinScoreMode.JOIN_SCORE_MIN))
+                            .build())
+                    .build());
+
+    Set<String> returnedBizIds = extractBizIds(response);
+    assertEquals(Set.of("biz_1", "biz_2", "biz_3"), returnedBizIds);
+
+    Map<String, Double> scores = extractBizIdScores(response);
+    assertEquals(2.0, scores.get("biz_1"), 0.001);
+    assertEquals(2.0, scores.get("biz_2"), 0.001);
+    assertEquals(6.0, scores.get("biz_3"), 0.001);
+  }
+
+  /** Test that inner query targeting a specific biz returns only that business. */
+  @Test
+  public void testSingleBusinessJoin() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(PRIMARY_INDEX)
+                    .setTopHits(10)
+                    .addRetrieveFields("biz_id_primary")
+                    .setQuery(
+                        Query.newBuilder()
+                            .setCrossIndexQuery(
+                                CrossIndexQuery.newBuilder()
+                                    .setIndex(SECONDARY_INDEX)
+                                    .setSecondaryField("biz_id_secondary")
+                                    .setPrimaryField("biz_id_primary")
+                                    .setQuery(
+                                        Query.newBuilder()
+                                            .setTermQuery(
+                                                TermQuery.newBuilder()
+                                                    .setField("biz_id_secondary")
+                                                    .setTextValue("biz_2")))
+                                    .setScoreMode(CrossIndexQuery.JoinScoreMode.JOIN_SCORE_NONE))
+                            .build())
+                    .build());
+
+    Set<String> returnedBizIds = extractBizIds(response);
+    assertEquals(Set.of("biz_2"), returnedBizIds);
+  }
+
+  /**
+   * Test JOIN_SCORE_TOTAL with a filtered inner query to verify scores reflect the correct count of
+   * matching secondary docs after filtering. Only covers >= 4 matches: biz_1 (covers=4, score 1.0)
+   * and biz_3 (covers=6, score 1.0).
+   */
+  @Test
+  public void testScoreTotalWithInnerFilter() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(PRIMARY_INDEX)
+                    .setTopHits(10)
+                    .addRetrieveFields("biz_id_primary")
+                    .setQuery(
+                        Query.newBuilder()
+                            .setCrossIndexQuery(
+                                CrossIndexQuery.newBuilder()
+                                    .setIndex(SECONDARY_INDEX)
+                                    .setSecondaryField("biz_id_secondary")
+                                    .setPrimaryField("biz_id_primary")
+                                    .setQuery(
+                                        Query.newBuilder()
+                                            .setRangeQuery(
+                                                RangeQuery.newBuilder()
+                                                    .setField("covers")
+                                                    .setLower("4")
+                                                    .setUpper("100")))
+                                    .setScoreMode(CrossIndexQuery.JoinScoreMode.JOIN_SCORE_TOTAL))
+                            .build())
+                    .build());
+
+    Set<String> returnedBizIds = extractBizIds(response);
+    assertEquals(Set.of("biz_1", "biz_3"), returnedBizIds);
+
+    // Each has exactly 1 matching secondary doc after the covers >= 4 filter
+    Map<String, Double> scores = extractBizIdScores(response);
+    assertEquals(1.0, scores.get("biz_1"), 0.001);
+    assertEquals(1.0, scores.get("biz_3"), 0.001);
+  }
+
+  /** max_terms within limit — query succeeds. Secondary has 4 docs total. */
+  @Test
+  public void testMaxTermsWithinLimit() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(PRIMARY_INDEX)
+                    .setTopHits(10)
+                    .addRetrieveFields("biz_id_primary")
+                    .setQuery(
+                        Query.newBuilder()
+                            .setCrossIndexQuery(
+                                CrossIndexQuery.newBuilder()
+                                    .setIndex(SECONDARY_INDEX)
+                                    .setSecondaryField("biz_id_secondary")
+                                    .setPrimaryField("biz_id_primary")
+                                    .setQuery(
+                                        Query.newBuilder()
+                                            .setMatchAllQuery(MatchAllQuery.newBuilder()))
+                                    .setScoreMode(CrossIndexQuery.JoinScoreMode.JOIN_SCORE_NONE)
+                                    .setMaxTerms(10))
+                            .build())
+                    .build());
+
+    Set<String> returnedBizIds = extractBizIds(response);
+    assertEquals(Set.of("biz_1", "biz_2", "biz_3"), returnedBizIds);
+  }
+
+  /** max_terms exceeded — error returned. Secondary has 4 docs, limit set to 2. */
+  @Test
+  public void testMaxTermsExceeded() {
+    try {
+      getGrpcServer()
+          .getBlockingStub()
+          .search(
+              SearchRequest.newBuilder()
+                  .setIndexName(PRIMARY_INDEX)
+                  .setTopHits(10)
+                  .setQuery(
+                      Query.newBuilder()
+                          .setCrossIndexQuery(
+                              CrossIndexQuery.newBuilder()
+                                  .setIndex(SECONDARY_INDEX)
+                                  .setSecondaryField("biz_id_secondary")
+                                  .setPrimaryField("biz_id_primary")
+                                  .setQuery(
+                                      Query.newBuilder()
+                                          .setMatchAllQuery(MatchAllQuery.newBuilder()))
+                                  .setScoreMode(CrossIndexQuery.JoinScoreMode.JOIN_SCORE_NONE)
+                                  .setMaxTerms(2))
+                          .build())
+                  .build());
+      fail("Expected exception for max_terms exceeded");
+    } catch (StatusRuntimeException e) {
+      assertTrue(
+          "Error should mention exceeding max_terms: " + e.getMessage(),
+          e.getMessage().contains("exceeding max_terms"));
+    }
+  }
+
+  private Set<String> extractBizIds(SearchResponse response) {
+    return response.getHitsList().stream()
+        .map(hit -> hit.getFieldsMap().get("biz_id_primary"))
+        .map(fieldValue -> fieldValue.getFieldValue(0).getTextValue())
+        .collect(Collectors.toSet());
+  }
+
+  private Map<String, Double> extractBizIdScores(SearchResponse response) {
+    return response.getHitsList().stream()
+        .collect(
+            Collectors.toMap(
+                hit -> hit.getFieldsMap().get("biz_id_primary").getFieldValue(0).getTextValue(),
+                hit -> (double) hit.getScore()));
+  }
+}

--- a/src/test/resources/registerFieldsCrossIndexPrimary.json
+++ b/src/test/resources/registerFieldsCrossIndexPrimary.json
@@ -1,0 +1,36 @@
+{
+  "indexName": "primary_index",
+  "field": [
+    {
+      "name": "biz_id_primary",
+      "type": "ATOM",
+      "search": true,
+      "storeDocValues": true
+    },
+    {
+      "name": "name",
+      "type": "TEXT",
+      "search": true,
+      "store": true,
+      "storeDocValues": true,
+      "analyzer": {
+        "custom": {
+          "tokenizer": {
+            "name": "standard"
+          },
+          "tokenFilters": [
+            {
+              "name": "lowercase"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "rating",
+      "type": "INT",
+      "search": true,
+      "storeDocValues": true
+    }
+  ]
+}

--- a/src/test/resources/registerFieldsCrossIndexSecondary.json
+++ b/src/test/resources/registerFieldsCrossIndexSecondary.json
@@ -1,0 +1,23 @@
+{
+  "indexName": "secondary_index",
+  "field": [
+    {
+      "name": "biz_id_secondary",
+      "type": "ATOM",
+      "search": true,
+      "storeDocValues": true
+    },
+    {
+      "name": "time_slot",
+      "type": "INT",
+      "search": true,
+      "storeDocValues": true
+    },
+    {
+      "name": "covers",
+      "type": "INT",
+      "search": true,
+      "storeDocValues": true
+    }
+  ]
+}


### PR DESCRIPTION
We have supported querying only one index at a time in a cluster, and we use nested documents for more complex data. However, reindexing a nested document requires reindexing the entire parent document as well, which can add a lot of additional load if the documents are large and updated frequently. Adding cross index query to overcome this. The more frequently updated data can be added to a different index and queried in the same query. 

This PR only allows filtering with a different index, and future work will enable retrieval of fields from matching cross-index documents and access to cross-index documents in rescorer. 

This PR is mostly AI generated.