### PR TITLE
Add Search Handling for Multi-Retriever Requests

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
@@ -537,10 +537,9 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
     LinkedHashMap<String, RetrieverContext> retrieverContexts =
         new LinkedHashMap<>(multiRetrieverContext.getRetrieverContextMap());
 
-    record RetrieverResult(
-        TopDocs topDocs, long totalHits, double searchTimeMs, double rescoreTimeMs) {}
+    record RetrieverMetrics(TopDocs topDocs, double searchTimeMs, double rescoreTimeMs) {}
 
-    ConcurrentHashMap<String, RetrieverResult> retrieverResults = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, RetrieverMetrics> retrieverResults = new ConcurrentHashMap<>();
     LinkedHashMap<String, Future<TopDocs>> retrieverFutures = new LinkedHashMap<>();
     for (Map.Entry<String, RetrieverContext> entry : retrieverContexts.entrySet()) {
       String name = entry.getKey();
@@ -556,7 +555,6 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
                         retrieverContext.getDocCollector().getWrappedManager());
                 TopDocs topDocs = result.getTopDocs();
                 double searchTimeMs = (System.nanoTime() - searchStart) / 1_000_000.0;
-                long totalHits = topDocs.totalHits.value();
 
                 double rescoreTimeMs = 0;
                 if (retrieverContext.getRescoreTask() != null) {
@@ -565,7 +563,7 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
                   rescoreTimeMs = (System.nanoTime() - rescoreStart) / 1_000_000.0;
                 }
                 retrieverResults.put(
-                    name, new RetrieverResult(topDocs, totalHits, searchTimeMs, rescoreTimeMs));
+                    name, new RetrieverMetrics(topDocs, searchTimeMs, rescoreTimeMs));
                 return topDocs;
               }));
     }
@@ -589,24 +587,25 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
     // Populate per-retriever diagnostics
     SearchResponse.Diagnostics.MultiRetrieverDiagnostics.Builder multiRetrieverDiagnosticsBuilder =
         diagnostics.getMultiRetrieverDiagnosticsBuilder();
