### PR TITLE
Fix filtering searcher manager for doc value updates

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NRTReplicaNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NRTReplicaNode.java
@@ -52,6 +52,7 @@ public class NRTReplicaNode extends ReplicaNode {
   private final String nodeName;
   private final boolean ackedCopy;
   private final boolean filterIncompatibleSegmentReaders;
+  private final NrtDataManager nrtDataManager;
   final NrtCopyThread nrtCopyThread;
 
   /* Just a wrapper class to hold our <hostName, port> pair so that we can send them to the Primary
@@ -83,6 +84,7 @@ public class NRTReplicaNode extends ReplicaNode {
     this.nodeName = nodeName;
     this.ackedCopy = ackedCopy;
     this.hostPort = hostPort;
+    this.nrtDataManager = nrtDataManager;
     replicaDeleterManager = decInitialCommit ? new ReplicaDeleterManager(this) : null;
     this.filterIncompatibleSegmentReaders = filterIncompatibleSegmentReaders;
 
@@ -167,7 +169,9 @@ public class NRTReplicaNode extends ReplicaNode {
       // Updating the reference is not thread safe, but since this happens under the object lock
       // and before the shard has stared, nothing should access the manager before the swap.
       ReferenceManager<IndexSearcher> oldMgr = mgr;
-      mgr = new FilteringSegmentInfosSearcherManager(getDirectory(), this, mgr, searcherFactory);
+      mgr =
+          new FilteringSegmentInfosSearcherManager(
+              getDirectory(), this, mgr, nrtDataManager.getLastPrimaryGen(), searcherFactory);
       oldMgr.close();
     }
     copyJobManager.start();

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NRTReplicaNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NRTReplicaNode.java
@@ -210,6 +210,10 @@ public class NRTReplicaNode extends ReplicaNode {
 
   @Override
   protected void finishNRTCopy(CopyJob job, long startNS) throws IOException {
+    if (filterIncompatibleSegmentReaders && mgr instanceof FilteringSegmentInfosSearcherManager) {
+      ((FilteringSegmentInfosSearcherManager) mgr)
+          .setCurrentPrimaryGen(job.getCopyState().primaryGen());
+    }
     super.finishNRTCopy(job, startNS);
 
     copyJobManager.finishNRTCopy(job);

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NrtDataManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NrtDataManager.java
@@ -129,6 +129,17 @@ public class NrtDataManager implements Closeable {
     return lastPointState;
   }
 
+  /**
+   * Get the primary generation from the last loaded NRT point state. Returns -1 if no point state
+   * has been loaded (i.e., no remote restore was performed).
+   *
+   * @return primary generation, or -1 if unknown
+   */
+  public long getLastPrimaryGen() {
+    NrtPointState state = lastPointState;
+    return state != null ? state.primaryGen : -1;
+  }
+
   /** Get the timestamp associated with the last loaded index version */
   public Instant getLastPointTimestamp() {
     return lastPointTimestamp;

--- a/src/main/java/org/apache/lucene/replicator/nrt/FilteringSegmentInfosSearcherManager.java
+++ b/src/main/java/org/apache/lucene/replicator/nrt/FilteringSegmentInfosSearcherManager.java
@@ -58,6 +58,7 @@ public class FilteringSegmentInfosSearcherManager extends SegmentInfosSearcherMa
       Directory dir,
       Node node,
       ReferenceManager<IndexSearcher> mgr,
+      long initialPrimaryGen,
       SearcherFactory searcherFactory)
       throws IOException {
     super(dir, node, ((SegmentInfosSearcherManager) mgr).getCurrentInfos(), searcherFactory);
@@ -67,6 +68,13 @@ public class FilteringSegmentInfosSearcherManager extends SegmentInfosSearcherMa
       searcherFactory = new SearcherFactory();
     }
     this.searcherFactory = searcherFactory;
+    // Seed refreshedPrimaryGen from the initial NRT point state so that the first NRT refresh
+    // correctly detects a primary change. Without this, refreshedPrimaryGen stays at -1, which
+    // suppresses the primaryChanged check and allows stale readers to be reused across a primary
+    // restart that happens between the initial index download and the first NRT copy.
+    if (initialPrimaryGen >= 0) {
+      this.refreshedPrimaryGen = initialPrimaryGen;
+    }
   }
 
   /**
@@ -93,13 +101,11 @@ public class FilteringSegmentInfosSearcherManager extends SegmentInfosSearcherMa
       localCurrentPrimaryGen = currentPrimaryGen;
       localRefreshedPrimaryGen = refreshedPrimaryGen;
     }
-    // Apply strict SCI ID check on the first refresh after the primary changes.
-    // This handles the gen-reuse case: after a primary restart the generation counters reset, so
-    // a new doc values update can produce the same fieldInfosGen as a pre-restart update. The
-    // simple "gen < old gen" check cannot detect this; comparing SegmentCommitInfo IDs (which are
-    // random per-advancement) is the reliable discriminator. We only pay this cost for the one
-    // refresh immediately after the primary changes; subsequent refreshes resume normal core
-    // sharing.
+    // All reader compatibility checks are only necessary on the first refresh after the primary
+    // changes: segment name reuse, backward gen, and the gen-reuse case (where the generation
+    // counter resets to a previously-used value after a restart) can only occur across a primary
+    // restart boundary. We only pay this cost for the one refresh immediately after the primary
+    // changes; subsequent refreshes resume normal core sharing.
     final boolean primaryChanged =
         localRefreshedPrimaryGen >= 0 && localCurrentPrimaryGen != localRefreshedPrimaryGen;
 
@@ -115,55 +121,82 @@ public class FilteringSegmentInfosSearcherManager extends SegmentInfosSearcherMa
         oldReadersMap.put(sr.getSegmentName(), i);
       }
       subs = new ArrayList<>();
+      int filteredCount = 0;
+      int reusedCount = 0;
       for (SegmentCommitInfo commitInfo : newInfos) {
         Integer oldReaderIndex = oldReadersMap.get(commitInfo.info.name);
         if (oldReaderIndex != null) {
           SegmentReader oldReader = (SegmentReader) leaves.get(oldReaderIndex).reader();
-          // check if old reader is compatible with new segment data
-          if (!Arrays.equals(commitInfo.info.getId(), oldReader.getSegmentInfo().info.getId())) {
-            logger.info(
-                "Skipping incompatible old reader, name: "
-                    + commitInfo.info.name
-                    + ", old id: "
-                    + StringHelper.idToString(oldReader.getSegmentInfo().info.getId())
-                    + ", new id: "
-                    + StringHelper.idToString(commitInfo.info.getId()));
-          } else if (primaryChanged
-              && !Arrays.equals(commitInfo.getId(), oldReader.getSegmentInfo().getId())) {
-            // Primary changed and the SegmentCommitInfo ID differs: this segment's commit state
-            // changed after the primary restart. Force a fresh reader to avoid sharing a
-            // SegmentDocValues cache that may hold stale producers from pre-restart generations.
-            logger.info(
-                "Skipping old reader after primary change, name: "
-                    + commitInfo.info.name
-                    + ", old commitInfo id: "
-                    + StringHelper.idToString(oldReader.getSegmentInfo().getId())
-                    + ", new commitInfo id: "
-                    + StringHelper.idToString(commitInfo.getId())
-                    + ", old primaryGen: "
-                    + localRefreshedPrimaryGen
-                    + ", new primaryGen: "
-                    + localCurrentPrimaryGen);
-          } else if (commitInfo.getFieldInfosGen() < oldReader.getSegmentInfo().getFieldInfosGen()
-              || commitInfo.getDelGen() < oldReader.getSegmentInfo().getDelGen()) {
-            // Generation went backwards (e.g. primary restarted and lost uncommitted doc values
-            // updates). Force a fresh reader with no shared core/segDocValues state to avoid
-            // inconsistent doc values data.
-            logger.info(
-                "Skipping old reader with backward generation, name: "
-                    + commitInfo.info.name
-                    + ", old fieldInfosGen: "
-                    + oldReader.getSegmentInfo().getFieldInfosGen()
-                    + ", new fieldInfosGen: "
-                    + commitInfo.getFieldInfosGen()
-                    + ", old delGen: "
-                    + oldReader.getSegmentInfo().getDelGen()
-                    + ", new delGen: "
-                    + commitInfo.getDelGen());
+          if (primaryChanged) {
+            // On the first refresh after a primary change, apply strict compatibility checks.
+            // All three conditions below can only occur due to a primary restart, so we only
+            // pay this cost once per primary change; subsequent refreshes resume normal core
+            // sharing.
+            if (!Arrays.equals(commitInfo.info.getId(), oldReader.getSegmentInfo().info.getId())) {
+              // Segment name was reused for entirely different data after a primary restart.
+              logger.info(
+                  "Skipping incompatible old reader, name: "
+                      + commitInfo.info.name
+                      + ", old id: "
+                      + StringHelper.idToString(oldReader.getSegmentInfo().info.getId())
+                      + ", new id: "
+                      + StringHelper.idToString(commitInfo.info.getId()));
+              filteredCount++;
+            } else if (!Arrays.equals(commitInfo.getId(), oldReader.getSegmentInfo().getId())) {
+              // SegmentCommitInfo ID differs: this segment's commit state changed after the
+              // primary restart. Force a fresh reader to avoid sharing a SegmentDocValues cache
+              // that may hold stale producers from pre-restart generations (gen-reuse case: the
+              // simple "gen < old gen" check cannot detect equal-but-different fieldInfosGen
+              // values).
+              logger.info(
+                  "Skipping old reader after primary change, name: "
+                      + commitInfo.info.name
+                      + ", old commitInfo id: "
+                      + StringHelper.idToString(oldReader.getSegmentInfo().getId())
+                      + ", new commitInfo id: "
+                      + StringHelper.idToString(commitInfo.getId())
+                      + ", old primaryGen: "
+                      + localRefreshedPrimaryGen
+                      + ", new primaryGen: "
+                      + localCurrentPrimaryGen);
+              filteredCount++;
+            } else if (commitInfo.getFieldInfosGen() < oldReader.getSegmentInfo().getFieldInfosGen()
+                || commitInfo.getDelGen() < oldReader.getSegmentInfo().getDelGen()) {
+              // Generation went backwards (e.g. primary restarted and lost uncommitted doc values
+              // updates). Force a fresh reader with no shared core/segDocValues state to avoid
+              // inconsistent doc values data.
+              logger.info(
+                  "Skipping old reader with backward generation, name: "
+                      + commitInfo.info.name
+                      + ", old fieldInfosGen: "
+                      + oldReader.getSegmentInfo().getFieldInfosGen()
+                      + ", new fieldInfosGen: "
+                      + commitInfo.getFieldInfosGen()
+                      + ", old delGen: "
+                      + oldReader.getSegmentInfo().getDelGen()
+                      + ", new delGen: "
+                      + commitInfo.getDelGen());
+              filteredCount++;
+            } else {
+              subs.add(oldReader);
+              reusedCount++;
+            }
           } else {
             subs.add(oldReader);
           }
         }
+      }
+      if (primaryChanged) {
+        logger.info(
+            "Primary generation changed ("
+                + localRefreshedPrimaryGen
+                + " -> "
+                + localCurrentPrimaryGen
+                + "), filtered "
+                + filteredCount
+                + " reader(s), reused "
+                + reusedCount
+                + " reader(s)");
       }
     }
 

--- a/src/main/java/org/apache/lucene/replicator/nrt/FilteringSegmentInfosSearcherManager.java
+++ b/src/main/java/org/apache/lucene/replicator/nrt/FilteringSegmentInfosSearcherManager.java
@@ -87,9 +87,7 @@ public class FilteringSegmentInfosSearcherManager extends SegmentInfosSearcherMa
         if (oldReaderIndex != null) {
           SegmentReader oldReader = (SegmentReader) leaves.get(oldReaderIndex).reader();
           // check if old reader is compatible with new segment data
-          if (Arrays.equals(commitInfo.info.getId(), oldReader.getSegmentInfo().info.getId())) {
-            subs.add(oldReader);
-          } else {
+          if (!Arrays.equals(commitInfo.info.getId(), oldReader.getSegmentInfo().info.getId())) {
             logger.info(
                 "Skipping incompatible old reader, name: "
                     + commitInfo.info.name
@@ -97,6 +95,24 @@ public class FilteringSegmentInfosSearcherManager extends SegmentInfosSearcherMa
                     + StringHelper.idToString(oldReader.getSegmentInfo().info.getId())
                     + ", new id: "
                     + StringHelper.idToString(commitInfo.info.getId()));
+          } else if (commitInfo.getFieldInfosGen() < oldReader.getSegmentInfo().getFieldInfosGen()
+              || commitInfo.getDelGen() < oldReader.getSegmentInfo().getDelGen()) {
+            // Generation went backwards (e.g. primary restarted and lost uncommitted doc values
+            // updates). Force a fresh reader with no shared core/segDocValues state to avoid
+            // inconsistent doc values data.
+            logger.info(
+                "Skipping old reader with backward generation, name: "
+                    + commitInfo.info.name
+                    + ", old fieldInfosGen: "
+                    + oldReader.getSegmentInfo().getFieldInfosGen()
+                    + ", new fieldInfosGen: "
+                    + commitInfo.getFieldInfosGen()
+                    + ", old delGen: "
+                    + oldReader.getSegmentInfo().getDelGen()
+                    + ", new delGen: "
+                    + commitInfo.getDelGen());
+          } else {
+            subs.add(oldReader);
           }
         }
       }

--- a/src/main/java/org/apache/lucene/replicator/nrt/FilteringSegmentInfosSearcherManager.java
+++ b/src/main/java/org/apache/lucene/replicator/nrt/FilteringSegmentInfosSearcherManager.java
@@ -51,6 +51,8 @@ public class FilteringSegmentInfosSearcherManager extends SegmentInfosSearcherMa
   private final Node node;
   private final AtomicInteger openReaderCount = new AtomicInteger();
   private final SearcherFactory searcherFactory;
+  private long refreshedPrimaryGen = -1;
+  private long currentPrimaryGen = -1;
 
   public FilteringSegmentInfosSearcherManager(
       Directory dir,
@@ -67,9 +69,40 @@ public class FilteringSegmentInfosSearcherManager extends SegmentInfosSearcherMa
     this.searcherFactory = searcherFactory;
   }
 
+  /**
+   * Notify this manager of the primary generation for the NRT point about to be refreshed. Must be
+   * called before the refresh is triggered (i.e., before {@link
+   * SegmentInfosSearcherManager#setCurrentInfos} leads to a {@code maybeRefresh}). When the primary
+   * generation changes, a stricter reader-compatibility check is applied for the next refresh to
+   * handle the gen-reuse case (where a primary restart resets generation counters to values that
+   * were previously used before the restart).
+   *
+   * @param primaryGen primary generation from the NRT copy state
+   */
+  public synchronized void setCurrentPrimaryGen(long primaryGen) {
+    this.currentPrimaryGen = primaryGen;
+  }
+
   @Override
   protected IndexSearcher refreshIfNeeded(IndexSearcher old) throws IOException {
     final SegmentInfos newInfos = getCurrentInfos();
+    // Snapshot primaryGen state under lock so it is consistent within this refresh.
+    final long localCurrentPrimaryGen;
+    final long localRefreshedPrimaryGen;
+    synchronized (this) {
+      localCurrentPrimaryGen = currentPrimaryGen;
+      localRefreshedPrimaryGen = refreshedPrimaryGen;
+    }
+    // Apply strict SCI ID check on the first refresh after the primary changes.
+    // This handles the gen-reuse case: after a primary restart the generation counters reset, so
+    // a new doc values update can produce the same fieldInfosGen as a pre-restart update. The
+    // simple "gen < old gen" check cannot detect this; comparing SegmentCommitInfo IDs (which are
+    // random per-advancement) is the reliable discriminator. We only pay this cost for the one
+    // refresh immediately after the primary changes; subsequent refreshes resume normal core
+    // sharing.
+    final boolean primaryChanged =
+        localRefreshedPrimaryGen >= 0 && localCurrentPrimaryGen != localRefreshedPrimaryGen;
+
     List<LeafReader> subs;
     if (old == null) {
       subs = null;
@@ -95,6 +128,22 @@ public class FilteringSegmentInfosSearcherManager extends SegmentInfosSearcherMa
                     + StringHelper.idToString(oldReader.getSegmentInfo().info.getId())
                     + ", new id: "
                     + StringHelper.idToString(commitInfo.info.getId()));
+          } else if (primaryChanged
+              && !Arrays.equals(commitInfo.getId(), oldReader.getSegmentInfo().getId())) {
+            // Primary changed and the SegmentCommitInfo ID differs: this segment's commit state
+            // changed after the primary restart. Force a fresh reader to avoid sharing a
+            // SegmentDocValues cache that may hold stale producers from pre-restart generations.
+            logger.info(
+                "Skipping old reader after primary change, name: "
+                    + commitInfo.info.name
+                    + ", old commitInfo id: "
+                    + StringHelper.idToString(oldReader.getSegmentInfo().getId())
+                    + ", new commitInfo id: "
+                    + StringHelper.idToString(commitInfo.getId())
+                    + ", old primaryGen: "
+                    + localRefreshedPrimaryGen
+                    + ", new primaryGen: "
+                    + localCurrentPrimaryGen);
           } else if (commitInfo.getFieldInfosGen() < oldReader.getSegmentInfo().getFieldInfosGen()
               || commitInfo.getDelGen() < oldReader.getSegmentInfo().getDelGen()) {
             // Generation went backwards (e.g. primary restarted and lost uncommitted doc values
@@ -123,7 +172,12 @@ public class FilteringSegmentInfosSearcherManager extends SegmentInfosSearcherMa
     addReaderClosedListenerFilter(r);
     node.message("refreshed to version=" + newInfos.getVersion() + " r=" + r);
     IndexReader oldReader = old != null ? old.getIndexReader() : null;
-    return SearcherManager.getSearcher(searcherFactory, r, oldReader);
+    IndexSearcher searcher = SearcherManager.getSearcher(searcherFactory, r, oldReader);
+    // Record the primary gen for this completed refresh so the next refresh can detect changes.
+    synchronized (this) {
+      refreshedPrimaryGen = localCurrentPrimaryGen;
+    }
+    return searcher;
   }
 
   private void addReaderClosedListenerFilter(IndexReader r) {

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/PrimaryRestartTests.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/PrimaryRestartTests.java
@@ -435,6 +435,96 @@ public class PrimaryRestartTests {
     replicaServer.verifySimpleDocIds("test_index", 1, 2, 3, 4, 5);
   }
 
+  /**
+   * Tests that the replica correctly handles the gen-reuse case: after a primary restart, the
+   * generation counter resets to the same value used before the restart, so a new doc values update
+   * produces the same fieldInfosGen as the pre-restart update. The simple "gen &lt; old gen" check
+   * cannot detect this; the primaryGen-gated SegmentCommitInfo ID check must catch it.
+   */
+  @Test
+  public void testPrimaryRestartDocValuesUpdateGenReuse() throws IOException {
+    TestServer primaryServer =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.REMOTE)
+            .withWriteDiscoveryFile(true)
+            .build();
+    primaryServer.createSimpleIndex("test_index");
+    primaryServer.startPrimaryIndex("test_index", -1, null);
+
+    // Commit base documents so they exist in a committed segment
+    primaryServer.addSimpleDocs("test_index", 1, 2, 3);
+    primaryServer.commit("test_index");
+    primaryServer.refresh("test_index");
+
+    TestServer replicaServer =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.REPLICA, -1, IndexDataLocationType.REMOTE)
+            .withAdditionalConfig(
+                String.join(
+                    "\n",
+                    "discoveryFileUpdateIntervalMs: 1000",
+                    "filterIncompatibleSegmentReaders: true"))
+            .build();
+
+    replicaServer.waitForReplication("test_index");
+    replicaServer.verifySimpleDocIds("test_index", 1, 2, 3);
+
+    // Apply update U1: advances fieldInfosGen to 1 (from -1) without committing.
+    primaryServer.addDocs(
+        List.of(
+            AddDocumentRequest.newBuilder()
+                .setIndexName("test_index")
+                .setRequestType(IndexingRequestType.UPDATE_DOC_VALUES)
+                .putFields("id", MultiValuedField.newBuilder().addValue("1").build())
+                .putFields("field1", MultiValuedField.newBuilder().addValue("999").build())
+                .build())
+            .stream());
+    primaryServer.refresh("test_index");
+    replicaServer.waitForReplication("test_index");
+    // Replica reader now has fieldInfosGen=1 for this segment.
+
+    // Restart primary: rolls fieldInfosGen back to -1 (loses U1).
+    primaryServer.restart();
+    primaryServer.verifySimpleDocIds("test_index", 1, 2, 3);
+
+    // Apply U2 on the restarted primary BEFORE any NRT refresh and BEFORE the replica
+    // re-registers. nextWriteFieldInfosGen resets to 1 after rollback, so U2 also gets
+    // fieldInfosGen=1 — same number as U1 but with a different SegmentCommitInfo ID.
+    // We use a field value of id*3=6 for doc id=2 so that verifySimpleDocIds passes
+    // when the fresh reader is opened correctly.
+    primaryServer.addDocs(
+        List.of(
+            AddDocumentRequest.newBuilder()
+                .setIndexName("test_index")
+                .setRequestType(IndexingRequestType.UPDATE_DOC_VALUES)
+                .putFields("id", MultiValuedField.newBuilder().addValue("2").build())
+                .putFields("field1", MultiValuedField.newBuilder().addValue("6").build())
+                .build())
+            .stream());
+
+    // Register the replica BEFORE the first post-restart refresh. No intermediate gen=-1
+    // NRT point has been sent, so the replica will go directly from gen=1 (U1) to gen=1
+    // (U2) when the refresh below fires — triggering the gen-reuse scenario.
+    replicaServer.registerWithPrimary("test_index");
+
+    // Flush U2 to create an NRT point with fieldInfosGen=1 (gen-reuse!). The primary
+    // sends this to the registered replica.
+    primaryServer.refresh("test_index");
+    // Advance primary version to ensure the replica copies and refreshes its readers.
+    primaryServer.addSimpleDocs("test_index", 4);
+    primaryServer.refresh("test_index");
+
+    replicaServer.waitForReplication("test_index");
+
+    // Without the primaryGen-gated SCI ID check, the replica reuses the stale reader from
+    // U1 (fieldInfosGen=1 == fieldInfosGen=1, so the backward-gen "<" check is false).
+    // The stale reader returns field1=999 for doc id=1 (U1 set it; U1 was rolled back so
+    // the correct committed value is id*3=3). verifySimpleDocIds fails with expected 3 but
+    // was 999. With the fix, a fresh reader is opened and field1=3 is returned correctly.
+    primaryServer.verifySimpleDocIds("test_index", 1, 2, 3, 4);
+    replicaServer.verifySimpleDocIds("test_index", 1, 2, 3, 4);
+  }
+
   private List<LeafReaderContext> getVersionLeaves(TestServer server, long version)
       throws IOException {
     IndexSearcher searcher =

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/PrimaryRestartTests.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/PrimaryRestartTests.java
@@ -18,6 +18,7 @@ package com.yelp.nrtsearch.server.grpc;
 import static org.junit.Assert.assertEquals;
 
 import com.yelp.nrtsearch.server.config.IndexStartConfig.IndexDataLocationType;
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest.MultiValuedField;
 import com.yelp.nrtsearch.server.grpc.SearchResponse.Hit;
 import java.io.IOException;
 import java.util.Collections;
@@ -361,6 +362,77 @@ public class PrimaryRestartTests {
         currentLeaves1, Set.of("_0", "_1", "_2", "_3"), Collections.emptySet());
     verifySegmentReaderStatus(
         currentLeaves2, Set.of("_0", "_1", "_2", "_3", "_4"), Collections.emptySet());
+  }
+
+  /**
+   * Verifies that replicas with filterIncompatibleSegmentReaders enabled can handle a primary
+   * restart that loses uncommitted doc values updates. Without the backward-generation check, the
+   * old SegmentReader's shared core/segDocValues state is reused for a segment whose fieldInfosGen
+   * has gone backwards, causing IllegalStateException when accessing numeric doc values.
+   */
+  @Test
+  public void testPrimaryRestartDocValuesUpdateFilter() throws IOException {
+    TestServer primaryServer =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.PRIMARY, 0, IndexDataLocationType.REMOTE)
+            .withWriteDiscoveryFile(true)
+            .build();
+    primaryServer.createSimpleIndex("test_index");
+    primaryServer.startPrimaryIndex("test_index", -1, null);
+
+    // Commit base documents so they exist in a committed segment
+    primaryServer.addSimpleDocs("test_index", 1, 2, 3);
+    primaryServer.commit("test_index");
+    primaryServer.refresh("test_index");
+
+    TestServer replicaServer =
+        TestServer.builder(folder)
+            .withAutoStartConfig(true, Mode.REPLICA, -1, IndexDataLocationType.REMOTE)
+            .withAdditionalConfig(
+                String.join(
+                    "\n",
+                    "discoveryFileUpdateIntervalMs: 1000",
+                    "filterIncompatibleSegmentReaders: true"))
+            .build();
+
+    replicaServer.waitForReplication("test_index");
+    replicaServer.verifySimpleDocIds("test_index", 1, 2, 3);
+
+    // Apply a doc values update to field1 for doc id=1 without committing.
+    // This advances fieldInfosGen for the committed segment on the primary.
+    primaryServer.addDocs(
+        List.of(
+            AddDocumentRequest.newBuilder()
+                .setIndexName("test_index")
+                .setRequestType(IndexingRequestType.UPDATE_DOC_VALUES)
+                .putFields("id", MultiValuedField.newBuilder().addValue("1").build())
+                .putFields("field1", MultiValuedField.newBuilder().addValue("999").build())
+                .build())
+            .stream());
+    // NRT refresh propagates the update to replica without committing
+    primaryServer.refresh("test_index");
+
+    replicaServer.waitForReplication("test_index");
+
+    // Restart primary: loses the uncommitted doc values update, fieldInfosGen rolls back
+    primaryServer.restart();
+    primaryServer.verifySimpleDocIds("test_index", 1, 2, 3);
+
+    replicaServer.registerWithPrimary("test_index");
+
+    // Advance primary version past the replica so it syncs and refreshes readers
+    primaryServer.addSimpleDocs("test_index", 4);
+    primaryServer.refresh("test_index");
+    primaryServer.addSimpleDocs("test_index", 5);
+    primaryServer.refresh("test_index");
+
+    replicaServer.waitForReplication("test_index");
+
+    // Without the backward-generation filter fix, the replica throws
+    // IllegalStateException("unexpected docvalues type NUMERIC for field 'field1' ...")
+    // when retrieving field1 for docs 1-3 whose segment reader has stale shared state.
+    primaryServer.verifySimpleDocIds("test_index", 1, 2, 3, 4, 5);
+    replicaServer.verifySimpleDocIds("test_index", 1, 2, 3, 4, 5);
   }
 
   private List<LeafReaderContext> getVersionLeaves(TestServer server, long version)


