### PR TITLE
Fix timeout issue with S3Backend download enum

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
@@ -50,6 +50,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -432,7 +433,7 @@ public class S3Backend implements RemoteBackend {
     return new Enumeration<>() {
       final long STATUS_INTERVAL_MS = 5000;
       long lastStatusTimeMs = System.currentTimeMillis();
-      final LinkedList<CompletableFuture<ResponseInputStream<GetObjectResponse>>> pendingParts =
+      final LinkedList<CompletableFuture<ResponseBytes<GetObjectResponse>>> pendingParts =
           new LinkedList<>();
       int currentPart = 1;
       int queuedPart = 1;
@@ -454,7 +455,7 @@ public class S3Backend implements RemoteBackend {
                       .key(key)
                       .partNumber(finalPart)
                       .build(),
-                  AsyncResponseTransformer.toBlockingInputStream()));
+                  AsyncResponseTransformer.toBytes()));
           queuedPart++;
         }
 
@@ -470,7 +471,7 @@ public class S3Backend implements RemoteBackend {
 
         // return stream for next part from fifo future queue
         try {
-          return pendingParts.pollFirst().get();
+          return pendingParts.pollFirst().get().asInputStream();
         } catch (Exception e) {
           throw new RuntimeException("Error downloading file part", e);
         }


### PR DESCRIPTION
I am seeing an issue where downloading a multipart warming queries can throw an `io.netty.handler.timeout.ReadTimeoutException`.

The issue appears to be that we eagerly start up `defaultParallelism` parts downloading. But using `toBlockingInputStream` creates a connection and maintains a separate internal buffer. When the buffer fills, the connection goes idle, and if it is idle for too long it throws a timeout. The chunks are consumed in order, so if the later parts are not accessed fast enough, we will see an issue.

The downloading has been changed to use the `toBytes` transformer. This will download the entire part into a full sized buffer, avoiding holding an open connection. This will use more memory, but will still be bound by `defaultParallelism` * `partSize`.