### PR TITLE
Expose additional options in the client ChannelConfig

### DIFF
--- a/clientlib/src/main/java/com/yelp/nrtsearch/server/grpc/ChannelConfig.java
+++ b/clientlib/src/main/java/com/yelp/nrtsearch/server/grpc/ChannelConfig.java
@@ -31,7 +31,10 @@ import java.util.concurrent.TimeUnit;
 @JsonInclude(Include.NON_NULL)
 public class ChannelConfig {
   private Boolean enableRetry;
+  private Integer maxRetryAttempts;
   private Integer maxHedgedAttempts;
+  private Long retryBufferSize;
+  private Long perRpcBufferLimit;
   private Integer maxInboundMessageSize;
   private Integer keepAliveTimeMs;
   private Integer keepAliveTimeoutMs;
@@ -45,20 +48,32 @@ public class ChannelConfig {
    * Constructor.
    *
    * @param enableRetry if the retry system should be enabled
+   * @param maxRetryAttempts channel level max for retry attempts
    * @param maxHedgedAttempts channel level max for hedge attempts
+   * @param retryBufferSize total retry buffer size in bytes per channel
+   * @param perRpcBufferLimit per-RPC byte limit for retry/hedging buffer
    * @param maxInboundMessageSize maximum size of inbound messages in bytes
+   * @param keepAliveTimeMs keep alive time in milliseconds
+   * @param keepAliveTimeoutMs keep alive timeout in milliseconds
+   * @param keepAliveWithoutCalls if keep alive should be sent without calls
    * @param serviceConfig additional service configuration
    */
   public ChannelConfig(
       Boolean enableRetry,
+      Integer maxRetryAttempts,
       Integer maxHedgedAttempts,
+      Long retryBufferSize,
+      Long perRpcBufferLimit,
       Integer maxInboundMessageSize,
       Integer keepAliveTimeMs,
       Integer keepAliveTimeoutMs,
       Boolean keepAliveWithoutCalls,
       ServiceConfig serviceConfig) {
     this.enableRetry = enableRetry;
+    this.maxRetryAttempts = maxRetryAttempts;
     this.maxHedgedAttempts = maxHedgedAttempts;
+    this.retryBufferSize = retryBufferSize;
+    this.perRpcBufferLimit = perRpcBufferLimit;
     this.maxInboundMessageSize = maxInboundMessageSize;
     this.keepAliveTimeMs = keepAliveTimeMs;
     this.keepAliveTimeoutMs = keepAliveTimeoutMs;
@@ -70,8 +85,20 @@ public class ChannelConfig {
     return enableRetry;
   }
 
+  public Integer getMaxRetryAttempts() {
+    return maxRetryAttempts;
+  }
+
   public Integer getMaxHedgedAttempts() {
     return maxHedgedAttempts;
+  }
+
+  public Long getRetryBufferSize() {
+    return retryBufferSize;
+  }
+
+  public Long getPerRpcBufferLimit() {
+    return perRpcBufferLimit;
   }
 
   public Integer getMaxInboundMessageSize() {
@@ -110,8 +137,17 @@ public class ChannelConfig {
         builder.disableRetry();
       }
     }
+    if (maxRetryAttempts != null) {
+      builder.maxRetryAttempts(maxRetryAttempts);
+    }
     if (maxHedgedAttempts != null) {
       builder.maxHedgedAttempts(maxHedgedAttempts);
+    }
+    if (retryBufferSize != null) {
+      builder.retryBufferSize(retryBufferSize);
+    }
+    if (perRpcBufferLimit != null) {
+      builder.perRpcBufferLimit(perRpcBufferLimit);
     }
     if (maxInboundMessageSize != null) {
       builder.maxInboundMessageSize(maxInboundMessageSize);
@@ -173,6 +209,10 @@ public class ChannelConfig {
       private List<MethodName> name;
       private String timeout;
       private HedgingPolicy hedgingPolicy;
+      private RetryPolicy retryPolicy;
+      private Boolean waitForReady;
+      private Double maxRequestMessageBytes;
+      private Double maxResponseMessageBytes;
 
       // Deserialization constructor
       public MethodConfig() {}
@@ -182,11 +222,22 @@ public class ChannelConfig {
        *
        * @param name method names, this must be specified and contain at least one value
        * @param timeout method deadline
-       * @param hedgingPolicy hedging config
+       * @param hedgingPolicy hedging config, mutually exclusive with retryPolicy
+       * @param retryPolicy retry config, mutually exclusive with hedgingPolicy
+       * @param waitForReady if RPCs should wait for the channel to be ready
+       * @param maxRequestMessageBytes max size of a request message in bytes
+       * @param maxResponseMessageBytes max size of a response message in bytes
        * @throws NullPointerException if name is null
        * @throws IllegalArgumentException if name is empty
        */
-      public MethodConfig(List<MethodName> name, String timeout, HedgingPolicy hedgingPolicy) {
+      public MethodConfig(
+          List<MethodName> name,
+          String timeout,
+          HedgingPolicy hedgingPolicy,
+          RetryPolicy retryPolicy,
+          Boolean waitForReady,
+          Double maxRequestMessageBytes,
+          Double maxResponseMessageBytes) {
         Objects.requireNonNull(name);
         if (name.isEmpty()) {
           throw new IllegalArgumentException("At least one method name must be specified");
@@ -194,6 +245,10 @@ public class ChannelConfig {
         this.name = name;
         this.timeout = timeout;
         this.hedgingPolicy = hedgingPolicy;
+        this.retryPolicy = retryPolicy;
+        this.waitForReady = waitForReady;
+        this.maxRequestMessageBytes = maxRequestMessageBytes;
+        this.maxResponseMessageBytes = maxResponseMessageBytes;
       }
 
       public List<MethodName> getName() {
@@ -206,6 +261,22 @@ public class ChannelConfig {
 
       public HedgingPolicy getHedgingPolicy() {
         return hedgingPolicy;
+      }
+
+      public RetryPolicy getRetryPolicy() {
+        return retryPolicy;
+      }
+
+      public Boolean getWaitForReady() {
+        return waitForReady;
+      }
+
+      public Double getMaxRequestMessageBytes() {
+        return maxRequestMessageBytes;
+      }
+
+      public Double getMaxResponseMessageBytes() {
+        return maxResponseMessageBytes;
       }
 
       /**
@@ -245,6 +316,72 @@ public class ChannelConfig {
 
         public List<String> getNonFatalStatusCodes() {
           return nonFatalStatusCodes;
+        }
+      }
+
+      /**
+       * Request retry configuration. See <a
+       * href="https://github.com/grpc/proposal/blob/master/A6-client-retries.md#retry-policy-1">docs</a>.
+       */
+      @JsonInclude(Include.NON_NULL)
+      public static class RetryPolicy {
+        private Double maxAttempts;
+        private String initialBackoff;
+        private String maxBackoff;
+        private Double backoffMultiplier;
+        private String perAttemptRecvTimeout;
+        private List<String> retryableStatusCodes;
+
+        // Deserialization constructor
+        public RetryPolicy() {}
+
+        /**
+         * Constructor.
+         *
+         * @param maxAttempts max number of retry attempts, including the initial attempt
+         * @param initialBackoff initial backoff duration (e.g. "0.1s")
+         * @param maxBackoff maximum backoff duration (e.g. "1s")
+         * @param backoffMultiplier multiplier applied to backoff between attempts
+         * @param perAttemptRecvTimeout per-attempt receive timeout duration
+         * @param retryableStatusCodes list of status codes that trigger a retry
+         */
+        public RetryPolicy(
+            Double maxAttempts,
+            String initialBackoff,
+            String maxBackoff,
+            Double backoffMultiplier,
+            String perAttemptRecvTimeout,
+            List<String> retryableStatusCodes) {
+          this.maxAttempts = maxAttempts;
+          this.initialBackoff = initialBackoff;
+          this.maxBackoff = maxBackoff;
+          this.backoffMultiplier = backoffMultiplier;
+          this.perAttemptRecvTimeout = perAttemptRecvTimeout;
+          this.retryableStatusCodes = retryableStatusCodes;
+        }
+
+        public Double getMaxAttempts() {
+          return maxAttempts;
+        }
+
+        public String getInitialBackoff() {
+          return initialBackoff;
+        }
+
+        public String getMaxBackoff() {
+          return maxBackoff;
+        }
+
+        public Double getBackoffMultiplier() {
+          return backoffMultiplier;
+        }
+
+        public String getPerAttemptRecvTimeout() {
+          return perAttemptRecvTimeout;
+        }
+
+        public List<String> getRetryableStatusCodes() {
+          return retryableStatusCodes;
         }
       }
     }

--- a/clientlib/src/test/java/com/yelp/nrtsearch/server/grpc/ChannelConfigTest.java
+++ b/clientlib/src/test/java/com/yelp/nrtsearch/server/grpc/ChannelConfigTest.java
@@ -70,6 +70,18 @@ public class ChannelConfigTest {
   }
 
   @Test
+  public void testMaxRetryAttempts() throws IOException {
+    String configJson = "{\"maxRetryAttempts\": 3}";
+    ChannelConfig config = OBJECT_MAPPER.readValue(configJson, ChannelConfig.class);
+
+    ManagedChannelBuilder<?> mockBuilder = mock(ManagedChannelBuilder.class);
+    config.configureChannelBuilder(mockBuilder, OBJECT_MAPPER);
+
+    verify(mockBuilder, times(1)).maxRetryAttempts(3);
+    verifyNoMoreInteractions(mockBuilder);
+  }
+
+  @Test
   public void testMaxHedgedAttempts() throws IOException {
     String configJson = "{\"maxHedgedAttempts\": 5}";
     ChannelConfig config = OBJECT_MAPPER.readValue(configJson, ChannelConfig.class);
@@ -78,6 +90,30 @@ public class ChannelConfigTest {
     config.configureChannelBuilder(mockBuilder, OBJECT_MAPPER);
 
     verify(mockBuilder, times(1)).maxHedgedAttempts(5);
+    verifyNoMoreInteractions(mockBuilder);
+  }
+
+  @Test
+  public void testRetryBufferSize() throws IOException {
+    String configJson = "{\"retryBufferSize\": 16777216}";
+    ChannelConfig config = OBJECT_MAPPER.readValue(configJson, ChannelConfig.class);
+
+    ManagedChannelBuilder<?> mockBuilder = mock(ManagedChannelBuilder.class);
+    config.configureChannelBuilder(mockBuilder, OBJECT_MAPPER);
+
+    verify(mockBuilder, times(1)).retryBufferSize(16777216L);
+    verifyNoMoreInteractions(mockBuilder);
+  }
+
+  @Test
+  public void testPerRpcBufferLimit() throws IOException {
+    String configJson = "{\"perRpcBufferLimit\": 1048576}";
+    ChannelConfig config = OBJECT_MAPPER.readValue(configJson, ChannelConfig.class);
+
+    ManagedChannelBuilder<?> mockBuilder = mock(ManagedChannelBuilder.class);
+    config.configureChannelBuilder(mockBuilder, OBJECT_MAPPER);
+
+    verify(mockBuilder, times(1)).perRpcBufferLimit(1048576L);
     verifyNoMoreInteractions(mockBuilder);
   }
 
@@ -131,12 +167,12 @@ public class ChannelConfigTest {
 
   @Test(expected = NullPointerException.class)
   public void testNullMethodName() {
-    new MethodConfig(null, null, null);
+    new MethodConfig(null, null, null, null, null, null, null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testNoMethodName() {
-    new MethodConfig(Collections.emptyList(), null, null);
+    new MethodConfig(Collections.emptyList(), null, null, null, null, null, null);
   }
 
   @Test
@@ -219,6 +255,119 @@ public class ChannelConfigTest {
     expectedHedgingConfig.put("hedgingDelay", "1s");
     expectedHedgingConfig.put("nonFatalStatusCodes", Collections.singletonList("UNAVAILABLE"));
     expectedMethodConfig.put("hedgingPolicy", expectedHedgingConfig);
+    expectedServiceConfig.put("methodConfig", Collections.singletonList(expectedMethodConfig));
+
+    verify(mockBuilder, times(1)).defaultServiceConfig(expectedServiceConfig);
+    verifyNoMoreInteractions(mockBuilder);
+    verifyServiceConfigSettable(expectedServiceConfig);
+  }
+
+  @Test
+  public void testMethodRetryPolicy() throws IOException {
+    String configJson =
+        "{\"serviceConfig\": {\"methodConfig\": [{\"name\": [{}], \"retryPolicy\": {\"maxAttempts\": 3, \"initialBackoff\": \"0.1s\", \"maxBackoff\": \"1s\", \"backoffMultiplier\": 2, \"retryableStatusCodes\": [\"UNAVAILABLE\"]}}]}}";
+    ChannelConfig config = OBJECT_MAPPER.readValue(configJson, ChannelConfig.class);
+
+    ManagedChannelBuilder<?> mockBuilder = mock(ManagedChannelBuilder.class);
+    config.configureChannelBuilder(mockBuilder, OBJECT_MAPPER);
+
+    Map<String, Object> expectedServiceConfig = new HashMap<>();
+    Map<String, Object> expectedMethodConfig = new HashMap<>();
+    Map<String, Object> expectedRetryPolicy = new HashMap<>();
+    expectedMethodConfig.put("name", Collections.singletonList(new HashMap<String, Object>()));
+    expectedRetryPolicy.put("maxAttempts", 3.0);
+    expectedRetryPolicy.put("initialBackoff", "0.1s");
+    expectedRetryPolicy.put("maxBackoff", "1s");
+    expectedRetryPolicy.put("backoffMultiplier", 2.0);
+    expectedRetryPolicy.put("retryableStatusCodes", Collections.singletonList("UNAVAILABLE"));
+    expectedMethodConfig.put("retryPolicy", expectedRetryPolicy);
+    expectedServiceConfig.put("methodConfig", Collections.singletonList(expectedMethodConfig));
+
+    verify(mockBuilder, times(1)).defaultServiceConfig(expectedServiceConfig);
+    verifyNoMoreInteractions(mockBuilder);
+    verifyServiceConfigSettable(expectedServiceConfig);
+  }
+
+  @Test
+  public void testMethodRetryPolicyWithPerAttemptRecvTimeout() throws IOException {
+    String configJson =
+        "{\"serviceConfig\": {\"methodConfig\": [{\"name\": [{}], \"retryPolicy\": {\"maxAttempts\": 3, \"initialBackoff\": \"0.1s\", \"maxBackoff\": \"1s\", \"backoffMultiplier\": 2, \"perAttemptRecvTimeout\": \"2s\", \"retryableStatusCodes\": [\"UNAVAILABLE\"]}}]}}";
+    ChannelConfig config = OBJECT_MAPPER.readValue(configJson, ChannelConfig.class);
+
+    ManagedChannelBuilder<?> mockBuilder = mock(ManagedChannelBuilder.class);
+    config.configureChannelBuilder(mockBuilder, OBJECT_MAPPER);
+
+    Map<String, Object> expectedServiceConfig = new HashMap<>();
+    Map<String, Object> expectedMethodConfig = new HashMap<>();
+    Map<String, Object> expectedRetryPolicy = new HashMap<>();
+    expectedMethodConfig.put("name", Collections.singletonList(new HashMap<String, Object>()));
+    expectedRetryPolicy.put("maxAttempts", 3.0);
+    expectedRetryPolicy.put("initialBackoff", "0.1s");
+    expectedRetryPolicy.put("maxBackoff", "1s");
+    expectedRetryPolicy.put("backoffMultiplier", 2.0);
+    expectedRetryPolicy.put("perAttemptRecvTimeout", "2s");
+    expectedRetryPolicy.put("retryableStatusCodes", Collections.singletonList("UNAVAILABLE"));
+    expectedMethodConfig.put("retryPolicy", expectedRetryPolicy);
+    expectedServiceConfig.put("methodConfig", Collections.singletonList(expectedMethodConfig));
+
+    verify(mockBuilder, times(1)).defaultServiceConfig(expectedServiceConfig);
+    verifyNoMoreInteractions(mockBuilder);
+    verifyServiceConfigSettable(expectedServiceConfig);
+  }
+
+  @Test
+  public void testMethodWaitForReady() throws IOException {
+    String configJson =
+        "{\"serviceConfig\": {\"methodConfig\": [{\"name\": [{}], \"waitForReady\": true}]}}";
+    ChannelConfig config = OBJECT_MAPPER.readValue(configJson, ChannelConfig.class);
+
+    ManagedChannelBuilder<?> mockBuilder = mock(ManagedChannelBuilder.class);
+    config.configureChannelBuilder(mockBuilder, OBJECT_MAPPER);
+
+    Map<String, Object> expectedServiceConfig = new HashMap<>();
+    Map<String, Object> expectedMethodConfig = new HashMap<>();
+    expectedMethodConfig.put("name", Collections.singletonList(new HashMap<String, Object>()));
+    expectedMethodConfig.put("waitForReady", true);
+    expectedServiceConfig.put("methodConfig", Collections.singletonList(expectedMethodConfig));
+
+    verify(mockBuilder, times(1)).defaultServiceConfig(expectedServiceConfig);
+    verifyNoMoreInteractions(mockBuilder);
+    verifyServiceConfigSettable(expectedServiceConfig);
+  }
+
+  @Test
+  public void testMethodMaxRequestMessageBytes() throws IOException {
+    String configJson =
+        "{\"serviceConfig\": {\"methodConfig\": [{\"name\": [{}], \"maxRequestMessageBytes\": 4194304}]}}";
+    ChannelConfig config = OBJECT_MAPPER.readValue(configJson, ChannelConfig.class);
+
+    ManagedChannelBuilder<?> mockBuilder = mock(ManagedChannelBuilder.class);
+    config.configureChannelBuilder(mockBuilder, OBJECT_MAPPER);
+
+    Map<String, Object> expectedServiceConfig = new HashMap<>();
+    Map<String, Object> expectedMethodConfig = new HashMap<>();
+    expectedMethodConfig.put("name", Collections.singletonList(new HashMap<String, Object>()));
+    expectedMethodConfig.put("maxRequestMessageBytes", 4194304.0);
+    expectedServiceConfig.put("methodConfig", Collections.singletonList(expectedMethodConfig));
+
+    verify(mockBuilder, times(1)).defaultServiceConfig(expectedServiceConfig);
+    verifyNoMoreInteractions(mockBuilder);
+    verifyServiceConfigSettable(expectedServiceConfig);
+  }
+
+  @Test
+  public void testMethodMaxResponseMessageBytes() throws IOException {
+    String configJson =
+        "{\"serviceConfig\": {\"methodConfig\": [{\"name\": [{}], \"maxResponseMessageBytes\": 8388608}]}}";
+    ChannelConfig config = OBJECT_MAPPER.readValue(configJson, ChannelConfig.class);
+
+    ManagedChannelBuilder<?> mockBuilder = mock(ManagedChannelBuilder.class);
+    config.configureChannelBuilder(mockBuilder, OBJECT_MAPPER);
+
+    Map<String, Object> expectedServiceConfig = new HashMap<>();
+    Map<String, Object> expectedMethodConfig = new HashMap<>();
+    expectedMethodConfig.put("name", Collections.singletonList(new HashMap<String, Object>()));
+    expectedMethodConfig.put("maxResponseMessageBytes", 8388608.0);
     expectedServiceConfig.put("methodConfig", Collections.singletonList(expectedMethodConfig));
 
     verify(mockBuilder, times(1)).defaultServiceConfig(expectedServiceConfig);


### PR DESCRIPTION
Adds missing gRPC retry and hedging configuration options to ChannelConfig.

  New channel-level fields:
  - maxRetryAttempts (Integer) — channel-level cap on retry attempts, counterpart to the existing maxHedgedAttempts
  - retryBufferSize (Long) — total retry buffer size in bytes per channel
  - perRpcBufferLimit (Long) — per-RPC byte limit for retry/hedging buffer

  New per-method service config fields on MethodConfig:
  - retryPolicy (RetryPolicy) — per-method retry policy with exponential backoff; supports maxAttempts, initialBackoff, maxBackoff, backoffMultiplier,
  retryableStatusCodes, and optional perAttemptRecvTimeout; mutually exclusive with hedgingPolicy
  - waitForReady (Boolean) — whether RPCs should wait for the channel to be ready
  - maxRequestMessageBytes (Double) — max request message size in bytes
  - maxResponseMessageBytes (Double) — max response message size in bytes

  Notes:
  - Mutual exclusivity of retryPolicy and hedgingPolicy is enforced by gRPC at channel creation time when defaultServiceConfig() is called, not at the Java level
  - Numeric service config fields use Double as required by proto3 JSON encoding
  - All new fields are nullable; omitting them preserves existing default channel behavior