-    for (Map.Entry<String, RetrieverResult> entry : retrieverResults.entrySet()) {
+    for (Map.Entry<String, RetrieverMetrics> entry : retrieverResults.entrySet()) {
       String name = entry.getKey();
-      RetrieverResult retrieverResult = entry.getValue();
+      RetrieverMetrics retrieverResult = entry.getValue();
       RetrieverContext.RetrieverType type = retrieverContexts.get(name).getRetrieverType();
+      org.apache.lucene.search.TotalHits luceneTotalHits = retrieverResult.topDocs().totalHits;
       TotalHits totalHits =
           TotalHits.newBuilder()
-              .setRelation(
-                  TotalHits.Relation.valueOf(retrieverResult.topDocs().totalHits.relation().name()))
-              .setValue(retrieverResult.totalHits())
+              .setRelation(TotalHits.Relation.valueOf(luceneTotalHits.relation().name()))
+              .setValue(luceneTotalHits.value())
               .build();
       SearchResponse.Diagnostics.RetrieverDiagnostics.Builder retrieverDiagBuilder;
       if (type == RetrieverContext.RetrieverType.KNN) {
-        // Preserve vectorDiagnostics already set by SearchRequestProcessor
+        // Preserve vectorDiagnostics already set by SearchRequestProcessor, then add timing
         retrieverDiagBuilder =
             multiRetrieverDiagnosticsBuilder
                 .getRetrieverDiagnosticsOrDefault(
                     name, SearchResponse.Diagnostics.RetrieverDiagnostics.getDefaultInstance())
-                .toBuilder();
+                .toBuilder()
+                .setSearchTimeMs(retrieverResult.searchTimeMs());
       } else {
         retrieverDiagBuilder =
             SearchResponse.Diagnostics.RetrieverDiagnostics.newBuilder()

--- a/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
@@ -50,6 +50,9 @@ import com.yelp.nrtsearch.server.search.SearchContext;
 import com.yelp.nrtsearch.server.search.SearchCutoffWrapper.CollectionTimeoutException;
 import com.yelp.nrtsearch.server.search.SearchRequestProcessor;
 import com.yelp.nrtsearch.server.search.SearcherResult;
+import com.yelp.nrtsearch.server.search.multiretriever.MultiRetrieverContext;
+import com.yelp.nrtsearch.server.search.multiretriever.RetrieverContext;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.score.BlendedScoreDoc;
 import com.yelp.nrtsearch.server.state.GlobalState;
 import com.yelp.nrtsearch.server.utils.ObjectToCompositeFieldTransformer;
 import com.yelp.nrtsearch.server.utils.ProtoMessagePrinter;
@@ -62,6 +65,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -174,79 +178,85 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
 
       long searchStartTime = System.nanoTime();
 
-      SearcherResult searcherResult;
-      if (!searchRequest.getFacetsList().isEmpty()) {
-        DrillDownQuery ddq = (DrillDownQuery) searchContext.getQuery();
+      TopDocs hits;
+      if (searchContext.getMultiRetrieverContext() != null) {
+        hits =
+            executeMultiRetriever(searchContext, s.searcher(), diagnostics, profileResultBuilder);
+      } else {
+        SearcherResult searcherResult;
+        if (!searchRequest.getFacetsList().isEmpty()) {
+          DrillDownQuery ddq = (DrillDownQuery) searchContext.getQuery();
 
-        List<FacetResult> grpcFacetResults = new ArrayList<>();
-        // Run the drill sideways search on the direct executor to run subtasks in the
-        // current (grpc) thread. If we use the search thread pool for this, it can cause a
-        // deadlock trying to execute the dependent parallel search tasks. Since we do not
-        // currently add additional drill down definitions, there will only be one drill
-        // sideways task per query.
-        DrillSideways drillS =
-            new DrillSidewaysImpl(
-                s.searcher(),
-                indexState.getFacetsConfig(),
-                s.taxonomyReader(),
-                searchRequest.getFacetsList(),
-                s,
-                indexState,
-                shardState,
-                searchContext.getQueryFields(),
-                grpcFacetResults,
-                DIRECT_EXECUTOR,
-                diagnostics);
-        DrillSideways.ConcurrentDrillSidewaysResult<SearcherResult> concurrentDrillSidewaysResult;
-        try {
-          concurrentDrillSidewaysResult =
-              drillS.search(ddq, searchContext.getCollector().getWrappedManager());
-        } catch (RuntimeException e) {
-          // Searching with DrillSideways wraps exceptions in a few layers.
-          // Try to find if this was caused by a timeout, if so, re-wrap
-          // so that the top level exception is the same as when not using facets.
-          CollectionTimeoutException timeoutException = findTimeoutException(e);
-          if (timeoutException != null) {
-            throw new CollectionTimeoutException(timeoutException.getMessage(), e);
+          List<FacetResult> grpcFacetResults = new ArrayList<>();
+          // Run the drill sideways search on the direct executor to run subtasks in the
+          // current (grpc) thread. If we use the search thread pool for this, it can cause a
+          // deadlock trying to execute the dependent parallel search tasks. Since we do not
+          // currently add additional drill down definitions, there will only be one drill
+          // sideways task per query.
+          DrillSideways drillS =
+              new DrillSidewaysImpl(
+                  s.searcher(),
+                  indexState.getFacetsConfig(),
+                  s.taxonomyReader(),
+                  searchRequest.getFacetsList(),
+                  s,
+                  indexState,
+                  shardState,
+                  searchContext.getQueryFields(),
+                  grpcFacetResults,
+                  DIRECT_EXECUTOR,
+                  diagnostics);
+          DrillSideways.ConcurrentDrillSidewaysResult<SearcherResult> concurrentDrillSidewaysResult;
+          try {
+            concurrentDrillSidewaysResult =
+                drillS.search(ddq, searchContext.getCollector().getWrappedManager());
+          } catch (RuntimeException e) {
+            // Searching with DrillSideways wraps exceptions in a few layers.
+            // Try to find if this was caused by a timeout, if so, re-wrap
+            // so that the top level exception is the same as when not using facets.
+            CollectionTimeoutException timeoutException = findTimeoutException(e);
+            if (timeoutException != null) {
+              throw new CollectionTimeoutException(timeoutException.getMessage(), e);
+            }
+            throw e;
           }
-          throw e;
+          searcherResult = concurrentDrillSidewaysResult.collectorResult;
+          searchContext.getResponseBuilder().addAllFacetResult(grpcFacetResults);
+          searchContext
+              .getResponseBuilder()
+              .addAllFacetResult(
+                  FacetTopDocs.facetTopDocsSample(
+                      searcherResult.getTopDocs(),
+                      searchRequest.getFacetsList(),
+                      indexState,
+                      s.searcher(),
+                      diagnostics));
+        } else {
+          try {
+            searcherResult =
+                s.searcher()
+                    .search(
+                        searchContext.getQuery(), searchContext.getCollector().getWrappedManager());
+          } catch (RuntimeException e) {
+            CollectionTimeoutException timeoutException = findTimeoutException(e);
+            if (timeoutException != null) {
+              throw new CollectionTimeoutException(timeoutException.getMessage(), e);
+            }
+            throw e;
+          }
         }
-        searcherResult = concurrentDrillSidewaysResult.collectorResult;
-        searchContext.getResponseBuilder().addAllFacetResult(grpcFacetResults);
+        hits = searcherResult.getTopDocs();
+
+        // add results from any extra collectors
         searchContext
             .getResponseBuilder()
-            .addAllFacetResult(
-                FacetTopDocs.facetTopDocsSample(
-                    searcherResult.getTopDocs(),
-                    searchRequest.getFacetsList(),
-                    indexState,
-                    s.searcher(),
-                    diagnostics));
-      } else {
-        try {
-          searcherResult =
-              s.searcher()
-                  .search(
-                      searchContext.getQuery(), searchContext.getCollector().getWrappedManager());
-        } catch (RuntimeException e) {
-          CollectionTimeoutException timeoutException = findTimeoutException(e);
-          if (timeoutException != null) {
-            throw new CollectionTimeoutException(timeoutException.getMessage(), e);
-          }
-          throw e;
-        }
+            .putAllCollectorResults(searcherResult.getCollectorResults());
+
+        searchContext.getResponseBuilder().setHitTimeout(searchContext.getCollector().hadTimeout());
+        searchContext
+            .getResponseBuilder()
+            .setTerminatedEarly(searchContext.getCollector().terminatedEarly());
       }
-      TopDocs hits = searcherResult.getTopDocs();
-
-      // add results from any extra collectors
-      searchContext
-          .getResponseBuilder()
-          .putAllCollectorResults(searcherResult.getCollectorResults());
-
-      searchContext.getResponseBuilder().setHitTimeout(searchContext.getCollector().hadTimeout());
-      searchContext
-          .getResponseBuilder()
-          .setTerminatedEarly(searchContext.getCollector().terminatedEarly());
 
       diagnostics.setFirstPassSearchTimeMs(((System.nanoTime() - searchStartTime) / 1000000.0));
 
@@ -513,6 +523,104 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
   }
 
   /**
+   * Execute per-retriever searches in parallel, apply optional per-retriever L1 rescoring, then
+   * blend the results into a single ranked TopDocs.
+   */
+  private TopDocs executeMultiRetriever(
+      SearchContext searchContext,
+      IndexSearcher searcher,
+      SearchResponse.Diagnostics.Builder diagnostics,
+      ProfileResult.Builder profileResultBuilder)
+      throws InterruptedException {
+    MultiRetrieverContext multiRetrieverContext = searchContext.getMultiRetrieverContext();
+    LinkedHashMap<String, RetrieverContext> retrieverContexts =
+        new LinkedHashMap<>(multiRetrieverContext.getRetrieverContextMap());
+
+    // Submit per-retriever searches to the executor to run concurrently.
+    // Each callable resolves to TopDocs; per-retriever L1 rescoring is applied inside.
+    // Per-retriever timing is tracked and merged after blend.
+    ConcurrentHashMap<String, Double> retrieverTimingsMs = new ConcurrentHashMap<>();
+    LinkedHashMap<String, Future<TopDocs>> retrieverFutures = new LinkedHashMap<>();
+    for (Map.Entry<String, RetrieverContext> entry : retrieverContexts.entrySet()) {
+      String name = entry.getKey();
+      RetrieverContext retrieverContext = entry.getValue();
+      retrieverFutures.put(
+          name,
+          searchExecutor.submit(
+              () -> {
+                long t0 = System.nanoTime();
+                SearcherResult result =
+                    searcher.search(
+                        retrieverContext.getQuery(),
+                        retrieverContext.getDocCollector().getWrappedManager());
+                TopDocs topDocs = result.getTopDocs();
+                if (retrieverContext.getRescoreTask() != null) {
+                  topDocs = retrieverContext.getRescoreTask().rescore(topDocs, searchContext);
+                }
+                retrieverTimingsMs.put(name, (System.nanoTime() - t0) / 1_000_000.0);
+                return topDocs;
+              }));
+    }
+
+    // Compute the blend window to cover rescorer windows and hits
+    // L2 rescorer then trims to the final topHits window.
+    int blendTopHits = searchContext.getStartHit() + searchContext.getTopHits();
+    for (RescoreTask rescorer : searchContext.getRescorers()) {
+      int windowSize = rescorer.getWindowSize();
+      if (windowSize > blendTopHits) {
+        blendTopHits = windowSize;
+      }
+    }
+    int hitsToLog = searchContext.getHitsToLog();
+    if (hitsToLog > 0) {
+      blendTopHits = Math.max(blendTopHits, hitsToLog + searchContext.getStartHit());
+    }
+
+    long blendStartTime = System.nanoTime();
+    TopDocs blendedHits =
+        multiRetrieverContext
+            .getBlenderOperation()
+            .blend(retrieverFutures, retrieverContexts, 0, blendTopHits);
+    double blenderTimeMs = (System.nanoTime() - blendStartTime) / 1_000_000.0;
+
+    // Merge per-retriever timings into diagnostics
+    SearchResponse.Diagnostics.MultiRetrieverDiagnostics.Builder multiRetrieverDiagnosticsBuilder =
+        diagnostics.getMultiRetrieverDiagnosticsBuilder();
+    for (Map.Entry<String, Double> timingEntry : retrieverTimingsMs.entrySet()) {
+      String name = timingEntry.getKey();
+      SearchResponse.Diagnostics.RetrieverDiagnostics existing =
+          multiRetrieverDiagnosticsBuilder.getRetrieverDiagnosticsOrDefault(name, null);
+      SearchResponse.Diagnostics.RetrieverDiagnostics.Builder retrieverDiagnosticsBuilder =
+          existing != null
+              ? existing.toBuilder()
+              : SearchResponse.Diagnostics.RetrieverDiagnostics.newBuilder();
+      retrieverDiagnosticsBuilder.setSearchTimeMs(timingEntry.getValue());
+      multiRetrieverDiagnosticsBuilder.putRetrieverDiagnostics(
+          name, retrieverDiagnosticsBuilder.build());
+    }
+    multiRetrieverDiagnosticsBuilder.setBlenderTimeMs(blenderTimeMs);
+
+    // Add per-retriever collector profiling stats
+    if (profileResultBuilder != null) {
+      ProfileResult.MultiRetrieverProfileResult.Builder multiRetrieverProfileBuilder =
+          profileResultBuilder.getMultiRetrieverProfileResultBuilder();
+      for (Map.Entry<String, RetrieverContext> entry : retrieverContexts.entrySet()) {
+        String name = entry.getKey();
+        ProfileResult.Builder retrieverProfile =
+            multiRetrieverProfileBuilder.getRetrieverProfileResultsOrDefault(name, null) != null
+                ? multiRetrieverProfileBuilder
+                    .getRetrieverProfileResultsOrDefault(name, ProfileResult.getDefaultInstance())
+                    .toBuilder()
+                : ProfileResult.newBuilder();
+        entry.getValue().getDocCollector().maybeAddProfiling(retrieverProfile);
+        multiRetrieverProfileBuilder.putRetrieverProfileResults(name, retrieverProfile.build());
+      }
+    }
+
+    return blendedHits;
+  }
+
+  /**
    * Given all the top documents, produce a slice of the documents starting from a start offset and
    * going up to the query needed maximum hits. There may be more top docs than the hitsCount limit,
    * if top docs sampling facets are used.
@@ -570,7 +678,21 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
       var hitResponse = context.getResponseBuilder().addHitsBuilder();
       ScoreDoc hit = hits.scoreDocs[hitIndex];
       hitResponse.setLuceneDocId(hit.doc);
-      context.getCollector().fillHitRanking(hitResponse, hit);
+      if (context.getMultiRetrieverContext() != null) {
+        // Expose per-retriever scores.
+        if (!Float.isNaN(hit.score)) {
+          hitResponse.setScore(hit.score);
+        }
+        if (hit instanceof BlendedScoreDoc blendedHit) {
+          for (Map.Entry<String, ScoreDoc> entry : blendedHit.getScoreDocs().entrySet()) {
+            if (!Float.isNaN(entry.getValue().score)) {
+              hitResponse.putRetrieverScores(entry.getKey(), entry.getValue().score);
+            }
+          }
+        }
+      } else {
+        context.getCollector().fillHitRanking(hitResponse, hit);
+      }
     }
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
@@ -50,6 +50,7 @@ import com.yelp.nrtsearch.server.search.SearchContext;
 import com.yelp.nrtsearch.server.search.SearchCutoffWrapper.CollectionTimeoutException;
 import com.yelp.nrtsearch.server.search.SearchRequestProcessor;
 import com.yelp.nrtsearch.server.search.SearcherResult;
+import com.yelp.nrtsearch.server.search.collectors.DocCollector;
 import com.yelp.nrtsearch.server.search.multiretriever.MultiRetrieverContext;
 import com.yelp.nrtsearch.server.search.multiretriever.RetrieverContext;
 import com.yelp.nrtsearch.server.search.multiretriever.blender.score.BlendedScoreDoc;
@@ -536,10 +537,10 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
     LinkedHashMap<String, RetrieverContext> retrieverContexts =
         new LinkedHashMap<>(multiRetrieverContext.getRetrieverContextMap());
 
-    // Submit per-retriever searches to the executor to run concurrently.
-    // Each callable resolves to TopDocs; per-retriever L1 rescoring is applied inside.
-    // Per-retriever timing is tracked and merged after blend.
-    ConcurrentHashMap<String, Double> retrieverTimingsMs = new ConcurrentHashMap<>();
+    record RetrieverResult(
+        TopDocs topDocs, long totalHits, double searchTimeMs, double rescoreTimeMs) {}
+
+    ConcurrentHashMap<String, RetrieverResult> retrieverResults = new ConcurrentHashMap<>();
     LinkedHashMap<String, Future<TopDocs>> retrieverFutures = new LinkedHashMap<>();
     for (Map.Entry<String, RetrieverContext> entry : retrieverContexts.entrySet()) {
       String name = entry.getKey();
@@ -548,33 +549,35 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
           name,
           searchExecutor.submit(
               () -> {
-                long t0 = System.nanoTime();
+                long searchStart = System.nanoTime();
                 SearcherResult result =
                     searcher.search(
                         retrieverContext.getQuery(),
                         retrieverContext.getDocCollector().getWrappedManager());
                 TopDocs topDocs = result.getTopDocs();
+                double searchTimeMs = (System.nanoTime() - searchStart) / 1_000_000.0;
+                long totalHits = topDocs.totalHits.value();
+
+                double rescoreTimeMs = 0;
                 if (retrieverContext.getRescoreTask() != null) {
+                  long rescoreStart = System.nanoTime();
                   topDocs = retrieverContext.getRescoreTask().rescore(topDocs, searchContext);
+                  rescoreTimeMs = (System.nanoTime() - rescoreStart) / 1_000_000.0;
                 }
-                retrieverTimingsMs.put(name, (System.nanoTime() - t0) / 1_000_000.0);
+                retrieverResults.put(
+                    name, new RetrieverResult(topDocs, totalHits, searchTimeMs, rescoreTimeMs));
                 return topDocs;
               }));
     }
 
-    // Compute the blend window to cover rescorer windows and hits
+    // Compute the blend window to cover rescorer windows and hits to log.
     // L2 rescorer then trims to the final topHits window.
-    int blendTopHits = searchContext.getStartHit() + searchContext.getTopHits();
-    for (RescoreTask rescorer : searchContext.getRescorers()) {
-      int windowSize = rescorer.getWindowSize();
-      if (windowSize > blendTopHits) {
-        blendTopHits = windowSize;
-      }
-    }
-    int hitsToLog = searchContext.getHitsToLog();
-    if (hitsToLog > 0) {
-      blendTopHits = Math.max(blendTopHits, hitsToLog + searchContext.getStartHit());
-    }
+    int blendTopHits =
+        DocCollector.computeNumHitsToCollect(
+            searchContext.getStartHit(),
+            searchContext.getTopHits(),
+            searchContext.getHitsToLog(),
+            searchContext.getRescorers());
 
     long blendStartTime = System.nanoTime();
     TopDocs blendedHits =
@@ -583,35 +586,50 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
             .blend(retrieverFutures, retrieverContexts, 0, blendTopHits);
     double blenderTimeMs = (System.nanoTime() - blendStartTime) / 1_000_000.0;
 
-    // Merge per-retriever timings into diagnostics
+    // Populate per-retriever diagnostics
     SearchResponse.Diagnostics.MultiRetrieverDiagnostics.Builder multiRetrieverDiagnosticsBuilder =
         diagnostics.getMultiRetrieverDiagnosticsBuilder();
-    for (Map.Entry<String, Double> timingEntry : retrieverTimingsMs.entrySet()) {
-      String name = timingEntry.getKey();
-      SearchResponse.Diagnostics.RetrieverDiagnostics existing =
-          multiRetrieverDiagnosticsBuilder.getRetrieverDiagnosticsOrDefault(name, null);
-      SearchResponse.Diagnostics.RetrieverDiagnostics.Builder retrieverDiagnosticsBuilder =
-          existing != null
-              ? existing.toBuilder()
-              : SearchResponse.Diagnostics.RetrieverDiagnostics.newBuilder();
-      retrieverDiagnosticsBuilder.setSearchTimeMs(timingEntry.getValue());
-      multiRetrieverDiagnosticsBuilder.putRetrieverDiagnostics(
-          name, retrieverDiagnosticsBuilder.build());
+    for (Map.Entry<String, RetrieverResult> entry : retrieverResults.entrySet()) {
+      String name = entry.getKey();
+      RetrieverResult retrieverResult = entry.getValue();
+      RetrieverContext.RetrieverType type = retrieverContexts.get(name).getRetrieverType();
+      TotalHits totalHits =
+          TotalHits.newBuilder()
+              .setRelation(
+                  TotalHits.Relation.valueOf(retrieverResult.topDocs().totalHits.relation().name()))
+              .setValue(retrieverResult.totalHits())
+              .build();
+      SearchResponse.Diagnostics.RetrieverDiagnostics.Builder retrieverDiagBuilder;
+      if (type == RetrieverContext.RetrieverType.KNN) {
+        // Preserve vectorDiagnostics already set by SearchRequestProcessor
+        retrieverDiagBuilder =
+            multiRetrieverDiagnosticsBuilder
+                .getRetrieverDiagnosticsOrDefault(
+                    name, SearchResponse.Diagnostics.RetrieverDiagnostics.getDefaultInstance())
+                .toBuilder();
+      } else {
+        retrieverDiagBuilder =
+            SearchResponse.Diagnostics.RetrieverDiagnostics.newBuilder()
+                .setSearchTimeMs(retrieverResult.searchTimeMs());
+      }
+      if (retrieverResult.rescoreTimeMs() > 0) {
+        retrieverDiagBuilder.setRescoreTimeMs(retrieverResult.rescoreTimeMs());
+      }
+      retrieverDiagBuilder.setTotalHits(totalHits);
+      multiRetrieverDiagnosticsBuilder.putRetrieverDiagnostics(name, retrieverDiagBuilder.build());
     }
     multiRetrieverDiagnosticsBuilder.setBlenderTimeMs(blenderTimeMs);
 
-    // Add per-retriever collector profiling stats
+    // Add per-retriever profiling stats
     if (profileResultBuilder != null) {
       ProfileResult.MultiRetrieverProfileResult.Builder multiRetrieverProfileBuilder =
           profileResultBuilder.getMultiRetrieverProfileResultBuilder();
       for (Map.Entry<String, RetrieverContext> entry : retrieverContexts.entrySet()) {
         String name = entry.getKey();
         ProfileResult.Builder retrieverProfile =
-            multiRetrieverProfileBuilder.getRetrieverProfileResultsOrDefault(name, null) != null
-                ? multiRetrieverProfileBuilder
-                    .getRetrieverProfileResultsOrDefault(name, ProfileResult.getDefaultInstance())
-                    .toBuilder()
-                : ProfileResult.newBuilder();
+            multiRetrieverProfileBuilder
+                .getRetrieverProfileResultsOrDefault(name, ProfileResult.getDefaultInstance())
+                .toBuilder();
         entry.getValue().getDocCollector().maybeAddProfiling(retrieverProfile);
         multiRetrieverProfileBuilder.putRetrieverProfileResults(name, retrieverProfile.build());
       }

--- a/src/main/java/com/yelp/nrtsearch/server/rescore/RescoreTask.java
+++ b/src/main/java/com/yelp/nrtsearch/server/rescore/RescoreTask.java
@@ -54,6 +54,10 @@ public class RescoreTask {
     return name;
   }
 
+  public int getWindowSize() {
+    return windowSize;
+  }
+
   public static Builder newBuilder() {
     return new Builder();
   }

--- a/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
@@ -653,8 +653,13 @@ public class SearchRequestProcessor {
     if (searchRequest.hasQuerySort()) {
       throw new IllegalArgumentException("QuerySort is not supported with MultiRetriever requests");
     }
-    // TODO: Remove once multi-retriever execution is implemented
-    throw new UnsupportedOperationException("Multi-retriever is not yet supported");
+    if (searchRequest.getFacetsCount() > 0) {
+      throw new IllegalArgumentException("Facets are not supported with MultiRetriever requests");
+    }
+    if (searchRequest.getCollectorsCount() > 0) {
+      throw new IllegalArgumentException(
+          "Collectors are not supported with MultiRetriever requests");
+    }
   }
 
   private static Query buildMultiRetrieverContextAndUnionQuery(

--- a/src/main/java/com/yelp/nrtsearch/server/search/collectors/DocCollector.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/collectors/DocCollector.java
@@ -22,6 +22,7 @@ import com.yelp.nrtsearch.server.grpc.Rescorer;
 import com.yelp.nrtsearch.server.grpc.SearchRequest;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import com.yelp.nrtsearch.server.index.IndexState;
+import com.yelp.nrtsearch.server.rescore.RescoreTask;
 import com.yelp.nrtsearch.server.search.SearchCollectorManager;
 import com.yelp.nrtsearch.server.search.SearchContext;
 import com.yelp.nrtsearch.server.search.SearchCutoffWrapper;
@@ -89,6 +90,21 @@ public abstract class DocCollector {
       }
     }
     for (Rescorer rescorer : request.getRescorersList()) {
+      int windowSize = rescorer.getWindowSize();
+      if (windowSize > 0 && windowSize > collectHits) {
+        collectHits = windowSize;
+      }
+    }
+    return collectHits;
+  }
+
+  public static int computeNumHitsToCollect(
+      int startHit, int topHits, int logHits, List<RescoreTask> rescorers) {
+    int collectHits = topHits;
+    if (logHits > 0) {
+      collectHits = Math.max(collectHits, logHits + startHit);
+    }
+    for (RescoreTask rescorer : rescorers) {
       int windowSize = rescorer.getWindowSize();
       if (windowSize > 0 && windowSize > collectHits) {
         collectHits = windowSize;

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderOperation.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderOperation.java
@@ -66,8 +66,7 @@ public interface BlenderOperation {
    * @param retrieverFutures per-retriever futures in declaration order, keyed by retriever name
    * @param retrieverContexts per-retriever contexts in declaration order, keyed by retriever name
    * @param startHit 0-based offset of the first blended hit to include in the result
-   * @param topHits maximum number of blended hits to return; {@code 0} returns empty; negative
-   *     values mean no limit
+   * @param topHits maximum number of blended hits to return; {@code 0} returns empty; must be >= 0
    * @return blended, sorted, paginated {@link TopDocs}
    * @throws RuntimeException wrapping any retriever {@link ExecutionException}, identified by name
    * @throws InterruptedException if the calling thread is interrupted while waiting
@@ -98,15 +97,12 @@ public interface BlenderOperation {
 
   /**
    * Select and return the requested pagination window from merged hits without sorting the full
-   * list. Uses a min-heap of size {@code k = startHit + topHits} to find the top-k hits in O(n log
-   * k) time and O(k) space. The heap entries are then sorted in O(k log k) to produce the final
-   * page order. When {@code topHits < 0} (no limit), {@code k = n} and the complexity degrades
-   * gracefully to O(n log n).
+   * list. Uses a min-heap of size {@code k = topHits} to find the top-k hits in O(n log k) time and
+   * O(k) space. The heap entries are then sorted in O(k log k) to produce the final page order.
    *
    * @param merged unsorted merged hits from {@link #mergeHits}
    * @param startHit 0-based offset of the first hit to include in the returned page
-   * @param topHits maximum number of hits to return; {@code 0} returns empty; negative values mean
-   *     no limit
+   * @param topHits maximum number of hits to return; {@code 0} returns empty; must be >= 0
    * @return paginated {@link TopDocs}
    */
   static TopDocs sortAndPaginate(Collection<BlendedScoreDoc> merged, int startHit, int topHits) {

--- a/src/test/java/com/yelp/nrtsearch/server/ServerTestCase.java
+++ b/src/test/java/com/yelp/nrtsearch/server/ServerTestCase.java
@@ -31,6 +31,7 @@ import com.yelp.nrtsearch.server.grpc.LuceneServerGrpc;
 import com.yelp.nrtsearch.server.grpc.Mode;
 import com.yelp.nrtsearch.server.grpc.NrtsearchClientBuilder;
 import com.yelp.nrtsearch.server.grpc.RefreshRequest;
+import com.yelp.nrtsearch.server.grpc.SearchRequest;
 import com.yelp.nrtsearch.server.grpc.SettingsRequest;
 import com.yelp.nrtsearch.server.grpc.StartIndexRequest;
 import com.yelp.nrtsearch.server.plugins.Plugin;
@@ -115,6 +116,22 @@ public class ServerTestCase {
       throw new RuntimeException(e);
     }
     return fieldDefRequestBuilder.build();
+  }
+
+  public static SearchRequest getSearchRequestFromResourceFile(String resourceFileName)
+      throws IOException {
+    InputStream fileStream = ServerTestCase.class.getResourceAsStream(resourceFileName);
+    String jsonText =
+        new BufferedReader(new InputStreamReader(fileStream, StandardCharsets.UTF_8))
+            .lines()
+            .collect(Collectors.joining(System.lineSeparator()));
+    SearchRequest.Builder builder = SearchRequest.newBuilder();
+    try {
+      JsonFormat.parser().merge(jsonText, builder);
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(e);
+    }
+    return builder.build();
   }
 
   public static AddDocumentResponse addDocuments(Stream<AddDocumentRequest> requestStream)

--- a/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
@@ -15,6 +15,8 @@
  */
 package com.yelp.nrtsearch.server.search;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -22,29 +24,47 @@ import static org.junit.Assert.fail;
 import com.yelp.nrtsearch.server.ServerTestCase;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest.MultiValuedField;
+import com.yelp.nrtsearch.server.grpc.Blender;
+import com.yelp.nrtsearch.server.grpc.Collector;
+import com.yelp.nrtsearch.server.grpc.Facet;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
+import com.yelp.nrtsearch.server.grpc.FunctionScoreQuery;
 import com.yelp.nrtsearch.server.grpc.KnnQuery;
 import com.yelp.nrtsearch.server.grpc.KnnRetriever;
 import com.yelp.nrtsearch.server.grpc.MatchQuery;
 import com.yelp.nrtsearch.server.grpc.MultiRetrieverRequest;
+import com.yelp.nrtsearch.server.grpc.ProfileResult;
 import com.yelp.nrtsearch.server.grpc.Query;
+import com.yelp.nrtsearch.server.grpc.QueryRescorer;
 import com.yelp.nrtsearch.server.grpc.QuerySortField;
+import com.yelp.nrtsearch.server.grpc.Rescorer;
 import com.yelp.nrtsearch.server.grpc.Retriever;
+import com.yelp.nrtsearch.server.grpc.ScorelessRawMergeBlender;
+import com.yelp.nrtsearch.server.grpc.Script;
 import com.yelp.nrtsearch.server.grpc.SearchRequest;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import com.yelp.nrtsearch.server.grpc.SearchResponse.Hit;
 import com.yelp.nrtsearch.server.grpc.SortFields;
 import com.yelp.nrtsearch.server.grpc.SortType;
+import com.yelp.nrtsearch.server.grpc.TermsCollector;
 import com.yelp.nrtsearch.server.grpc.TextRetriever;
-import com.yelp.nrtsearch.server.index.IndexState;
+import com.yelp.nrtsearch.server.grpc.WeightedRrfBlender;
+import com.yelp.nrtsearch.server.grpc.WeightedScoreOrderBlender;
 import io.grpc.StatusRuntimeException;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
-import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager;
+import java.util.Set;
 import org.junit.ClassRule;
 import org.junit.Test;
 
 public class MultiRetrieverSearchTest extends ServerTestCase {
+
+  private static final double SCORE_DELTA = 1e-5;
+  // Max RRF score a doc can get from a single retriever with k=60: 1/(60+1)
+  private static final double RRF_RANK1_K60 = 1.0 / 61.0;
 
   @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
@@ -97,7 +117,7 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
         .build();
   }
 
-  private Retriever knnRetriever() {
+  private Retriever knnRetriever(int k) {
     return Retriever.newBuilder()
         .setName("knn")
         .setKnnRetriever(
@@ -107,9 +127,32 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
                         .setField("vector_field")
                         .addAllQueryVector(List.of(0.1f, 0.2f, 0.3f))
                         .setNumCandidates(10)
-                        .setK(5)
+                        .setK(k)
                         .build())
                 .build())
+        .build();
+  }
+
+  /**
+   * Rescorer that replaces every hit's score with {@code constant} (queryWeight=0 drops original).
+   */
+  private static Rescorer constantScoreRescorer(double constant, int windowSize, String name) {
+    return Rescorer.newBuilder()
+        .setName(name)
+        .setWindowSize(windowSize)
+        .setQueryRescorer(
+            QueryRescorer.newBuilder()
+                .setQueryWeight(0.0f)
+                .setRescoreQueryWeight(1.0f)
+                .setRescoreQuery(
+                    Query.newBuilder()
+                        .setFunctionScoreQuery(
+                            FunctionScoreQuery.newBuilder()
+                                .setScript(
+                                    Script.newBuilder()
+                                        .setLang("js")
+                                        .setSource(String.valueOf(constant))))
+                        .build()))
         .build();
   }
 
@@ -119,24 +162,24 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
       getGrpcServer().getBlockingStub().search(request);
       fail("Expected error");
     } catch (StatusRuntimeException e) {
-      assertTrue(
-          "Expected message containing: " + expectedMessage + ", got: " + e.getMessage(),
-          e.getMessage().contains(expectedMessage));
+      assertTrue(e.getMessage().contains(expectedMessage));
     }
   }
 
-  @Test
-  public void testEmptyRetrieversList() {
-    assertSearchError(
-        baseRequest().setMultiRetriever(MultiRetrieverRequest.newBuilder().build()).build(),
-        "MultiRetriever request must have at least one retriever");
+  private static Set<Integer> docIds(SearchResponse response) {
+    Set<Integer> ids = new HashSet<>();
+    for (Hit hit : response.getHitsList()) ids.add(hit.getLuceneDocId());
+    return ids;
   }
 
   @Test
-  public void testMultiRetrieverWithQueryParams() {
-    MultiRetrieverRequest multiRetriever =
+  public void testValidationErrors() {
+    MultiRetrieverRequest oneRetriever =
         MultiRetrieverRequest.newBuilder().addRetrievers(textRetriever(5)).build();
 
+    assertSearchError(
+        baseRequest().setMultiRetriever(MultiRetrieverRequest.newBuilder().build()).build(),
+        "MultiRetriever request must have at least one retriever");
     assertSearchError(
         baseRequest()
             .setQuery(
@@ -144,30 +187,12 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
                     .setMatchQuery(
                         MatchQuery.newBuilder().setField("text_field").setQuery("test").build())
                     .build())
-            .setMultiRetriever(multiRetriever)
+            .setMultiRetriever(oneRetriever)
             .build(),
         "Query should not be set along with a MultiRetriever request");
-
     assertSearchError(
-        baseRequest().setQueryText("test").setMultiRetriever(multiRetriever).build(),
+        baseRequest().setQueryText("test").setMultiRetriever(oneRetriever).build(),
         "QueryText should not be set along with a MultiRetriever request");
-
-    assertSearchError(
-        baseRequest()
-            .setQuerySort(
-                QuerySortField.newBuilder()
-                    .setFields(
-                        SortFields.newBuilder()
-                            .addSortedFields(SortType.newBuilder().setFieldName("doc_id").build())
-                            .build())
-                    .build())
-            .setMultiRetriever(multiRetriever)
-            .build(),
-        "QuerySort is not supported with MultiRetriever requests");
-  }
-
-  @Test
-  public void testMultiRetrieverWithKnnQuery() {
     assertSearchError(
         baseRequest()
             .addKnn(
@@ -177,50 +202,368 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
                     .setNumCandidates(10)
                     .setK(5)
                     .build())
-            .setMultiRetriever(
-                MultiRetrieverRequest.newBuilder().addRetrievers(textRetriever(5)).build())
+            .setMultiRetriever(oneRetriever)
             .build(),
         "Knn Query should not be set along with a MultiRetriever request");
-  }
-
-  // TODO: Remove this test after Multi-retriever implementation
-  @Test
-  public void testMultiRetrieverSearchUnsupported() {
+    assertSearchError(
+        baseRequest()
+            .setQuerySort(
+                QuerySortField.newBuilder()
+                    .setFields(
+                        SortFields.newBuilder()
+                            .addSortedFields(SortType.newBuilder().setFieldName("doc_id").build())
+                            .build())
+                    .build())
+            .setMultiRetriever(oneRetriever)
+            .build(),
+        "QuerySort is not supported with MultiRetriever requests");
     assertSearchError(
         baseRequest()
             .setMultiRetriever(
                 MultiRetrieverRequest.newBuilder()
                     .addRetrievers(textRetriever(5))
-                    .addRetrievers(knnRetriever())
+                    .setBlender(Blender.newBuilder().build())
                     .build())
             .build(),
-        "Multi-retriever is not yet supported");
+        "Unsupported blender type");
+  }
+
+  // TODO: Remove after adding Facets and Collectors support
+  @Test
+  public void testAggregationsNotSupported() {
+    MultiRetrieverRequest twoRetrievers =
+        MultiRetrieverRequest.newBuilder()
+            .addRetrievers(textRetriever(5))
+            .addRetrievers(knnRetriever(5))
+            .build();
+
+    assertSearchError(
+        baseRequest()
+            .setMultiRetriever(twoRetrievers)
+            .addFacets(Facet.newBuilder().setName("doc_id").setTopN(5).build())
+            .build(),
+        "Facets are not supported with MultiRetriever requests");
+    assertSearchError(
+        baseRequest()
+            .setMultiRetriever(twoRetrievers)
+            .putCollectors(
+                "terms",
+                Collector.newBuilder()
+                    .setTerms(TermsCollector.newBuilder().setField("doc_id").setSize(5).build())
+                    .build())
+            .build(),
+        "Collectors are not supported with MultiRetriever requests");
+  }
+
+  /**
+   * Single text retriever, k=60. Score at rank r = 1/(60+r) exactly. All 10 docs match "test",
+   * returned in strictly descending score order with doc_id field populated.
+   */
+  @Test
+  public void testTextOnlyRrfScores() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                baseRequest()
+                    .addRetrieveFields("doc_id")
+                    .setMultiRetriever(
+                        MultiRetrieverRequest.newBuilder()
+                            .addRetrievers(textRetriever(10))
+                            .setBlender(
+                                Blender.newBuilder()
+                                    .setWeightedRrf(
+                                        WeightedRrfBlender.newBuilder().setRankConstant(60))
+                                    .build())
+                            .build())
+                    .build());
+
+    assertEquals(10, response.getHitsCount());
+    assertEquals(10, response.getTotalHits().getValue());
+    assertEquals(10, docIds(response).size());
+
+    List<Hit> hits = response.getHitsList();
+    double prevScore = Double.MAX_VALUE;
+    for (int i = 0; i < hits.size(); i++) {
+      double score = hits.get(i).getScore();
+      assertEquals(1.0 / (60 + i + 1), score, SCORE_DELTA);
+      assertTrue(score < prevScore);
+      prevScore = score;
+      assertFalse(hits.get(i).getFieldsOrThrow("doc_id").getFieldValueList().isEmpty());
+    }
+  }
+
+  /**
+   * Text (10 hits) + KNN (k=5). All KNN hits are also text hits → 10 unique docs. Docs appearing in
+   * both retrievers get contributions from two sources, so their RRF score > 1/(60+1) (the max from
+   * a single retriever). The top 5 must therefore be the 5 KNN docs.
+   */
+  @Test
+  public void testTextAndKnnRrfScoresAndOrdering() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                baseRequest()
+                    .setTopHits(10)
+                    .addRetrieveFields("doc_id")
+                    .setMultiRetriever(
+                        MultiRetrieverRequest.newBuilder()
+                            .addRetrievers(textRetriever(10))
+                            .addRetrievers(knnRetriever(5))
+                            .setBlender(
+                                Blender.newBuilder()
+                                    .setWeightedRrf(
+                                        WeightedRrfBlender.newBuilder().setRankConstant(60))
+                                    .build())
+                            .build())
+                    .build());
+
+    assertEquals(10, response.getHitsCount());
+    assertEquals(10, docIds(response).size());
+
+    List<Hit> hits = response.getHitsList();
+    for (int i = 0; i < hits.size(); i++) {
+      assertTrue(hits.get(i).getScore() > 0);
+      if (i > 0) assertTrue(hits.get(i).getScore() <= hits.get(i - 1).getScore());
+      assertFalse(hits.get(i).getFieldsOrThrow("doc_id").getFieldValueList().isEmpty());
+    }
+    for (int i = 0; i < 5; i++) assertTrue(hits.get(i).getScore() > RRF_RANK1_K60);
+    for (int i = 5; i < 10; i++) assertTrue(hits.get(i).getScore() <= RRF_RANK1_K60);
+
+    // Top-5 docs appear in both retrievers → both retriever scores present
+    for (int i = 0; i < 5; i++) {
+      assertTrue(hits.get(i).getRetrieverScoresMap().containsKey("text"));
+      assertTrue(hits.get(i).getRetrieverScoresMap().containsKey("knn"));
+      assertTrue(hits.get(i).getRetrieverScoresMap().get("text") > 0);
+      assertEquals(1.0, hits.get(i).getRetrieverScoresMap().get("knn"), SCORE_DELTA);
+    }
+    // Bottom-5 docs appear only in the text retriever → only "text" score present
+    for (int i = 5; i < 10; i++) {
+      assertTrue(hits.get(i).getRetrieverScoresMap().containsKey("text"));
+      assertFalse(hits.get(i).getRetrieverScoresMap().containsKey("knn"));
+    }
+  }
+
+  /**
+   * KNN-only, cosine=1.0 for all docs (parallel vectors), boost=1. WeightedScoreOrder MAX produces
+   * score=1.0 for every hit. k=5 → exactly 5 unique hits.
+   */
+  @Test
+  public void testKnnWeightedScoreOrderScores() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                baseRequest()
+                    .setMultiRetriever(
+                        MultiRetrieverRequest.newBuilder()
+                            .addRetrievers(knnRetriever(5))
+                            .setBlender(
+                                Blender.newBuilder()
+                                    .setWeightedScoreOrder(
+                                        WeightedScoreOrderBlender.newBuilder()
+                                            .setScoreMode(WeightedScoreOrderBlender.ScoreMode.MAX)
+                                            .build())
+                                    .build())
+                            .build())
+                    .build());
+
+    assertEquals(5, response.getHitsCount());
+    assertEquals(5, docIds(response).size());
+    for (Hit hit : response.getHitsList()) assertEquals(1.0, hit.getScore(), SCORE_DELTA);
+  }
+
+  /** Deduplicates across retrievers and assigns score=0 to all hits. */
+  @Test
+  public void testScorelessRawMerge() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                baseRequest()
+                    .setTopHits(10)
+                    .setMultiRetriever(
+                        MultiRetrieverRequest.newBuilder()
+                            .addRetrievers(textRetriever(10))
+                            .addRetrievers(knnRetriever(5))
+                            .setBlender(
+                                Blender.newBuilder()
+                                    .setScorelessRawMerge(
+                                        ScorelessRawMergeBlender.newBuilder().build())
+                                    .build())
+                            .build())
+                    .build());
+
+    assertEquals(10, response.getHitsCount());
+    assertEquals(10, docIds(response).size());
+    for (Hit hit : response.getHitsList()) assertEquals(0.0, hit.getScore(), SCORE_DELTA);
+  }
+
+  /**
+   * L1 rescorer on the text retriever replaces all scores with 7.0 before blending.
+   * WeightedScoreOrder MAX with boost=1 sees post-L1 scores, so every blended hit must have
+   * score=7.0.
+   */
+  @Test
+  public void testL1RescorerAppliedBeforeBlend() {
+    Retriever textWithL1 =
+        Retriever.newBuilder()
+            .setName("text")
+            .setTextRetriever(
+                TextRetriever.newBuilder()
+                    .setQuery(
+                        Query.newBuilder()
+                            .setMatchQuery(
+                                MatchQuery.newBuilder()
+                                    .setField("text_field")
+                                    .setQuery("test")
+                                    .build())
+                            .build())
+                    .setTopHits(10)
+                    .build())
+            .setRescorer(constantScoreRescorer(7.0, 10, "l1_text"))
+            .build();
+
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                baseRequest()
+                    .setMultiRetriever(
+                        MultiRetrieverRequest.newBuilder()
+                            .addRetrievers(textWithL1)
+                            .setBlender(
+                                Blender.newBuilder()
+                                    .setWeightedScoreOrder(
+                                        WeightedScoreOrderBlender.newBuilder()
+                                            .setScoreMode(WeightedScoreOrderBlender.ScoreMode.MAX)
+                                            .build())
+                                    .build())
+                            .build())
+                    .build());
+
+    assertEquals(10, response.getHitsCount());
+    for (Hit hit : response.getHitsList()) assertEquals(7.0, hit.getScore(), SCORE_DELTA);
+  }
+
+  /**
+   * L2 rescorer on the SearchRequest runs post-blend. Constant score=3.0 replaces every blended
+   * hit's score. Rescorer timing must appear in diagnostics.
+   */
+  @Test
+  public void testL2RescorerAppliedPostBlend() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                baseRequest()
+                    .addRescorers(constantScoreRescorer(3.0, 20, "l2_rescorer"))
+                    .setMultiRetriever(
+                        MultiRetrieverRequest.newBuilder()
+                            .addRetrievers(textRetriever(10))
+                            .addRetrievers(knnRetriever(5))
+                            .setBlender(
+                                Blender.newBuilder()
+                                    .setWeightedRrf(
+                                        WeightedRrfBlender.newBuilder().setRankConstant(60))
+                                    .build())
+                            .build())
+                    .build());
+
+    assertEquals(10, response.getHitsCount());
+    for (Hit hit : response.getHitsList()) assertEquals(3.0, hit.getScore(), SCORE_DELTA);
+    assertTrue(response.getDiagnostics().getRescorersTimeMsMap().containsKey("l2_rescorer"));
+    assertTrue(response.getDiagnostics().getRescoreTimeMs() >= 0);
   }
 
   @Test
