### PR TITLE
Add S3ClientMetrics

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
@@ -93,6 +93,7 @@ import com.yelp.nrtsearch.server.monitoring.NrtMetrics;
 import com.yelp.nrtsearch.server.monitoring.NrtsearchMonitoringServerInterceptor;
 import com.yelp.nrtsearch.server.monitoring.ProcStatCollector;
 import com.yelp.nrtsearch.server.monitoring.QueryCacheCollector;
+import com.yelp.nrtsearch.server.monitoring.S3ClientMetrics;
 import com.yelp.nrtsearch.server.monitoring.S3DownloadStreamWrapper;
 import com.yelp.nrtsearch.server.monitoring.SearchResponseCollector;
 import com.yelp.nrtsearch.server.monitoring.ThreadPoolCollector;
@@ -275,6 +276,7 @@ public class NrtsearchServer {
     // register Indexing metrics such as individual addDocument, updateDocValue latencies and qps
     IndexingMetrics.register(prometheusRegistry);
     S3DownloadStreamWrapper.register(prometheusRegistry);
+    S3ClientMetrics.register(prometheusRegistry);
   }
 
   /** Main launches the server from the command line. */

--- a/src/main/java/com/yelp/nrtsearch/server/monitoring/S3ClientMetrics.java
+++ b/src/main/java/com/yelp/nrtsearch/server/monitoring/S3ClientMetrics.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.monitoring;
+
+import io.prometheus.metrics.core.metrics.Counter;
+import io.prometheus.metrics.core.metrics.Gauge;
+import io.prometheus.metrics.core.metrics.Summary;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.metrics.CoreMetric;
+import software.amazon.awssdk.http.HttpMetric;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricPublisher;
+
+/**
+ * Prometheus {@link MetricPublisher} implementation that translates AWS SDK v2 S3 client metrics
+ * into Prometheus metrics. Captures per-operation latency, error rates, retry counts, and HTTP
+ * connection pool state.
+ *
+ * <p>Register with the {@link PrometheusRegistry} via {@link #register(PrometheusRegistry)} and
+ * attach to S3 clients via {@link
+ * software.amazon.awssdk.core.client.config.ClientOverrideConfiguration#addMetricPublisher}.
+ *
+ * <p>The singleton instance {@link #getInstance()} is shared across sync and async S3 clients so
+ * connection pool gauges reflect a single consistent view.
+ */
+public class S3ClientMetrics implements MetricPublisher {
+  private static final Logger logger = LoggerFactory.getLogger(S3ClientMetrics.class);
+
+  private static final S3ClientMetrics INSTANCE = new S3ClientMetrics();
+
+  // --- Counters ---
+
+  public static final Counter apiCallTotal =
+      Counter.builder()
+          .name("nrt_s3_api_call_total")
+          .help("Total number of S3 API calls.")
+          .labelNames("operation")
+          .build();
+
+  public static final Counter apiCallErrorTotal =
+      Counter.builder()
+          .name("nrt_s3_api_call_error_total")
+          .help("Total number of failed S3 API calls.")
+          .labelNames("operation", "error_type")
+          .build();
+
+  public static final Counter retryTotal =
+      Counter.builder()
+          .name("nrt_s3_retry_total")
+          .help("Total number of S3 API call retry attempts.")
+          .labelNames("operation")
+          .build();
+
+  // --- Summaries (p50/p95/p99) ---
+
+  public static final Summary apiCallDuration =
+      Summary.builder()
+          .name("nrt_s3_api_call_duration_ms")
+          .help("End-to-end duration of S3 API calls in milliseconds.")
+          .labelNames("operation")
+          .quantile(0.5, 0.05)
+          .quantile(0.95, 0.01)
+          .quantile(0.99, 0.01)
+          .build();
+
+  public static final Summary timeToFirstByte =
+      Summary.builder()
+          .name("nrt_s3_time_to_first_byte_ms")
+          .help("Time to first byte for S3 API call attempts in milliseconds.")
+          .labelNames("operation")
+          .quantile(0.5, 0.05)
+          .quantile(0.95, 0.01)
+          .quantile(0.99, 0.01)
+          .build();
+
+  public static final Summary concurrencyAcquireDuration =
+      Summary.builder()
+          .name("nrt_s3_concurrency_acquire_duration_ms")
+          .help(
+              "Time to acquire a connection from the HTTP connection pool for S3 API calls, in"
+                  + " milliseconds.")
+          .labelNames("operation")
+          .quantile(0.5, 0.05)
+          .quantile(0.95, 0.01)
+          .quantile(0.99, 0.01)
+          .build();
+
+  // --- Gauges (connection pool, last-seen values) ---
+
+  public static final Gauge connectionPoolAvailable =
+      Gauge.builder()
+          .name("nrt_s3_connection_pool_available")
+          .help("Number of available connections in the S3 HTTP connection pool.")
+          .build();
+
+  public static final Gauge connectionPoolLeased =
+      Gauge.builder()
+          .name("nrt_s3_connection_pool_leased")
+          .help("Number of leased (in-use) connections in the S3 HTTP connection pool.")
+          .build();
+
+  public static final Gauge connectionPoolPending =
+      Gauge.builder()
+          .name("nrt_s3_connection_pool_pending")
+          .help("Number of requests waiting to acquire a connection from the S3 connection pool.")
+          .build();
+
+  public static final Gauge connectionPoolMax =
+      Gauge.builder()
+          .name("nrt_s3_connection_pool_max")
+          .help("Maximum number of connections in the S3 HTTP connection pool.")
+          .build();
+
+  private S3ClientMetrics() {}
+
+  public static S3ClientMetrics getInstance() {
+    return INSTANCE;
+  }
+
+  public static void register(PrometheusRegistry registry) {
+    registry.register(apiCallTotal);
+    registry.register(apiCallErrorTotal);
+    registry.register(retryTotal);
+    registry.register(apiCallDuration);
+    registry.register(timeToFirstByte);
+    registry.register(concurrencyAcquireDuration);
+    registry.register(connectionPoolAvailable);
+    registry.register(connectionPoolLeased);
+    registry.register(connectionPoolPending);
+    registry.register(connectionPoolMax);
+  }
+
+  @Override
+  public void publish(MetricCollection metricCollection) {
+    try {
+      List<String> operationNames = metricCollection.metricValues(CoreMetric.OPERATION_NAME);
+      String operation = operationNames.isEmpty() ? "Unknown" : operationNames.get(0);
+
+      apiCallTotal.labelValues(operation).inc();
+
+      List<Boolean> successValues = metricCollection.metricValues(CoreMetric.API_CALL_SUCCESSFUL);
+      if (!successValues.isEmpty() && Boolean.FALSE.equals(successValues.get(0))) {
+        List<String> errorTypes = metricCollection.metricValues(CoreMetric.ERROR_TYPE);
+        String errorType = errorTypes.isEmpty() ? "Unknown" : errorTypes.get(0);
+        apiCallErrorTotal.labelValues(operation, errorType).inc();
+      }
+
+      List<Integer> retryCounts = metricCollection.metricValues(CoreMetric.RETRY_COUNT);
+      if (!retryCounts.isEmpty() && retryCounts.get(0) > 0) {
+        retryTotal.labelValues(operation).inc(retryCounts.get(0));
+      }
+
+      List<java.time.Duration> callDurations =
+          metricCollection.metricValues(CoreMetric.API_CALL_DURATION);
+      if (!callDurations.isEmpty()) {
+        apiCallDuration
+            .labelValues(operation)
+            .observe(callDurations.get(0).toNanos() / 1_000_000.0);
+      }
+
+      List<MetricCollection> attempts = metricCollection.children();
+      for (MetricCollection attempt : attempts) {
+        List<java.time.Duration> ttfbValues = attempt.metricValues(CoreMetric.TIME_TO_FIRST_BYTE);
+        if (!ttfbValues.isEmpty()) {
+          timeToFirstByte.labelValues(operation).observe(ttfbValues.get(0).toNanos() / 1_000_000.0);
+        }
+
+        List<java.time.Duration> acquireDurations =
+            attempt.metricValues(HttpMetric.CONCURRENCY_ACQUIRE_DURATION);
+        if (!acquireDurations.isEmpty()) {
+          concurrencyAcquireDuration
+              .labelValues(operation)
+              .observe(acquireDurations.get(0).toNanos() / 1_000_000.0);
+        }
+      }
+
+      // Update connection pool gauges from the last attempt (most current snapshot)
+      if (!attempts.isEmpty()) {
+        MetricCollection lastAttempt = attempts.get(attempts.size() - 1);
+
+        List<Integer> available = lastAttempt.metricValues(HttpMetric.AVAILABLE_CONCURRENCY);
+        if (!available.isEmpty()) {
+          connectionPoolAvailable.set(available.get(0));
+        }
+
+        List<Integer> leased = lastAttempt.metricValues(HttpMetric.LEASED_CONCURRENCY);
+        if (!leased.isEmpty()) {
+          connectionPoolLeased.set(leased.get(0));
+        }
+
+        List<Integer> pending = lastAttempt.metricValues(HttpMetric.PENDING_CONCURRENCY_ACQUIRES);
+        if (!pending.isEmpty()) {
+          connectionPoolPending.set(pending.get(0));
+        }
+
+        List<Integer> max = lastAttempt.metricValues(HttpMetric.MAX_CONCURRENCY);
+        if (!max.isEmpty()) {
+          connectionPoolMax.set(max.get(0));
+        }
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to publish S3 client metrics", e);
+    }
+  }
+
+  @Override
+  public void close() {
+    // no-op: metrics lifecycle is managed by the PrometheusRegistry
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Util.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Util.java
@@ -18,6 +18,7 @@ package com.yelp.nrtsearch.server.remote.s3;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
+import com.yelp.nrtsearch.server.monitoring.S3ClientMetrics;
 import java.net.URI;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -482,16 +483,18 @@ public class S3Util {
     }
 
     int maxRetries = configuration.getMaxS3ClientRetries();
-    software.amazon.awssdk.core.client.config.ClientOverrideConfiguration overrideConfig = null;
+    software.amazon.awssdk.core.client.config.ClientOverrideConfiguration.Builder
+        overrideConfigBuilder =
+            software.amazon.awssdk.core.client.config.ClientOverrideConfiguration.builder()
+                .addMetricPublisher(S3ClientMetrics.getInstance());
     if (maxRetries > 0) {
       RetryPolicy retryPolicy =
           RetryPolicy.builder(RetryMode.STANDARD).numRetries(maxRetries).build();
-      overrideConfig =
-          software.amazon.awssdk.core.client.config.ClientOverrideConfiguration.builder()
-              .retryPolicy(retryPolicy)
-              .build();
-      clientBuilder.overrideConfiguration(overrideConfig);
+      overrideConfigBuilder.retryPolicy(retryPolicy);
     }
+    software.amazon.awssdk.core.client.config.ClientOverrideConfiguration overrideConfig =
+        overrideConfigBuilder.build();
+    clientBuilder.overrideConfiguration(overrideConfig);
 
     S3Client s3Client = clientBuilder.build();
 

--- a/src/test/java/com/yelp/nrtsearch/server/monitoring/S3ClientMetricsTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/monitoring/S3ClientMetricsTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.monitoring;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import io.prometheus.metrics.model.snapshots.MetricSnapshots;
+import io.prometheus.metrics.model.snapshots.SummarySnapshot;
+import java.time.Duration;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.core.metrics.CoreMetric;
+import software.amazon.awssdk.http.HttpMetric;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricCollector;
+
+public class S3ClientMetricsTest {
+
+  @Before
+  public void setUp() {
+    // Clear all static metric state between tests
+    S3ClientMetrics.apiCallTotal.clear();
+    S3ClientMetrics.apiCallErrorTotal.clear();
+    S3ClientMetrics.retryTotal.clear();
+    S3ClientMetrics.apiCallDuration.clear();
+    S3ClientMetrics.timeToFirstByte.clear();
+    S3ClientMetrics.concurrencyAcquireDuration.clear();
+    S3ClientMetrics.connectionPoolAvailable.set(0);
+    S3ClientMetrics.connectionPoolLeased.set(0);
+    S3ClientMetrics.connectionPoolPending.set(0);
+    S3ClientMetrics.connectionPoolMax.set(0);
+  }
+
+  /** Returns the first SummaryDataPointSnapshot for the given operation label. */
+  private static SummarySnapshot.SummaryDataPointSnapshot getSummaryDataPoint(
+      io.prometheus.metrics.core.metrics.Summary summary, String operation) {
+    SummarySnapshot snapshot = summary.collect();
+    return snapshot.getDataPoints().stream()
+        .filter(dp -> operation.equals(dp.getLabels().get("operation")))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("No data point for operation: " + operation));
+  }
+
+  private static MetricCollection buildApiCallCollection(
+      String operation, boolean success, int retryCount, Duration callDuration) {
+    MetricCollector collector = MetricCollector.create("ApiCall");
+    collector.reportMetric(CoreMetric.OPERATION_NAME, operation);
+    collector.reportMetric(CoreMetric.API_CALL_SUCCESSFUL, success);
+    collector.reportMetric(CoreMetric.RETRY_COUNT, retryCount);
+    if (callDuration != null) {
+      collector.reportMetric(CoreMetric.API_CALL_DURATION, callDuration);
+    }
+    return collector.collect();
+  }
+
+  private static MetricCollection buildApiCallCollectionWithError(
+      String operation, String errorType) {
+    MetricCollector collector = MetricCollector.create("ApiCall");
+    collector.reportMetric(CoreMetric.OPERATION_NAME, operation);
+    collector.reportMetric(CoreMetric.API_CALL_SUCCESSFUL, false);
+    collector.reportMetric(CoreMetric.RETRY_COUNT, 0);
+    collector.reportMetric(CoreMetric.ERROR_TYPE, errorType);
+    return collector.collect();
+  }
+
+  @Test
+  public void testSuccessfulApiCallIncrementsCounter() {
+    MetricCollection collection = buildApiCallCollection("GetObject", true, 0, null);
+    S3ClientMetrics.getInstance().publish(collection);
+
+    assertEquals(1.0, S3ClientMetrics.apiCallTotal.labelValues("GetObject").get(), 0.001);
+    assertEquals(0.0, S3ClientMetrics.retryTotal.labelValues("GetObject").get(), 0.001);
+  }
+
+  @Test
+  public void testApiCallDurationObserved() {
+    MetricCollection collection =
+        buildApiCallCollection("PutObject", true, 0, Duration.ofMillis(150));
+    S3ClientMetrics.getInstance().publish(collection);
+
+    SummarySnapshot.SummaryDataPointSnapshot dp =
+        getSummaryDataPoint(S3ClientMetrics.apiCallDuration, "PutObject");
+    assertEquals(1, dp.getCount());
+    assertEquals(150.0, dp.getSum(), 0.001);
+  }
+
+  @Test
+  public void testFailedApiCallIncrementsErrorCounter() {
+    MetricCollection collection = buildApiCallCollectionWithError("GetObject", "THROTTLING");
+    S3ClientMetrics.getInstance().publish(collection);
+
+    assertEquals(1.0, S3ClientMetrics.apiCallTotal.labelValues("GetObject").get(), 0.001);
+    assertEquals(
+        1.0, S3ClientMetrics.apiCallErrorTotal.labelValues("GetObject", "THROTTLING").get(), 0.001);
+  }
+
+  @Test
+  public void testFailedApiCallWithServerError() {
+    MetricCollection collection = buildApiCallCollectionWithError("HeadObject", "SERVER_ERROR");
+    S3ClientMetrics.getInstance().publish(collection);
+
+    assertEquals(
+        1.0,
+        S3ClientMetrics.apiCallErrorTotal.labelValues("HeadObject", "SERVER_ERROR").get(),
+        0.001);
+  }
+
+  @Test
+  public void testRetryCountAddedToRetryTotal() {
+    MetricCollection collection = buildApiCallCollection("GetObject", true, 3, null);
+    S3ClientMetrics.getInstance().publish(collection);
+
+    assertEquals(3.0, S3ClientMetrics.retryTotal.labelValues("GetObject").get(), 0.001);
+  }
+
+  @Test
+  public void testZeroRetriesDoesNotIncrementRetryCounter() {
+    MetricCollection collection = buildApiCallCollection("GetObject", true, 0, null);
+    S3ClientMetrics.getInstance().publish(collection);
+
+    assertEquals(0.0, S3ClientMetrics.retryTotal.labelValues("GetObject").get(), 0.001);
+  }
+
+  @Test
+  public void testAttemptChildMetrics() {
+    MetricCollector collector = MetricCollector.create("ApiCall");
+    collector.reportMetric(CoreMetric.OPERATION_NAME, "GetObject");
+    collector.reportMetric(CoreMetric.API_CALL_SUCCESSFUL, true);
+    collector.reportMetric(CoreMetric.RETRY_COUNT, 0);
+
+    MetricCollector attempt = collector.createChild("ApiCallAttempt");
+    attempt.reportMetric(CoreMetric.TIME_TO_FIRST_BYTE, Duration.ofMillis(50));
+    attempt.reportMetric(HttpMetric.CONCURRENCY_ACQUIRE_DURATION, Duration.ofMillis(5));
+    attempt.reportMetric(HttpMetric.AVAILABLE_CONCURRENCY, 45);
+    attempt.reportMetric(HttpMetric.LEASED_CONCURRENCY, 5);
+    attempt.reportMetric(HttpMetric.PENDING_CONCURRENCY_ACQUIRES, 2);
+    attempt.reportMetric(HttpMetric.MAX_CONCURRENCY, 50);
+    attempt.collect();
+
+    MetricCollection collection = collector.collect();
+    S3ClientMetrics.getInstance().publish(collection);
+
+    SummarySnapshot.SummaryDataPointSnapshot ttfbDp =
+        getSummaryDataPoint(S3ClientMetrics.timeToFirstByte, "GetObject");
+    assertEquals(1, ttfbDp.getCount());
+    assertEquals(50.0, ttfbDp.getSum(), 0.001);
+
+    SummarySnapshot.SummaryDataPointSnapshot acquireDp =
+        getSummaryDataPoint(S3ClientMetrics.concurrencyAcquireDuration, "GetObject");
+    assertEquals(1, acquireDp.getCount());
+    assertEquals(5.0, acquireDp.getSum(), 0.001);
+
+    assertEquals(45.0, S3ClientMetrics.connectionPoolAvailable.get(), 0.001);
+    assertEquals(5.0, S3ClientMetrics.connectionPoolLeased.get(), 0.001);
+    assertEquals(2.0, S3ClientMetrics.connectionPoolPending.get(), 0.001);
+    assertEquals(50.0, S3ClientMetrics.connectionPoolMax.get(), 0.001);
+  }
+
+  @Test
+  public void testConnectionPoolGaugesUpdatedFromLastAttempt() {
+    MetricCollector collector = MetricCollector.create("ApiCall");
+    collector.reportMetric(CoreMetric.OPERATION_NAME, "GetObject");
+    collector.reportMetric(CoreMetric.API_CALL_SUCCESSFUL, true);
+    collector.reportMetric(CoreMetric.RETRY_COUNT, 1);
+
+    // First attempt
+    MetricCollector attempt1 = collector.createChild("ApiCallAttempt");
+    attempt1.reportMetric(HttpMetric.AVAILABLE_CONCURRENCY, 30);
+    attempt1.reportMetric(HttpMetric.LEASED_CONCURRENCY, 20);
+    attempt1.collect();
+
+    // Second (last) attempt — should win for pool gauges
+    MetricCollector attempt2 = collector.createChild("ApiCallAttempt");
+    attempt2.reportMetric(HttpMetric.AVAILABLE_CONCURRENCY, 10);
+    attempt2.reportMetric(HttpMetric.LEASED_CONCURRENCY, 40);
+    attempt2.collect();
+
+    MetricCollection collection = collector.collect();
+    S3ClientMetrics.getInstance().publish(collection);
+
+    assertEquals(10.0, S3ClientMetrics.connectionPoolAvailable.get(), 0.001);
+    assertEquals(40.0, S3ClientMetrics.connectionPoolLeased.get(), 0.001);
+  }
+
+  @Test
+  public void testMultipleOperationsTrackedSeparately() {
+    S3ClientMetrics.getInstance()
+        .publish(buildApiCallCollection("GetObject", true, 0, Duration.ofMillis(100)));
+    S3ClientMetrics.getInstance()
+        .publish(buildApiCallCollection("GetObject", true, 0, Duration.ofMillis(200)));
+    S3ClientMetrics.getInstance()
+        .publish(buildApiCallCollection("PutObject", true, 0, Duration.ofMillis(300)));
+
+    assertEquals(2.0, S3ClientMetrics.apiCallTotal.labelValues("GetObject").get(), 0.001);
+    assertEquals(1.0, S3ClientMetrics.apiCallTotal.labelValues("PutObject").get(), 0.001);
+    assertEquals(
+        300.0, getSummaryDataPoint(S3ClientMetrics.apiCallDuration, "GetObject").getSum(), 0.001);
+    assertEquals(
+        300.0, getSummaryDataPoint(S3ClientMetrics.apiCallDuration, "PutObject").getSum(), 0.001);
+  }
+
+  @Test
+  public void testMissingOperationNameDefaultsToUnknown() {
+    MetricCollector collector = MetricCollector.create("ApiCall");
+    collector.reportMetric(CoreMetric.API_CALL_SUCCESSFUL, true);
+    collector.reportMetric(CoreMetric.RETRY_COUNT, 0);
+    MetricCollection collection = collector.collect();
+
+    S3ClientMetrics.getInstance().publish(collection);
+
+    assertEquals(1.0, S3ClientMetrics.apiCallTotal.labelValues("Unknown").get(), 0.001);
+  }
+
+  @Test
+  public void testMissingErrorTypeDefaultsToUnknown() {
+    MetricCollector collector = MetricCollector.create("ApiCall");
+    collector.reportMetric(CoreMetric.OPERATION_NAME, "GetObject");
+    collector.reportMetric(CoreMetric.API_CALL_SUCCESSFUL, false);
+    collector.reportMetric(CoreMetric.RETRY_COUNT, 0);
+    MetricCollection collection = collector.collect();
+
+    S3ClientMetrics.getInstance().publish(collection);
+
+    assertEquals(
+        1.0, S3ClientMetrics.apiCallErrorTotal.labelValues("GetObject", "Unknown").get(), 0.001);
+  }
+
+  @Test
+  public void testNoAttemptsDoesNotUpdatePoolGauges() {
+    MetricCollection collection = buildApiCallCollection("HeadObject", true, 0, null);
+    S3ClientMetrics.getInstance().publish(collection);
+
+    // Gauges should remain at 0.0 (initial value) since no attempt children
+    assertEquals(0.0, S3ClientMetrics.connectionPoolAvailable.get(), 0.001);
+    assertEquals(0.0, S3ClientMetrics.connectionPoolLeased.get(), 0.001);
+  }
+
+  @Test
+  public void testRegisterAddsAllMetricsToRegistry() {
+    PrometheusRegistry registry = new PrometheusRegistry();
+    S3ClientMetrics.register(registry);
+
+    MetricSnapshots snapshots = registry.scrape();
+    long s3MetricCount =
+        snapshots.stream().filter(s -> s.getMetadata().getName().startsWith("nrt_s3_")).count();
+    // 3 counters + 3 summaries (each produces _count, _sum, and quantile series) + 4 gauges = 10
+    assertEquals(10, s3MetricCount);
+  }
+
+  @Test
+  public void testGetInstanceReturnsSingleton() {
+    assertNotNull(S3ClientMetrics.getInstance());
+    assertEquals(S3ClientMetrics.getInstance(), S3ClientMetrics.getInstance());
+  }
+
+  @Test
+  public void testSubMillisecondDuration() {
+    MetricCollector collector = MetricCollector.create("ApiCall");
+    collector.reportMetric(CoreMetric.OPERATION_NAME, "HeadObject");
+    collector.reportMetric(CoreMetric.API_CALL_SUCCESSFUL, true);
+    collector.reportMetric(CoreMetric.RETRY_COUNT, 0);
+    collector.reportMetric(CoreMetric.API_CALL_DURATION, Duration.ofNanos(500_000)); // 0.5ms
+    MetricCollection collection = collector.collect();
+
+    S3ClientMetrics.getInstance().publish(collection);
+
+    assertEquals(
+        0.5, getSummaryDataPoint(S3ClientMetrics.apiCallDuration, "HeadObject").getSum(), 0.001);
+  }
+}


### PR DESCRIPTION
Add AWS SDK v2 S3 client metrics via MetricPublisher

  Summary

  - Implements S3ClientMetrics, a custom MetricPublisher that translates AWS SDK v2 per-call metrics into Prometheus metrics and exposes them at /status/metrics
  - Wires the publisher into the ClientOverrideConfiguration for both the sync S3Client and the Java-based S3AsyncClient in S3Util.buildS3ClientBundle()
  - No new dependencies required — metrics-spi is already a transitive dependency of sdk-core

  Metrics added

  Counters (labeled by operation, e.g. GetObject, PutObject):
  - nrt_s3_api_call_total — total S3 API calls
  - nrt_s3_api_call_error_total — failed calls, also labeled by error_type (THROTTLING, SERVER_ERROR, CONFIGURED_TIMEOUT, IO, OTHER)
  - nrt_s3_retry_total — total retry attempts

  Summaries (p50/p95/p99, labeled by operation):
  - nrt_s3_api_call_duration_ms — end-to-end call latency
  - nrt_s3_time_to_first_byte_ms — time to first byte per attempt
  - nrt_s3_concurrency_acquire_duration_ms — time waiting to acquire a connection from the pool

  Gauges (connection pool state, unlabeled since the pool is shared across operations):
  - nrt_s3_connection_pool_available — idle connections
  - nrt_s3_connection_pool_leased — active (in-use) connections
  - nrt_s3_connection_pool_pending — requests queued waiting for a connection
  - nrt_s3_connection_pool_max — pool capacity

  Notes

  - Metrics are always-on (no config flag) — consistent with most other metrics in the codebase, and the per-call overhead is negligible compared to the existing per-byte
  nrt_s3_download_bytes_total
  - The CRT async client does not support ClientOverrideConfiguration/MetricPublisher and is unaffected