### PR DESCRIPTION
Fix FilteringSegmentInfosSearcherManager for doc values update edge cases

  FilteringSegmentInfosSearcherManager is an opt-in (filterIncompatibleSegmentReaders: true) extension of the NRT searcher manager that filters stale SegmentReader instances during refresh, for replicas where a primary restart may reuse segment names for previously-synced uncommitted data.

  Problems fixed

  Backward generation not detected

  After a primary restart, uncommitted doc values updates are lost and fieldInfosGen/delGen roll back. The old SegmentReader (whose shared segDocValues cache holds the pre-restart state) was being reused, causing IllegalStateException: unexpected docvalues type on the refreshed reader.

  Gen-reuse not detected

  After a restart the primary's generation counter resets to its initial value. If a new doc values update is applied, it gets the same fieldInfosGen as the pre-restart update. The backward-gen < check returns false (equal, not less), so the stale reader is reused and returns stale field values.

  Changes

  - Backward generation check: force a fresh reader when commitInfo.getFieldInfosGen() < oldReader.getFieldInfosGen() or commitInfo.getDelGen() < oldReader.getDelGen().
  - Gen-reuse detection via SegmentCommitInfo ID: a primaryChanged flag (true on the first refresh after the primary generation changes) gates a check comparing SegmentCommitInfo IDs (random UUIDs advanced on each doc values write). These are unique per advancement so they catch equal-but-different generation
  numbers.
  - Restructured filter logic: all three filter conditions can only occur across a primary restart boundary, so they are all now gated under primaryChanged. Normal refreshes skip all checks entirely.
  - Summary log line: after processing a primary change, logs "Primary generation changed (X -> Y), filtered N reader(s), reused M reader(s)".
  - Correct refreshedPrimaryGen initialization: previously defaulted to -1, suppressing primaryChanged detection for the first refresh after startup. Now seeded from NrtDataManager.getLastPrimaryGen(), which reads the primaryGen from the downloaded NrtPointState — the reliable source, since Node.PRIMARY_GEN_KEY in
  SegmentInfos user data is only written on a PrimaryNode.commit().
  - NrtDataManager.getLastPrimaryGen() added as a clean public API; NRTReplicaNode now stores nrtDataManager as a field so it's available at start() time.

  Tests

  Six integration tests in PrimaryRestartTests cover the scenarios:
  - testPrimaryRestartReplicationFilterIncompatible — conflicting segments are filtered and replica converges to primary state
  - testPreviousReplicaSearcher — old searchers retained in SearcherLifetimeManager remain valid after filtering
  - testCleanupPreviousSearcher — segment readers from pruned searchers are closed while current ones are retained
  - testPrimaryRestartDocValuesUpdateFilter — backward-gen check prevents stale shared doc values state after restart
  - testPrimaryRestartDocValuesUpdateGenReuse — SCI ID check catches the gen-reuse case where fieldInfosGen is equal but represents different data