### PR TITLE
Add option to pad warming query uplaod from initial download

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/index/IndexState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/IndexState.java
@@ -282,7 +282,8 @@ public abstract class IndexState implements Closeable {
               configuration.getServiceName(),
               indexName,
               warmerConfig.getMaxWarmingQueries(),
-              warmerConfig.getWarmBasicQueryOnlyPerc());
+              warmerConfig.getWarmBasicQueryOnlyPerc(),
+              warmerConfig.isPadWithDownloadedRequests());
     }
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/warming/Warmer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/warming/Warmer.java
@@ -50,10 +50,12 @@ public class Warmer {
   private final RemoteBackend remoteBackend;
   private final String service;
   private final List<SearchRequest> warmingRequests;
+  private volatile List<SearchRequest> downloadedWarmingRequests = Collections.emptyList();
   private final ReservoirSampler reservoirSampler;
   private final String index;
   private final int maxWarmingQueries;
   private final int warmBasicQueryOnlyPerc;
+  private final boolean padWithDownloadedRequests;
   protected final ThreadLocal<Random> randomThreadLocal;
 
   public Warmer(RemoteBackend remoteBackend, String service, String index, int maxWarmingQueries) {
@@ -66,6 +68,16 @@ public class Warmer {
       String index,
       int maxWarmingQueries,
       int warmBasicQueryOnlyPerc) {
+    this(remoteBackend, service, index, maxWarmingQueries, warmBasicQueryOnlyPerc, false);
+  }
+
+  public Warmer(
+      RemoteBackend remoteBackend,
+      String service,
+      String index,
+      int maxWarmingQueries,
+      int warmBasicQueryOnlyPerc,
+      boolean padWithDownloadedRequests) {
     this.remoteBackend = remoteBackend;
     this.service = service;
     this.index = index;
@@ -73,6 +85,7 @@ public class Warmer {
     this.reservoirSampler = new ReservoirSampler(maxWarmingQueries);
     this.maxWarmingQueries = maxWarmingQueries;
     this.warmBasicQueryOnlyPerc = warmBasicQueryOnlyPerc;
+    this.padWithDownloadedRequests = padWithDownloadedRequests;
     this.randomThreadLocal = ThreadLocal.withInitial(Random::new);
   }
 
@@ -99,9 +112,25 @@ public class Warmer {
 
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     int count = 0;
-    List<SearchRequest> warmingRequestsToBackup;
+    List<SearchRequest> observedRequests;
     synchronized (warmingRequests) {
-      warmingRequestsToBackup = new ArrayList<>(warmingRequests);
+      observedRequests = new ArrayList<>(warmingRequests);
+    }
+    List<SearchRequest> warmingRequestsToBackup;
+    if (padWithDownloadedRequests) {
+      List<SearchRequest> downloaded = this.downloadedWarmingRequests;
+      int deficit = maxWarmingQueries - observedRequests.size();
+      if (deficit > 0 && !downloaded.isEmpty()) {
+        int fromIndex = Math.max(0, downloaded.size() - deficit);
+        List<SearchRequest> padding = downloaded.subList(fromIndex, downloaded.size());
+        warmingRequestsToBackup = new ArrayList<>(padding.size() + observedRequests.size());
+        warmingRequestsToBackup.addAll(padding);
+        warmingRequestsToBackup.addAll(observedRequests);
+      } else {
+        warmingRequestsToBackup = observedRequests;
+      }
+    } else {
+      warmingRequestsToBackup = observedRequests;
     }
     try (Writer writer =
         new OutputStreamWriter(byteArrayOutputStream, StateUtils.getValidatingUTF8Encoder())) {
@@ -153,6 +182,7 @@ public class Warmer {
               new NamedThreadFactory("warming-"),
               new ThreadPoolExecutor.CallerRunsPolicy());
     }
+    List<SearchRequest> downloadedQueries = padWithDownloadedRequests ? new ArrayList<>() : null;
     try (BufferedReader reader =
         new BufferedReader(
             new InputStreamReader(
@@ -162,7 +192,11 @@ public class Warmer {
       int count = 0, basicCount = 0;
       while ((line = reader.readLine()) != null) {
         boolean isStripped = randomThreadLocal.get().nextInt(100) < warmBasicQueryOnlyPerc;
-        processLine(indexState, searchHandler, threadPoolExecutor, line, isStripped);
+        SearchRequest originalRequest =
+            processLine(indexState, searchHandler, threadPoolExecutor, line, isStripped);
+        if (downloadedQueries != null) {
+          downloadedQueries.add(originalRequest);
+        }
         count++;
         if (isStripped) {
           basicCount++;
@@ -174,6 +208,9 @@ public class Warmer {
           count - basicCount,
           basicCount,
           (System.currentTimeMillis() - startMS) / 1000.0);
+      if (downloadedQueries != null) {
+        this.downloadedWarmingRequests = Collections.unmodifiableList(downloadedQueries);
+      }
     } finally {
       if (threadPoolExecutor != null) {
         threadPoolExecutor.shutdown();
@@ -182,7 +219,7 @@ public class Warmer {
     }
   }
 
-  private void processLine(
+  private SearchRequest processLine(
       IndexState indexState,
       SearchHandler searchHandler,
       ThreadPoolExecutor threadPoolExecutor,
@@ -191,6 +228,7 @@ public class Warmer {
       throws InvalidProtocolBufferException, SearchHandler.SearchHandlerException {
     SearchRequest.Builder builder = SearchRequest.newBuilder();
     JsonFormat.parser().merge(line, builder);
+    SearchRequest originalRequest = builder.build();
     if (warmBasicQuery) {
       WarmingUtils.simplifySearchRequestForWarming(builder);
     }
@@ -200,5 +238,6 @@ public class Warmer {
     } else {
       threadPoolExecutor.submit(() -> searchHandler.handle(indexState, searchRequest));
     }
+    return originalRequest;
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/warming/WarmerConfig.java
+++ b/src/main/java/com/yelp/nrtsearch/server/warming/WarmerConfig.java
@@ -23,11 +23,13 @@ public class WarmerConfig {
   private static final int DEFAULT_WARMING_PARALLELISM = 1;
   private static final int DEFAULT_WARM_BASIC_QUERY_ONLY_PERC = 0;
   private static final boolean DEFAULT_WARM_ON_STARTUP = false;
+  private static final boolean DEFAULT_PAD_WITH_DOWNLOADED_REQUESTS = false;
 
   private final int maxWarmingQueries;
   private final int warmingParallelism;
   private final int warmBasicQueryOnlyPerc;
   private final boolean warmOnStartup;
+  private final boolean padWithDownloadedRequests;
 
   /**
    * Configuration for warmer.
@@ -37,16 +39,20 @@ public class WarmerConfig {
    * @param warmBasicQueryOnlyPerc percentage of warming queries that should be basic queries for
    *     the fast boostrap
    * @param warmOnStartup if true will try to download queries from S3 and use them to warm
+   * @param padWithDownloadedRequests if true, backup will be padded with the most recent downloaded
+   *     queries when fewer than maxWarmingQueries have been observed
    */
   public WarmerConfig(
       int maxWarmingQueries,
       int warmingParallelism,
       int warmBasicQueryOnlyPerc,
-      boolean warmOnStartup) {
+      boolean warmOnStartup,
+      boolean padWithDownloadedRequests) {
     this.maxWarmingQueries = maxWarmingQueries;
     this.warmingParallelism = warmingParallelism;
     this.warmBasicQueryOnlyPerc = warmBasicQueryOnlyPerc;
     this.warmOnStartup = warmOnStartup;
+    this.padWithDownloadedRequests = padWithDownloadedRequests;
   }
 
   public static WarmerConfig fromConfig(YamlConfigReader configReader) {
@@ -59,9 +65,16 @@ public class WarmerConfig {
             CONFIG_PREFIX + "warmBasicQueryOnlyPerc", DEFAULT_WARM_BASIC_QUERY_ONLY_PERC);
     boolean warmOnStartup =
         configReader.getBoolean(CONFIG_PREFIX + "warmOnStartup", DEFAULT_WARM_ON_STARTUP);
+    boolean padWithDownloadedRequests =
+        configReader.getBoolean(
+            CONFIG_PREFIX + "padWithDownloadedRequests", DEFAULT_PAD_WITH_DOWNLOADED_REQUESTS);
 
     return new WarmerConfig(
-        maxWarmingQueries, warmingParallelism, warmBasicQueryOnlyPerc, warmOnStartup);
+        maxWarmingQueries,
+        warmingParallelism,
+        warmBasicQueryOnlyPerc,
+        warmOnStartup,
+        padWithDownloadedRequests);
   }
 
   public int getMaxWarmingQueries() {
@@ -78,5 +91,9 @@ public class WarmerConfig {
 
   public boolean isWarmOnStartup() {
     return warmOnStartup;
+  }
+
+  public boolean isPadWithDownloadedRequests() {
+    return padWithDownloadedRequests;
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/warming/WarmerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/warming/WarmerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import com.google.protobuf.util.JsonFormat;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.FunctionScoreQuery;
 import com.yelp.nrtsearch.server.grpc.Query;
@@ -172,6 +173,176 @@ public class WarmerTest {
       verify(mockSearchHandler, times(warmingCountPerQuery)).handle(mockIndexState, testRequest);
     }
     verifyNoMoreInteractions(mockSearchHandler);
+  }
+
+  @Test
+  public void testBackupPadsWithDownloadedQueries()
+      throws IOException, SearchHandler.SearchHandlerException, InterruptedException {
+    Warmer warmer6 = new Warmer(remoteBackend, service, index, 6, 0, true);
+    List<String> downloadedJson = new ArrayList<>(getTestSearchRequestsAsJsonStrings());
+    // Add 2 more distinct queries to get 6 total
+    downloadedJson.add(
+        "{\"indexName\":\"test_index\",\"query\":{\"functionScoreQuery\":{\"query\":{\"termQuery\":{\"field\":\"field4\"}},\"script\":{\"lang\":\"js\",\"source\":\"3 * 5\"}}}}");
+    downloadedJson.add(
+        "{\"indexName\":\"test_index\",\"query\":{\"functionScoreQuery\":{\"query\":{\"termQuery\":{\"field\":\"field5\"}},\"script\":{\"lang\":\"js\",\"source\":\"3 * 5\"}}}}");
+    remoteBackend.uploadWarmingQueries(service, index, getWarmingBytes(downloadedJson));
+
+    IndexState mockIndexState = mock(IndexState.class);
+    SearchHandler mockSearchHandler = mock(SearchHandler.class);
+    warmer6.warmFromS3(mockIndexState, 0, mockSearchHandler);
+
+    // Add only 2 observed queries (deficit of 4)
+    warmer6.addSearchRequest(SearchRequest.newBuilder().setIndexName(index).setTopHits(1).build());
+    warmer6.addSearchRequest(SearchRequest.newBuilder().setIndexName(index).setTopHits(2).build());
+
+    warmer6.backupWarmingQueriesToS3(service);
+
+    List<String> backedUpLines = readBackedUpLines();
+    Assertions.assertThat(backedUpLines).hasSize(6);
+  }
+
+  @Test
+  public void testBackupNoPaddingWhenFull()
+      throws IOException, SearchHandler.SearchHandlerException, InterruptedException {
+    Warmer warmerWithPad = new Warmer(remoteBackend, service, index, 4, 0, true);
+    remoteBackend.uploadWarmingQueries(
+        service, index, getWarmingBytes(getTestSearchRequestsAsJsonStrings()));
+
+    IndexState mockIndexState = mock(IndexState.class);
+    SearchHandler mockSearchHandler = mock(SearchHandler.class);
+    warmerWithPad.warmFromS3(mockIndexState, 0, mockSearchHandler);
+
+    // Fill reservoir completely
+    getTestSearchRequests().forEach(warmerWithPad::addSearchRequest);
+
+    warmerWithPad.backupWarmingQueriesToS3(service);
+
+    List<String> backedUpLines = readBackedUpLines();
+    // Only the 4 observed queries, no padding needed
+    Assertions.assertThat(backedUpLines).hasSize(4);
+    Assertions.assertThat(backedUpLines).containsAll(getTestSearchRequestsAsJsonStrings());
+  }
+
+  @Test
+  public void testBackupNoPaddingWhenNoDownload() throws IOException {
+    // Never call warmFromS3
+    warmer.addSearchRequest(SearchRequest.newBuilder().setIndexName(index).setTopHits(1).build());
+    warmer.addSearchRequest(SearchRequest.newBuilder().setIndexName(index).setTopHits(2).build());
+
+    warmer.backupWarmingQueriesToS3(service);
+
+    List<String> backedUpLines = readBackedUpLines();
+    Assertions.assertThat(backedUpLines).hasSize(2);
+  }
+
+  @Test
+  public void testBackupNoPaddingWhenFlagDisabled()
+      throws IOException, SearchHandler.SearchHandlerException, InterruptedException {
+    // padWithDownloadedRequests defaults to false
+    remoteBackend.uploadWarmingQueries(
+        service, index, getWarmingBytes(getTestSearchRequestsAsJsonStrings()));
+
+    IndexState mockIndexState = mock(IndexState.class);
+    SearchHandler mockSearchHandler = mock(SearchHandler.class);
+    warmer.warmFromS3(mockIndexState, 0, mockSearchHandler);
+
+    // Only 1 observed query -- would be padded if flag were enabled
+    warmer.addSearchRequest(SearchRequest.newBuilder().setIndexName(index).setTopHits(1).build());
+
+    warmer.backupWarmingQueriesToS3(service);
+
+    List<String> backedUpLines = readBackedUpLines();
+    // No padding: only the 1 observed query
+    Assertions.assertThat(backedUpLines).hasSize(1);
+  }
+
+  @Test
+  public void testBackupPaddingWithFewerDownloadedThanDeficit()
+      throws IOException, SearchHandler.SearchHandlerException, InterruptedException {
+    Warmer warmer6 = new Warmer(remoteBackend, service, index, 6, 0, true);
+    // Only 2 downloaded, deficit will be 5 when 1 observed
+    List<String> downloadedJson =
+        List.of(
+            getTestSearchRequestsAsJsonStrings().get(0),
+            getTestSearchRequestsAsJsonStrings().get(1));
+    remoteBackend.uploadWarmingQueries(service, index, getWarmingBytes(downloadedJson));
+
+    IndexState mockIndexState = mock(IndexState.class);
+    SearchHandler mockSearchHandler = mock(SearchHandler.class);
+    warmer6.warmFromS3(mockIndexState, 0, mockSearchHandler);
+
+    warmer6.addSearchRequest(SearchRequest.newBuilder().setIndexName(index).setTopHits(1).build());
+
+    warmer6.backupWarmingQueriesToS3(service);
+
+    List<String> backedUpLines = readBackedUpLines();
+    // 2 downloaded + 1 observed = 3 total (less than maxWarmingQueries=6)
+    Assertions.assertThat(backedUpLines).hasSize(3);
+  }
+
+  @Test
+  public void testBackupPaddingOrderIsCorrect()
+      throws IOException, SearchHandler.SearchHandlerException, InterruptedException {
+    Warmer warmerWithPad = new Warmer(remoteBackend, service, index, 4, 0, true);
+    // Upload 4 queries [A, B, C, D]
+    remoteBackend.uploadWarmingQueries(
+        service, index, getWarmingBytes(getTestSearchRequestsAsJsonStrings()));
+
+    IndexState mockIndexState = mock(IndexState.class);
+    SearchHandler mockSearchHandler = mock(SearchHandler.class);
+    warmerWithPad.warmFromS3(mockIndexState, 0, mockSearchHandler);
+
+    // Add 1 observed query [E] -- distinct from the downloaded ones
+    SearchRequest observedRequest =
+        SearchRequest.newBuilder().setIndexName(index).setTopHits(99).build();
+    warmerWithPad.addSearchRequest(observedRequest);
+
+    warmerWithPad.backupWarmingQueriesToS3(service);
+
+    List<String> backedUpLines = readBackedUpLines();
+    // Should be [B, C, D, E] -- last 3 from downloaded prepended, then the 1 observed
+    Assertions.assertThat(backedUpLines).hasSize(4);
+    // Observed query appears last
+    String observedJson =
+        JsonFormat.printer().omittingInsignificantWhitespace().print(observedRequest);
+    Assertions.assertThat(backedUpLines.get(3)).isEqualTo(observedJson);
+    // First 3 are the last 3 downloaded queries (B, C, D = indices 1, 2, 3)
+    List<String> expectedDownloaded = getTestSearchRequestsAsJsonStrings();
+    Assertions.assertThat(backedUpLines.get(0)).isEqualTo(expectedDownloaded.get(1));
+    Assertions.assertThat(backedUpLines.get(1)).isEqualTo(expectedDownloaded.get(2));
+    Assertions.assertThat(backedUpLines.get(2)).isEqualTo(expectedDownloaded.get(3));
+  }
+
+  @Test
+  public void testBackupAllFromDownloadedWhenNoObserved()
+      throws IOException, SearchHandler.SearchHandlerException, InterruptedException {
+    Warmer warmerWithPad = new Warmer(remoteBackend, service, index, 4, 0, true);
+    remoteBackend.uploadWarmingQueries(
+        service, index, getWarmingBytes(getTestSearchRequestsAsJsonStrings()));
+
+    IndexState mockIndexState = mock(IndexState.class);
+    SearchHandler mockSearchHandler = mock(SearchHandler.class);
+    warmerWithPad.warmFromS3(mockIndexState, 0, mockSearchHandler);
+
+    // No observed queries added
+    warmerWithPad.backupWarmingQueriesToS3(service);
+
+    List<String> backedUpLines = readBackedUpLines();
+    Assertions.assertThat(backedUpLines).hasSize(4);
+    Assertions.assertThat(backedUpLines)
+        .containsExactlyElementsOf(getTestSearchRequestsAsJsonStrings());
+  }
+
+  private List<String> readBackedUpLines() throws IOException {
+    InputStream queriesStream = remoteBackend.downloadWarmingQueries(service, index);
+    List<String> lines = new ArrayList<>();
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(queriesStream))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        lines.add(line);
+      }
+    }
+    return lines;
   }
 
   private byte[] getWarmingBytes(List<String> queryStrings) throws IOException {


### PR DESCRIPTION
Adds new config option `warmer.padWithDownloadedRequests`. When set, the initially downloaded warming queries are saved, and used to pad the observed queries during a warming query backup. This is only needed if the number of observed queries is less than `maxQueries`.

This feature is useful in cases where clusters get very low traffic. It allow queries to be accumulated over time, rather than requiring that they happen within a single server runtime. Each backup would make forward progress towards `maxQueries`.