-  public void testBuildAndResolveKnnQueryResultAndDiagnostics() throws Exception {
-    IndexState indexState = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX);
-    SearcherTaxonomyManager.SearcherAndTaxonomy searcherAndTaxonomy =
-        indexState.getShard(0).acquire();
-    try {
-      KnnQuery knnQuery =
-          KnnQuery.newBuilder()
-              .setField("vector_field")
-              .addAllQueryVector(List.of(0.1f, 0.2f, 0.3f))
-              .setNumCandidates(10)
-              .setK(5)
-              .build();
+  public void testMultiRetrieverDiagnostics() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                baseRequest()
+                    .setMultiRetriever(
+                        MultiRetrieverRequest.newBuilder()
+                            .addRetrievers(textRetriever(10))
+                            .addRetrievers(knnRetriever(5))
+                            .setBlender(
+                                Blender.newBuilder()
+                                    .setWeightedRrf(
+                                        WeightedRrfBlender.newBuilder().setRankConstant(60))
+                                    .build())
+                            .build())
+                    .build());
 
-      KnnUtils.KnnResolveResult result =
-          KnnUtils.buildAndResolveKnnQuery(knnQuery, indexState, searcherAndTaxonomy.searcher());
+    assertTrue(response.getDiagnostics().hasMultiRetrieverDiagnostics());
+    SearchResponse.Diagnostics.MultiRetrieverDiagnostics diag =
+        response.getDiagnostics().getMultiRetrieverDiagnostics();
+    assertNotNull(diag.getRetrieverDiagnosticsOrDefault("text", null));
+    assertNotNull(diag.getRetrieverDiagnosticsOrDefault("knn", null));
+    assertTrue(diag.getRetrieverDiagnosticsOrThrow("text").getSearchTimeMs() >= 0);
+    assertTrue(diag.getRetrieverDiagnosticsOrThrow("knn").getSearchTimeMs() >= 0);
+    assertTrue(diag.getBlenderTimeMs() >= 0);
+    assertTrue(response.getDiagnostics().getFirstPassSearchTimeMs() >= 0);
+  }
 
