### PR TITLE
Add score based and scoreless blender

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -836,11 +836,12 @@ message KnnRetriever {
 }
 
 // Blender to merge Multi-Retriever topDocs
-// TODO: Additional blenders will be added
 message Blender {
     oneof blenderType {
         WeightedRrfBlender weightedRrf = 1;
+        WeightedScoreOrderBlender weightedScoreOrder = 2;
         PluginBlender plugin = 3;
+        ScorelessRawMergeBlender scorelessRawMerge = 4;
     }
 }
 
@@ -849,6 +850,33 @@ message WeightedRrfBlender {
     // Reduces the impact of rank differences between retrievers. Default: 60
     int32 rankConstant = 1;
 }
+
+// Weighted Score Order Blender. Blends raw retriever scores multiplied by each retriever's boost.
+message WeightedScoreOrderBlender {
+    // How per-retriever weighted scores are combined for documents appearing in multiple retrievers.
+    // Default: MAX
+    ScoreMode scoreMode = 1;
+
+    // How per-retriever weighted scores are combined when the same document appears in multiple
+    // retrievers.
+    enum ScoreMode {
+        // Use the highest weighted score across all retrievers.
+        MAX = 0;
+        // Sum all weighted retriever scores.
+        SUM = 1;
+        // Average all weighted retriever scores.
+        AVG = 2;
+    }
+}
+
+// Scoreless Raw Merge Blender. Deduplicates hits across retrievers and preserves all per-retriever
+// raw ScoreDocs under each BlendedScoreDoc, but assigns score 0 to every result. Sorting and
+// pagination are skipped.
+// set is returned. Intended for two use cases:
+//   1. Client-side ranking: the caller applies its own ranking (e.g. global RRF across shards)
+//      over the returned raw per-retriever scores.
+//   2. Server-side rescoring: a downstream rescorer receives all deduplicated candidates and do rescoring.
+message ScorelessRawMergeBlender {}
 
 message PluginBlender {
     // Registered blender plugin name

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderCreator.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderCreator.java
@@ -20,7 +20,9 @@ import com.yelp.nrtsearch.server.grpc.Blender;
 import com.yelp.nrtsearch.server.grpc.PluginBlender;
 import com.yelp.nrtsearch.server.plugins.BlenderPlugin;
 import com.yelp.nrtsearch.server.plugins.Plugin;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.operation.ScorelessRawMergeBlenderOperation;
 import com.yelp.nrtsearch.server.search.multiretriever.blender.operation.WeightedRrfBlenderOperation;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.operation.WeightedScoreOrderBlenderOperation;
 import com.yelp.nrtsearch.server.utils.StructValueTransformer;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,6 +49,9 @@ public class BlenderCreator {
   public BlenderOperation getBlenderOperation(Blender blender) {
     return switch (blender.getBlenderTypeCase()) {
       case WEIGHTEDRRF -> new WeightedRrfBlenderOperation(blender.getWeightedRrf());
+      case WEIGHTEDSCOREORDER ->
+          new WeightedScoreOrderBlenderOperation(blender.getWeightedScoreOrder());
+      case SCORELESSRAWMERGE -> new ScorelessRawMergeBlenderOperation();
       case PLUGIN -> getPluginBlender(blender.getPlugin());
       default ->
           throw new IllegalArgumentException(

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/ScorelessRawMergeBlenderOperation.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/ScorelessRawMergeBlenderOperation.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever.blender.operation;
+
+import com.yelp.nrtsearch.server.search.multiretriever.RetrieverContext;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.BlenderOperation;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.score.BlendedScoreDoc;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.score.WeightedScoreDoc;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+
+/**
+ * {@link BlenderOperation} that deduplicates hits across retrievers (accumulating per-retriever
+ * {@link ScoreDoc}s in a single {@link WeightedScoreDoc}) but assigns score 0 to every result and
+ * skips sorting and pagination. Intended for callers that handle ranking and pagination on the
+ * client side.
+ */
+public class ScorelessRawMergeBlenderOperation implements BlenderOperation {
+
+  /**
+   * Deduplicates hits by doc ID across retrievers. Each unique document is represented by a {@link
+   * WeightedScoreDoc} with weight 0, so {@link BlendedScoreDoc#score} remains 0 regardless of how
+   * many retrievers contributed. All per-retriever hits for the same document are preserved in
+   * {@link BlendedScoreDoc#getScoreDocs()}.
+   */
+  @Override
+  public Collection<BlendedScoreDoc> mergeHits(
+      LinkedHashMap<String, TopDocs> retrieverResults,
+      LinkedHashMap<String, RetrieverContext> retrieverContexts) {
+
+    Map<Integer, BlendedScoreDoc> merged = new HashMap<>();
+
+    for (Map.Entry<String, TopDocs> entry : retrieverResults.entrySet()) {
+      for (ScoreDoc scoreDoc : entry.getValue().scoreDocs) {
+        BlendedScoreDoc existing = merged.get(scoreDoc.doc);
+        if (existing == null) {
+          merged.put(
+              scoreDoc.doc,
+              new WeightedScoreDoc(entry.getKey(), scoreDoc, 0f, WeightedScoreDoc.ScoreMode.MAX));
+        } else {
+          existing.add(entry.getKey(), 0, 0f, scoreDoc);
+        }
+      }
+    }
+
+    return merged.values();
+  }
+
+  /**
+   * Collects results via {@link #mergeHits}, then returns them as-is without sorting or pagination.
+   * The {@code startHit} and {@code topHits} parameters are ignored.
+   */
+  @Override
+  public TopDocs blend(
+      LinkedHashMap<String, Future<TopDocs>> retrieverFutures,
+      LinkedHashMap<String, RetrieverContext> retrieverContexts,
+      int startHit,
+      int topHits)
+      throws InterruptedException {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    for (Map.Entry<String, Future<TopDocs>> entry : retrieverFutures.entrySet()) {
+      String name = entry.getKey();
+      try {
+        results.put(name, entry.getValue().get());
+      } catch (ExecutionException e) {
+        Throwable cause = e.getCause() != null ? e.getCause() : e;
+        throw new RuntimeException("Retriever '" + name + "' failed: " + cause.getMessage(), cause);
+      }
+    }
+
+    Collection<BlendedScoreDoc> merged = mergeHits(results, retrieverContexts);
+    return new TopDocs(
+        new TotalHits(merged.size(), TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO),
+        merged.toArray(ScoreDoc[]::new));
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/WeightedScoreOrderBlenderOperation.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/WeightedScoreOrderBlenderOperation.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever.blender.operation;
+
+import com.yelp.nrtsearch.server.grpc.WeightedScoreOrderBlender;
+import com.yelp.nrtsearch.server.search.multiretriever.RetrieverContext;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.BlenderOperation;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.score.BlendedScoreDoc;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.score.WeightedScoreDoc;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+
+/**
+ * {@link BlenderOperation} that blends raw retriever scores weighted by each retriever's boost.
+ *
+ * <p>Each document's blended score is computed from {@code score * boost} contributions across all
+ * retrievers, combined according to the configured {@link WeightedScoreDoc.ScoreMode}:
+ *
+ * <ul>
+ *   <li>{@link WeightedScoreDoc.ScoreMode#MAX} — highest weighted score wins (default).
+ *   <li>{@link WeightedScoreDoc.ScoreMode#SUM} — sum of all weighted scores.
+ *   <li>{@link WeightedScoreDoc.ScoreMode#AVG} — average of all weighted scores.
+ * </ul>
+ */
+public class WeightedScoreOrderBlenderOperation implements BlenderOperation {
+
+  private final WeightedScoreDoc.ScoreMode scoreMode;
+
+  public WeightedScoreOrderBlenderOperation(WeightedScoreOrderBlender config) {
+    this.scoreMode = toScoreMode(config.getScoreMode());
+  }
+
+  @Override
+  public Collection<BlendedScoreDoc> mergeHits(
+      LinkedHashMap<String, TopDocs> retrieverResults,
+      LinkedHashMap<String, RetrieverContext> retrieverContexts) {
+
+    Map<Integer, BlendedScoreDoc> merged = new HashMap<>();
+
+    for (Map.Entry<String, TopDocs> entry : retrieverResults.entrySet()) {
+      ScoreDoc[] scoreDocs = entry.getValue().scoreDocs;
+      float boost = retrieverContexts.get(entry.getKey()).getBoost();
+
+      for (ScoreDoc scoreDoc : scoreDocs) {
+        BlendedScoreDoc existing = merged.get(scoreDoc.doc);
+        if (existing == null) {
+          merged.put(
+              scoreDoc.doc, new WeightedScoreDoc(entry.getKey(), scoreDoc, boost, scoreMode));
+        } else {
+          existing.add(entry.getKey(), 0, boost, scoreDoc);
+        }
+      }
+    }
+
+    return merged.values();
+  }
+
+  private static WeightedScoreDoc.ScoreMode toScoreMode(
+      WeightedScoreOrderBlender.ScoreMode grpcMode) {
+    return switch (grpcMode) {
+      case MAX -> WeightedScoreDoc.ScoreMode.MAX;
+      case SUM -> WeightedScoreDoc.ScoreMode.SUM;
+      case AVG -> WeightedScoreDoc.ScoreMode.AVG;
+      case UNRECOGNIZED ->
+          throw new IllegalArgumentException("Unsupported score mode: " + grpcMode);
+    };
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/ScorelessRawMergeBlenderOperationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/ScorelessRawMergeBlenderOperationTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever.blender.operation;
+
+import static org.junit.Assert.assertEquals;
+
+import com.yelp.nrtsearch.server.search.multiretriever.RetrieverContext;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.score.BlendedScoreDoc;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.junit.Test;
+
+public class ScorelessRawMergeBlenderOperationTest {
+
+  private static final float DELTA = 1e-6f;
+
+  private static TopDocs topDocs(int[] docIds, float[] scores) {
+    ScoreDoc[] scoreDocs = new ScoreDoc[docIds.length];
+    for (int i = 0; i < docIds.length; i++) {
+      scoreDocs[i] = new ScoreDoc(docIds[i], scores[i], 0);
+    }
+    return new TopDocs(new TotalHits(docIds.length, TotalHits.Relation.EQUAL_TO), scoreDocs);
+  }
+
+  private static RetrieverContext retriever(String name) {
+    return RetrieverContext.newBuilder(name).build();
+  }
+
+  private static Future<TopDocs> future(TopDocs td) {
+    return CompletableFuture.completedFuture(td);
+  }
+
+  private static Map<Integer, BlendedScoreDoc> toDocMap(Collection<BlendedScoreDoc> docs) {
+    return docs.stream().collect(Collectors.toMap(d -> d.doc, d -> d));
+  }
+
+  // ---- mergeHits ----
+
+  @Test
+  public void testAllScoresAreZero() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(new int[] {1, 2}, new float[] {3.0f, 5.0f}));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text"));
+
+    Collection<BlendedScoreDoc> merged =
+        new ScorelessRawMergeBlenderOperation().mergeHits(results, contexts);
+
+    assertEquals(2, merged.size());
+    for (BlendedScoreDoc doc : merged) {
+      assertEquals(0f, doc.score, DELTA);
+    }
+  }
+
+  @Test
+  public void testDeduplicationKeepsAllRetrieverHits() {
+    // doc 5 in both retrievers — deduped to one entry, both raw hits preserved
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(new int[] {5}, new float[] {2.0f}));
+    results.put("knn", topDocs(new int[] {5}, new float[] {4.0f}));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text"));
+    contexts.put("knn", retriever("knn"));
+
+    Collection<BlendedScoreDoc> merged =
+        new ScorelessRawMergeBlenderOperation().mergeHits(results, contexts);
+
+    assertEquals(1, merged.size());
+    BlendedScoreDoc doc = merged.iterator().next();
+    assertEquals(5, doc.doc);
+    assertEquals(0f, doc.score, DELTA);
+    assertEquals(2, doc.getScoreDocs().size());
+  }
+
+  @Test
+  public void testRawScoresPreservedInScoreDocs() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(new int[] {5}, new float[] {2.0f}));
+    results.put("knn", topDocs(new int[] {5}, new float[] {4.0f}));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text"));
+    contexts.put("knn", retriever("knn"));
+
+    BlendedScoreDoc doc =
+        new ScorelessRawMergeBlenderOperation().mergeHits(results, contexts).iterator().next();
+
+    assertEquals(2.0f, doc.getScoreDocs().get("text").score, DELTA);
+    assertEquals(4.0f, doc.getScoreDocs().get("knn").score, DELTA);
+  }
+
+  @Test
+  public void testNonOverlappingRetrievers() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(new int[] {1}, new float[] {1.0f}));
+    results.put("knn", topDocs(new int[] {2}, new float[] {1.0f}));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text"));
+    contexts.put("knn", retriever("knn"));
+
+    Collection<BlendedScoreDoc> merged =
+        new ScorelessRawMergeBlenderOperation().mergeHits(results, contexts);
+
+    assertEquals(2, merged.size());
+    Map<Integer, BlendedScoreDoc> byDoc = toDocMap(merged);
+    assertEquals(1, byDoc.get(1).getScoreDocs().size());
+    assertEquals(1, byDoc.get(2).getScoreDocs().size());
+  }
+
+  @Test
+  public void testEmptyResults() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(new int[] {}, new float[] {}));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text"));
+
+    assertEquals(0, new ScorelessRawMergeBlenderOperation().mergeHits(results, contexts).size());
+  }
+
+  // ---- blend: no sort, no pagination ----
+
+  @Test
+  public void testBlendIgnoresPagination() throws InterruptedException {
+    LinkedHashMap<String, Future<TopDocs>> futures = new LinkedHashMap<>();
+    futures.put(
+        "text", future(topDocs(new int[] {1, 2, 3, 4, 5}, new float[] {1f, 1f, 1f, 1f, 1f})));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text"));
+
+    TopDocs result = new ScorelessRawMergeBlenderOperation().blend(futures, contexts, 2, 2);
+
+    // All 5 hits returned despite startHit=2 topHits=2
+    assertEquals(5, result.scoreDocs.length);
+  }
+
+  @Test
+  public void testBlendDeduplicates() throws InterruptedException {
+    LinkedHashMap<String, Future<TopDocs>> futures = new LinkedHashMap<>();
+    futures.put("text", future(topDocs(new int[] {7}, new float[] {1f})));
+    futures.put("knn", future(topDocs(new int[] {7}, new float[] {2f})));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text"));
+    contexts.put("knn", retriever("knn"));
+
+    TopDocs result = new ScorelessRawMergeBlenderOperation().blend(futures, contexts, 0, 10);
+
+    assertEquals(1, result.scoreDocs.length);
+    assertEquals(0f, result.scoreDocs[0].score, DELTA);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/WeightedScoreOrderBlenderOperationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/WeightedScoreOrderBlenderOperationTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever.blender.operation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.yelp.nrtsearch.server.grpc.WeightedScoreOrderBlender;
+import com.yelp.nrtsearch.server.search.multiretriever.RetrieverContext;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.score.BlendedScoreDoc;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.junit.Test;
+
+public class WeightedScoreOrderBlenderOperationTest {
+
+  private static final float DELTA = 1e-6f;
+
+  private static WeightedScoreOrderBlenderOperation operation(
+      WeightedScoreOrderBlender.ScoreMode mode) {
+    return new WeightedScoreOrderBlenderOperation(
+        WeightedScoreOrderBlender.newBuilder().setScoreMode(mode).build());
+  }
+
+  private static WeightedScoreOrderBlenderOperation defaultOperation() {
+    // Default proto enum value (MAX) is 0, so an unset scoreMode also yields MAX
+    return new WeightedScoreOrderBlenderOperation(WeightedScoreOrderBlender.newBuilder().build());
+  }
+
+  private static TopDocs topDocs(int[] docIds, float[] scores) {
+    ScoreDoc[] scoreDocs = new ScoreDoc[docIds.length];
+    for (int i = 0; i < docIds.length; i++) {
+      scoreDocs[i] = new ScoreDoc(docIds[i], scores[i], 0);
+    }
+    return new TopDocs(new TotalHits(docIds.length, TotalHits.Relation.EQUAL_TO), scoreDocs);
+  }
+
+  private static RetrieverContext retriever(String name, float boost) {
+    return RetrieverContext.newBuilder(name).boost(boost).build();
+  }
+
+  private static Map<Integer, Float> toScoreMap(Collection<BlendedScoreDoc> docs) {
+    return docs.stream().collect(Collectors.toMap(d -> d.doc, d -> d.score));
+  }
+
+  // ---- single retriever ----
+
+  @Test
+  public void testSingleRetriever() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(new int[] {10, 20}, new float[] {3.0f, 1.5f}));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text", 2.0f));
+
+    Collection<BlendedScoreDoc> merged = defaultOperation().mergeHits(results, contexts);
+
+    assertEquals(2, merged.size());
+    Map<Integer, Float> scores = toScoreMap(merged);
+    assertEquals(6.0f, scores.get(10), DELTA); // 3.0 * 2.0
+    assertEquals(3.0f, scores.get(20), DELTA); // 1.5 * 2.0
+  }
+
+  // ---- two retrievers, no overlap ----
+
+  @Test
+  public void testTwoRetrieversNoDuplicate() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(new int[] {1}, new float[] {4.0f}));
+    results.put("knn", topDocs(new int[] {2}, new float[] {2.0f}));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text", 1.0f));
+    contexts.put("knn", retriever("knn", 1.0f));
+
+    Map<Integer, Float> scores = toScoreMap(defaultOperation().mergeHits(results, contexts));
+    assertEquals(4.0f, scores.get(1), DELTA);
+    assertEquals(2.0f, scores.get(2), DELTA);
+  }
+
+  // ---- deduplication: MAX mode ----
+
+  @Test
+  public void testDeduplicationMax() {
+    // doc 5 appears in both retrievers; MAX picks the higher weighted score
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(new int[] {5}, new float[] {3.0f}));
+    results.put("knn", topDocs(new int[] {5}, new float[] {5.0f}));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text", 1.0f)); // weighted = 3.0
+    contexts.put("knn", retriever("knn", 1.0f)); // weighted = 5.0
+
+    Collection<BlendedScoreDoc> merged =
+        operation(WeightedScoreOrderBlender.ScoreMode.MAX).mergeHits(results, contexts);
+
+    assertEquals(1, merged.size());
+    BlendedScoreDoc doc = merged.iterator().next();
+    assertEquals(5, doc.doc);
+    assertEquals(5.0f, doc.score, DELTA);
+    assertEquals(2, doc.getScoreDocs().size());
+  }
+
+  // ---- deduplication: SUM mode ----
+
+  @Test
+  public void testDeduplicationSum() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(new int[] {5}, new float[] {3.0f}));
+    results.put("knn", topDocs(new int[] {5}, new float[] {2.0f}));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text", 2.0f)); // weighted = 6.0
+    contexts.put("knn", retriever("knn", 1.0f)); // weighted = 2.0
+
+    Collection<BlendedScoreDoc> merged =
+        operation(WeightedScoreOrderBlender.ScoreMode.SUM).mergeHits(results, contexts);
+
+    assertEquals(1, merged.size());
+    assertEquals(8.0f, merged.iterator().next().score, DELTA); // 6.0 + 2.0
+  }
+
+  // ---- deduplication: AVG mode ----
+
+  @Test
+  public void testDeduplicationAvg() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(new int[] {5}, new float[] {4.0f}));
+    results.put("knn", topDocs(new int[] {5}, new float[] {2.0f}));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text", 1.0f)); // weighted = 4.0
+    contexts.put("knn", retriever("knn", 1.0f)); // weighted = 2.0
+
+    Collection<BlendedScoreDoc> merged =
+        operation(WeightedScoreOrderBlender.ScoreMode.AVG).mergeHits(results, contexts);
+
+    assertEquals(1, merged.size());
+    assertEquals(3.0f, merged.iterator().next().score, DELTA); // (4.0 + 2.0) / 2
+  }
+
+  // ---- boost scaling ----
+
+  @Test
+  public void testBoostScalesScore() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(new int[] {1}, new float[] {2.0f}));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text", 3.0f));
+
+    Map<Integer, Float> scores = toScoreMap(defaultOperation().mergeHits(results, contexts));
+    assertEquals(6.0f, scores.get(1), DELTA); // 2.0 * 3.0
+  }
+
+  // ---- default score mode (unset enum → MAX) ----
+
+  @Test
+  public void testDefaultScoreModeIsMax() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(new int[] {7}, new float[] {1.0f}));
+    results.put("knn", topDocs(new int[] {7}, new float[] {5.0f}));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text", 1.0f));
+    contexts.put("knn", retriever("knn", 1.0f));
+
+    Collection<BlendedScoreDoc> merged = defaultOperation().mergeHits(results, contexts);
+    assertEquals(5.0f, merged.iterator().next().score, DELTA);
+  }
+
+  // ---- unknown score mode ----
+
+  @Test
+  public void testUnrecognizedScoreModeThrows() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new WeightedScoreOrderBlenderOperation(
+                WeightedScoreOrderBlender.newBuilder()
+                    .setScoreModeValue(99) // unknown proto enum value → UNRECOGNIZED
+                    .build()));
+  }
+
+  // ---- empty results ----
+
+  @Test
+  public void testEmptyRetrieverResults() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(new int[] {}, new float[] {}));
+
+    LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
+    contexts.put("text", retriever("text", 1.0f));
+
+    assertEquals(0, defaultOperation().mergeHits(results, contexts).size());
+  }
+}


### PR DESCRIPTION
https://jira.yelpcorp.com/browse/RP-14961
https://jira.yelpcorp.com/browse/RP-14963

Add two more builtin blenders:
1. score based blending, to support max/sum/avg for relevance blending
2. scoreless blending, to support coordinator global RRF