### PR TITLE
Switch to java s3 async client

### DIFF
--- a/docs/server_configuration.rst
+++ b/docs/server_configuration.rst
@@ -82,6 +82,11 @@ Example server configuration
      - Path to AWS credentials (if using S3 for remote storage); Will use the DefaultAWSCredentialsProviderChain if omitted.
      - null
 
+   * - enableGlobalBucketAccess
+     - bool
+     - If enabled, the S3 client uses cross-region access, allowing it to access buckets in any region without requiring an exact region match.
+     - false
+
    * - deadlineCancellation
      - bool
      - Enables gRPC deadline based cancellation of requests. A request is cancelled early if it exceeds the deadline. Currently only supported by the search endpoint.
@@ -445,4 +450,121 @@ Example server configuration
      - list
      - List of index file extensions to preload. Including '*' will preload all files.
      - ['*']
+
+.. list-table:: `S3 Remote Storage Configuration <https://github.com/Yelp/nrtsearch/blob/master/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Util.java>`_ (``remoteConfig.s3.*``)
+   :widths: 25 10 50 25
+   :header-rows: 1
+
+   * - Property
+     - Type
+     - Description
+     - Default
+
+   * - asyncClientType
+     - str
+     - Type of async S3 client to use for index file transfers. ``java`` uses the Netty-based ``S3AsyncClient`` (recommended; supports ``MetricPublisher`` and full connection pool configuration). ``crt`` uses the AWS C Runtime ``S3CrtAsyncClient`` (higher throughput but limited observability).
+     - java
+
+   * - metrics
+     - bool
+     - If enabled, tracks S3 download byte counts per index via the ``nrt_s3_download_bytes_total`` Prometheus metric.
+     - false
+
+   * - rateLimitPerSecond
+     - str
+     - Maximum download throughput for S3 operations. Accepts a plain byte count or a size string with a suffix (e.g. ``500mb``, ``1gb``). Set to ``0`` to disable rate limiting.
+     - 0 (unlimited)
+
+   * - rateLimitWindowSeconds
+     - int
+     - Window duration in seconds for the download rate limiter. Must be > 0.
+     - 1
+
+   * - downloadBatchSize
+     - int
+     - Maximum number of index files downloaded concurrently in a single batch during bootstrap. When set to ``0``, the server's ``defaultParallelism`` value is used.
+     - 0
+
+.. list-table:: `S3 Java Async Client Configuration <https://github.com/Yelp/nrtsearch/blob/master/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Util.java>`_ (``remoteConfig.s3.java.*``)
+   :widths: 25 10 50 25
+   :header-rows: 1
+
+   * - Property
+     - Type
+     - Description
+     - Default
+
+   * - minimumPartSize
+     - str
+     - Minimum size of each part in a multipart upload or download. Accepts a plain byte count or a size string with a suffix (e.g. ``16mb``).
+     - 8mb
+
+   * - thresholdSize
+     - str
+     - File size threshold above which multipart upload is used. Accepts a plain byte count or a size string with a suffix.
+     - 8mb
+
+   * - apiCallBufferSize
+     - str
+     - Buffer size for API calls in bytes. Accepts a plain byte count or a size string with a suffix. Set to ``0`` to use the SDK default.
+     - 0 (SDK default)
+
+   * - maxInFlightParts
+     - int
+     - Maximum number of concurrent in-flight multipart parts during a transfer. Set to ``0`` to use the SDK default.
+     - 0 (SDK default)
+
+   * - ioThreads
+     - int
+     - Number of Netty NIO event loop threads. Each thread can multiplex many connections. Set to ``0`` to use the SDK default (``2 * numCPUs``).
+     - 0 (SDK default)
+
+   * - maxConnections
+     - int
+     - Maximum number of concurrent HTTP connections in the Netty connection pool. Set to ``0`` to use the SDK default of 50.
+     - 100
+
+   * - connectionTimeoutMs
+     - int
+     - TCP connection establishment timeout in milliseconds. Set to ``0`` to use the SDK default of 2000ms.
+     - 0 (SDK default)
+
+   * - connectionAcquisitionTimeoutMs
+     - int
+     - Maximum time in milliseconds to wait for a connection from the pool before failing. Increase this or ``maxConnections`` when seeing pool exhaustion errors during high-concurrency bootstrap. Set to ``0`` to use the SDK default of 10000ms.
+     - 60000
+
+   * - maxPendingConnectionAcquires
+     - int
+     - Maximum number of requests that can be queued waiting for a connection from the pool. Set to ``0`` to use the SDK default of 10000.
+     - 0 (SDK default)
+
+.. list-table:: `S3 CRT Async Client Configuration <https://github.com/Yelp/nrtsearch/blob/master/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Util.java>`_ (``remoteConfig.s3.crt.*``)
+   :widths: 25 10 50 25
+   :header-rows: 1
+
+   * - Property
+     - Type
+     - Description
+     - Default
+
+   * - minimumPartSize
+     - str
+     - Minimum size of each part in a multipart transfer. Accepts a plain byte count or a size string with a suffix (e.g. ``16mb``).
+     - 8mb
+
+   * - targetThroughputInGbps
+     - float
+     - Target throughput in Gbps. The CRT client uses this to auto-size its connection count and buffers. Mutually exclusive with ``maxConcurrency``; set to ``0`` to use the SDK default.
+     - 0 (SDK default)
+
+   * - maxConcurrency
+     - int
+     - Hard cap on the number of concurrent S3 connections. Mutually exclusive with ``targetThroughputInGbps``; set to ``0`` to use the SDK default.
+     - 0 (SDK default)
+
+   * - maxNativeMemoryLimit
+     - str
+     - Hard cap on the amount of native (off-heap) memory the CRT client may use. Accepts a plain byte count or a size string with a suffix. Set to ``0`` for unlimited.
+     - 0 (unlimited)
 