-      assertNotNull(result.resolvedQuery());
-      assertNotNull(result.vectorDiagnostics());
-      assertTrue(
-          "Expected vector search to find hits",
-          result.vectorDiagnostics().getTotalHits().getValue() > 0);
-    } finally {
-      indexState.getShard(0).release(searcherAndTaxonomy);
+  @Test
+  public void testProfilingPopulatesPerRetrieverResults() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                baseRequest()
+                    .setProfile(true)
+                    .setMultiRetriever(
+                        MultiRetrieverRequest.newBuilder()
+                            .addRetrievers(textRetriever(10))
+                            .addRetrievers(knnRetriever(5))
+                            .setBlender(
+                                Blender.newBuilder()
+                                    .setWeightedRrf(
+                                        WeightedRrfBlender.newBuilder().setRankConstant(60))
+                                    .build())
+                            .build())
+                    .build());
+
+    assertTrue(response.hasProfileResult());
+    ProfileResult profile = response.getProfileResult();
+    assertTrue(profile.hasMultiRetrieverProfileResult());
+    assertTrue(
+        profile
+            .getMultiRetrieverProfileResult()
+            .getRetrieverProfileResultsMap()
+            .containsKey("text"));
+    assertTrue(
+        profile
+            .getMultiRetrieverProfileResult()
+            .getRetrieverProfileResultsMap()
+            .containsKey("knn"));
+
+    ProfileResult textProfile =
+        profile.getMultiRetrieverProfileResult().getRetrieverProfileResultsOrThrow("text");
+    assertFalse(textProfile.getParsedQuery().isEmpty());
+    assertFalse(textProfile.getRewrittenQuery().isEmpty());
+  }
+
+  @Test
+  public void testJsonMultiRetrieverRrfRequest() throws Exception {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(getSearchRequestFromResourceFile("/search/multiRetrieverRrfRequest.json"));
+
+    assertEquals(10, response.getHitsCount());
+    assertEquals(10, docIds(response).size());
+    List<Hit> hits = response.getHitsList();
+    for (int i = 0; i < hits.size(); i++) {
+      assertTrue(hits.get(i).getScore() > 0);
+      if (i > 0) assertTrue(hits.get(i).getScore() <= hits.get(i - 1).getScore());
+      assertFalse(hits.get(i).getFieldsOrThrow("doc_id").getFieldValueList().isEmpty());
+      assertFalse(hits.get(i).getFieldsOrThrow("text_field").getFieldValueList().isEmpty());
     }
+    for (int i = 0; i < 5; i++) assertTrue(hits.get(i).getScore() > RRF_RANK1_K60);
+    for (int i = 5; i < 10; i++) assertTrue(hits.get(i).getScore() <= RRF_RANK1_K60);
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
@@ -515,8 +515,10 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
 
     SearchResponse.Diagnostics.RetrieverDiagnostics knnDiag =
         diag.getRetrieverDiagnosticsOrThrow("knn");
-    // KNN retriever: vectorDiagnostics from SearchRequestProcessor, totalHits from handler
+    // KNN retriever: vectorDiagnostics from SearchRequestProcessor, timing and totalHits from
+    // handler
     assertTrue(knnDiag.hasVectorDiagnostics());
+    assertTrue(knnDiag.getSearchTimeMs() >= 0);
     assertEquals(5, knnDiag.getTotalHits().getValue());
 
     assertTrue(diag.getBlenderTimeMs() >= 0);

--- a/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
@@ -17,7 +17,6 @@ package com.yelp.nrtsearch.server.search;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -445,6 +444,14 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
 
     assertEquals(10, response.getHitsCount());
     for (Hit hit : response.getHitsList()) assertEquals(7.0, hit.getScore(), SCORE_DELTA);
+    // L1 rescorer timing must appear in per-retriever diagnostics
+    SearchResponse.Diagnostics.RetrieverDiagnostics textDiag =
+        response
+            .getDiagnostics()
+            .getMultiRetrieverDiagnostics()
+            .getRetrieverDiagnosticsOrThrow("text");
+    assertTrue(textDiag.getRescoreTimeMs() > 0);
+    assertEquals(10, textDiag.getTotalHits().getValue());
   }
 
   /**
@@ -499,10 +506,19 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
     assertTrue(response.getDiagnostics().hasMultiRetrieverDiagnostics());
     SearchResponse.Diagnostics.MultiRetrieverDiagnostics diag =
         response.getDiagnostics().getMultiRetrieverDiagnostics();
-    assertNotNull(diag.getRetrieverDiagnosticsOrDefault("text", null));
-    assertNotNull(diag.getRetrieverDiagnosticsOrDefault("knn", null));
-    assertTrue(diag.getRetrieverDiagnosticsOrThrow("text").getSearchTimeMs() >= 0);
-    assertTrue(diag.getRetrieverDiagnosticsOrThrow("knn").getSearchTimeMs() >= 0);
+
+    SearchResponse.Diagnostics.RetrieverDiagnostics textDiag =
+        diag.getRetrieverDiagnosticsOrThrow("text");
+    // Text retriever: searchTimeMs and totalHits populated by handler
+    assertTrue(textDiag.getSearchTimeMs() >= 0);
+    assertEquals(10, textDiag.getTotalHits().getValue());
+
+    SearchResponse.Diagnostics.RetrieverDiagnostics knnDiag =
+        diag.getRetrieverDiagnosticsOrThrow("knn");
+    // KNN retriever: vectorDiagnostics from SearchRequestProcessor, totalHits from handler
+    assertTrue(knnDiag.hasVectorDiagnostics());
+    assertEquals(5, knnDiag.getTotalHits().getValue());
+
     assertTrue(diag.getBlenderTimeMs() >= 0);
     assertTrue(response.getDiagnostics().getFirstPassSearchTimeMs() >= 0);
   }

--- a/src/test/resources/search/multiRetrieverRrfRequest.json
+++ b/src/test/resources/search/multiRetrieverRrfRequest.json
@@ -1,0 +1,38 @@
+{
+  "indexName": "test_index",
+  "startHit": 0,
+  "topHits": 10,
+  "retrieveFields": ["doc_id", "text_field"],
+  "multiRetriever": {
+    "retrievers": [
+      {
+        "name": "text",
+        "textRetriever": {
+          "query": {
+            "matchQuery": {
+              "field": "text_field",
+              "query": "test"
+            }
+          },
+          "topHits": 10
+        }
+      },
+      {
+        "name": "knn",
+        "knnRetriever": {
+          "knnQuery": {
+            "field": "vector_field",
+            "queryVector": [0.1, 0.2, 0.3],
+            "numCandidates": 10,
+            "k": 5
+          }
+        }
+      }
+    ],
+    "blender": {
+      "weightedRrf": {
+        "rankConstant": 60
+      }
+    }
+  }
+}


### PR DESCRIPTION
File changes:

**SearchRequestProcessor.java** — Removed the UnsupportedOperationException blocker. Added explicit validation rejecting facets and collectors with multi-retriever. This will be implemented in future PR.                                                                                                                                                    
                                                                                                                                                                                     
**SearchHandler.java**                                                                                                                        
  - Submits per-retriever searcher.search() calls to searchExecutor in parallel
  - Applies per-retriever L1 rescorers inside each callable                                                                                                                          
  - Computes a blend window large enough for downstream L2 rescorers and hits-to-log
  - Calls blenderOperation.blend() for all blender types (RRF, WeightedScoreOrder, ScorelessRawMerge, Plugin)                                                                        
  - Sets blended scores on Hit via direct ScoreDoc.score (bypassing the no-op HitCountCollector)                                                                                     
  - Populates Hit.retrieverScores from BlendedScoreDoc.scoreDocs per-retriever raw scores                                                                                            
  - Records per-retriever search timings and blender timing in MultiRetrieverDiagnostics                                                                                             
  - Calls maybeAddProfiling() on per-retriever collectors when profile=true                                                                                                            
                                                                                                                                                                                     
**RescoreTask.java** — Added getWindowSize() accessor needed by executeMultiRetriever.                                                                                                 
                                                                                                                                                                                     
**ServerTestCase.java** — Added getSearchRequestFromResourceFile() helper for JSON-driven tests.                                                                                                                                                                                                                                   

**MultiRetrieverSearchTest.java** — 15 tests covering validation, all three blender types, diagnostics, profiling, and a JSON-driven end-to-end test.

**MultiRetrieverRrfRequest.json** — JSON fixture representing a real client request.