### PR TITLE
Add blender framework for multi-retriever search

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
@@ -106,6 +106,7 @@ import com.yelp.nrtsearch.server.script.ScriptService;
 import com.yelp.nrtsearch.server.search.FetchTaskCreator;
 import com.yelp.nrtsearch.server.search.cache.NrtQueryCache;
 import com.yelp.nrtsearch.server.search.collectors.CollectorCreator;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.BlenderCreator;
 import com.yelp.nrtsearch.server.similarity.SimilarityCreator;
 import com.yelp.nrtsearch.server.state.GlobalState;
 import com.yelp.nrtsearch.tools.cli.VersionProvider;
@@ -466,6 +467,7 @@ public class NrtsearchServer {
     private void initExtendableComponents(NrtsearchConfig configuration, List<Plugin> plugins) {
       // this block should be in alphabetical order
       AnalyzerCreator.initialize(configuration, plugins);
+      BlenderCreator.initialize(configuration, plugins);
       CollectorCreator.initialize(configuration, plugins);
       CustomRequestProcessor.initialize(configuration, plugins);
       FetchTaskCreator.initialize(configuration, plugins);

--- a/src/main/java/com/yelp/nrtsearch/server/plugins/BlenderPlugin.java
+++ b/src/main/java/com/yelp/nrtsearch/server/plugins/BlenderPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Yelp Inc.
+ * Copyright 2026 Yelp Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/yelp/nrtsearch/server/plugins/BlenderPlugin.java
+++ b/src/main/java/com/yelp/nrtsearch/server/plugins/BlenderPlugin.java
@@ -16,6 +16,7 @@
 package com.yelp.nrtsearch.server.plugins;
 
 import com.yelp.nrtsearch.server.search.multiretriever.blender.BlenderOperation;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.BlenderProvider;
 import java.util.Collections;
 import java.util.Map;
 
@@ -25,14 +26,10 @@ import java.util.Map;
  * com.yelp.nrtsearch.server.grpc.PluginBlender} message as part of the {@link
  * com.yelp.nrtsearch.server.grpc.Blender} in a {@link
  * com.yelp.nrtsearch.server.grpc.MultiRetrieverRequest}.
- *
- * <p>Implementations should be stateless; any per-request parameters are available at execution
- * time via the {@link com.yelp.nrtsearch.server.grpc.Blender} proto passed to {@link
- * BlenderOperation#mergeHits}.
  */
 public interface BlenderPlugin {
-  /** Get map of blender name to {@link BlenderOperation} instance for registration. */
-  default Map<String, BlenderOperation> getBlenders() {
+  /** Get map of blender name to {@link BlenderProvider} for registration. */
+  default Map<String, BlenderProvider<? extends BlenderOperation>> getBlenders() {
     return Collections.emptyMap();
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/plugins/BlenderPlugin.java
+++ b/src/main/java/com/yelp/nrtsearch/server/plugins/BlenderPlugin.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.plugins;
+
+import com.yelp.nrtsearch.server.search.multiretriever.blender.BlenderOperation;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Plugin interface for providing custom {@link BlenderOperation}s. Provides info for registration
+ * of blenders by name. These blenders can be invoked by sending a {@link
+ * com.yelp.nrtsearch.server.grpc.PluginBlender} message as part of the {@link
+ * com.yelp.nrtsearch.server.grpc.Blender} in a {@link
+ * com.yelp.nrtsearch.server.grpc.MultiRetrieverRequest}.
+ *
+ * <p>Implementations should be stateless; any per-request parameters are available at execution
+ * time via the {@link com.yelp.nrtsearch.server.grpc.Blender} proto passed to {@link
+ * BlenderOperation#mergeHits}.
+ */
+public interface BlenderPlugin {
+  /** Get map of blender name to {@link BlenderOperation} instance for registration. */
+  default Map<String, BlenderOperation> getBlenders() {
+    return Collections.emptyMap();
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/search/SearchContext.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/SearchContext.java
@@ -23,6 +23,7 @@ import com.yelp.nrtsearch.server.index.IndexState;
 import com.yelp.nrtsearch.server.index.ShardState;
 import com.yelp.nrtsearch.server.rescore.RescoreTask;
 import com.yelp.nrtsearch.server.search.collectors.DocCollector;
+import com.yelp.nrtsearch.server.search.multiretriever.MultiRetrieverContext;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
@@ -52,6 +52,8 @@ import com.yelp.nrtsearch.server.search.collectors.HitCountCollector;
 import com.yelp.nrtsearch.server.search.collectors.MyTopSuggestDocsCollector;
 import com.yelp.nrtsearch.server.search.collectors.RelevanceCollector;
 import com.yelp.nrtsearch.server.search.collectors.SortFieldCollector;
+import com.yelp.nrtsearch.server.search.multiretriever.MultiRetrieverContext;
+import com.yelp.nrtsearch.server.search.multiretriever.RetrieverContext;
 import com.yelp.nrtsearch.server.utils.ScriptParamsUtils;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
@@ -54,6 +54,8 @@ import com.yelp.nrtsearch.server.search.collectors.RelevanceCollector;
 import com.yelp.nrtsearch.server.search.collectors.SortFieldCollector;
 import com.yelp.nrtsearch.server.search.multiretriever.MultiRetrieverContext;
 import com.yelp.nrtsearch.server.search.multiretriever.RetrieverContext;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.BlenderCreator;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.BlenderOperation;
 import com.yelp.nrtsearch.server.utils.ScriptParamsUtils;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -766,6 +768,10 @@ public class SearchRequestProcessor {
             retriever.getName(), retrieverProfileResult.build());
       }
     }
+    Blender blenderProto = searchRequest.getMultiRetriever().getBlender();
+    BlenderOperation blenderOperation =
+        BlenderCreator.getInstance().getBlenderOperation(blenderProto);
+    multiRetrieverContextBuilder.blenderOperation(blenderOperation).blender(blenderProto);
     searchContextBuilder.setMultiRetrieverContext(multiRetrieverContextBuilder.build());
     diagnostics.setMultiRetrieverDiagnostics(multiRetrieverDiagnostics);
     if (doProfile) {

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/MultiRetrieverContext.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/MultiRetrieverContext.java
@@ -15,15 +15,21 @@
  */
 package com.yelp.nrtsearch.server.search.multiretriever;
 
+import com.yelp.nrtsearch.server.grpc.Blender;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.BlenderOperation;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class MultiRetrieverContext {
   private final Map<String, RetrieverContext> retrieverContextMap;
+  private final BlenderOperation blenderOperation;
+  private final Blender blender;
 
   private MultiRetrieverContext(Builder builder) {
     this.retrieverContextMap = Collections.unmodifiableMap(builder.retrieverContextMap);
+    this.blenderOperation = builder.blenderOperation;
+    this.blender = builder.blender;
   }
 
   public static Builder newBuilder() {
@@ -33,6 +39,8 @@ public class MultiRetrieverContext {
   public static class Builder {
     private final LinkedHashMap<String, RetrieverContext> retrieverContextMap =
         new LinkedHashMap<>();
+    private BlenderOperation blenderOperation;
+    private Blender blender;
 
     private Builder() {}
 
@@ -42,6 +50,16 @@ public class MultiRetrieverContext {
             "Retriever key: " + retrieverContext.getName() + " is already present");
       }
       retrieverContextMap.put(retrieverContext.getName(), retrieverContext);
+      return this;
+    }
+
+    public Builder blenderOperation(BlenderOperation blenderOperation) {
+      this.blenderOperation = blenderOperation;
+      return this;
+    }
+
+    public Builder blender(Blender blender) {
+      this.blender = blender;
       return this;
     }
 
@@ -60,5 +78,13 @@ public class MultiRetrieverContext {
 
   public Map<String, RetrieverContext> getRetrieverContextMap() {
     return retrieverContextMap;
+  }
+
+  public BlenderOperation getBlenderOperation() {
+    return blenderOperation;
+  }
+
+  public Blender getBlender() {
+    return blender;
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/MultiRetrieverContext.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/MultiRetrieverContext.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.yelp.nrtsearch.server.search;
+package com.yelp.nrtsearch.server.search.multiretriever;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/RetrieverContext.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/RetrieverContext.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.yelp.nrtsearch.server.search;
+package com.yelp.nrtsearch.server.search.multiretriever;
 
 import com.yelp.nrtsearch.server.rescore.RescoreTask;
 import com.yelp.nrtsearch.server.search.collectors.DocCollector;

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Yelp Inc.
+ * Copyright 2026 Yelp Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderCreator.java
@@ -21,35 +21,32 @@ import com.yelp.nrtsearch.server.grpc.PluginBlender;
 import com.yelp.nrtsearch.server.plugins.BlenderPlugin;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.search.multiretriever.blender.operation.WeightedRrfBlenderOperation;
+import com.yelp.nrtsearch.server.utils.StructValueTransformer;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Class to handle the creation of {@link BlenderOperation} instances. Plugin blenders are
- * registered as stateless instances; any per-request parameters are accessed at execution time via
- * the {@link Blender} proto passed to {@link BlenderOperation#mergeHits}.
- */
+/** Class to handle the creation of {@link BlenderOperation} instances. */
 public class BlenderCreator {
 
   private static BlenderCreator instance;
 
-  private final Map<String, BlenderOperation> blendersMap = new HashMap<>();
+  private final Map<String, BlenderProvider<? extends BlenderOperation>> pluginsMap =
+      new HashMap<>();
 
-  public BlenderCreator(NrtsearchConfig configuration) {
-    blendersMap.put(Blender.BlenderTypeCase.WEIGHTEDRRF.name(), new WeightedRrfBlenderOperation());
-  }
+  public BlenderCreator(NrtsearchConfig configuration) {}
 
   /**
    * Get a {@link BlenderOperation} for the given {@link Blender} config. Dispatches on the {@code
-   * blender_type} oneof: built-in types are instantiated directly; plugin blenders are looked up by
-   * the name in the {@link PluginBlender} message.
+   * blender_type} oneof: built-in types are instantiated directly from the config; plugin blenders
+   * are instantiated via their registered {@link BlenderProvider} with the decoded {@link
+   * PluginBlender#getParams()}.
    *
    * @param blender grpc blender config
    * @return blender operation
    */
   public BlenderOperation getBlenderOperation(Blender blender) {
     return switch (blender.getBlenderTypeCase()) {
-      case WEIGHTEDRRF -> blendersMap.get(Blender.BlenderTypeCase.WEIGHTEDRRF.name());
+      case WEIGHTEDRRF -> new WeightedRrfBlenderOperation(blender.getWeightedRrf());
       case PLUGIN -> getPluginBlender(blender.getPlugin());
       default ->
           throw new IllegalArgumentException(
@@ -58,33 +55,33 @@ public class BlenderCreator {
   }
 
   /**
-   * Look up a registered plugin {@link BlenderOperation} by name. Per-request parameters are
-   * available to the operation at execution time via the {@link Blender} proto.
+   * Look up a registered plugin {@link BlenderProvider} by name and instantiate it with the decoded
+   * params from the {@link PluginBlender} message.
    *
-   * @param grpcPluginBlender grpc message carrying the plugin name
-   * @return registered blender instance
+   * @param grpcPluginBlender grpc message carrying the plugin name and params
+   * @return blender operation instance
    */
   public BlenderOperation getPluginBlender(PluginBlender grpcPluginBlender) {
-    BlenderOperation operation = blendersMap.get(grpcPluginBlender.getName());
-    if (operation == null) {
+    BlenderProvider<?> provider = pluginsMap.get(grpcPluginBlender.getName());
+    if (provider == null) {
       throw new IllegalArgumentException(
           "Invalid blender name: "
               + grpcPluginBlender.getName()
               + ", must be one of: "
-              + blendersMap.keySet());
+              + pluginsMap.keySet());
     }
-    return operation;
+    return provider.get(StructValueTransformer.transformStruct(grpcPluginBlender.getParams()));
   }
 
-  private void register(Map<String, BlenderOperation> blenders) {
+  private void register(Map<String, BlenderProvider<? extends BlenderOperation>> blenders) {
     blenders.forEach(this::register);
   }
 
-  private void register(String name, BlenderOperation blender) {
-    if (blendersMap.containsKey(name)) {
+  private void register(String name, BlenderProvider<? extends BlenderOperation> provider) {
+    if (pluginsMap.containsKey(name)) {
       throw new IllegalArgumentException("Blender " + name + " already exists");
     }
-    blendersMap.put(name, blender);
+    pluginsMap.put(name, provider);
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderCreator.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever.blender;
+
+import com.yelp.nrtsearch.server.config.NrtsearchConfig;
+import com.yelp.nrtsearch.server.grpc.Blender;
+import com.yelp.nrtsearch.server.grpc.PluginBlender;
+import com.yelp.nrtsearch.server.plugins.BlenderPlugin;
+import com.yelp.nrtsearch.server.plugins.Plugin;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.operation.WeightedRrfBlenderOperation;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Class to handle the creation of {@link BlenderOperation} instances. Plugin blenders are
+ * registered as stateless instances; any per-request parameters are accessed at execution time via
+ * the {@link Blender} proto passed to {@link BlenderOperation#mergeHits}.
+ */
+public class BlenderCreator {
+
+  private static BlenderCreator instance;
+
+  private final Map<String, BlenderOperation> blendersMap = new HashMap<>();
+
+  public BlenderCreator(NrtsearchConfig configuration) {
+    blendersMap.put(Blender.BlenderTypeCase.WEIGHTEDRRF.name(), new WeightedRrfBlenderOperation());
+  }
+
+  /**
+   * Get a {@link BlenderOperation} for the given {@link Blender} config. Dispatches on the {@code
+   * blender_type} oneof: built-in types are instantiated directly; plugin blenders are looked up by
+   * the name in the {@link PluginBlender} message.
+   *
+   * @param blender grpc blender config
+   * @return blender operation
+   */
+  public BlenderOperation getBlenderOperation(Blender blender) {
+    return switch (blender.getBlenderTypeCase()) {
+      case WEIGHTEDRRF -> blendersMap.get(Blender.BlenderTypeCase.WEIGHTEDRRF.name());
+      case PLUGIN -> getPluginBlender(blender.getPlugin());
+      default ->
+          throw new IllegalArgumentException(
+              "Unsupported blender type: " + blender.getBlenderTypeCase());
+    };
+  }
+
+  /**
+   * Look up a registered plugin {@link BlenderOperation} by name. Per-request parameters are
+   * available to the operation at execution time via the {@link Blender} proto.
+   *
+   * @param grpcPluginBlender grpc message carrying the plugin name
+   * @return registered blender instance
+   */
+  public BlenderOperation getPluginBlender(PluginBlender grpcPluginBlender) {
+    BlenderOperation operation = blendersMap.get(grpcPluginBlender.getName());
+    if (operation == null) {
+      throw new IllegalArgumentException(
+          "Invalid blender name: "
+              + grpcPluginBlender.getName()
+              + ", must be one of: "
+              + blendersMap.keySet());
+    }
+    return operation;
+  }
+
+  private void register(Map<String, BlenderOperation> blenders) {
+    blenders.forEach(this::register);
+  }
+
+  private void register(String name, BlenderOperation blender) {
+    if (blendersMap.containsKey(name)) {
+      throw new IllegalArgumentException("Blender " + name + " already exists");
+    }
+    blendersMap.put(name, blender);
+  }
+
+  /**
+   * Initialize singleton instance of {@link BlenderCreator}. Registers any additional {@link
+   * BlenderOperation} implementations provided by {@link BlenderPlugin}s.
+   *
+   * @param configuration service configuration
+   * @param plugins list of loaded plugins
+   */
+  public static void initialize(NrtsearchConfig configuration, Iterable<Plugin> plugins) {
+    instance = new BlenderCreator(configuration);
+    for (Plugin plugin : plugins) {
+      if (plugin instanceof BlenderPlugin blenderPlugin) {
+        instance.register(blenderPlugin.getBlenders());
+      }
+    }
+  }
+
+  /** Get singleton instance. */
+  public static BlenderCreator getInstance() {
+    return instance;
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderOperation.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderOperation.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever.blender;
+
+import com.yelp.nrtsearch.server.plugins.BlenderPlugin;
+import com.yelp.nrtsearch.server.search.multiretriever.RetrieverContext;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.score.BlendedScoreDoc;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+
+/**
+ * Interface for blending results from multiple retrievers into a single ranked {@link TopDocs}.
+ * Implementations are registered by name via {@link BlenderPlugin} and instantiated through {@link
+ * BlenderCreator}.
+ *
+ * <p>The entry point is {@link #blend}, which accepts already-submitted per-retriever {@link
+ * Future}s (keyed by name), collects their results, then merges, sorts, and paginates. Callers are
+ * responsible for submitting retriever searches to an executor before calling {@code blend}; the
+ * futures run concurrently and this method blocks until all complete.
+ *
+ * <p>Implementations define the merge logic in {@link #mergeHits}, which operates on the raw
+ * per-retriever hits before sorting and pagination are applied by the framework.
+ */
+public interface BlenderOperation {
+
+  /**
+   * Merge per-retriever hits into an unsorted, unpaginated flat list. Implementations deduplicate
+   * hits that appear in multiple retrievers and assign each a combined score (e.g. via RRF or a
+   * score-mode fold). The returned collection will be sorted by {@link BlendedScoreDoc#score} and
+   * paginated by the caller.
+   *
+   * @param retrieverResults per-retriever {@link TopDocs} in declaration order, keyed by name
+   * @param blender blender proto config
+   * @param retrieverContexts per-retriever contexts in declaration order, keyed by name
+   * @return merged hits, unsorted and unpaginated
+   */
+  Collection<BlendedScoreDoc> mergeHits(
+      LinkedHashMap<String, TopDocs> retrieverResults,
+      com.yelp.nrtsearch.server.grpc.Blender blender,
+      LinkedHashMap<String, RetrieverContext> retrieverContexts);
+
+  /**
+   * Collects results from already-submitted retriever futures, then merges, sorts, and paginates.
+   * Blocks until all futures complete. Callers must submit retriever searches to an executor before
+   * calling this method so that the futures run concurrently.
+   *
+   * @param retrieverFutures per-retriever futures in declaration order, keyed by retriever name
+   * @param blender blender proto config
+   * @param retrieverContexts per-retriever contexts in declaration order, keyed by retriever name
+   * @param startHit 0-based offset of the first blended hit to include in the result
+   * @param topHits maximum number of blended hits to return; {@code 0} returns empty; negative
+   *     values mean no limit
+   * @return blended, sorted, paginated {@link TopDocs}
+   * @throws RuntimeException wrapping any retriever {@link ExecutionException}, identified by name
+   * @throws InterruptedException if the calling thread is interrupted while waiting
+   */
+  default TopDocs blend(
+      LinkedHashMap<String, Future<TopDocs>> retrieverFutures,
+      com.yelp.nrtsearch.server.grpc.Blender blender,
+      LinkedHashMap<String, RetrieverContext> retrieverContexts,
+      int startHit,
+      int topHits)
+      throws InterruptedException {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    for (Map.Entry<String, Future<TopDocs>> entry : retrieverFutures.entrySet()) {
+      String name = entry.getKey();
+      try {
+        results.put(name, entry.getValue().get());
+      } catch (ExecutionException e) {
+        Throwable cause = e.getCause() != null ? e.getCause() : e;
+        throw new RuntimeException("Retriever '" + name + "' failed: " + cause.getMessage(), cause);
+      }
+    }
+    Collection<BlendedScoreDoc> merged = mergeHits(results, blender, retrieverContexts);
+    return sortAndPaginate(merged, startHit, topHits);
+  }
+
+  /**
+   * Select and return the requested pagination window from merged hits without sorting the full
+   * list. Uses a min-heap of size {@code k = startHit + topHits} to find the top-k hits in O(n log
+   * k) time and O(k) space. The heap entries are then sorted in O(k log k) to produce the final
+   * page order. When {@code topHits < 0} (no limit), {@code k = n} and the complexity degrades
+   * gracefully to O(n log n).
+   *
+   * @param merged unsorted merged hits from {@link #mergeHits}
+   * @param startHit 0-based offset of the first hit to include in the returned page
+   * @param topHits maximum number of hits to return; {@code 0} returns empty; negative values mean
+   *     no limit
+   * @return paginated {@link TopDocs}
+   */
+  static TopDocs sortAndPaginate(Collection<BlendedScoreDoc> merged, int startHit, int topHits) {
+    int total = merged.size();
+    if (topHits == 0) {
+      return new TopDocs(
+          new TotalHits(total, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO), new ScoreDoc[0]);
+    }
+    // Heap capacity is bounded by topHits to avoid materializing docs outside the window.
+    // `total` is preserved as the true deduplicated hit count for TotalHits reporting.
+    int capacity = (topHits > 0 && topHits < total) ? topHits : total;
+
+    // Min-heap of size capacity ordered by score ascending: the root is always the
+    // smallest score in the heap, so any incoming doc that beats the root displaces it.
+    PriorityQueue<BlendedScoreDoc> heap =
+        new PriorityQueue<>(capacity + 1, (a, b) -> Float.compare(a.score, b.score));
+
+    for (BlendedScoreDoc doc : merged) {
+      if (heap.size() < capacity) {
+        heap.offer(doc);
+      } else if (doc.score > heap.peek().score) {
+        heap.poll();
+        heap.offer(doc);
+      }
+    }
+
+    // Drain via poll() — each call removes the current minimum — filling the array from the end
+    // so the result is in descending score order without a separate sort pass.
+    int heapSize = heap.size();
+    BlendedScoreDoc[] topK = new BlendedScoreDoc[heapSize];
+    for (int i = heapSize - 1; i >= 0; i--) {
+      topK[i] = heap.poll();
+    }
+
+    // Slice out the requested page window.
+    int from = Math.min(startHit, heapSize);
+    ScoreDoc[] page = Arrays.copyOfRange(topK, from, heapSize, ScoreDoc[].class);
+
+    return new TopDocs(new TotalHits(total, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO), page);
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderOperation.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Yelp Inc.
+ * Copyright 2026 Yelp Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,13 +111,13 @@ public interface BlenderOperation {
    */
   static TopDocs sortAndPaginate(Collection<BlendedScoreDoc> merged, int startHit, int topHits) {
     int total = merged.size();
-    if (topHits == 0) {
+    if (startHit > topHits || topHits <= 0) {
       return new TopDocs(
           new TotalHits(total, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO), new ScoreDoc[0]);
     }
     // Heap capacity is bounded by topHits to avoid materializing docs outside the window.
     // `total` is preserved as the true deduplicated hit count for TotalHits reporting.
-    int capacity = (topHits > 0 && topHits < total) ? topHits : total;
+    int capacity = Math.min(topHits, total);
 
     // Min-heap of size capacity ordered by score ascending: the root is always the
     // smallest score in the heap, so any incoming doc that beats the root displaces it.

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderOperation.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderOperation.java
@@ -51,13 +51,11 @@ public interface BlenderOperation {
    * paginated by the caller.
    *
    * @param retrieverResults per-retriever {@link TopDocs} in declaration order, keyed by name
-   * @param blender blender proto config
    * @param retrieverContexts per-retriever contexts in declaration order, keyed by name
    * @return merged hits, unsorted and unpaginated
    */
   Collection<BlendedScoreDoc> mergeHits(
       LinkedHashMap<String, TopDocs> retrieverResults,
-      com.yelp.nrtsearch.server.grpc.Blender blender,
       LinkedHashMap<String, RetrieverContext> retrieverContexts);
 
   /**
@@ -66,7 +64,6 @@ public interface BlenderOperation {
    * calling this method so that the futures run concurrently.
    *
    * @param retrieverFutures per-retriever futures in declaration order, keyed by retriever name
-   * @param blender blender proto config
    * @param retrieverContexts per-retriever contexts in declaration order, keyed by retriever name
    * @param startHit 0-based offset of the first blended hit to include in the result
    * @param topHits maximum number of blended hits to return; {@code 0} returns empty; negative
@@ -77,11 +74,14 @@ public interface BlenderOperation {
    */
   default TopDocs blend(
       LinkedHashMap<String, Future<TopDocs>> retrieverFutures,
-      com.yelp.nrtsearch.server.grpc.Blender blender,
       LinkedHashMap<String, RetrieverContext> retrieverContexts,
       int startHit,
       int topHits)
       throws InterruptedException {
+    if (topHits == 0 || startHit > topHits) {
+      return new TopDocs(
+          new TotalHits(0, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO), new ScoreDoc[0]);
+    }
     LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
     for (Map.Entry<String, Future<TopDocs>> entry : retrieverFutures.entrySet()) {
       String name = entry.getKey();
@@ -92,7 +92,7 @@ public interface BlenderOperation {
         throw new RuntimeException("Retriever '" + name + "' failed: " + cause.getMessage(), cause);
       }
     }
-    Collection<BlendedScoreDoc> merged = mergeHits(results, blender, retrieverContexts);
+    Collection<BlendedScoreDoc> merged = mergeHits(results, retrieverContexts);
     return sortAndPaginate(merged, startHit, topHits);
   }
 
@@ -111,10 +111,6 @@ public interface BlenderOperation {
    */
   static TopDocs sortAndPaginate(Collection<BlendedScoreDoc> merged, int startHit, int topHits) {
     int total = merged.size();
-    if (startHit > topHits || topHits <= 0) {
-      return new TopDocs(
-          new TotalHits(total, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO), new ScoreDoc[0]);
-    }
     // Heap capacity is bounded by topHits to avoid materializing docs outside the window.
     // `total` is preserved as the true deduplicated hit count for TotalHits reporting.
     int capacity = Math.min(topHits, total);

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderProvider.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever.blender;
+
+import java.util.Map;
+
+/**
+ * Interface for getting a {@link BlenderOperation} implementation initialized with the given
+ * parameters map.
+ *
+ * @param <T> blender operation type
+ */
+@FunctionalInterface
+public interface BlenderProvider<T extends BlenderOperation> {
+
+  /**
+   * Get a {@link BlenderOperation} implementation initialized with the given parameters.
+   *
+   * @param params blender parameters decoded from {@link
+   *     com.yelp.nrtsearch.server.grpc.PluginBlender}
+   * @return {@link BlenderOperation} instance
+   */
+  T get(Map<String, Object> params);
+}

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/WeightedRrfBlenderOperation.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/WeightedRrfBlenderOperation.java
@@ -66,9 +66,10 @@ public class WeightedRrfBlenderOperation implements BlenderOperation {
 
         BlendedScoreDoc existing = merged.get(scoreDoc.doc);
         if (existing == null) {
-          merged.put(scoreDoc.doc, new WeightedRRFScoreDoc(scoreDoc, rank, boost, k));
+          merged.put(
+              scoreDoc.doc, new WeightedRRFScoreDoc(entry.getKey(), scoreDoc, rank, boost, k));
         } else {
-          existing.add(rank, boost, scoreDoc);
+          existing.add(entry.getKey(), rank, boost, scoreDoc);
         }
       }
     }

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/WeightedRrfBlenderOperation.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/WeightedRrfBlenderOperation.java
@@ -15,7 +15,6 @@
  */
 package com.yelp.nrtsearch.server.search.multiretriever.blender.operation;
 
-import com.yelp.nrtsearch.server.grpc.Blender;
 import com.yelp.nrtsearch.server.grpc.WeightedRrfBlender;
 import com.yelp.nrtsearch.server.search.multiretriever.RetrieverContext;
 import com.yelp.nrtsearch.server.search.multiretriever.blender.BlenderOperation;
@@ -35,24 +34,25 @@ import org.apache.lucene.search.TopDocs;
  *
  * <ul>
  *   <li>{@code rank} is the 1-based position in that retriever's result list,
- *   <li>{@code k} is the smoothing constant from {@link WeightedRrfBlender#getRankConstant()}
- *       (defaults to {@link WeightedRRFScoreDoc#DEFAULT_K} when 0),
+ *   <li>{@code k} is the smoothing constant extracted from {@link
+ *       WeightedRrfBlender#getRankConstant()} at construction time (defaults to {@link
+ *       WeightedRRFScoreDoc#DEFAULT_K} when 0),
  *   <li>{@code boost} is taken from {@link RetrieverContext#getBoost()}.
  * </ul>
  */
 public class WeightedRrfBlenderOperation implements BlenderOperation {
 
+  private final int k;
+
+  public WeightedRrfBlenderOperation(WeightedRrfBlender config) {
+    this.k =
+        config.getRankConstant() > 0 ? config.getRankConstant() : WeightedRRFScoreDoc.DEFAULT_K;
+  }
+
   @Override
   public Collection<BlendedScoreDoc> mergeHits(
       LinkedHashMap<String, TopDocs> retrieverResults,
-      Blender blender,
       LinkedHashMap<String, RetrieverContext> retrieverContexts) {
-
-    WeightedRrfBlender rrfConfig = blender.getWeightedRrf();
-    int k =
-        rrfConfig.getRankConstant() > 0
-            ? rrfConfig.getRankConstant()
-            : WeightedRRFScoreDoc.DEFAULT_K;
 
     Map<Integer, BlendedScoreDoc> merged = new HashMap<>();
 

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/WeightedRrfBlenderOperation.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/WeightedRrfBlenderOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Yelp Inc.
+ * Copyright 2026 Yelp Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/WeightedRrfBlenderOperation.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/WeightedRrfBlenderOperation.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever.blender.operation;
+
+import com.yelp.nrtsearch.server.grpc.Blender;
+import com.yelp.nrtsearch.server.grpc.WeightedRrfBlender;
+import com.yelp.nrtsearch.server.search.multiretriever.RetrieverContext;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.BlenderOperation;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.score.BlendedScoreDoc;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.score.WeightedRRFScoreDoc;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+
+/**
+ * {@link BlenderOperation} implementing Reciprocal Rank Fusion (RRF).
+ *
+ * <p>Each retriever contributes {@code boost / (k + rank)} to the fused score, where:
+ *
+ * <ul>
+ *   <li>{@code rank} is the 1-based position in that retriever's result list,
+ *   <li>{@code k} is the smoothing constant from {@link WeightedRrfBlender#getRankConstant()}
+ *       (defaults to {@link WeightedRRFScoreDoc#DEFAULT_K} when 0),
+ *   <li>{@code boost} is taken from {@link RetrieverContext#getBoost()}.
+ * </ul>
+ */
+public class WeightedRrfBlenderOperation implements BlenderOperation {
+
+  @Override
+  public Collection<BlendedScoreDoc> mergeHits(
+      LinkedHashMap<String, TopDocs> retrieverResults,
+      Blender blender,
+      LinkedHashMap<String, RetrieverContext> retrieverContexts) {
+
+    WeightedRrfBlender rrfConfig = blender.getWeightedRrf();
+    int k =
+        rrfConfig.getRankConstant() > 0
+            ? rrfConfig.getRankConstant()
+            : WeightedRRFScoreDoc.DEFAULT_K;
+
+    Map<Integer, BlendedScoreDoc> merged = new HashMap<>();
+
+    for (Map.Entry<String, TopDocs> entry : retrieverResults.entrySet()) {
+      ScoreDoc[] scoreDocs = entry.getValue().scoreDocs;
+      float boost = retrieverContexts.get(entry.getKey()).getBoost();
+
+      for (int i = 0; i < scoreDocs.length; i++) {
+        ScoreDoc scoreDoc = scoreDocs[i];
+        int rank = i + 1; // 1-based
+
+        BlendedScoreDoc existing = merged.get(scoreDoc.doc);
+        if (existing == null) {
+          merged.put(scoreDoc.doc, new WeightedRRFScoreDoc(scoreDoc, rank, boost, k));
+        } else {
+          existing.add(rank, boost, scoreDoc);
+        }
+      }
+    }
+
+    return merged.values();
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/BlendedScoreDoc.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/BlendedScoreDoc.java
@@ -15,8 +15,8 @@
  */
 package com.yelp.nrtsearch.server.search.multiretriever.blender.score;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.apache.lucene.search.ScoreDoc;
 
 /**
@@ -25,39 +25,47 @@ import org.apache.lucene.search.ScoreDoc;
  * score and must be kept up to date by each {@link #add} implementation. It drives result ordering
  * directly — no separate sorting-score indirection.
  *
- * <p>The original per-retriever hits are preserved in {@link #scoreDocs} in insertion order for
- * diagnostics and downstream inspection.
+ * <p>The original per-retriever hits are preserved in {@link #scoreDocs}, keyed by retriever name
+ * in insertion order, for diagnostics and downstream inspection.
  *
- * <p>Subclasses define their own merging semantics by implementing {@link #add(int, float,
+ * <p>Subclasses define their own merging semantics by implementing {@link #add(String, int, float,
  * ScoreDoc)}, which is called for every retriever hit after the first. The first hit is supplied at
  * construction time.
  */
 public abstract class BlendedScoreDoc extends ScoreDoc {
 
   /**
-   * Per-retriever hits merged into this entry, in insertion order. The first element is always the
-   * hit supplied at construction time.
+   * Per-retriever hits merged into this entry, keyed by retriever name in insertion order. The
+   * first entry is always the hit supplied at construction time.
    */
-  public final List<ScoreDoc> scoreDocs;
+  protected final LinkedHashMap<String, ScoreDoc> scoreDocs;
 
   /**
+   * @param firstRetrieverName name of the first retriever contributing a hit
    * @param baseDoc the first retriever hit; its {@code doc} and {@code shardIndex} are inherited,
    *     and it is prepopulated into {@link #scoreDocs}
    * @param blendedScore initial blended score derived from {@code baseDoc} by the subclass
    */
-  protected BlendedScoreDoc(ScoreDoc baseDoc, float blendedScore) {
+  protected BlendedScoreDoc(String firstRetrieverName, ScoreDoc baseDoc, float blendedScore) {
     super(baseDoc.doc, blendedScore, baseDoc.shardIndex);
-    this.scoreDocs = new ArrayList<>();
-    this.scoreDocs.add(baseDoc);
+    this.scoreDocs = new LinkedHashMap<>();
+    this.scoreDocs.put(firstRetrieverName, baseDoc);
+  }
+
+  /** Returns the per-retriever hits merged into this entry, keyed by retriever name. */
+  public Map<String, ScoreDoc> getScoreDocs() {
+    return scoreDocs;
   }
 
   /**
    * Merge a new retriever hit into this entry. Implementations must update {@link #score} to
-   * reflect the new blended value and append {@code scoreDoc} to {@link #scoreDocs}.
+   * reflect the new blended value and insert {@code scoreDoc} into {@link #scoreDocs} under {@code
+   * retrieverName}.
    *
+   * @param retrieverName name of the retriever contributing this hit
    * @param rank 1-based rank of the document in the new retriever's result list
    * @param weight per-retriever weight (e.g. boost)
    * @param scoreDoc raw hit from the new retriever
    */
-  public abstract void add(int rank, float weight, ScoreDoc scoreDoc);
+  public abstract void add(String retrieverName, int rank, float weight, ScoreDoc scoreDoc);
 }

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/BlendedScoreDoc.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/BlendedScoreDoc.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever.blender.score;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.lucene.search.ScoreDoc;
+
+/**
+ * Abstract {@link ScoreDoc} that merges multiple retriever hits for the same document into a single
+ * ranked entry. The {@link #score} field (inherited from {@link ScoreDoc}) is the live blended
+ * score and must be kept up to date by each {@link #add} implementation. It drives result ordering
+ * directly — no separate sorting-score indirection.
+ *
+ * <p>The original per-retriever hits are preserved in {@link #scoreDocs} in insertion order for
+ * diagnostics and downstream inspection.
+ *
+ * <p>Subclasses define their own merging semantics by implementing {@link #add(int, float,
+ * ScoreDoc)}, which is called for every retriever hit after the first. The first hit is supplied at
+ * construction time.
+ */
+public abstract class BlendedScoreDoc extends ScoreDoc {
+
+  /**
+   * Per-retriever hits merged into this entry, in insertion order. The first element is always the
+   * hit supplied at construction time.
+   */
+  public final List<ScoreDoc> scoreDocs;
+
+  /**
+   * @param baseDoc the first retriever hit; its {@code doc} and {@code shardIndex} are inherited,
+   *     and it is prepopulated into {@link #scoreDocs}
+   * @param blendedScore initial blended score derived from {@code baseDoc} by the subclass
+   */
+  protected BlendedScoreDoc(ScoreDoc baseDoc, float blendedScore) {
+    super(baseDoc.doc, blendedScore, baseDoc.shardIndex);
+    this.scoreDocs = new ArrayList<>();
+    this.scoreDocs.add(baseDoc);
+  }
+
+  /**
+   * Merge a new retriever hit into this entry. Implementations must update {@link #score} to
+   * reflect the new blended value and append {@code scoreDoc} to {@link #scoreDocs}.
+   *
+   * @param rank 1-based rank of the document in the new retriever's result list
+   * @param weight per-retriever weight (e.g. boost)
+   * @param scoreDoc raw hit from the new retriever
+   */
+  public abstract void add(int rank, float weight, ScoreDoc scoreDoc);
+}

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/WeightedRRFScoreDoc.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/WeightedRRFScoreDoc.java
@@ -39,24 +39,27 @@ public class WeightedRRFScoreDoc extends BlendedScoreDoc {
   /**
    * Convenience constructor using {@link #DEFAULT_K} and weight 1.0.
    *
+   * @param firstRetrieverName name of the first retriever contributing a hit
    * @param baseDoc the first retriever hit
    * @param firstRank 1-based rank in the first retriever's result list; must be &ge; 1
    */
-  public WeightedRRFScoreDoc(ScoreDoc baseDoc, int firstRank) {
-    this(baseDoc, firstRank, 1.0f, DEFAULT_K);
+  public WeightedRRFScoreDoc(String firstRetrieverName, ScoreDoc baseDoc, int firstRank) {
+    this(firstRetrieverName, baseDoc, firstRank, 1.0f, DEFAULT_K);
   }
 
   /**
    * Full constructor.
    *
+   * @param firstRetrieverName name of the first retriever contributing a hit
    * @param baseDoc the first retriever hit
    * @param firstRank 1-based rank in the first retriever's result list; must be &ge; 1
    * @param firstWeight per-retriever weight for the first retriever
    * @param k RRF smoothing constant; must be &ge; 1
    * @throws IllegalArgumentException if {@code firstRank} &lt; 1 or {@code k} &lt; 1
    */
-  public WeightedRRFScoreDoc(ScoreDoc baseDoc, int firstRank, float firstWeight, int k) {
-    super(baseDoc, firstWeight / (k + firstRank));
+  public WeightedRRFScoreDoc(
+      String firstRetrieverName, ScoreDoc baseDoc, int firstRank, float firstWeight, int k) {
+    super(firstRetrieverName, baseDoc, firstWeight / (k + firstRank));
     if (k < 1) throw new IllegalArgumentException("k must be >= 1, got: " + k);
     if (firstRank < 1)
       throw new IllegalArgumentException("firstRank must be >= 1, got: " + firstRank);
@@ -64,13 +67,13 @@ public class WeightedRRFScoreDoc extends BlendedScoreDoc {
   }
 
   /**
-   * Adds {@code weight / (k + rank)} to {@link #score} and appends the raw hit to {@link
-   * #scoreDocs}.
+   * Adds {@code weight / (k + rank)} to {@link #score} and stores the raw hit in {@link #scoreDocs}
+   * under {@code retrieverName}.
    */
   @Override
-  public void add(int rank, float weight, ScoreDoc scoreDoc) {
+  public void add(String retrieverName, int rank, float weight, ScoreDoc scoreDoc) {
     score += weight / (k + rank);
-    scoreDocs.add(scoreDoc);
+    scoreDocs.put(retrieverName, scoreDoc);
   }
 
   /** Returns the smoothing constant {@code k} this instance was constructed with. */

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/WeightedRRFScoreDoc.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/WeightedRRFScoreDoc.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever.blender.score;
+
+import org.apache.lucene.search.ScoreDoc;
+
+/**
+ * {@link BlendedScoreDoc} implementing Reciprocal Rank Fusion (RRF). {@link #score} accumulates the
+ * sum of {@code weight / (k + rank)} contributions across all retrievers and is updated on every
+ * {@link #add} call.
+ *
+ * <p>{@code k} is a smoothing constant (default {@value #DEFAULT_K}) that dampens the advantage of
+ * top-ranked documents. Higher values give more weight to documents appearing consistently across
+ * retrievers; lower values amplify first-place dominance.
+ *
+ * <p>Reference: Cormack, Clarke &amp; Buettcher (2009), "Reciprocal Rank Fusion outperforms
+ * Condorcet and individual Rank Learning Methods."
+ */
+public class WeightedRRFScoreDoc extends BlendedScoreDoc {
+
+  /** Default smoothing constant used by most RRF literature and practice. */
+  public static final int DEFAULT_K = 60;
+
+  private final int k;
+
+  /**
+   * Convenience constructor using {@link #DEFAULT_K} and weight 1.0.
+   *
+   * @param baseDoc the first retriever hit
+   * @param firstRank 1-based rank in the first retriever's result list; must be &ge; 1
+   */
+  public WeightedRRFScoreDoc(ScoreDoc baseDoc, int firstRank) {
+    this(baseDoc, firstRank, 1.0f, DEFAULT_K);
+  }
+
+  /**
+   * Full constructor.
+   *
+   * @param baseDoc the first retriever hit
+   * @param firstRank 1-based rank in the first retriever's result list; must be &ge; 1
+   * @param firstWeight per-retriever weight for the first retriever
+   * @param k RRF smoothing constant; must be &ge; 1
+   * @throws IllegalArgumentException if {@code firstRank} &lt; 1 or {@code k} &lt; 1
+   */
+  public WeightedRRFScoreDoc(ScoreDoc baseDoc, int firstRank, float firstWeight, int k) {
+    super(baseDoc, firstWeight / (k + firstRank));
+    if (k < 1) throw new IllegalArgumentException("k must be >= 1, got: " + k);
+    if (firstRank < 1)
+      throw new IllegalArgumentException("firstRank must be >= 1, got: " + firstRank);
+    this.k = k;
+  }
+
+  /**
+   * Adds {@code weight / (k + rank)} to {@link #score} and appends the raw hit to {@link
+   * #scoreDocs}.
+   */
+  @Override
+  public void add(int rank, float weight, ScoreDoc scoreDoc) {
+    score += weight / (k + rank);
+    scoreDocs.add(scoreDoc);
+  }
+
+  /** Returns the smoothing constant {@code k} this instance was constructed with. */
+  public int getK() {
+    return k;
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/WeightedScoreDoc.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/WeightedScoreDoc.java
@@ -46,23 +46,25 @@ public class WeightedScoreDoc extends BlendedScoreDoc {
   private final ScoreMode scoreMode;
 
   /**
+   * @param firstRetrieverName name of the first retriever contributing a hit
    * @param baseDoc the first retriever hit; its raw score is multiplied by {@code firstWeight} to
    *     produce the initial blended score
    * @param firstWeight per-retriever weight applied to the first score
    * @param scoreMode how per-retriever scores are combined
    */
-  public WeightedScoreDoc(ScoreDoc baseDoc, float firstWeight, ScoreMode scoreMode) {
-    super(baseDoc, baseDoc.score * firstWeight);
+  public WeightedScoreDoc(
+      String firstRetrieverName, ScoreDoc baseDoc, float firstWeight, ScoreMode scoreMode) {
+    super(firstRetrieverName, baseDoc, baseDoc.score * firstWeight);
     this.scoreMode = scoreMode;
   }
 
   /**
    * Updates {@link #score} by combining the weighted {@code scoreDoc.score} with the current value
-   * according to {@link #scoreMode}, then appends the raw hit to {@link #scoreDocs}. The {@code
-   * rank} parameter is unused — score blending is rank-independent.
+   * according to {@link #scoreMode}, then stores the raw hit in {@link #scoreDocs} under {@code
+   * retrieverName}. The {@code rank} parameter is unused — score blending is rank-independent.
    */
   @Override
-  public void add(int rank, float weight, ScoreDoc scoreDoc) {
+  public void add(String retrieverName, int rank, float weight, ScoreDoc scoreDoc) {
     float weighted = scoreDoc.score * weight;
     score =
         switch (scoreMode) {
@@ -70,6 +72,6 @@ public class WeightedScoreDoc extends BlendedScoreDoc {
           case SUM -> score + weighted;
           case AVG -> (score * scoreDocs.size() + weighted) / (scoreDocs.size() + 1);
         };
-    scoreDocs.add(scoreDoc);
+    scoreDocs.put(retrieverName, scoreDoc);
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/WeightedScoreDoc.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/WeightedScoreDoc.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever.blender.score;
+
+import org.apache.lucene.search.ScoreDoc;
+
+/**
+ * {@link BlendedScoreDoc} that blends per-retriever scores into {@link #score}. Each retriever's
+ * raw score is multiplied by its weight before being combined according to the configured {@link
+ * ScoreMode}:
+ *
+ * <ul>
+ *   <li>{@link ScoreMode#MAX} — highest weighted score across retrievers (default).
+ *   <li>{@link ScoreMode#SUM} — sum of all weighted retriever scores.
+ *   <li>{@link ScoreMode#AVG} — running average of all weighted retriever scores.
+ * </ul>
+ */
+public class WeightedScoreDoc extends BlendedScoreDoc {
+
+  /**
+   * Strategy for combining per-retriever scores when the same document appears in more than one
+   * retriever's results.
+   */
+  public enum ScoreMode {
+    /** Use the highest weighted score across all retrievers. */
+    MAX,
+    /** Sum all weighted retriever scores. */
+    SUM,
+    /** Average all weighted retriever scores. */
+    AVG
+  }
+
+  private final ScoreMode scoreMode;
+
+  /**
+   * @param baseDoc the first retriever hit; its raw score is multiplied by {@code firstWeight} to
+   *     produce the initial blended score
+   * @param firstWeight per-retriever weight applied to the first score
+   * @param scoreMode how per-retriever scores are combined
+   */
+  public WeightedScoreDoc(ScoreDoc baseDoc, float firstWeight, ScoreMode scoreMode) {
+    super(baseDoc, baseDoc.score * firstWeight);
+    this.scoreMode = scoreMode;
+  }
+
+  /**
+   * Updates {@link #score} by combining the weighted {@code scoreDoc.score} with the current value
+   * according to {@link #scoreMode}, then appends the raw hit to {@link #scoreDocs}. The {@code
+   * rank} parameter is unused — score blending is rank-independent.
+   */
+  @Override
+  public void add(int rank, float weight, ScoreDoc scoreDoc) {
+    float weighted = scoreDoc.score * weight;
+    score =
+        switch (scoreMode) {
+          case MAX -> Math.max(score, weighted);
+          case SUM -> score + weighted;
+          case AVG -> (score * scoreDocs.size() + weighted) / (scoreDocs.size() + 1);
+        };
+    scoreDocs.add(scoreDoc);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/search/SearchContextTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/SearchContextTest.java
@@ -29,6 +29,8 @@ import com.yelp.nrtsearch.server.grpc.SearchResponse.SearchState;
 import com.yelp.nrtsearch.server.index.IndexState;
 import com.yelp.nrtsearch.server.search.collectors.CollectorCreatorContext;
 import com.yelp.nrtsearch.server.search.collectors.DocCollector;
+import com.yelp.nrtsearch.server.search.multiretriever.MultiRetrieverContext;
+import com.yelp.nrtsearch.server.search.multiretriever.RetrieverContext;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.IOException;
 import java.util.Collections;

--- a/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/MultiRetrieverContextTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/MultiRetrieverContextTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.yelp.nrtsearch.server.search;
+package com.yelp.nrtsearch.server.search.multiretriever;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;

--- a/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/RetrieverContextTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/RetrieverContextTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.yelp.nrtsearch.server.search;
+package com.yelp.nrtsearch.server.search.multiretriever;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;

--- a/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderCreatorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderCreatorTest.java
@@ -16,7 +16,6 @@
 package com.yelp.nrtsearch.server.search.multiretriever.blender;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -35,20 +34,25 @@ public class BlenderCreatorTest {
 
   /** Test plugin that extends {@link Plugin} and implements {@link BlenderPlugin}. */
   private static class TestBlenderPlugin extends Plugin implements BlenderPlugin {
-    private final Map<String, BlenderOperation> blenders;
+    private final Map<String, BlenderProvider<? extends BlenderOperation>> blenders;
 
-    TestBlenderPlugin(Map<String, BlenderOperation> blenders) {
+    TestBlenderPlugin(Map<String, BlenderProvider<? extends BlenderOperation>> blenders) {
       this.blenders = blenders;
     }
 
     @Override
-    public Map<String, BlenderOperation> getBlenders() {
+    public Map<String, BlenderProvider<? extends BlenderOperation>> getBlenders() {
       return blenders;
     }
   }
 
   private static BlenderOperation stubOp() {
-    return (results, blender, contexts) -> Collections.emptyList();
+    return (results, contexts) -> Collections.emptyList();
+  }
+
+  private static BlenderProvider<BlenderOperation> stubProvider() {
+    BlenderOperation op = stubOp();
+    return params -> op;
   }
 
   private static Blender weightedRrfBlender() {
@@ -67,23 +71,23 @@ public class BlenderCreatorTest {
   }
 
   @Test
-  public void testWeightedRrfReturnsSameInstance() {
+  public void testWeightedRrfReturnsNewInstancePerCall() {
     BlenderCreator creator = new BlenderCreator(null);
     BlenderOperation first = creator.getBlenderOperation(weightedRrfBlender());
     BlenderOperation second = creator.getBlenderOperation(weightedRrfBlender());
-    assertSame(first, second);
+    assertTrue(first instanceof WeightedRrfBlenderOperation);
+    assertTrue(second instanceof WeightedRrfBlenderOperation);
   }
 
   @Test
   public void testPluginRegistrationAndLookup() {
-    BlenderOperation op = stubOp();
-    Plugin plugin = new TestBlenderPlugin(Map.of("my_blender", op));
+    Plugin plugin = new TestBlenderPlugin(Map.of("my_blender", stubProvider()));
 
     BlenderCreator.initialize(null, List.of(plugin));
 
     BlenderOperation found =
         BlenderCreator.getInstance().getBlenderOperation(pluginBlender("my_blender"));
-    assertSame(op, found);
+    assertNotNull(found);
   }
 
   @Test
@@ -97,8 +101,8 @@ public class BlenderCreatorTest {
   @Test
   public void testDuplicatePluginRegistrationThrows() {
     // Two plugins both register the same name — second one must throw
-    Plugin plugin1 = new TestBlenderPlugin(Map.of("shared_name", stubOp()));
-    Plugin plugin2 = new TestBlenderPlugin(Map.of("shared_name", stubOp()));
+    Plugin plugin1 = new TestBlenderPlugin(Map.of("shared_name", stubProvider()));
+    Plugin plugin2 = new TestBlenderPlugin(Map.of("shared_name", stubProvider()));
 
     assertThrows(
         IllegalArgumentException.class,

--- a/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderCreatorTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderCreatorTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever.blender;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.yelp.nrtsearch.server.grpc.Blender;
+import com.yelp.nrtsearch.server.grpc.PluginBlender;
+import com.yelp.nrtsearch.server.grpc.WeightedRrfBlender;
+import com.yelp.nrtsearch.server.plugins.BlenderPlugin;
+import com.yelp.nrtsearch.server.plugins.Plugin;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.operation.WeightedRrfBlenderOperation;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class BlenderCreatorTest {
+
+  /** Test plugin that extends {@link Plugin} and implements {@link BlenderPlugin}. */
+  private static class TestBlenderPlugin extends Plugin implements BlenderPlugin {
+    private final Map<String, BlenderOperation> blenders;
+
+    TestBlenderPlugin(Map<String, BlenderOperation> blenders) {
+      this.blenders = blenders;
+    }
+
+    @Override
+    public Map<String, BlenderOperation> getBlenders() {
+      return blenders;
+    }
+  }
+
+  private static BlenderOperation stubOp() {
+    return (results, blender, contexts) -> Collections.emptyList();
+  }
+
+  private static Blender weightedRrfBlender() {
+    return Blender.newBuilder().setWeightedRrf(WeightedRrfBlender.newBuilder().build()).build();
+  }
+
+  private static Blender pluginBlender(String name) {
+    return Blender.newBuilder().setPlugin(PluginBlender.newBuilder().setName(name).build()).build();
+  }
+
+  @Test
+  public void testWeightedRrfReturnsCorrectType() {
+    BlenderCreator creator = new BlenderCreator(null);
+    BlenderOperation op = creator.getBlenderOperation(weightedRrfBlender());
+    assertTrue(op instanceof WeightedRrfBlenderOperation);
+  }
+
+  @Test
+  public void testWeightedRrfReturnsSameInstance() {
+    BlenderCreator creator = new BlenderCreator(null);
+    BlenderOperation first = creator.getBlenderOperation(weightedRrfBlender());
+    BlenderOperation second = creator.getBlenderOperation(weightedRrfBlender());
+    assertSame(first, second);
+  }
+
+  @Test
+  public void testPluginRegistrationAndLookup() {
+    BlenderOperation op = stubOp();
+    Plugin plugin = new TestBlenderPlugin(Map.of("my_blender", op));
+
+    BlenderCreator.initialize(null, List.of(plugin));
+
+    BlenderOperation found =
+        BlenderCreator.getInstance().getBlenderOperation(pluginBlender("my_blender"));
+    assertSame(op, found);
+  }
+
+  @Test
+  public void testUnknownPluginThrows() {
+    BlenderCreator creator = new BlenderCreator(null);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> creator.getPluginBlender(PluginBlender.newBuilder().setName("nonexistent").build()));
+  }
+
+  @Test
+  public void testDuplicatePluginRegistrationThrows() {
+    // Two plugins both register the same name — second one must throw
+    Plugin plugin1 = new TestBlenderPlugin(Map.of("shared_name", stubOp()));
+    Plugin plugin2 = new TestBlenderPlugin(Map.of("shared_name", stubOp()));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> BlenderCreator.initialize(null, List.of(plugin1, plugin2)));
+  }
+
+  @Test
+  public void testUnsupportedBlenderTypeThrows() {
+    BlenderCreator creator = new BlenderCreator(null);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> creator.getBlenderOperation(Blender.newBuilder().build()));
+  }
+
+  @Test
+  public void testInitializeSetsInstance() {
+    BlenderCreator.initialize(null, List.of());
+    assertNotNull(BlenderCreator.getInstance());
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderOperationSortAndPaginateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderOperationSortAndPaginateTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever.blender;
+
+import static org.junit.Assert.assertEquals;
+
+import com.yelp.nrtsearch.server.search.multiretriever.blender.score.BlendedScoreDoc;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.score.WeightedScoreDoc;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.junit.Test;
+
+public class BlenderOperationSortAndPaginateTest {
+
+  private static BlendedScoreDoc doc(int docId, float score) {
+    return new WeightedScoreDoc(
+        new ScoreDoc(docId, score, 0), 1.0f, WeightedScoreDoc.ScoreMode.MAX);
+  }
+
+  @Test
+  public void testEmpty() {
+    TopDocs result = BlenderOperation.sortAndPaginate(List.of(), 0, 10);
+    assertEquals(0, result.scoreDocs.length);
+    assertEquals(0, result.totalHits.value());
+  }
+
+  @Test
+  public void testSingleDoc() {
+    TopDocs result = BlenderOperation.sortAndPaginate(List.of(doc(1, 1.0f)), 0, 10);
+    assertEquals(1, result.scoreDocs.length);
+    assertEquals(1, result.scoreDocs[0].doc);
+    assertEquals(1, result.totalHits.value());
+  }
+
+  @Test
+  public void testSortedDescending() {
+    List<BlendedScoreDoc> merged = new ArrayList<>();
+    merged.add(doc(3, 0.3f));
+    merged.add(doc(1, 1.0f));
+    merged.add(doc(2, 0.5f));
+
+    TopDocs result = BlenderOperation.sortAndPaginate(merged, 0, 10);
+
+    assertEquals(3, result.scoreDocs.length);
+    assertEquals(1, result.scoreDocs[0].doc); // score 1.0
+    assertEquals(2, result.scoreDocs[1].doc); // score 0.5
+    assertEquals(3, result.scoreDocs[2].doc); // score 0.3
+  }
+
+  @Test
+  public void testTopHitsLimit() {
+    List<BlendedScoreDoc> merged = new ArrayList<>();
+    merged.add(doc(1, 1.0f));
+    merged.add(doc(2, 0.8f));
+    merged.add(doc(3, 0.6f));
+    merged.add(doc(4, 0.4f));
+
+    TopDocs result = BlenderOperation.sortAndPaginate(merged, 0, 2);
+
+    assertEquals(2, result.scoreDocs.length);
+    assertEquals(4, result.totalHits.value()); // total is deduplicated count, not page size
+    assertEquals(1, result.scoreDocs[0].doc);
+    assertEquals(2, result.scoreDocs[1].doc);
+  }
+
+  @Test
+  public void testStartHitPagination() {
+    List<BlendedScoreDoc> merged = new ArrayList<>();
+    merged.add(doc(1, 1.0f));
+    merged.add(doc(2, 0.8f));
+    merged.add(doc(3, 0.6f));
+
+    TopDocs result = BlenderOperation.sortAndPaginate(merged, 1, 10);
+
+    assertEquals(2, result.scoreDocs.length);
+    assertEquals(2, result.scoreDocs[0].doc); // doc 1 was skipped
+    assertEquals(3, result.scoreDocs[1].doc);
+  }
+
+  @Test
+  public void testTopHitsZeroReturnsEmpty() {
+    List<BlendedScoreDoc> merged = new ArrayList<>();
+    for (int i = 1; i <= 5; i++) {
+      merged.add(doc(i, i * 0.1f));
+    }
+
+    TopDocs result = BlenderOperation.sortAndPaginate(merged, 0, 0);
+    assertEquals(0, result.scoreDocs.length);
+    assertEquals(5, result.totalHits.value()); // total count still reported
+  }
+
+  @Test
+  public void testStartHitBeyondResults() {
+    List<BlendedScoreDoc> merged = List.of(doc(1, 1.0f), doc(2, 0.5f));
+    TopDocs result = BlenderOperation.sortAndPaginate(merged, 5, 10);
+    assertEquals(0, result.scoreDocs.length);
+    assertEquals(2, result.totalHits.value());
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderOperationSortAndPaginateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderOperationSortAndPaginateTest.java
@@ -93,18 +93,6 @@ public class BlenderOperationSortAndPaginateTest {
   }
 
   @Test
-  public void testTopHitsZeroReturnsEmpty() {
-    List<BlendedScoreDoc> merged = new ArrayList<>();
-    for (int i = 1; i <= 5; i++) {
-      merged.add(doc(i, i * 0.1f));
-    }
-
-    TopDocs result = BlenderOperation.sortAndPaginate(merged, 0, 0);
-    assertEquals(0, result.scoreDocs.length);
-    assertEquals(5, result.totalHits.value()); // total count still reported
-  }
-
-  @Test
   public void testStartHitBeyondResults() {
     List<BlendedScoreDoc> merged = List.of(doc(1, 1.0f), doc(2, 0.5f));
     TopDocs result = BlenderOperation.sortAndPaginate(merged, 5, 10);

--- a/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderOperationSortAndPaginateTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderOperationSortAndPaginateTest.java
@@ -29,7 +29,7 @@ public class BlenderOperationSortAndPaginateTest {
 
   private static BlendedScoreDoc doc(int docId, float score) {
     return new WeightedScoreDoc(
-        new ScoreDoc(docId, score, 0), 1.0f, WeightedScoreDoc.ScoreMode.MAX);
+        "r1", new ScoreDoc(docId, score, 0), 1.0f, WeightedScoreDoc.ScoreMode.MAX);
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/WeightedRrfBlenderOperationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/WeightedRrfBlenderOperationTest.java
@@ -115,7 +115,7 @@ public class WeightedRrfBlenderOperationTest {
     BlendedScoreDoc doc = merged.iterator().next();
     assertEquals(5, doc.doc);
     assertEquals(1.0f / 61 + 1.0f / 61, doc.score, DELTA);
-    assertEquals(2, doc.scoreDocs.size()); // baseDoc + second hit appended via add()
+    assertEquals(2, doc.getScoreDocs().size()); // baseDoc + second hit appended via add()
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/WeightedRrfBlenderOperationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/WeightedRrfBlenderOperationTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever.blender.operation;
+
+import static org.junit.Assert.assertEquals;
+
+import com.yelp.nrtsearch.server.grpc.Blender;
+import com.yelp.nrtsearch.server.grpc.WeightedRrfBlender;
+import com.yelp.nrtsearch.server.search.multiretriever.RetrieverContext;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.score.BlendedScoreDoc;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.score.WeightedRRFScoreDoc;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.junit.Test;
+
+public class WeightedRrfBlenderOperationTest {
+
+  private static final float DELTA = 1e-6f;
+
+  private static final WeightedRrfBlenderOperation OPERATION = new WeightedRrfBlenderOperation();
+
+  private static Blender blenderWithK(int k) {
+    return Blender.newBuilder()
+        .setWeightedRrf(WeightedRrfBlender.newBuilder().setRankConstant(k).build())
+        .build();
+  }
+
+  private static Blender defaultBlender() {
+    return blenderWithK(0); // 0 → falls back to DEFAULT_K
+  }
+
+  private static TopDocs topDocs(int... docIds) {
+    ScoreDoc[] scoreDocs = new ScoreDoc[docIds.length];
+    for (int i = 0; i < docIds.length; i++) {
+      scoreDocs[i] = new ScoreDoc(docIds[i], 1.0f, 0);
+    }
+    return new TopDocs(new TotalHits(docIds.length, TotalHits.Relation.EQUAL_TO), scoreDocs);
+  }
+
+  private static RetrieverContext retriever(String name, float boost) {
+    return RetrieverContext.newBuilder(name).boost(boost).build();
+  }
+
+  private static Map<Integer, Float> toScoreMap(Collection<BlendedScoreDoc> docs) {
+    return docs.stream().collect(Collectors.toMap(d -> d.doc, d -> d.score));
+  }
+
+  @Test
+  public void testSingleRetriever() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(10, 20, 30));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text", 1.0f));
+
+    Collection<BlendedScoreDoc> merged = OPERATION.mergeHits(results, blenderWithK(60), contexts);
+
+    assertEquals(3, merged.size());
+    Map<Integer, Float> scores = toScoreMap(merged);
+    assertEquals(1.0f / 61, scores.get(10), DELTA); // rank 1
+    assertEquals(1.0f / 62, scores.get(20), DELTA); // rank 2
+    assertEquals(1.0f / 63, scores.get(30), DELTA); // rank 3
+  }
+
+  @Test
+  public void testTwoRetrieversNoDuplicate() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(1));
+    results.put("knn", topDocs(2));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text", 1.0f));
+    contexts.put("knn", retriever("knn", 1.0f));
+
+    Collection<BlendedScoreDoc> merged = OPERATION.mergeHits(results, blenderWithK(60), contexts);
+
+    assertEquals(2, merged.size());
+    Map<Integer, Float> scores = toScoreMap(merged);
+    assertEquals(1.0f / 61, scores.get(1), DELTA);
+    assertEquals(1.0f / 61, scores.get(2), DELTA);
+  }
+
+  @Test
+  public void testDeduplication() {
+    // doc 5 appears in both retrievers at rank 1 — scores should be summed
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(5));
+    results.put("knn", topDocs(5));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text", 1.0f));
+    contexts.put("knn", retriever("knn", 1.0f));
+
+    Collection<BlendedScoreDoc> merged = OPERATION.mergeHits(results, blenderWithK(60), contexts);
+
+    assertEquals(1, merged.size());
+    BlendedScoreDoc doc = merged.iterator().next();
+    assertEquals(5, doc.doc);
+    assertEquals(1.0f / 61 + 1.0f / 61, doc.score, DELTA);
+    assertEquals(2, doc.scoreDocs.size()); // baseDoc + second hit appended via add()
+  }
+
+  @Test
+  public void testDefaultKFallbackWhenZero() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(1));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text", 1.0f));
+
+    Collection<BlendedScoreDoc> merged = OPERATION.mergeHits(results, defaultBlender(), contexts);
+
+    float expected = 1.0f / (WeightedRRFScoreDoc.DEFAULT_K + 1);
+    assertEquals(expected, merged.iterator().next().score, DELTA);
+  }
+
+  @Test
+  public void testCustomK() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(1));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text", 1.0f));
+
+    Collection<BlendedScoreDoc> merged = OPERATION.mergeHits(results, blenderWithK(10), contexts);
+
+    assertEquals(1.0f / 11, merged.iterator().next().score, DELTA);
+  }
+
+  @Test
+  public void testBoostScalesScore() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(1));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text", 2.0f));
+
+    Collection<BlendedScoreDoc> merged = OPERATION.mergeHits(results, blenderWithK(60), contexts);
+
+    assertEquals(2.0f / 61, merged.iterator().next().score, DELTA);
+  }
+
+  @Test
+  public void testEmptyRetrieverResults() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs());
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text", 1.0f));
+
+    Collection<BlendedScoreDoc> merged = OPERATION.mergeHits(results, defaultBlender(), contexts);
+    assertEquals(0, merged.size());
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/WeightedRrfBlenderOperationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/WeightedRrfBlenderOperationTest.java
@@ -17,7 +17,6 @@ package com.yelp.nrtsearch.server.search.multiretriever.blender.operation;
 
 import static org.junit.Assert.assertEquals;
 
-import com.yelp.nrtsearch.server.grpc.Blender;
 import com.yelp.nrtsearch.server.grpc.WeightedRrfBlender;
 import com.yelp.nrtsearch.server.search.multiretriever.RetrieverContext;
 import com.yelp.nrtsearch.server.search.multiretriever.blender.score.BlendedScoreDoc;
@@ -35,16 +34,13 @@ public class WeightedRrfBlenderOperationTest {
 
   private static final float DELTA = 1e-6f;
 
-  private static final WeightedRrfBlenderOperation OPERATION = new WeightedRrfBlenderOperation();
-
-  private static Blender blenderWithK(int k) {
-    return Blender.newBuilder()
-        .setWeightedRrf(WeightedRrfBlender.newBuilder().setRankConstant(k).build())
-        .build();
+  private static WeightedRrfBlenderOperation operationWithK(int k) {
+    return new WeightedRrfBlenderOperation(
+        WeightedRrfBlender.newBuilder().setRankConstant(k).build());
   }
 
-  private static Blender defaultBlender() {
-    return blenderWithK(0); // 0 → falls back to DEFAULT_K
+  private static WeightedRrfBlenderOperation defaultOperation() {
+    return operationWithK(0); // 0 → falls back to DEFAULT_K
   }
 
   private static TopDocs topDocs(int... docIds) {
@@ -71,7 +67,7 @@ public class WeightedRrfBlenderOperationTest {
     LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
     contexts.put("text", retriever("text", 1.0f));
 
-    Collection<BlendedScoreDoc> merged = OPERATION.mergeHits(results, blenderWithK(60), contexts);
+    Collection<BlendedScoreDoc> merged = operationWithK(60).mergeHits(results, contexts);
 
     assertEquals(3, merged.size());
     Map<Integer, Float> scores = toScoreMap(merged);
@@ -90,7 +86,7 @@ public class WeightedRrfBlenderOperationTest {
     contexts.put("text", retriever("text", 1.0f));
     contexts.put("knn", retriever("knn", 1.0f));
 
-    Collection<BlendedScoreDoc> merged = OPERATION.mergeHits(results, blenderWithK(60), contexts);
+    Collection<BlendedScoreDoc> merged = operationWithK(60).mergeHits(results, contexts);
 
     assertEquals(2, merged.size());
     Map<Integer, Float> scores = toScoreMap(merged);
@@ -109,7 +105,7 @@ public class WeightedRrfBlenderOperationTest {
     contexts.put("text", retriever("text", 1.0f));
     contexts.put("knn", retriever("knn", 1.0f));
 
-    Collection<BlendedScoreDoc> merged = OPERATION.mergeHits(results, blenderWithK(60), contexts);
+    Collection<BlendedScoreDoc> merged = operationWithK(60).mergeHits(results, contexts);
 
     assertEquals(1, merged.size());
     BlendedScoreDoc doc = merged.iterator().next();
@@ -126,7 +122,7 @@ public class WeightedRrfBlenderOperationTest {
     LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
     contexts.put("text", retriever("text", 1.0f));
 
-    Collection<BlendedScoreDoc> merged = OPERATION.mergeHits(results, defaultBlender(), contexts);
+    Collection<BlendedScoreDoc> merged = defaultOperation().mergeHits(results, contexts);
 
     float expected = 1.0f / (WeightedRRFScoreDoc.DEFAULT_K + 1);
     assertEquals(expected, merged.iterator().next().score, DELTA);
@@ -140,7 +136,7 @@ public class WeightedRrfBlenderOperationTest {
     LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
     contexts.put("text", retriever("text", 1.0f));
 
-    Collection<BlendedScoreDoc> merged = OPERATION.mergeHits(results, blenderWithK(10), contexts);
+    Collection<BlendedScoreDoc> merged = operationWithK(10).mergeHits(results, contexts);
 
     assertEquals(1.0f / 11, merged.iterator().next().score, DELTA);
   }
@@ -153,7 +149,7 @@ public class WeightedRrfBlenderOperationTest {
     LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
     contexts.put("text", retriever("text", 2.0f));
 
-    Collection<BlendedScoreDoc> merged = OPERATION.mergeHits(results, blenderWithK(60), contexts);
+    Collection<BlendedScoreDoc> merged = operationWithK(60).mergeHits(results, contexts);
 
     assertEquals(2.0f / 61, merged.iterator().next().score, DELTA);
   }
@@ -166,7 +162,7 @@ public class WeightedRrfBlenderOperationTest {
     LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
     contexts.put("text", retriever("text", 1.0f));
 
-    Collection<BlendedScoreDoc> merged = OPERATION.mergeHits(results, defaultBlender(), contexts);
+    Collection<BlendedScoreDoc> merged = defaultOperation().mergeHits(results, contexts);
     assertEquals(0, merged.size());
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/WeightedRRFScoreDocTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/WeightedRRFScoreDocTest.java
@@ -27,18 +27,18 @@ public class WeightedRRFScoreDocTest {
   @Test
   public void testDefaultConstructorScore() {
     // weight=1.0, k=DEFAULT_K=60, rank=1 → score = 1.0 / (60 + 1)
-    WeightedRRFScoreDoc doc = new WeightedRRFScoreDoc(new ScoreDoc(10, 0f, 0), 1);
+    WeightedRRFScoreDoc doc = new WeightedRRFScoreDoc("r1", new ScoreDoc(10, 0f, 0), 1);
     assertEquals(1.0f / (WeightedRRFScoreDoc.DEFAULT_K + 1), doc.score, DELTA);
     assertEquals(10, doc.doc);
     assertEquals(0, doc.shardIndex);
     assertEquals(WeightedRRFScoreDoc.DEFAULT_K, doc.getK());
-    assertEquals(1, doc.scoreDocs.size());
+    assertEquals(1, doc.getScoreDocs().size());
   }
 
   @Test
   public void testFullConstructorScore() {
     // weight=2.0, k=10, rank=3 → score = 2.0 / (10 + 3)
-    WeightedRRFScoreDoc doc = new WeightedRRFScoreDoc(new ScoreDoc(5, 0f, 1), 3, 2.0f, 10);
+    WeightedRRFScoreDoc doc = new WeightedRRFScoreDoc("r1", new ScoreDoc(5, 0f, 1), 3, 2.0f, 10);
     assertEquals(2.0f / 13, doc.score, DELTA);
     assertEquals(5, doc.doc);
     assertEquals(1, doc.shardIndex);
@@ -47,44 +47,46 @@ public class WeightedRRFScoreDocTest {
 
   @Test
   public void testAddAccumulatesScore() {
-    WeightedRRFScoreDoc doc = new WeightedRRFScoreDoc(new ScoreDoc(1, 0f, 0), 1, 1.0f, 10);
+    WeightedRRFScoreDoc doc = new WeightedRRFScoreDoc("r1", new ScoreDoc(1, 0f, 0), 1, 1.0f, 10);
     float initialScore = doc.score; // 1.0 / 11
 
     ScoreDoc hit = new ScoreDoc(1, 0.5f, 0);
-    doc.add(2, 1.0f, hit); // += 1.0 / (10 + 2) = 1/12
+    doc.add("r2", 2, 1.0f, hit); // += 1.0 / (10 + 2) = 1/12
 
     assertEquals(initialScore + 1.0f / 12, doc.score, DELTA);
   }
 
   @Test
   public void testAddAppendsScoredDocs() {
-    WeightedRRFScoreDoc doc = new WeightedRRFScoreDoc(new ScoreDoc(1, 0f, 0), 1, 1.0f, 10);
-    assertEquals(1, doc.scoreDocs.size()); // baseDoc pre-populated
+    WeightedRRFScoreDoc doc = new WeightedRRFScoreDoc("r1", new ScoreDoc(1, 0f, 0), 1, 1.0f, 10);
+    assertEquals(1, doc.getScoreDocs().size()); // baseDoc pre-populated
 
     ScoreDoc hit1 = new ScoreDoc(1, 0.9f, 0);
     ScoreDoc hit2 = new ScoreDoc(1, 0.8f, 0);
-    doc.add(2, 1.0f, hit1);
-    doc.add(3, 1.0f, hit2);
+    doc.add("r2", 2, 1.0f, hit1);
+    doc.add("r3", 3, 1.0f, hit2);
 
-    assertEquals(3, doc.scoreDocs.size());
-    assertEquals(hit1, doc.scoreDocs.get(1));
-    assertEquals(hit2, doc.scoreDocs.get(2));
+    assertEquals(3, doc.getScoreDocs().size());
+    assertEquals(hit1, doc.getScoreDocs().get("r2"));
+    assertEquals(hit2, doc.getScoreDocs().get("r3"));
   }
 
   @Test
   public void testBoostScalesScore() {
-    WeightedRRFScoreDoc unboosted = new WeightedRRFScoreDoc(new ScoreDoc(1, 0f, 0), 1, 1.0f, 60);
-    WeightedRRFScoreDoc boosted = new WeightedRRFScoreDoc(new ScoreDoc(1, 0f, 0), 1, 3.0f, 60);
+    WeightedRRFScoreDoc unboosted =
+        new WeightedRRFScoreDoc("r1", new ScoreDoc(1, 0f, 0), 1, 1.0f, 60);
+    WeightedRRFScoreDoc boosted =
+        new WeightedRRFScoreDoc("r1", new ScoreDoc(1, 0f, 0), 1, 3.0f, 60);
     assertEquals(3.0f * unboosted.score, boosted.score, DELTA);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidK() {
-    new WeightedRRFScoreDoc(new ScoreDoc(1, 0f, 0), 1, 1.0f, 0);
+    new WeightedRRFScoreDoc("r1", new ScoreDoc(1, 0f, 0), 1, 1.0f, 0);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidFirstRank() {
-    new WeightedRRFScoreDoc(new ScoreDoc(1, 0f, 0), 0, 1.0f, 60);
+    new WeightedRRFScoreDoc("r1", new ScoreDoc(1, 0f, 0), 0, 1.0f, 60);
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/WeightedRRFScoreDocTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/WeightedRRFScoreDocTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever.blender.score;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.lucene.search.ScoreDoc;
+import org.junit.Test;
+
+public class WeightedRRFScoreDocTest {
+
+  private static final float DELTA = 1e-6f;
+
+  @Test
+  public void testDefaultConstructorScore() {
+    // weight=1.0, k=DEFAULT_K=60, rank=1 → score = 1.0 / (60 + 1)
+    WeightedRRFScoreDoc doc = new WeightedRRFScoreDoc(new ScoreDoc(10, 0f, 0), 1);
+    assertEquals(1.0f / (WeightedRRFScoreDoc.DEFAULT_K + 1), doc.score, DELTA);
+    assertEquals(10, doc.doc);
+    assertEquals(0, doc.shardIndex);
+    assertEquals(WeightedRRFScoreDoc.DEFAULT_K, doc.getK());
+    assertEquals(1, doc.scoreDocs.size());
+  }
+
+  @Test
+  public void testFullConstructorScore() {
+    // weight=2.0, k=10, rank=3 → score = 2.0 / (10 + 3)
+    WeightedRRFScoreDoc doc = new WeightedRRFScoreDoc(new ScoreDoc(5, 0f, 1), 3, 2.0f, 10);
+    assertEquals(2.0f / 13, doc.score, DELTA);
+    assertEquals(5, doc.doc);
+    assertEquals(1, doc.shardIndex);
+    assertEquals(10, doc.getK());
+  }
+
+  @Test
+  public void testAddAccumulatesScore() {
+    WeightedRRFScoreDoc doc = new WeightedRRFScoreDoc(new ScoreDoc(1, 0f, 0), 1, 1.0f, 10);
+    float initialScore = doc.score; // 1.0 / 11
+
+    ScoreDoc hit = new ScoreDoc(1, 0.5f, 0);
+    doc.add(2, 1.0f, hit); // += 1.0 / (10 + 2) = 1/12
+
+    assertEquals(initialScore + 1.0f / 12, doc.score, DELTA);
+  }
+
+  @Test
+  public void testAddAppendsScoredDocs() {
+    WeightedRRFScoreDoc doc = new WeightedRRFScoreDoc(new ScoreDoc(1, 0f, 0), 1, 1.0f, 10);
+    assertEquals(1, doc.scoreDocs.size()); // baseDoc pre-populated
+
+    ScoreDoc hit1 = new ScoreDoc(1, 0.9f, 0);
+    ScoreDoc hit2 = new ScoreDoc(1, 0.8f, 0);
+    doc.add(2, 1.0f, hit1);
+    doc.add(3, 1.0f, hit2);
+
+    assertEquals(3, doc.scoreDocs.size());
+    assertEquals(hit1, doc.scoreDocs.get(1));
+    assertEquals(hit2, doc.scoreDocs.get(2));
+  }
+
+  @Test
+  public void testBoostScalesScore() {
+    WeightedRRFScoreDoc unboosted = new WeightedRRFScoreDoc(new ScoreDoc(1, 0f, 0), 1, 1.0f, 60);
+    WeightedRRFScoreDoc boosted = new WeightedRRFScoreDoc(new ScoreDoc(1, 0f, 0), 1, 3.0f, 60);
+    assertEquals(3.0f * unboosted.score, boosted.score, DELTA);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidK() {
+    new WeightedRRFScoreDoc(new ScoreDoc(1, 0f, 0), 1, 1.0f, 0);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidFirstRank() {
+    new WeightedRRFScoreDoc(new ScoreDoc(1, 0f, 0), 0, 1.0f, 60);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/WeightedScoreDocTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/WeightedScoreDocTest.java
@@ -29,7 +29,7 @@ public class WeightedScoreDocTest {
   @Test
   public void testInitialScore() {
     WeightedScoreDoc doc =
-        new WeightedScoreDoc(new ScoreDoc(5, 0.8f, 1), 2.0f, WeightedScoreDoc.ScoreMode.MAX);
+        new WeightedScoreDoc("r1", new ScoreDoc(5, 0.8f, 1), 2.0f, WeightedScoreDoc.ScoreMode.MAX);
     assertEquals(5, doc.doc);
     assertEquals(1, doc.shardIndex);
     assertEquals(2.0f * 0.8f, doc.score, DELTA);
@@ -38,9 +38,9 @@ public class WeightedScoreDocTest {
   @Test
   public void testInitialScoreDocsContainsBaseDoc() {
     ScoreDoc base = new ScoreDoc(3, 0.5f, 0);
-    WeightedScoreDoc doc = new WeightedScoreDoc(base, 1.0f, WeightedScoreDoc.ScoreMode.SUM);
-    assertEquals(1, doc.scoreDocs.size());
-    assertEquals(base, doc.scoreDocs.get(0));
+    WeightedScoreDoc doc = new WeightedScoreDoc("r1", base, 1.0f, WeightedScoreDoc.ScoreMode.SUM);
+    assertEquals(1, doc.getScoreDocs().size());
+    assertEquals(base, doc.getScoreDocs().get("r1"));
   }
 
   // --- MAX mode ---
@@ -49,9 +49,9 @@ public class WeightedScoreDocTest {
   public void testMaxKeepsHigher() {
     // initial score = 1.0 * 0.6 = 0.6
     WeightedScoreDoc doc =
-        new WeightedScoreDoc(new ScoreDoc(1, 0.6f, 0), 1.0f, WeightedScoreDoc.ScoreMode.MAX);
+        new WeightedScoreDoc("r1", new ScoreDoc(1, 0.6f, 0), 1.0f, WeightedScoreDoc.ScoreMode.MAX);
     // add weighted = 1.0 * 0.9 = 0.9 → max(0.6, 0.9) = 0.9
-    doc.add(1, 1.0f, new ScoreDoc(1, 0.9f, 0));
+    doc.add("r2", 1, 1.0f, new ScoreDoc(1, 0.9f, 0));
     assertEquals(0.9f, doc.score, DELTA);
   }
 
@@ -59,9 +59,9 @@ public class WeightedScoreDocTest {
   public void testMaxKeepsCurrentWhenHigher() {
     // initial score = 1.0 * 0.9 = 0.9
     WeightedScoreDoc doc =
-        new WeightedScoreDoc(new ScoreDoc(1, 0.9f, 0), 1.0f, WeightedScoreDoc.ScoreMode.MAX);
+        new WeightedScoreDoc("r1", new ScoreDoc(1, 0.9f, 0), 1.0f, WeightedScoreDoc.ScoreMode.MAX);
     // add weighted = 1.0 * 0.3 = 0.3 → max(0.9, 0.3) = 0.9
-    doc.add(1, 1.0f, new ScoreDoc(1, 0.3f, 0));
+    doc.add("r2", 1, 1.0f, new ScoreDoc(1, 0.3f, 0));
     assertEquals(0.9f, doc.score, DELTA);
   }
 
@@ -69,9 +69,9 @@ public class WeightedScoreDocTest {
   public void testMaxWithWeight() {
     // initial score = 1.0 * 0.5 = 0.5
     WeightedScoreDoc doc =
-        new WeightedScoreDoc(new ScoreDoc(1, 0.5f, 0), 1.0f, WeightedScoreDoc.ScoreMode.MAX);
+        new WeightedScoreDoc("r1", new ScoreDoc(1, 0.5f, 0), 1.0f, WeightedScoreDoc.ScoreMode.MAX);
     // add: weight=3.0, rawScore=0.3 → weighted = 0.9 → max(0.5, 0.9) = 0.9
-    doc.add(1, 3.0f, new ScoreDoc(1, 0.3f, 0));
+    doc.add("r2", 1, 3.0f, new ScoreDoc(1, 0.3f, 0));
     assertEquals(0.9f, doc.score, DELTA);
   }
 
@@ -81,17 +81,17 @@ public class WeightedScoreDocTest {
   public void testSumAccumulates() {
     // initial score = 1.0 * 0.4 = 0.4
     WeightedScoreDoc doc =
-        new WeightedScoreDoc(new ScoreDoc(1, 0.4f, 0), 1.0f, WeightedScoreDoc.ScoreMode.SUM);
-    doc.add(1, 1.0f, new ScoreDoc(1, 0.3f, 0)); // += 0.3 → 0.7
-    doc.add(1, 2.0f, new ScoreDoc(1, 0.1f, 0)); // += 0.2 → 0.9
+        new WeightedScoreDoc("r1", new ScoreDoc(1, 0.4f, 0), 1.0f, WeightedScoreDoc.ScoreMode.SUM);
+    doc.add("r2", 1, 1.0f, new ScoreDoc(1, 0.3f, 0)); // += 0.3 → 0.7
+    doc.add("r3", 1, 2.0f, new ScoreDoc(1, 0.1f, 0)); // += 0.2 → 0.9
     assertEquals(0.9f, doc.score, DELTA);
   }
 
   @Test
   public void testSumWithWeight() {
     WeightedScoreDoc doc =
-        new WeightedScoreDoc(new ScoreDoc(1, 0.5f, 0), 1.0f, WeightedScoreDoc.ScoreMode.SUM);
-    doc.add(1, 2.0f, new ScoreDoc(1, 0.5f, 0)); // weighted = 1.0
+        new WeightedScoreDoc("r1", new ScoreDoc(1, 0.5f, 0), 1.0f, WeightedScoreDoc.ScoreMode.SUM);
+    doc.add("r2", 1, 2.0f, new ScoreDoc(1, 0.5f, 0)); // weighted = 1.0
     assertEquals(1.5f, doc.score, DELTA);
   }
 
@@ -101,9 +101,9 @@ public class WeightedScoreDocTest {
   public void testAvgTwoRetrievers() {
     // initial score = 1.0 * 0.6 = 0.6
     WeightedScoreDoc doc =
-        new WeightedScoreDoc(new ScoreDoc(1, 0.6f, 0), 1.0f, WeightedScoreDoc.ScoreMode.AVG);
+        new WeightedScoreDoc("r1", new ScoreDoc(1, 0.6f, 0), 1.0f, WeightedScoreDoc.ScoreMode.AVG);
     // add weighted = 1.0 * 0.4 = 0.4 → avg(0.6, 0.4) = 0.5
-    doc.add(1, 1.0f, new ScoreDoc(1, 0.4f, 0));
+    doc.add("r2", 1, 1.0f, new ScoreDoc(1, 0.4f, 0));
     assertEquals(0.5f, doc.score, DELTA);
   }
 
@@ -111,9 +111,9 @@ public class WeightedScoreDocTest {
   public void testAvgThreeRetrievers() {
     // initial = 0.9
     WeightedScoreDoc doc =
-        new WeightedScoreDoc(new ScoreDoc(1, 0.9f, 0), 1.0f, WeightedScoreDoc.ScoreMode.AVG);
-    doc.add(1, 1.0f, new ScoreDoc(1, 0.3f, 0)); // avg(0.9, 0.3) = 0.6
-    doc.add(1, 1.0f, new ScoreDoc(1, 0.6f, 0)); // avg(0.6, 0.6, 0.6) = 0.6
+        new WeightedScoreDoc("r1", new ScoreDoc(1, 0.9f, 0), 1.0f, WeightedScoreDoc.ScoreMode.AVG);
+    doc.add("r2", 1, 1.0f, new ScoreDoc(1, 0.3f, 0)); // avg(0.9, 0.3) = 0.6
+    doc.add("r3", 1, 1.0f, new ScoreDoc(1, 0.6f, 0)); // avg(0.6, 0.6, 0.6) = 0.6
     assertEquals(0.6f, doc.score, DELTA);
   }
 
@@ -122,10 +122,10 @@ public class WeightedScoreDocTest {
   @Test
   public void testScoreDocsGrowsOnAdd() {
     WeightedScoreDoc doc =
-        new WeightedScoreDoc(new ScoreDoc(1, 0.5f, 0), 1.0f, WeightedScoreDoc.ScoreMode.SUM);
-    assertEquals(1, doc.scoreDocs.size());
-    doc.add(1, 1.0f, new ScoreDoc(1, 0.3f, 0));
-    doc.add(1, 1.0f, new ScoreDoc(1, 0.2f, 0));
-    assertEquals(3, doc.scoreDocs.size());
+        new WeightedScoreDoc("r1", new ScoreDoc(1, 0.5f, 0), 1.0f, WeightedScoreDoc.ScoreMode.SUM);
+    assertEquals(1, doc.getScoreDocs().size());
+    doc.add("r2", 1, 1.0f, new ScoreDoc(1, 0.3f, 0));
+    doc.add("r3", 1, 1.0f, new ScoreDoc(1, 0.2f, 0));
+    assertEquals(3, doc.getScoreDocs().size());
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/WeightedScoreDocTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/WeightedScoreDocTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever.blender.score;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.lucene.search.ScoreDoc;
+import org.junit.Test;
+
+public class WeightedScoreDocTest {
+
+  private static final float DELTA = 1e-6f;
+
+  // --- constructor ---
+
+  @Test
+  public void testInitialScore() {
+    WeightedScoreDoc doc =
+        new WeightedScoreDoc(new ScoreDoc(5, 0.8f, 1), 2.0f, WeightedScoreDoc.ScoreMode.MAX);
+    assertEquals(5, doc.doc);
+    assertEquals(1, doc.shardIndex);
+    assertEquals(2.0f * 0.8f, doc.score, DELTA);
+  }
+
+  @Test
+  public void testInitialScoreDocsContainsBaseDoc() {
+    ScoreDoc base = new ScoreDoc(3, 0.5f, 0);
+    WeightedScoreDoc doc = new WeightedScoreDoc(base, 1.0f, WeightedScoreDoc.ScoreMode.SUM);
+    assertEquals(1, doc.scoreDocs.size());
+    assertEquals(base, doc.scoreDocs.get(0));
+  }
+
+  // --- MAX mode ---
+
+  @Test
+  public void testMaxKeepsHigher() {
+    // initial score = 1.0 * 0.6 = 0.6
+    WeightedScoreDoc doc =
+        new WeightedScoreDoc(new ScoreDoc(1, 0.6f, 0), 1.0f, WeightedScoreDoc.ScoreMode.MAX);
+    // add weighted = 1.0 * 0.9 = 0.9 → max(0.6, 0.9) = 0.9
+    doc.add(1, 1.0f, new ScoreDoc(1, 0.9f, 0));
+    assertEquals(0.9f, doc.score, DELTA);
+  }
+
+  @Test
+  public void testMaxKeepsCurrentWhenHigher() {
+    // initial score = 1.0 * 0.9 = 0.9
+    WeightedScoreDoc doc =
+        new WeightedScoreDoc(new ScoreDoc(1, 0.9f, 0), 1.0f, WeightedScoreDoc.ScoreMode.MAX);
+    // add weighted = 1.0 * 0.3 = 0.3 → max(0.9, 0.3) = 0.9
+    doc.add(1, 1.0f, new ScoreDoc(1, 0.3f, 0));
+    assertEquals(0.9f, doc.score, DELTA);
+  }
+
+  @Test
+  public void testMaxWithWeight() {
+    // initial score = 1.0 * 0.5 = 0.5
+    WeightedScoreDoc doc =
+        new WeightedScoreDoc(new ScoreDoc(1, 0.5f, 0), 1.0f, WeightedScoreDoc.ScoreMode.MAX);
+    // add: weight=3.0, rawScore=0.3 → weighted = 0.9 → max(0.5, 0.9) = 0.9
+    doc.add(1, 3.0f, new ScoreDoc(1, 0.3f, 0));
+    assertEquals(0.9f, doc.score, DELTA);
+  }
+
+  // --- SUM mode ---
+
+  @Test
+  public void testSumAccumulates() {
+    // initial score = 1.0 * 0.4 = 0.4
+    WeightedScoreDoc doc =
+        new WeightedScoreDoc(new ScoreDoc(1, 0.4f, 0), 1.0f, WeightedScoreDoc.ScoreMode.SUM);
+    doc.add(1, 1.0f, new ScoreDoc(1, 0.3f, 0)); // += 0.3 → 0.7
+    doc.add(1, 2.0f, new ScoreDoc(1, 0.1f, 0)); // += 0.2 → 0.9
+    assertEquals(0.9f, doc.score, DELTA);
+  }
+
+  @Test
+  public void testSumWithWeight() {
+    WeightedScoreDoc doc =
+        new WeightedScoreDoc(new ScoreDoc(1, 0.5f, 0), 1.0f, WeightedScoreDoc.ScoreMode.SUM);
+    doc.add(1, 2.0f, new ScoreDoc(1, 0.5f, 0)); // weighted = 1.0
+    assertEquals(1.5f, doc.score, DELTA);
+  }
+
+  // --- AVG mode ---
+
+  @Test
+  public void testAvgTwoRetrievers() {
+    // initial score = 1.0 * 0.6 = 0.6
+    WeightedScoreDoc doc =
+        new WeightedScoreDoc(new ScoreDoc(1, 0.6f, 0), 1.0f, WeightedScoreDoc.ScoreMode.AVG);
+    // add weighted = 1.0 * 0.4 = 0.4 → avg(0.6, 0.4) = 0.5
+    doc.add(1, 1.0f, new ScoreDoc(1, 0.4f, 0));
+    assertEquals(0.5f, doc.score, DELTA);
+  }
+
+  @Test
+  public void testAvgThreeRetrievers() {
+    // initial = 0.9
+    WeightedScoreDoc doc =
+        new WeightedScoreDoc(new ScoreDoc(1, 0.9f, 0), 1.0f, WeightedScoreDoc.ScoreMode.AVG);
+    doc.add(1, 1.0f, new ScoreDoc(1, 0.3f, 0)); // avg(0.9, 0.3) = 0.6
+    doc.add(1, 1.0f, new ScoreDoc(1, 0.6f, 0)); // avg(0.6, 0.6, 0.6) = 0.6
+    assertEquals(0.6f, doc.score, DELTA);
+  }
+
+  // --- scoreDocs tracking ---
+
+  @Test
+  public void testScoreDocsGrowsOnAdd() {
+    WeightedScoreDoc doc =
+        new WeightedScoreDoc(new ScoreDoc(1, 0.5f, 0), 1.0f, WeightedScoreDoc.ScoreMode.SUM);
+    assertEquals(1, doc.scoreDocs.size());
+    doc.add(1, 1.0f, new ScoreDoc(1, 0.3f, 0));
+    doc.add(1, 1.0f, new ScoreDoc(1, 0.2f, 0));
+    assertEquals(3, doc.scoreDocs.size());
+  }
+}


### PR DESCRIPTION
[RP-14960](https://jira.yelpcorp.com/browse/RP-14960) - blender interface
[RP-14962](https://jira.yelpcorp.com/browse/RP-14962) - RRF impl

Introduces the blender layer that merges per-retriever TopDocs into a single ranked result set:
- Create dedicated multiretriever packages to include all multiretriever related classes under search
- Create BlenderPlugin and BlenderOperation to support extensible blenders.
- Create builtin weightRRF Blender Operation