--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
@@ -668,6 +668,10 @@ public class S3Backend implements RemoteBackend {
     int effectiveBatchSize = downloadBatchSize > 0 ? downloadBatchSize : defaultParallelism;
     int totalFiles = fileList.size();
     int batchStart = 0;
+    long totalExpectedBytes = files.values().stream().mapToLong(m -> m.length).sum();
+    S3ProgressListenerImpl downloadProgressListener =
+        new S3ProgressListenerImpl(
+            service, indexIdentifier, "download_index_files", totalExpectedBytes);
 
     while (batchStart < totalFiles) {
       int batchEnd = Math.min(batchStart + effectiveBatchSize, totalFiles);
@@ -683,13 +687,6 @@ public class S3Backend implements RemoteBackend {
       List<FileDownload> downloadList = new LinkedList<>();
       boolean hasFailure = false;
       Throwable failureCause = null;
-      long batchExpectedBytes =
-          batch.stream()
-              .mapToLong(p -> files.get(p.fileName()) != null ? files.get(p.fileName()).length : 0)
-              .sum();
-      S3ProgressListenerImpl batchProgressListener =
-          new S3ProgressListenerImpl(
-              service, indexIdentifier, "download_index_files", batchExpectedBytes);
 
       for (FileNamePair pair : batch) {
         String backendKey = backendPrefix + pair.backendFileName;
@@ -699,7 +696,7 @@ public class S3Backend implements RemoteBackend {
                 .getObjectRequest(
                     GetObjectRequest.builder().bucket(serviceBucket).key(backendKey).build())
                 .destination(localFile)
-                .addTransferListener(batchProgressListener)
+                .addTransferListener(downloadProgressListener)
                 .build();
         try {
           FileDownload download = transferManager.downloadFile(request);

--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
@@ -603,6 +603,10 @@ public class S3Backend implements RemoteBackend {
       throws IOException {
     List<FileNamePair> fileList = getFileNamePairs(files);
     String backendPrefix = getIndexDataPrefix(service, indexIdentifier);
+    long totalUploadBytes = files.values().stream().mapToLong(m -> m.length).sum();
+    S3ProgressListenerImpl uploadProgressListener =
+        new S3ProgressListenerImpl(
+            service, indexIdentifier, "upload_index_files", totalUploadBytes);
     List<FileUpload> uploadList = new LinkedList<>();
     boolean hasFailure = false;
     Throwable failureCause = null;
@@ -614,8 +618,7 @@ public class S3Backend implements RemoteBackend {
               .putObjectRequest(
                   PutObjectRequest.builder().bucket(serviceBucket).key(backendKey).build())
               .source(localFile)
-              .addTransferListener(
-                  new S3ProgressListenerImpl(service, indexIdentifier, "upload_index_files"))
+              .addTransferListener(uploadProgressListener)
               .build();
       try {
         if (transferManager == null) {
@@ -680,6 +683,13 @@ public class S3Backend implements RemoteBackend {
       List<FileDownload> downloadList = new LinkedList<>();
       boolean hasFailure = false;
       Throwable failureCause = null;
+      long batchExpectedBytes =
+          batch.stream()
+              .mapToLong(p -> files.get(p.fileName()) != null ? files.get(p.fileName()).length : 0)
+              .sum();
+      S3ProgressListenerImpl batchProgressListener =
+          new S3ProgressListenerImpl(
+              service, indexIdentifier, "download_index_files", batchExpectedBytes);
 
       for (FileNamePair pair : batch) {
         String backendKey = backendPrefix + pair.backendFileName;
@@ -689,8 +699,7 @@ public class S3Backend implements RemoteBackend {
                 .getObjectRequest(
                     GetObjectRequest.builder().bucket(serviceBucket).key(backendKey).build())
                 .destination(localFile)
-                .addTransferListener(
-                    new S3ProgressListenerImpl(service, indexIdentifier, "download_index_files"))
+                .addTransferListener(batchProgressListener)
                 .build();
         try {
           FileDownload download = transferManager.downloadFile(request);

--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3ProgressListenerImpl.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3ProgressListenerImpl.java
@@ -41,16 +41,28 @@ public class S3ProgressListenerImpl implements TransferListener {
   private final String serviceName;
   private final String resource;
   private final String operation;
+  private final long totalExpectedBytes;
 
   private final Semaphore lock = new Semaphore(1);
   private final AtomicLong totalBytesTransferred = new AtomicLong();
   private long bytesTransferredSinceLastLog = 0;
   private LocalDateTime lastLoggedTime = LocalDateTime.now();
 
-  public S3ProgressListenerImpl(String serviceName, String resource, String operation) {
+  /**
+   * Constructor.
+   *
+   * @param serviceName service name
+   * @param resource resource identifier
+   * @param operation operation name (e.g. "download_index_files")
+   * @param totalExpectedBytes total expected bytes across all files for this listener, used to
+   *     compute percent complete in log output; use -1 if unknown
+   */
+  public S3ProgressListenerImpl(
+      String serviceName, String resource, String operation, long totalExpectedBytes) {
     this.serviceName = serviceName;
     this.resource = resource;
     this.operation = operation;
+    this.totalExpectedBytes = totalExpectedBytes;
   }
 
   @Override
@@ -69,10 +81,18 @@ public class S3ProgressListenerImpl implements TransferListener {
 
         if (bytesTransferredSinceLastLog > LOG_THRESHOLD_BYTES
             || secondsSinceLastLog > LOG_THRESHOLD_SECONDS) {
-          logger.info(
-              String.format(
-                  "service: %s, resource: %s, %s transferred bytes: %s",
-                  serviceName, resource, operation, totalBytes));
+          if (totalExpectedBytes > 0) {
+            double pct = 100.0 * totalBytes / totalExpectedBytes;
+            logger.info(
+                String.format(
+                    "service: %s, resource: %s, %s transferred bytes: %s (%.1f%%)",
+                    serviceName, resource, operation, totalBytes, pct));
+          } else {
+            logger.info(
+                String.format(
+                    "service: %s, resource: %s, %s transferred bytes: %s",
+                    serviceName, resource, operation, totalBytes));
+          }
           bytesTransferredSinceLastLog = 0;
           lastLoggedTime = LocalDateTime.now();
         }

--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3ProgressListenerImpl.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3ProgressListenerImpl.java
@@ -15,9 +15,8 @@
  */
 package com.yelp.nrtsearch.server.remote.s3;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.util.concurrent.Semaphore;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,25 +27,24 @@ import software.amazon.awssdk.transfer.s3.progress.TransferListener;
  * software.amazon.awssdk.transfer.s3.S3TransferManager}.
  *
  * <p>Note on progress tracking semantics: The AWS SDK v2's {@code
- * progressSnapshot().transferredBytes()} returns incremental bytes transferred since the last event
- * (delta), not cumulative total. This class maintains a cumulative total via {@code
- * totalBytesTransferred} for accurate progress reporting.
+ * progressSnapshot().transferredBytes()} returns the cumulative bytes transferred so far for an
+ * individual file transfer, not a delta. This class tracks the last-seen value per transfer request
+ * to compute actual deltas, which are then accumulated into {@code totalBytesTransferred}.
  */
 public class S3ProgressListenerImpl implements TransferListener {
   private static final Logger logger = LoggerFactory.getLogger(S3ProgressListenerImpl.class);
 
-  private static final long LOG_THRESHOLD_BYTES = 1024 * 1024 * 500; // 500 MB
-  private static final long LOG_THRESHOLD_SECONDS = 30;
+  private static final long LOG_INTERVAL_NS = TimeUnit.SECONDS.toNanos(30);
 
   private final String serviceName;
   private final String resource;
   private final String operation;
   private final long totalExpectedBytes;
 
-  private final Semaphore lock = new Semaphore(1);
+  // Tracks the last cumulative snapshot value per transfer request to compute deltas.
+  private final ConcurrentHashMap<Object, Long> lastSeenBytes = new ConcurrentHashMap<>();
   private final AtomicLong totalBytesTransferred = new AtomicLong();
-  private long bytesTransferredSinceLastLog = 0;
-  private LocalDateTime lastLoggedTime = LocalDateTime.now();
+  private final AtomicLong lastLoggedNanos = new AtomicLong(System.nanoTime());
 
   /**
    * Constructor.
@@ -67,37 +65,26 @@ public class S3ProgressListenerImpl implements TransferListener {
 
   @Override
   public void bytesTransferred(Context.BytesTransferred context) {
-    // AWS SDK v2 returns incremental bytes (delta) per event, not cumulative
-    long bytesTransferred = context.progressSnapshot().transferredBytes();
-    long totalBytes = totalBytesTransferred.addAndGet(bytesTransferred);
+    // transferredBytes() is cumulative for this individual file transfer; compute the delta.
+    long current = context.progressSnapshot().transferredBytes();
+    Long prev = lastSeenBytes.put(context.request(), current);
+    long delta = prev == null ? current : current - prev;
+    long total = totalBytesTransferred.addAndGet(delta);
 
-    boolean acquired = lock.tryAcquire();
-
-    if (acquired) {
-      try {
-        bytesTransferredSinceLastLog += bytesTransferred;
-        long secondsSinceLastLog =
-            Duration.between(lastLoggedTime, LocalDateTime.now()).getSeconds();
-
-        if (bytesTransferredSinceLastLog > LOG_THRESHOLD_BYTES
-            || secondsSinceLastLog > LOG_THRESHOLD_SECONDS) {
-          if (totalExpectedBytes > 0) {
-            double pct = 100.0 * totalBytes / totalExpectedBytes;
-            logger.info(
-                String.format(
-                    "service: %s, resource: %s, %s transferred bytes: %s (%.1f%%)",
-                    serviceName, resource, operation, totalBytes, pct));
-          } else {
-            logger.info(
-                String.format(
-                    "service: %s, resource: %s, %s transferred bytes: %s",
-                    serviceName, resource, operation, totalBytes));
-          }
-          bytesTransferredSinceLastLog = 0;
-          lastLoggedTime = LocalDateTime.now();
-        }
-      } finally {
-        lock.release();
+    long now = System.nanoTime();
+    long last = lastLoggedNanos.get();
+    if (now - last >= LOG_INTERVAL_NS && lastLoggedNanos.compareAndSet(last, now)) {
+      if (totalExpectedBytes > 0) {
+        double pct = 100.0 * total / totalExpectedBytes;
+        logger.info(
+            String.format(
+                "service: %s, resource: %s, %s transferred bytes: %s (%.1f%%)",
+                serviceName, resource, operation, total, pct));
+      } else {
+        logger.info(
+            String.format(
+                "service: %s, resource: %s, %s transferred bytes: %s",
+                serviceName, resource, operation, total));
       }
     }
   }

--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Util.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Util.java
@@ -240,13 +240,13 @@ public class S3Util {
           configuration.getConfigReader().getInteger(CONFIG_PREFIX + "maxInFlightParts", 0);
       int ioThreads = configuration.getConfigReader().getInteger(CONFIG_PREFIX + "ioThreads", 0);
       int maxConnections =
-          configuration.getConfigReader().getInteger(CONFIG_PREFIX + "maxConnections", 0);
+          configuration.getConfigReader().getInteger(CONFIG_PREFIX + "maxConnections", 100);
       int connectionTimeoutMs =
           configuration.getConfigReader().getInteger(CONFIG_PREFIX + "connectionTimeoutMs", 0);
       int connectionAcquisitionTimeoutMs =
           configuration
               .getConfigReader()
-              .getInteger(CONFIG_PREFIX + "connectionAcquisitionTimeoutMs", 0);
+              .getInteger(CONFIG_PREFIX + "connectionAcquisitionTimeoutMs", 60_000);
       int maxPendingConnectionAcquires =
           configuration
               .getConfigReader()
@@ -272,11 +272,11 @@ public class S3Util {
      * @param maxInFlightParts max in-flight multipart parts (0 means SDK default)
      * @param ioThreads number of Netty I/O threads (0 means SDK default)
      * @param maxConnections max connections in the Netty connection pool (0 means SDK default of
-     *     50)
+     *     50; config default is 100)
      * @param connectionTimeoutMs TCP connection timeout in milliseconds (0 means SDK default of
      *     2000)
      * @param connectionAcquisitionTimeoutMs timeout to acquire a connection from the pool in
-     *     milliseconds (0 means SDK default of 10000)
+     *     milliseconds (0 means SDK default of 10000; config default is 60000)
      * @param maxPendingConnectionAcquires max requests queued waiting for a connection (0 means SDK
      *     default of 10000)
      * @throws IllegalArgumentException if minimumPartSizeInBytes or thresholdSizeInBytes are <= 0,
@@ -376,7 +376,8 @@ public class S3Util {
     }
 
     /**
-     * Get the max connections in the Netty connection pool (0 means SDK default of 50).
+     * Get the max connections in the Netty connection pool (0 means SDK default of 50; config
+     * default is 100).
      *
      * @return max connections
      */
@@ -395,7 +396,7 @@ public class S3Util {
 
     /**
      * Get the timeout to acquire a connection from the pool in milliseconds (0 means SDK default of
-     * 10000).
+     * 10000; config default is 60000).
      *
      * @return connection acquisition timeout in milliseconds
      */
@@ -495,7 +496,7 @@ public class S3Util {
     S3Client s3Client = clientBuilder.build();
 
     String asyncClientType =
-        configuration.getConfigReader().getString("remoteConfig.s3.asyncClientType", "crt");
+        configuration.getConfigReader().getString("remoteConfig.s3.asyncClientType", "java");
     S3AsyncClient s3AsyncClient;
     if (asyncClientType.equalsIgnoreCase("java")) {
       s3AsyncClient =

--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Util.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Util.java
@@ -20,6 +20,7 @@ import com.google.common.base.Strings;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import java.net.URI;
 import java.nio.file.Paths;
+import java.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
@@ -214,6 +215,10 @@ public class S3Util {
     private final long apiCallBufferSizeInBytes;
     private final int maxInFlightParts;
     private final int ioThreads;
+    private final int maxConnections;
+    private final int connectionTimeoutMs;
+    private final int connectionAcquisitionTimeoutMs;
+    private final int maxPendingConnectionAcquires;
 
     /**
      * Create S3JavaAsyncConfig from NrtsearchConfig.
@@ -234,12 +239,28 @@ public class S3Util {
       int maxInFlightParts =
           configuration.getConfigReader().getInteger(CONFIG_PREFIX + "maxInFlightParts", 0);
       int ioThreads = configuration.getConfigReader().getInteger(CONFIG_PREFIX + "ioThreads", 0);
+      int maxConnections =
+          configuration.getConfigReader().getInteger(CONFIG_PREFIX + "maxConnections", 0);
+      int connectionTimeoutMs =
+          configuration.getConfigReader().getInteger(CONFIG_PREFIX + "connectionTimeoutMs", 0);
+      int connectionAcquisitionTimeoutMs =
+          configuration
+              .getConfigReader()
+              .getInteger(CONFIG_PREFIX + "connectionAcquisitionTimeoutMs", 0);
+      int maxPendingConnectionAcquires =
+          configuration
+              .getConfigReader()
+              .getInteger(CONFIG_PREFIX + "maxPendingConnectionAcquires", 0);
       return new S3JavaAsyncConfig(
           minimumPartSizeInBytes,
           thresholdSizeInBytes,
           apiCallBufferSizeInBytes,
           maxInFlightParts,
-          ioThreads);
+          ioThreads,
+          maxConnections,
+          connectionTimeoutMs,
+          connectionAcquisitionTimeoutMs,
+          maxPendingConnectionAcquires);
     }
 
     /**
@@ -250,15 +271,27 @@ public class S3Util {
      * @param apiCallBufferSizeInBytes API call buffer size in bytes (0 means SDK default)
      * @param maxInFlightParts max in-flight multipart parts (0 means SDK default)
      * @param ioThreads number of Netty I/O threads (0 means SDK default)
+     * @param maxConnections max connections in the Netty connection pool (0 means SDK default of
+     *     50)
+     * @param connectionTimeoutMs TCP connection timeout in milliseconds (0 means SDK default of
+     *     2000)
+     * @param connectionAcquisitionTimeoutMs timeout to acquire a connection from the pool in
+     *     milliseconds (0 means SDK default of 10000)
+     * @param maxPendingConnectionAcquires max requests queued waiting for a connection (0 means SDK
+     *     default of 10000)
      * @throws IllegalArgumentException if minimumPartSizeInBytes or thresholdSizeInBytes are <= 0,
-     *     or if apiCallBufferSizeInBytes, maxInFlightParts, or ioThreads are < 0
+     *     or if any other parameter is < 0
      */
     public S3JavaAsyncConfig(
         long minimumPartSizeInBytes,
         long thresholdSizeInBytes,
         long apiCallBufferSizeInBytes,
         int maxInFlightParts,
-        int ioThreads) {
+        int ioThreads,
+        int maxConnections,
+        int connectionTimeoutMs,
+        int connectionAcquisitionTimeoutMs,
+        int maxPendingConnectionAcquires) {
       if (minimumPartSizeInBytes <= 0) {
         throw new IllegalArgumentException("minimumPartSizeInBytes must be > 0");
       }
@@ -274,11 +307,27 @@ public class S3Util {
       if (ioThreads < 0) {
         throw new IllegalArgumentException("ioThreads must be >= 0");
       }
+      if (maxConnections < 0) {
+        throw new IllegalArgumentException("maxConnections must be >= 0");
+      }
+      if (connectionTimeoutMs < 0) {
+        throw new IllegalArgumentException("connectionTimeoutMs must be >= 0");
+      }
+      if (connectionAcquisitionTimeoutMs < 0) {
+        throw new IllegalArgumentException("connectionAcquisitionTimeoutMs must be >= 0");
+      }
+      if (maxPendingConnectionAcquires < 0) {
+        throw new IllegalArgumentException("maxPendingConnectionAcquires must be >= 0");
+      }
       this.minimumPartSizeInBytes = minimumPartSizeInBytes;
       this.thresholdSizeInBytes = thresholdSizeInBytes;
       this.apiCallBufferSizeInBytes = apiCallBufferSizeInBytes;
       this.maxInFlightParts = maxInFlightParts;
       this.ioThreads = ioThreads;
+      this.maxConnections = maxConnections;
+      this.connectionTimeoutMs = connectionTimeoutMs;
+      this.connectionAcquisitionTimeoutMs = connectionAcquisitionTimeoutMs;
+      this.maxPendingConnectionAcquires = maxPendingConnectionAcquires;
     }
 
     /**
@@ -324,6 +373,43 @@ public class S3Util {
      */
     public int getIoThreads() {
       return ioThreads;
+    }
+
+    /**
+     * Get the max connections in the Netty connection pool (0 means SDK default of 50).
+     *
+     * @return max connections
+     */
+    public int getMaxConnections() {
+      return maxConnections;
+    }
+
+    /**
+     * Get the TCP connection timeout in milliseconds (0 means SDK default of 2000).
+     *
+     * @return connection timeout in milliseconds
+     */
+    public int getConnectionTimeoutMs() {
+      return connectionTimeoutMs;
+    }
+
+    /**
+     * Get the timeout to acquire a connection from the pool in milliseconds (0 means SDK default of
+     * 10000).
+     *
+     * @return connection acquisition timeout in milliseconds
+     */
+    public int getConnectionAcquisitionTimeoutMs() {
+      return connectionAcquisitionTimeoutMs;
+    }
+
+    /**
+     * Get the max requests queued waiting for a connection (0 means SDK default of 10000).
+     *
+     * @return max pending connection acquires
+     */
+    public int getMaxPendingConnectionAcquires() {
+      return maxPendingConnectionAcquires;
     }
   }
 
@@ -430,12 +516,16 @@ public class S3Util {
       boolean globalBucketAccess) {
     S3JavaAsyncConfig javaConfig = S3JavaAsyncConfig.fromConfig(configuration);
     logger.info(
-        "S3 Java async client config: minimumPartSizeInBytes={}, thresholdSizeInBytes={}, apiCallBufferSizeInBytes={}, maxInFlightParts={}, ioThreads={}",
+        "S3 Java async client config: minimumPartSizeInBytes={}, thresholdSizeInBytes={}, apiCallBufferSizeInBytes={}, maxInFlightParts={}, ioThreads={}, maxConnections={}, connectionTimeoutMs={}, connectionAcquisitionTimeoutMs={}, maxPendingConnectionAcquires={}",
         javaConfig.getMinimumPartSizeInBytes(),
         javaConfig.getThresholdSizeInBytes(),
         javaConfig.getApiCallBufferSizeInBytes(),
         javaConfig.getMaxInFlightParts(),
-        javaConfig.getIoThreads());
+        javaConfig.getIoThreads(),
+        javaConfig.getMaxConnections(),
+        javaConfig.getConnectionTimeoutMs(),
+        javaConfig.getConnectionAcquisitionTimeoutMs(),
+        javaConfig.getMaxPendingConnectionAcquires());
 
     MultipartConfiguration.Builder multipartBuilder =
         MultipartConfiguration.builder()
@@ -457,11 +547,30 @@ public class S3Util {
             .region(s3Client.serviceClientConfiguration().region())
             .multipartEnabled(true)
             .multipartConfiguration(multipartBuilder.build());
-    if (javaConfig.getIoThreads() > 0) {
-      builder.httpClientBuilder(
-          NettyNioAsyncHttpClient.builder()
-              .eventLoopGroupBuilder(
-                  SdkEventLoopGroup.builder().numberOfThreads(javaConfig.getIoThreads())));
+    if (javaConfig.getIoThreads() > 0
+        || javaConfig.getMaxConnections() > 0
+        || javaConfig.getConnectionTimeoutMs() > 0
+        || javaConfig.getConnectionAcquisitionTimeoutMs() > 0
+        || javaConfig.getMaxPendingConnectionAcquires() > 0) {
+      NettyNioAsyncHttpClient.Builder nettyBuilder = NettyNioAsyncHttpClient.builder();
+      if (javaConfig.getIoThreads() > 0) {
+        nettyBuilder.eventLoopGroupBuilder(
+            SdkEventLoopGroup.builder().numberOfThreads(javaConfig.getIoThreads()));
+      }
+      if (javaConfig.getMaxConnections() > 0) {
+        nettyBuilder.maxConcurrency(javaConfig.getMaxConnections());
+      }
+      if (javaConfig.getConnectionTimeoutMs() > 0) {
+        nettyBuilder.connectionTimeout(Duration.ofMillis(javaConfig.getConnectionTimeoutMs()));
+      }
+      if (javaConfig.getConnectionAcquisitionTimeoutMs() > 0) {
+        nettyBuilder.connectionAcquisitionTimeout(
+            Duration.ofMillis(javaConfig.getConnectionAcquisitionTimeoutMs()));
+      }
+      if (javaConfig.getMaxPendingConnectionAcquires() > 0) {
+        nettyBuilder.maxPendingConnectionAcquires(javaConfig.getMaxPendingConnectionAcquires());
+      }
+      builder.httpClientBuilder(nettyBuilder);
     }
     if (overrideConfig != null) {
       builder.overrideConfiguration(overrideConfig);

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/RestoreCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/RestoreCommand.java
@@ -123,11 +123,23 @@ public class RestoreCommand implements Callable<Integer> {
   private String snapshotServiceName;
 
   @CommandLine.Option(
-      names = {"--copyThreads"},
+      names = {"--maxConcurrency"},
+      description = "Maximum connection to make to S3, (default: ${DEFAULT-VALUE})",
+      defaultValue = "100")
+  int maxConcurrency;
+
+  @CommandLine.Option(
+      names = {"--copyBatchSize"},
+      description = "Number of copy operations to submit per batch, (default: ${DEFAULT-VALUE})",
+      defaultValue = "20")
+  int copyBatchSize;
+
+  @CommandLine.Option(
+      names = {"--connectionAcquisitionTimeoutMs"},
       description =
-          "Number of threads to use when copying index files, (default: ${DEFAULT-VALUE})",
-      defaultValue = "10")
-  int copyThreads;
+          "Connection acquisition timeout in milliseconds for async S3 client, (default: ${DEFAULT-VALUE})",
+      defaultValue = "60000")
+  long connectionAcquisitionTimeoutMs;
 
   @CommandLine.Option(
       names = {"--maxRetry"},
@@ -147,7 +159,13 @@ public class RestoreCommand implements Callable<Integer> {
     if (s3ClientBundle == null) {
       s3ClientBundle =
           StateCommandUtils.createS3ClientBundle(
-              bucketName, region, credsFile, credsProfile, maxRetry, copyThreads);
+              bucketName,
+              region,
+              credsFile,
+              credsProfile,
+              maxRetry,
+              maxConcurrency,
+              connectionAcquisitionTimeoutMs);
     }
     S3Backend s3Backend =
         new S3Backend(bucketName, false, S3Backend.DEFAULT_CONFIG, s3ClientBundle);
@@ -213,24 +231,28 @@ public class RestoreCommand implements Callable<Integer> {
     System.out.println("Restoring index data: " + backendIndexFiles);
 
     S3TransferManager transferManager = s3Backend.getTransferManager();
-    List<Copy> copyJobs = new ArrayList<>();
-    for (String fileName : backendIndexFiles) {
-      CopyObjectRequest copyObjectRequest =
-          CopyObjectRequest.builder()
-              .sourceBucket(bucketName)
-              .sourceKey(snapshotDataRoot + fileName)
-              .destinationBucket(bucketName)
-              .destinationKey(restoreDataPrefix + fileName)
-              .build();
-      final String finalFileName = fileName;
-      Copy copy =
-          transferManager.copy(CopyRequest.builder().copyObjectRequest(copyObjectRequest).build());
-      copyJobs.add(copy);
-      System.out.println("Started copy: " + finalFileName);
-    }
-    for (Copy copyJob : copyJobs) {
-      CompletedCopy completedCopy = copyJob.completionFuture().join();
-      System.out.println("Completed copy");
+    List<String> fileList = new ArrayList<>(backendIndexFiles);
+    for (int batchStart = 0; batchStart < fileList.size(); batchStart += copyBatchSize) {
+      int batchEnd = Math.min(batchStart + copyBatchSize, fileList.size());
+      List<Copy> copyJobs = new ArrayList<>();
+      for (String fileName : fileList.subList(batchStart, batchEnd)) {
+        CopyObjectRequest copyObjectRequest =
+            CopyObjectRequest.builder()
+                .sourceBucket(bucketName)
+                .sourceKey(snapshotDataRoot + fileName)
+                .destinationBucket(bucketName)
+                .destinationKey(restoreDataPrefix + fileName)
+                .build();
+        Copy copy =
+            transferManager.copy(
+                CopyRequest.builder().copyObjectRequest(copyObjectRequest).build());
+        copyJobs.add(copy);
+        System.out.println("Started copy: " + fileName);
+      }
+      for (Copy copyJob : copyJobs) {
+        CompletedCopy completedCopy = copyJob.completionFuture().join();
+        System.out.println("Completed copy");
+      }
     }
     s3Backend.setCurrentResource(restorePointStatePrefix, pointStateFileName);
   }

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/SnapshotCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/backup/SnapshotCommand.java
@@ -96,11 +96,23 @@ public class SnapshotCommand implements Callable<Integer> {
   private String snapshotRoot;
 
   @CommandLine.Option(
-      names = {"--copyThreads"},
+      names = {"--maxConcurrency"},
+      description = "Maximum connection to make to S3, (default: ${DEFAULT-VALUE})",
+      defaultValue = "100")
+  int maxConcurrency;
+
+  @CommandLine.Option(
+      names = {"--copyBatchSize"},
+      description = "Number of copy operations to submit per batch, (default: ${DEFAULT-VALUE})",
+      defaultValue = "20")
+  int copyBatchSize;
+
+  @CommandLine.Option(
+      names = {"--connectionAcquisitionTimeoutMs"},
       description =
-          "Number of threads to use when copying index files, (default: ${DEFAULT-VALUE})",
-      defaultValue = "10")
-  int copyThreads;
+          "Connection acquisition timeout in milliseconds for async S3 client, (default: ${DEFAULT-VALUE})",
+      defaultValue = "60000")
+  long connectionAcquisitionTimeoutMs;
 
   @CommandLine.Option(
       names = {"--maxRetry"},
@@ -120,7 +132,13 @@ public class SnapshotCommand implements Callable<Integer> {
     if (s3ClientBundle == null) {
       s3ClientBundle =
           StateCommandUtils.createS3ClientBundle(
-              bucketName, region, credsFile, credsProfile, maxRetry, copyThreads);
+              bucketName,
+              region,
+              credsFile,
+              credsProfile,
+              maxRetry,
+              maxConcurrency,
+              connectionAcquisitionTimeoutMs);
     }
     S3Backend s3Backend =
         new S3Backend(bucketName, false, S3Backend.DEFAULT_CONFIG, s3ClientBundle);
@@ -182,28 +200,32 @@ public class SnapshotCommand implements Callable<Integer> {
     long totalDataSizeBytes = 0;
 
     S3TransferManager transferManager = s3Backend.getTransferManager();
-    List<Copy> copyJobs = new ArrayList<>();
-    for (String fileName : indexDataFiles) {
-      String sourceKey = indexDataKeyPrefix + fileName;
-      HeadObjectRequest headRequest =
-          HeadObjectRequest.builder().bucket(bucketName).key(sourceKey).build();
-      totalDataSizeBytes += s3Backend.getS3().headObject(headRequest).contentLength();
-      CopyObjectRequest copyObjectRequest =
-          CopyObjectRequest.builder()
-              .sourceBucket(bucketName)
-              .sourceKey(sourceKey)
-              .destinationBucket(bucketName)
-              .destinationKey(snapshotIndexDataRoot + fileName)
-              .build();
-      final String finalFileName = fileName;
-      Copy copy =
-          transferManager.copy(CopyRequest.builder().copyObjectRequest(copyObjectRequest).build());
-      copyJobs.add(copy);
-      System.out.println("Started copy: " + finalFileName);
-    }
-    for (Copy copyJob : copyJobs) {
-      CompletedCopy completedCopy = copyJob.completionFuture().join();
-      System.out.println("Completed copy");
+    List<String> fileList = new ArrayList<>(indexDataFiles);
+    for (int batchStart = 0; batchStart < fileList.size(); batchStart += copyBatchSize) {
+      int batchEnd = Math.min(batchStart + copyBatchSize, fileList.size());
+      List<Copy> copyJobs = new ArrayList<>();
+      for (String fileName : fileList.subList(batchStart, batchEnd)) {
+        String sourceKey = indexDataKeyPrefix + fileName;
+        HeadObjectRequest headRequest =
+            HeadObjectRequest.builder().bucket(bucketName).key(sourceKey).build();
+        totalDataSizeBytes += s3Backend.getS3().headObject(headRequest).contentLength();
+        CopyObjectRequest copyObjectRequest =
+            CopyObjectRequest.builder()
+                .sourceBucket(bucketName)
+                .sourceKey(sourceKey)
+                .destinationBucket(bucketName)
+                .destinationKey(snapshotIndexDataRoot + fileName)
+                .build();
+        Copy copy =
+            transferManager.copy(
+                CopyRequest.builder().copyObjectRequest(copyObjectRequest).build());
+        copyJobs.add(copy);
+        System.out.println("Started copy: " + fileName);
+      }
+      for (Copy copyJob : copyJobs) {
+        CompletedCopy completedCopy = copyJob.completionFuture().join();
+        System.out.println("Completed copy");
+      }
     }
 
     PutObjectRequest putObjectRequest =

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/incremental/RestoreIncrementalCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/incremental/RestoreIncrementalCommand.java
@@ -113,11 +113,23 @@ public class RestoreIncrementalCommand implements Callable<Integer> {
   private String snapshotServiceName;
 
   @CommandLine.Option(
-      names = {"--copyThreads"},
+      names = {"--maxConcurrency"},
+      description = "Maximum connection to make to S3, (default: ${DEFAULT-VALUE})",
+      defaultValue = "100")
+  int maxConcurrency;
+
+  @CommandLine.Option(
+      names = {"--copyBatchSize"},
+      description = "Number of copy operations to submit per batch, (default: ${DEFAULT-VALUE})",
+      defaultValue = "20")
+  int copyBatchSize;
+
+  @CommandLine.Option(
+      names = {"--connectionAcquisitionTimeoutMs"},
       description =
-          "Number of threads to use when copying index files, (default: ${DEFAULT-VALUE})",
-      defaultValue = "10")
-  int copyThreads;
+          "Connection acquisition timeout in milliseconds for async S3 client, (default: ${DEFAULT-VALUE})",
+      defaultValue = "60000")
+  long connectionAcquisitionTimeoutMs;
 
   @CommandLine.Option(
       names = {"--maxRetry"},
@@ -213,12 +225,22 @@ public class RestoreIncrementalCommand implements Callable<Integer> {
         this.transferManager;
     boolean shouldCloseTransferManager = false;
     if (transferManagerToUse == null) {
+      software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient.Builder nettyBuilder =
+          software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient.builder();
+      if (maxConcurrency > 0) {
+        nettyBuilder.maxConcurrency(maxConcurrency);
+      }
+      if (connectionAcquisitionTimeoutMs > 0) {
+        nettyBuilder.connectionAcquisitionTimeout(
+            java.time.Duration.ofMillis(connectionAcquisitionTimeoutMs));
+      }
       software.amazon.awssdk.services.s3.S3AsyncClient s3AsyncClient =
-          software.amazon.awssdk.services.s3.S3AsyncClient.crtBuilder()
+          software.amazon.awssdk.services.s3.S3AsyncClient.builder()
               .credentialsProvider(
                   LegacyStateCommandUtils.createCredentialsProvider(credsFile, credsProfile))
               .region(s3Client.serviceClientConfiguration().region())
-              .maxConcurrency(copyThreads)
+              .multipartEnabled(true)
+              .httpClientBuilder(nettyBuilder)
               .build();
       transferManagerToUse =
           software.amazon.awssdk.transfer.s3.S3TransferManager.builder()
@@ -227,25 +249,28 @@ public class RestoreIncrementalCommand implements Callable<Integer> {
       shouldCloseTransferManager = true;
     }
     try {
-      List<Copy> copyJobs = new ArrayList<>();
-      for (String fileName : indexFiles) {
-        CopyObjectRequest copyObjectRequest =
-            CopyObjectRequest.builder()
-                .sourceBucket(bucketName)
-                .sourceKey(snapshotDataRoot + fileName)
-                .destinationBucket(bucketName)
-                .destinationKey(restoreDataKeyPrefix + fileName)
-                .build();
-        final String finalFileName = fileName;
-        Copy copy =
-            transferManagerToUse.copy(
-                CopyRequest.builder().copyObjectRequest(copyObjectRequest).build());
-        copyJobs.add(copy);
-        System.out.println("Started copy: " + finalFileName);
-      }
-      for (Copy copyJob : copyJobs) {
-        CompletedCopy completedCopy = copyJob.completionFuture().join();
-        System.out.println("Completed copy");
+      List<String> fileList = new ArrayList<>(indexFiles);
+      for (int batchStart = 0; batchStart < fileList.size(); batchStart += copyBatchSize) {
+        int batchEnd = Math.min(batchStart + copyBatchSize, fileList.size());
+        List<Copy> copyJobs = new ArrayList<>();
+        for (String fileName : fileList.subList(batchStart, batchEnd)) {
+          CopyObjectRequest copyObjectRequest =
+              CopyObjectRequest.builder()
+                  .sourceBucket(bucketName)
+                  .sourceKey(snapshotDataRoot + fileName)
+                  .destinationBucket(bucketName)
+                  .destinationKey(restoreDataKeyPrefix + fileName)
+                  .build();
+          Copy copy =
+              transferManagerToUse.copy(
+                  CopyRequest.builder().copyObjectRequest(copyObjectRequest).build());
+          copyJobs.add(copy);
+          System.out.println("Started copy: " + fileName);
+        }
+        for (Copy copyJob : copyJobs) {
+          CompletedCopy completedCopy = copyJob.completionFuture().join();
+          System.out.println("Completed copy");
+        }
       }
     } finally {
       if (shouldCloseTransferManager) {

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/incremental/SnapshotIncrementalCommand.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/legacy/incremental/SnapshotIncrementalCommand.java
@@ -92,11 +92,23 @@ public class SnapshotIncrementalCommand implements Callable<Integer> {
   private String snapshotRoot;
 
   @CommandLine.Option(
-      names = {"--copyThreads"},
+      names = {"--maxConcurrency"},
+      description = "Maximum connection to make to S3, (default: ${DEFAULT-VALUE})",
+      defaultValue = "100")
+  int maxConcurrency;
+
+  @CommandLine.Option(
+      names = {"--copyBatchSize"},
+      description = "Number of copy operations to submit per batch, (default: ${DEFAULT-VALUE})",
+      defaultValue = "20")
+  int copyBatchSize;
+
+  @CommandLine.Option(
+      names = {"--connectionAcquisitionTimeoutMs"},
       description =
-          "Number of threads to use when copying index files, (default: ${DEFAULT-VALUE})",
-      defaultValue = "10")
-  int copyThreads;
+          "Connection acquisition timeout in milliseconds for async S3 client, (default: ${DEFAULT-VALUE})",
+      defaultValue = "60000")
+  long connectionAcquisitionTimeoutMs;
 
   @CommandLine.Option(
       names = {"--maxRetry"},
@@ -195,41 +207,54 @@ public class SnapshotIncrementalCommand implements Callable<Integer> {
     S3TransferManager transferManagerToUse = this.transferManager;
     boolean shouldCloseTransferManager = false;
     if (transferManagerToUse == null) {
+      software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient.Builder nettyBuilder =
+          software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient.builder();
+      if (maxConcurrency > 0) {
+        nettyBuilder.maxConcurrency(maxConcurrency);
+      }
+      if (connectionAcquisitionTimeoutMs > 0) {
+        nettyBuilder.connectionAcquisitionTimeout(
+            java.time.Duration.ofMillis(connectionAcquisitionTimeoutMs));
+      }
       software.amazon.awssdk.services.s3.S3AsyncClient s3AsyncClient =
-          software.amazon.awssdk.services.s3.S3AsyncClient.crtBuilder()
+          software.amazon.awssdk.services.s3.S3AsyncClient.builder()
               .credentialsProvider(
                   LegacyStateCommandUtils.createCredentialsProvider(credsFile, credsProfile))
               .region(s3Client.serviceClientConfiguration().region())
-              .maxConcurrency(copyThreads)
+              .multipartEnabled(true)
+              .httpClientBuilder(nettyBuilder)
               .build();
       transferManagerToUse = S3TransferManager.builder().s3Client(s3AsyncClient).build();
       shouldCloseTransferManager = true;
     }
     try {
-      List<Copy> copyJobs = new ArrayList<>();
-      for (String fileName : indexDataFiles) {
-        String sourceKey = indexDataKeyPrefix + fileName;
-        HeadObjectRequest headRequest =
-            HeadObjectRequest.builder().bucket(bucketName).key(sourceKey).build();
-        HeadObjectResponse headResponse = versionManager.getS3().headObject(headRequest);
-        totalDataSizeBytes += headResponse.contentLength();
-        CopyObjectRequest copyObjectRequest =
-            CopyObjectRequest.builder()
-                .sourceBucket(bucketName)
-                .sourceKey(sourceKey)
-                .destinationBucket(bucketName)
-                .destinationKey(snapshotIndexDataRoot + fileName)
-                .build();
-        final String finalFileName = fileName;
-        Copy copy =
-            transferManagerToUse.copy(
-                CopyRequest.builder().copyObjectRequest(copyObjectRequest).build());
-        copyJobs.add(copy);
-        System.out.println("Started copy: " + finalFileName);
-      }
-      for (Copy copyJob : copyJobs) {
-        CompletedCopy completedCopy = copyJob.completionFuture().join();
-        System.out.println("Completed copy");
+      List<String> fileList = new ArrayList<>(indexDataFiles);
+      for (int batchStart = 0; batchStart < fileList.size(); batchStart += copyBatchSize) {
+        int batchEnd = Math.min(batchStart + copyBatchSize, fileList.size());
+        List<Copy> copyJobs = new ArrayList<>();
+        for (String fileName : fileList.subList(batchStart, batchEnd)) {
+          String sourceKey = indexDataKeyPrefix + fileName;
+          HeadObjectRequest headRequest =
+              HeadObjectRequest.builder().bucket(bucketName).key(sourceKey).build();
+          HeadObjectResponse headResponse = versionManager.getS3().headObject(headRequest);
+          totalDataSizeBytes += headResponse.contentLength();
+          CopyObjectRequest copyObjectRequest =
+              CopyObjectRequest.builder()
+                  .sourceBucket(bucketName)
+                  .sourceKey(sourceKey)
+                  .destinationBucket(bucketName)
+                  .destinationKey(snapshotIndexDataRoot + fileName)
+                  .build();
+          Copy copy =
+              transferManagerToUse.copy(
+                  CopyRequest.builder().copyObjectRequest(copyObjectRequest).build());
+          copyJobs.add(copy);
+          System.out.println("Started copy: " + fileName);
+        }
+        for (Copy copyJob : copyJobs) {
+          CompletedCopy completedCopy = copyJob.completionFuture().join();
+          System.out.println("Completed copy");
+        }
       }
     } finally {
       if (shouldCloseTransferManager) {

--- a/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/StateCommandUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/tools/nrt_utils/state/StateCommandUtils.java
@@ -29,15 +29,16 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Paths;
+import java.time.Duration;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
 import software.amazon.awssdk.services.s3.model.GetBucketLocationRequest;
 import software.amazon.awssdk.services.s3.model.GetBucketLocationResponse;
 
@@ -152,15 +153,49 @@ public class StateCommandUtils {
       String credsProfile,
       int maxRetry,
       int maxConcurrency) {
+    return createS3ClientBundle(
+        bucketName, region, credsFile, credsProfile, maxRetry, maxConcurrency, 0);
+  }
+
+  /**
+   * Get an S3 client bundle usable for remote state operations.
+   *
+   * @param bucketName s3 bucket
+   * @param region aws region, such as us-west-2, or null to detect
+   * @param credsFile file containing aws credentials, or null for default
+   * @param credsProfile profile to use from credentials file
+   * @param maxRetry maximum number of retry attempts
+   * @param maxConcurrency maximum number of concurrent async S3 requests, or 0 to use SDK default
+   * @param connectionAcquisitionTimeoutMs connection acquisition timeout in ms, or 0 to use SDK
+   *     default
+   * @return S3ClientBundle containing sync and async clients
+   */
+  public static S3Util.S3ClientBundle createS3ClientBundle(
+      String bucketName,
+      String region,
+      String credsFile,
+      String credsProfile,
+      int maxRetry,
+      int maxConcurrency,
+      long connectionAcquisitionTimeoutMs) {
     S3Client s3Client = createS3Client(bucketName, region, credsFile, credsProfile, maxRetry);
-    S3CrtAsyncClientBuilder crtBuilder =
-        S3AsyncClient.crtBuilder()
+    software.amazon.awssdk.services.s3.S3AsyncClientBuilder asyncBuilder =
+        S3AsyncClient.builder()
             .credentialsProvider(createCredentialsProvider(credsFile, credsProfile))
-            .region(s3Client.serviceClientConfiguration().region());
-    if (maxConcurrency > 0) {
-      crtBuilder.maxConcurrency(maxConcurrency);
+            .region(s3Client.serviceClientConfiguration().region())
+            .multipartEnabled(true);
+    if (maxConcurrency > 0 || connectionAcquisitionTimeoutMs > 0) {
+      NettyNioAsyncHttpClient.Builder nettyBuilder = NettyNioAsyncHttpClient.builder();
+      if (maxConcurrency > 0) {
+        nettyBuilder.maxConcurrency(maxConcurrency);
+      }
+      if (connectionAcquisitionTimeoutMs > 0) {
+        nettyBuilder.connectionAcquisitionTimeout(
+            Duration.ofMillis(connectionAcquisitionTimeoutMs));
+      }
+      asyncBuilder.httpClientBuilder(nettyBuilder);
     }
-    return new S3Util.S3ClientBundle(s3Client, crtBuilder.build());
+    return new S3Util.S3ClientBundle(s3Client, asyncBuilder.build());
   }
 
   /**

--- a/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3UtilTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3UtilTest.java
@@ -156,6 +156,10 @@ public class S3UtilTest {
     assertEquals(0L, javaConfig.getApiCallBufferSizeInBytes());
     assertEquals(0, javaConfig.getMaxInFlightParts());
     assertEquals(0, javaConfig.getIoThreads());
+    assertEquals(0, javaConfig.getMaxConnections());
+    assertEquals(0, javaConfig.getConnectionTimeoutMs());
+    assertEquals(0, javaConfig.getConnectionAcquisitionTimeoutMs());
+    assertEquals(0, javaConfig.getMaxPendingConnectionAcquires());
   }
 
   @Test
@@ -169,7 +173,11 @@ public class S3UtilTest {
             + "      thresholdSize: 32mb\n"
             + "      apiCallBufferSize: 64mb\n"
             + "      maxInFlightParts: 8\n"
-            + "      ioThreads: 16\n";
+            + "      ioThreads: 16\n"
+            + "      maxConnections: 100\n"
+            + "      connectionTimeoutMs: 5000\n"
+            + "      connectionAcquisitionTimeoutMs: 30000\n"
+            + "      maxPendingConnectionAcquires: 20000\n";
     NrtsearchConfig config = new NrtsearchConfig(new ByteArrayInputStream(configStr.getBytes()));
     S3JavaAsyncConfig javaConfig = S3JavaAsyncConfig.fromConfig(config);
 
@@ -178,26 +186,47 @@ public class S3UtilTest {
     assertEquals(64 * 1024 * 1024L, javaConfig.getApiCallBufferSizeInBytes());
     assertEquals(8, javaConfig.getMaxInFlightParts());
     assertEquals(16, javaConfig.getIoThreads());
+    assertEquals(100, javaConfig.getMaxConnections());
+    assertEquals(5000, javaConfig.getConnectionTimeoutMs());
+    assertEquals(30000, javaConfig.getConnectionAcquisitionTimeoutMs());
+    assertEquals(20000, javaConfig.getMaxPendingConnectionAcquires());
   }
 
   @Test
   public void testS3JavaAsyncConfig_invalidMinimumPartSize() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> new S3JavaAsyncConfig(0L, 8 * 1024 * 1024L, 0L, 0, 0));
+        () -> new S3JavaAsyncConfig(0L, 8 * 1024 * 1024L, 0L, 0, 0, 0, 0, 0, 0));
     assertThrows(
         IllegalArgumentException.class,
-        () -> new S3JavaAsyncConfig(-1L, 8 * 1024 * 1024L, 0L, 0, 0));
+        () -> new S3JavaAsyncConfig(-1L, 8 * 1024 * 1024L, 0L, 0, 0, 0, 0, 0, 0));
   }
 
   @Test
   public void testS3JavaAsyncConfig_invalidThresholdSize() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> new S3JavaAsyncConfig(8 * 1024 * 1024L, 0L, 0L, 0, 0));
+        () -> new S3JavaAsyncConfig(8 * 1024 * 1024L, 0L, 0L, 0, 0, 0, 0, 0, 0));
     assertThrows(
         IllegalArgumentException.class,
-        () -> new S3JavaAsyncConfig(8 * 1024 * 1024L, -1L, 0L, 0, 0));
+        () -> new S3JavaAsyncConfig(8 * 1024 * 1024L, -1L, 0L, 0, 0, 0, 0, 0, 0));
+  }
+
+  @Test
+  public void testS3JavaAsyncConfig_invalidNettySettings() {
+    long minPart = 8 * 1024 * 1024L;
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new S3JavaAsyncConfig(minPart, minPart, 0L, 0, 0, -1, 0, 0, 0));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new S3JavaAsyncConfig(minPart, minPart, 0L, 0, 0, 0, -1, 0, 0));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new S3JavaAsyncConfig(minPart, minPart, 0L, 0, 0, 0, 0, -1, 0));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new S3JavaAsyncConfig(minPart, minPart, 0L, 0, 0, 0, 0, 0, -1));
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3UtilTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3UtilTest.java
@@ -156,9 +156,9 @@ public class S3UtilTest {
     assertEquals(0L, javaConfig.getApiCallBufferSizeInBytes());
     assertEquals(0, javaConfig.getMaxInFlightParts());
     assertEquals(0, javaConfig.getIoThreads());
-    assertEquals(0, javaConfig.getMaxConnections());
+    assertEquals(100, javaConfig.getMaxConnections());
     assertEquals(0, javaConfig.getConnectionTimeoutMs());
-    assertEquals(0, javaConfig.getConnectionAcquisitionTimeoutMs());
+    assertEquals(60_000, javaConfig.getConnectionAcquisitionTimeoutMs());
     assertEquals(0, javaConfig.getMaxPendingConnectionAcquires());
   }
 
@@ -251,7 +251,7 @@ public class S3UtilTest {
     com.yelp.nrtsearch.server.config.YamlConfigReader configReader =
         mock(com.yelp.nrtsearch.server.config.YamlConfigReader.class);
     when(config.getConfigReader()).thenReturn(configReader);
-    when(configReader.getString("remoteConfig.s3.asyncClientType", "crt"))
+    when(configReader.getString("remoteConfig.s3.asyncClientType", "java"))
         .thenReturn("unknown_type");
 
     // The final sync S3Client built from builderA.build()


### PR DESCRIPTION
Summary

  This PR improves the S3 client configuration and download/copy reliability for both the server and nrt_utils CLI commands. It also make the `java` s3 async client the default client type (from `crt`)

  Netty HTTP client tuning for Java async S3 client (S3Util)

  - Added four new config options under remoteConfig.s3.java.*:
    - maxConnections (default: 100) — controls the Netty connection pool size; previously hardcoded to the SDK default of 50, which caused
  TimeoutException: Acquire operation took longer than 10000 milliseconds during bootstrap when many concurrent multipart downloads were in flight
    - connectionAcquisitionTimeoutMs (default: 60,000ms) — how long to wait for a connection from the pool before failing
    - connectionTimeoutMs (default: SDK default) — TCP connection establishment timeout
    - maxPendingConnectionAcquires (default: SDK default) — max requests queued waiting for a connection
  - Changed asyncClientType default from crt to java

  S3 progress listener fixes (S3ProgressListenerImpl)

  - Fixed incorrect progress percentages (previously showed values like 520,000%) caused by treating progressSnapshot().transferredBytes() as a delta when
  it is actually cumulative per file; now tracks per-file last-seen bytes in a ConcurrentHashMap to compute true deltas
  - Fixed log spam caused by a broken byte-threshold throttle that was also inflated by the same bug; replaced with a CAS-based time throttle (logs at most
   once per 30 seconds)
  - Added percentage complete to the log line when total expected bytes are known

  Global progress tracking (S3Backend)

  - downloadIndexFiles() and uploadIndexFiles() now share a single S3ProgressListenerImpl across all batches, so progress reflects the entire operation
  rather than resetting each batch

  Java async client for nrt_utils commands

  Replaced all remaining uses of S3AsyncClient.crtBuilder() in nrt_utils with the Java async client (S3AsyncClient.builder().multipartEnabled(true)):
  - StateCommandUtils.createS3ClientBundle()
  - backup/SnapshotCommand, backup/RestoreCommand
  - legacy/incremental/SnapshotIncrementalCommand, legacy/incremental/RestoreIncrementalCommand

  New CLI options for snapshot/restore commands

  Added to SnapshotCommand, RestoreCommand, SnapshotIncrementalCommand, and RestoreIncrementalCommand:
  - --maxConcurrency (default: 100) — Netty connection pool size for the async S3 client used during file copies (renamed from --copyThreads)
  - --copyBatchSize (default: 20) — number of S3 copy operations submitted concurrently before waiting for completion
  - --connectionAcquisitionTimeoutMs (default: 60,000ms) — connection acquisition timeout for the async S3 client

  Documentation

  Added remoteConfig.s3.*, remoteConfig.s3.java.*, and remoteConfig.s3.crt.* config tables to docs/server_configuration.rst.