### PR TITLE
Add ScriptRescorer to re-score blended results

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -1344,6 +1344,14 @@ message QueryRescorer {
     double rescoreQueryWeight = 3;
 }
 
+// Defines a rescorer which uses a script to compute a new score for each hit.
+// The script has access to _score (the score from the previous pass, e.g. blended score)
+// and doc values via the doc map. Useful for boosting blended results with field-level signals.
+message ScriptRescorer {
+    // Script to execute per document; must return a double
+    Script script = 1;
+}
+
 // Defines a rescorer which is executed after the first search pass
 message Rescorer {
     // Maximum number of hits from previous phase to rescore
@@ -1353,6 +1361,8 @@ message Rescorer {
         QueryRescorer queryRescorer = 2;
         // Rescore with plugin registered rescorer
         PluginRescorer pluginRescorer = 3;
+        // Rescore with a script
+        ScriptRescorer scriptRescorer = 5;
     }
     // Must be unique for each Rescorer
     string name = 4;

--- a/src/main/java/com/yelp/nrtsearch/server/rescore/ScriptRescore.java
+++ b/src/main/java/com/yelp/nrtsearch/server/rescore/ScriptRescore.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.rescore;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DoubleValues;
+import org.apache.lucene.search.DoubleValuesSource;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+
+/**
+ * {@link RescoreOperation} that re-scores each hit by evaluating a {@link DoubleValuesSource}
+ * (typically compiled from a {@link com.yelp.nrtsearch.server.script.ScoreScript}). The script
+ * receives the previous-pass score via the {@code _score} expression variable and doc values via
+ * {@code doc}.
+ */
+public class ScriptRescore implements RescoreOperation {
+
+  private final DoubleValuesSource scriptSource;
+
+  public ScriptRescore(DoubleValuesSource scriptSource) {
+    this.scriptSource = scriptSource;
+  }
+
+  @Override
+  public TopDocs rescore(TopDocs hits, RescoreContext context) throws IOException {
+    IndexSearcher searcher = context.getSearchContext().getSearcherAndTaxonomy().searcher();
+
+    // Sort hits by doc id so we can walk leaves in one forward pass.
+    ScoreDoc[] scoreDocs = hits.scoreDocs.clone();
+    Arrays.sort(scoreDocs, (a, b) -> Integer.compare(a.doc, b.doc));
+
+    List<LeafReaderContext> leaves = searcher.getIndexReader().leaves();
+
+    int leafIndex = 0;
+    DoubleValues scriptValues = null;
+    TopDocsScoreValues scoreValues = null;
+
+    for (ScoreDoc scoreDoc : scoreDocs) {
+      // Advance to the leaf that contains this global doc id.
+      while (leafIndex < leaves.size() - 1 && leaves.get(leafIndex + 1).docBase <= scoreDoc.doc) {
+        leafIndex++;
+        scriptValues = null; // entering a new segment
+      }
+
+      if (scriptValues == null) {
+        LeafReaderContext leaf = leaves.get(leafIndex);
+        // TopDocsScoreValues exposes the previous-pass score as _score to the script.
+        scoreValues = new TopDocsScoreValues(scoreDocs, leaf.docBase);
+        scriptValues = scriptSource.getValues(leaf, scoreValues);
+      }
+
+      int segmentDocId = scoreDoc.doc - leaves.get(leafIndex).docBase;
+      scriptValues.advanceExact(segmentDocId);
+      scoreDoc.score = (float) scriptValues.doubleValue();
+    }
+
+    // Re-sort by new score descending.
+    Arrays.sort(scoreDocs, (a, b) -> Float.compare(b.score, a.score));
+
+    // Trim to windowSize, mirroring Lucene QueryRescorer behaviour.
+    int windowSize = context.getWindowSize();
+    if (windowSize < scoreDocs.length) {
+      ScoreDoc[] trimmed = new ScoreDoc[windowSize];
+      System.arraycopy(scoreDocs, 0, trimmed, 0, windowSize);
+      scoreDocs = trimmed;
+    }
+
+    return new TopDocs(new TotalHits(hits.totalHits.value(), hits.totalHits.relation()), scoreDocs);
+  }
+
+  /**
+   * Exposes the previous-pass score from a sorted {@link ScoreDoc} array as a {@link DoubleValues},
+   * so the script engine can read it as the {@code _score} expression variable. Looks up the score
+   * by converting the segment-local doc id back to a global doc id using {@code docBase}.
+   */
+  private static class TopDocsScoreValues extends DoubleValues {
+    private final ScoreDoc[] scoreDocs;
+    private final int docBase;
+    private double score;
+
+    TopDocsScoreValues(ScoreDoc[] scoreDocs, int docBase) {
+      this.scoreDocs = scoreDocs;
+      this.docBase = docBase;
+    }
+
+    @Override
+    public double doubleValue() {
+      return score;
+    }
+
+    @Override
+    public boolean advanceExact(int segmentDocId) {
+      int globalDocId = docBase + segmentDocId;
+      for (ScoreDoc sd : scoreDocs) {
+        if (sd.doc == globalDocId) {
+          score = sd.score;
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/rescore/ScriptRescore.java
+++ b/src/main/java/com/yelp/nrtsearch/server/rescore/ScriptRescore.java
@@ -15,8 +15,10 @@
  */
 package com.yelp.nrtsearch.server.rescore;
 
+import com.yelp.nrtsearch.server.query.QueryUtils;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DoubleValues;
@@ -28,11 +30,28 @@ import org.apache.lucene.search.TotalHits;
 
 /**
  * {@link RescoreOperation} that re-scores each hit by evaluating a {@link DoubleValuesSource}
- * (typically compiled from a {@link com.yelp.nrtsearch.server.script.ScoreScript}). The script
- * receives the previous-pass score via the {@code _score} expression variable and doc values via
- * {@code doc}.
+ * (typically compiled from a {@link com.yelp.nrtsearch.server.script.ScoreScript}). The
+ * previous-pass score is passed as the {@link DoubleValues} {@code scores} argument to {@link
+ * DoubleValuesSource#getValues}. How that score is surfaced to the script author depends on the
+ * script engine:
+ *
+ * <ul>
+ *   <li><b>JS (Lucene expression)</b> – accessible as the {@code _score} variable, resolved via
+ *       {@link com.yelp.nrtsearch.server.field.FieldDefBindings} to {@link
+ *       DoubleValuesSource#SCORES}.
+ *   <li><b>Custom {@link com.yelp.nrtsearch.server.script.ScoreScript} subclasses</b> – accessible
+ *       via {@link com.yelp.nrtsearch.server.script.ScoreScript#get_score()}.
+ * </ul>
  */
 public class ScriptRescore implements RescoreOperation {
+
+  // Ascending by doc id then shard index — used to walk segment leaves in one forward pass.
+  // Mirrors the ordering of TopDocs' private BY_DOC_ID / DEFAULT_TIE_BREAKER.
+  private static final Comparator<ScoreDoc> BY_DOC_ID =
+      Comparator.comparingInt((ScoreDoc d) -> d.doc).thenComparingInt(d -> d.shardIndex);
+  // Descending by score; ties broken by doc id then shard index (consistent with TopDocs.merge).
+  private static final Comparator<ScoreDoc> BY_SCORE_DESC =
+      Comparator.<ScoreDoc>comparingDouble(d -> -d.score).thenComparing(BY_DOC_ID);
 
   private final DoubleValuesSource scriptSource;
 
@@ -46,13 +65,13 @@ public class ScriptRescore implements RescoreOperation {
 
     // Sort hits by doc id so we can walk leaves in one forward pass.
     ScoreDoc[] scoreDocs = hits.scoreDocs.clone();
-    Arrays.sort(scoreDocs, (a, b) -> Integer.compare(a.doc, b.doc));
+    Arrays.sort(scoreDocs, BY_DOC_ID);
 
     List<LeafReaderContext> leaves = searcher.getIndexReader().leaves();
 
     int leafIndex = 0;
     DoubleValues scriptValues = null;
-    TopDocsScoreValues scoreValues = null;
+    QueryUtils.SettableDoubleValues scoreValues = new QueryUtils.SettableDoubleValues();
 
     for (ScoreDoc scoreDoc : scoreDocs) {
       // Advance to the leaf that contains this global doc id.
@@ -63,18 +82,17 @@ public class ScriptRescore implements RescoreOperation {
 
       if (scriptValues == null) {
         LeafReaderContext leaf = leaves.get(leafIndex);
-        // TopDocsScoreValues exposes the previous-pass score as _score to the script.
-        scoreValues = new TopDocsScoreValues(scoreDocs, leaf.docBase);
         scriptValues = scriptSource.getValues(leaf, scoreValues);
       }
 
+      scoreValues.setValue(scoreDoc.score);
       int segmentDocId = scoreDoc.doc - leaves.get(leafIndex).docBase;
       scriptValues.advanceExact(segmentDocId);
       scoreDoc.score = (float) scriptValues.doubleValue();
     }
 
     // Re-sort by new score descending.
-    Arrays.sort(scoreDocs, (a, b) -> Float.compare(b.score, a.score));
+    Arrays.sort(scoreDocs, BY_SCORE_DESC);
 
     // Trim to windowSize, mirroring Lucene QueryRescorer behaviour.
     int windowSize = context.getWindowSize();
@@ -85,38 +103,5 @@ public class ScriptRescore implements RescoreOperation {
     }
 
     return new TopDocs(new TotalHits(hits.totalHits.value(), hits.totalHits.relation()), scoreDocs);
-  }
-
-  /**
-   * Exposes the previous-pass score from a sorted {@link ScoreDoc} array as a {@link DoubleValues},
-   * so the script engine can read it as the {@code _score} expression variable. Looks up the score
-   * by converting the segment-local doc id back to a global doc id using {@code docBase}.
-   */
-  private static class TopDocsScoreValues extends DoubleValues {
-    private final ScoreDoc[] scoreDocs;
-    private final int docBase;
-    private double score;
-
-    TopDocsScoreValues(ScoreDoc[] scoreDocs, int docBase) {
-      this.scoreDocs = scoreDocs;
-      this.docBase = docBase;
-    }
-
-    @Override
-    public double doubleValue() {
-      return score;
-    }
-
-    @Override
-    public boolean advanceExact(int segmentDocId) {
-      int globalDocId = docBase + segmentDocId;
-      for (ScoreDoc sd : scoreDocs) {
-        if (sd.doc == globalDocId) {
-          score = sd.score;
-          return true;
-        }
-      }
-      return false;
-    }
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
@@ -42,6 +42,7 @@ import com.yelp.nrtsearch.server.rescore.QueryRescore;
 import com.yelp.nrtsearch.server.rescore.RescoreOperation;
 import com.yelp.nrtsearch.server.rescore.RescoreTask;
 import com.yelp.nrtsearch.server.rescore.RescorerCreator;
+import com.yelp.nrtsearch.server.rescore.ScriptRescore;
 import com.yelp.nrtsearch.server.script.RuntimeScript;
 import com.yelp.nrtsearch.server.script.ScoreScript;
 import com.yelp.nrtsearch.server.script.ScriptService;
@@ -569,9 +570,16 @@ public class SearchRequestProcessor {
     } else if (rescorer.hasPluginRescorer()) {
       PluginRescorer plugin = rescorer.getPluginRescorer();
       rescoreOperation = RescorerCreator.getInstance().createRescorer(plugin);
+    } else if (rescorer.hasScriptRescorer()) {
+      com.yelp.nrtsearch.server.grpc.Script script = rescorer.getScriptRescorer().getScript();
+      ScoreScript.Factory factory =
+          ScriptService.getInstance().compile(script, ScoreScript.CONTEXT);
+      Map<String, Object> params = ScriptParamsUtils.decodeParams(script.getParamsMap());
+      DocLookup docLookup = indexState.docLookup;
+      rescoreOperation = new ScriptRescore(factory.newFactory(params, docLookup));
     } else {
       throw new IllegalArgumentException(
-          "Rescorer should define either QueryRescorer or PluginRescorer");
+          "Rescorer should define one of: QueryRescorer, PluginRescorer, ScriptRescorer");
     }
 
     return RescoreTask.newBuilder()

--- a/src/test/java/com/yelp/nrtsearch/server/rescore/ScriptRescoreTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/rescore/ScriptRescoreTest.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.rescore;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Collections;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DoubleValues;
+import org.apache.lucene.search.DoubleValuesSource;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.TotalHits.Relation;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ScriptRescoreTest {
+
+  /** DoubleValuesSource that returns a fixed value regardless of doc. */
+  private static DoubleValuesSource constantSource(double value) {
+    return new DoubleValuesSource() {
+      @Override
+      public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores) {
+        return new DoubleValues() {
+          @Override
+          public double doubleValue() {
+            return value;
+          }
+
+          @Override
+          public boolean advanceExact(int doc) {
+            return true;
+          }
+        };
+      }
+
+      @Override
+      public boolean needsScores() {
+        return false;
+      }
+
+      @Override
+      public DoubleValuesSource rewrite(IndexSearcher reader) {
+        return this;
+      }
+
+      @Override
+      public int hashCode() {
+        return Double.hashCode(value);
+      }
+
+      @Override
+      public boolean equals(Object obj) {
+        return this == obj;
+      }
+
+      @Override
+      public String toString() {
+        return "constant(" + value + ")";
+      }
+
+      @Override
+      public boolean isCacheable(LeafReaderContext ctx) {
+        return true;
+      }
+    };
+  }
+
+  /**
+   * DoubleValuesSource that returns {@code multiplier * previousScore} using the scores
+   * DoubleValues passed by ScriptRescore (simulating get_score() in a script).
+   */
+  private static DoubleValuesSource multiplierOfPreviousScore(double multiplier) {
+    return new DoubleValuesSource() {
+      @Override
+      public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores) {
+        return new DoubleValues() {
+          @Override
+          public double doubleValue() throws IOException {
+            return scores.doubleValue() * multiplier;
+          }
+
+          @Override
+          public boolean advanceExact(int doc) throws IOException {
+            return scores.advanceExact(doc);
+          }
+        };
+      }
+
+      @Override
+      public boolean needsScores() {
+        return true;
+      }
+
+      @Override
+      public DoubleValuesSource rewrite(IndexSearcher reader) {
+        return this;
+      }
+
+      @Override
+      public int hashCode() {
+        return Double.hashCode(multiplier);
+      }
+
+      @Override
+      public boolean equals(Object obj) {
+        return this == obj;
+      }
+
+      @Override
+      public String toString() {
+        return "multiplier(" + multiplier + ")";
+      }
+
+      @Override
+      public boolean isCacheable(LeafReaderContext ctx) {
+        return false;
+      }
+    };
+  }
+
+  private RescoreContext buildContext(IndexSearcher searcher) {
+    com.yelp.nrtsearch.server.search.SearchContext searchContext =
+        mock(com.yelp.nrtsearch.server.search.SearchContext.class);
+    org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager.SearcherAndTaxonomy sat =
+        mock(org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager.SearcherAndTaxonomy.class);
+    when(searchContext.getSearcherAndTaxonomy()).thenReturn(sat);
+    when(sat.searcher()).thenReturn(searcher);
+    return new RescoreContext(3, searchContext);
+  }
+
+  @Test
+  public void testConstantScoreReplacesPreviousScore() throws Exception {
+    // Build a tiny in-memory index with 3 docs spread across two segments.
+    try (org.apache.lucene.store.ByteBuffersDirectory dir =
+            new org.apache.lucene.store.ByteBuffersDirectory();
+        org.apache.lucene.index.IndexWriter writer =
+            new org.apache.lucene.index.IndexWriter(
+                dir,
+                new org.apache.lucene.index.IndexWriterConfig()
+                    .setMergePolicy(org.apache.lucene.index.NoMergePolicy.INSTANCE))) {
+
+      writer.addDocument(Collections.emptyList());
+      writer.addDocument(Collections.emptyList());
+      writer.commit();
+      writer.addDocument(Collections.emptyList());
+      writer.commit();
+
+      try (org.apache.lucene.index.DirectoryReader reader =
+          org.apache.lucene.index.DirectoryReader.open(dir)) {
+        IndexSearcher searcher = new IndexSearcher(reader);
+
+        ScoreDoc[] input = {new ScoreDoc(0, 3.0f), new ScoreDoc(1, 2.0f), new ScoreDoc(2, 1.0f)};
+        TopDocs hits = new TopDocs(new TotalHits(3, Relation.EQUAL_TO), input);
+
+        ScriptRescore rescorer = new ScriptRescore(constantSource(5.0));
+        TopDocs result = rescorer.rescore(hits, buildContext(searcher));
+
+        assertEquals(3, result.scoreDocs.length);
+        // All docs get score 5.0 — order may vary but scores should all be 5.0.
+        for (ScoreDoc sd : result.scoreDocs) {
+          assertEquals(5.0f, sd.score, 0.0001f);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testScoreOrderAfterRescore() throws Exception {
+    try (org.apache.lucene.store.ByteBuffersDirectory dir =
+            new org.apache.lucene.store.ByteBuffersDirectory();
+        org.apache.lucene.index.IndexWriter writer =
+            new org.apache.lucene.index.IndexWriter(
+                dir,
+                new org.apache.lucene.index.IndexWriterConfig()
+                    .setMergePolicy(org.apache.lucene.index.NoMergePolicy.INSTANCE))) {
+
+      // Three docs in one segment.
+      writer.addDocument(Collections.emptyList()); // doc 0
+      writer.addDocument(Collections.emptyList()); // doc 1
+      writer.addDocument(Collections.emptyList()); // doc 2
+      writer.commit();
+
+      try (org.apache.lucene.index.DirectoryReader reader =
+          org.apache.lucene.index.DirectoryReader.open(dir)) {
+        IndexSearcher searcher = new IndexSearcher(reader);
+
+        // Input scores: doc0=1, doc1=2, doc2=3 (ascending).
+        ScoreDoc[] input = {new ScoreDoc(2, 3.0f), new ScoreDoc(1, 2.0f), new ScoreDoc(0, 1.0f)};
+        TopDocs hits = new TopDocs(new TotalHits(3, Relation.EQUAL_TO), input);
+
+        // Script doubles the previous score.
+        ScriptRescore rescorer = new ScriptRescore(multiplierOfPreviousScore(2.0));
+        TopDocs result = rescorer.rescore(hits, buildContext(searcher));
+
+        assertEquals(3, result.scoreDocs.length);
+        // Scores doubled: doc2=6, doc1=4, doc0=2, still descending.
+        assertEquals(6.0f, result.scoreDocs[0].score, 0.0001f);
+        assertEquals(2, result.scoreDocs[0].doc);
+        assertEquals(4.0f, result.scoreDocs[1].score, 0.0001f);
+        assertEquals(1, result.scoreDocs[1].doc);
+        assertEquals(2.0f, result.scoreDocs[2].score, 0.0001f);
+        assertEquals(0, result.scoreDocs[2].doc);
+      }
+    }
+  }
+
+  @Test
+  public void testRescoreAcrossMultipleSegments() throws Exception {
+    try (org.apache.lucene.store.ByteBuffersDirectory dir =
+            new org.apache.lucene.store.ByteBuffersDirectory();
+        org.apache.lucene.index.IndexWriter writer =
+            new org.apache.lucene.index.IndexWriter(
+                dir,
+                new org.apache.lucene.index.IndexWriterConfig()
+                    .setMergePolicy(org.apache.lucene.index.NoMergePolicy.INSTANCE))) {
+
+      // Two docs in segment 0 (docBase=0), one doc in segment 1 (docBase=2).
+      writer.addDocument(Collections.emptyList()); // global doc 0
+      writer.addDocument(Collections.emptyList()); // global doc 1
+      writer.commit();
+      writer.addDocument(Collections.emptyList()); // global doc 2
+      writer.commit();
+
+      try (org.apache.lucene.index.DirectoryReader reader =
+          org.apache.lucene.index.DirectoryReader.open(dir)) {
+        IndexSearcher searcher = new IndexSearcher(reader);
+
+        ScoreDoc[] input = {new ScoreDoc(0, 10.0f), new ScoreDoc(1, 5.0f), new ScoreDoc(2, 1.0f)};
+        TopDocs hits = new TopDocs(new TotalHits(3, Relation.EQUAL_TO), input);
+
+        ScriptRescore rescorer = new ScriptRescore(multiplierOfPreviousScore(3.0));
+        TopDocs result = rescorer.rescore(hits, buildContext(searcher));
+
+        assertEquals(3, result.scoreDocs.length);
+        assertEquals(30.0f, result.scoreDocs[0].score, 0.0001f);
+        assertEquals(0, result.scoreDocs[0].doc);
+        assertEquals(15.0f, result.scoreDocs[1].score, 0.0001f);
+        assertEquals(1, result.scoreDocs[1].doc);
+        assertEquals(3.0f, result.scoreDocs[2].score, 0.0001f);
+        assertEquals(2, result.scoreDocs[2].doc);
+      }
+    }
+  }
+
+  @Test
+  public void testRescoreInvertsOrderWhenScriptInvertsScores() throws Exception {
+    try (org.apache.lucene.store.ByteBuffersDirectory dir =
+            new org.apache.lucene.store.ByteBuffersDirectory();
+        org.apache.lucene.index.IndexWriter writer =
+            new org.apache.lucene.index.IndexWriter(
+                dir,
+                new org.apache.lucene.index.IndexWriterConfig()
+                    .setMergePolicy(org.apache.lucene.index.NoMergePolicy.INSTANCE))) {
+
+      writer.addDocument(Collections.emptyList()); // doc 0
+      writer.addDocument(Collections.emptyList()); // doc 1
+      writer.addDocument(Collections.emptyList()); // doc 2
+      writer.commit();
+
+      try (org.apache.lucene.index.DirectoryReader reader =
+          org.apache.lucene.index.DirectoryReader.open(dir)) {
+        IndexSearcher searcher = new IndexSearcher(reader);
+
+        // Initial ranking: doc2 > doc1 > doc0 by score.
+        ScoreDoc[] input = {new ScoreDoc(2, 3.0f), new ScoreDoc(1, 2.0f), new ScoreDoc(0, 1.0f)};
+        TopDocs hits = new TopDocs(new TotalHits(3, Relation.EQUAL_TO), input);
+
+        // Script replaces score with a constant low value for higher scores and high for lower —
+        // simulated by assigning (4 - previousScore): doc2 gets 1, doc1 gets 2, doc0 gets 3.
+        DoubleValuesSource invertingSource =
+            new DoubleValuesSource() {
+              @Override
+              public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores) {
+                return new DoubleValues() {
+                  @Override
+                  public double doubleValue() throws IOException {
+                    return 4.0 - scores.doubleValue();
+                  }
+
+                  @Override
+                  public boolean advanceExact(int doc) throws IOException {
+                    return scores.advanceExact(doc);
+                  }
+                };
+              }
+
+              @Override
+              public boolean needsScores() {
+                return true;
+              }
+
+              @Override
+              public DoubleValuesSource rewrite(IndexSearcher r) {
+                return this;
+              }
+
+              @Override
+              public int hashCode() {
+                return 42;
+              }
+
+              @Override
+              public boolean equals(Object o) {
+                return this == o;
+              }
+
+              @Override
+              public String toString() {
+                return "invert";
+              }
+
+              @Override
+              public boolean isCacheable(LeafReaderContext ctx) {
+                return false;
+              }
+            };
+
+        ScriptRescore rescorer = new ScriptRescore(invertingSource);
+        TopDocs result = rescorer.rescore(hits, buildContext(searcher));
+
+        assertEquals(3, result.scoreDocs.length);
+        // After inversion: doc0 should be first (score 3), doc1 second (2), doc2 third (1).
+        assertEquals(0, result.scoreDocs[0].doc);
+        assertEquals(3.0f, result.scoreDocs[0].score, 0.0001f);
+        assertEquals(1, result.scoreDocs[1].doc);
+        assertEquals(2.0f, result.scoreDocs[1].score, 0.0001f);
+        assertEquals(2, result.scoreDocs[2].doc);
+        assertEquals(1.0f, result.scoreDocs[2].score, 0.0001f);
+      }
+    }
+  }
+
+  @Test
+  public void testTotalHitsPreserved() throws Exception {
+    try (org.apache.lucene.store.ByteBuffersDirectory dir =
+            new org.apache.lucene.store.ByteBuffersDirectory();
+        org.apache.lucene.index.IndexWriter writer =
+            new org.apache.lucene.index.IndexWriter(
+                dir,
+                new org.apache.lucene.index.IndexWriterConfig()
+                    .setMergePolicy(org.apache.lucene.index.NoMergePolicy.INSTANCE))) {
+
+      writer.addDocument(Collections.emptyList());
+      writer.commit();
+
+      try (org.apache.lucene.index.DirectoryReader reader =
+          org.apache.lucene.index.DirectoryReader.open(dir)) {
+        IndexSearcher searcher = new IndexSearcher(reader);
+
+        TopDocs hits =
+            new TopDocs(
+                new TotalHits(999, Relation.GREATER_THAN_OR_EQUAL_TO),
+                new ScoreDoc[] {new ScoreDoc(0, 1.0f)});
+
+        ScriptRescore rescorer = new ScriptRescore(constantSource(2.0));
+        TopDocs result = rescorer.rescore(hits, buildContext(searcher));
+
+        assertEquals(999, result.totalHits.value());
+        assertEquals(Relation.GREATER_THAN_OR_EQUAL_TO, result.totalHits.relation());
+      }
+    }
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/rescore/ScriptRescorerIntegrationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/rescore/ScriptRescorerIntegrationTest.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.rescore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.yelp.nrtsearch.server.ServerTestCase;
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
+import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
+import com.yelp.nrtsearch.server.grpc.Query;
+import com.yelp.nrtsearch.server.grpc.RangeQuery;
+import com.yelp.nrtsearch.server.grpc.Rescorer;
+import com.yelp.nrtsearch.server.grpc.Script;
+import com.yelp.nrtsearch.server.grpc.ScriptRescorer;
+import com.yelp.nrtsearch.server.grpc.SearchRequest;
+import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import io.grpc.StatusRuntimeException;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.NoMergePolicy;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * Integration tests for {@link ScriptRescore} wired through the full search stack via {@code
+ * scriptRescorer} in a {@link Rescorer} proto.
+ *
+ * <p>The index has 100 docs with:
+ *
+ * <ul>
+ *   <li>{@code int_score} = (100 - doc_id) — used as a field-based boost signal
+ *   <li>{@code int_field} = doc_id — used for range queries
+ * </ul>
+ */
+public class ScriptRescorerIntegrationTest extends ServerTestCase {
+
+  private static final String TEST_INDEX = "test_index";
+  private static final int NUM_DOCS = 100;
+  private static final int SEGMENT_CHUNK = 10;
+
+  @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  @Override
+  public List<String> getIndices() {
+    return Collections.singletonList(TEST_INDEX);
+  }
+
+  @Override
+  public FieldDefRequest getIndexDef(String name) throws IOException {
+    return getFieldsFromResourceFile("/rescore/RescoreRegisterFields.json");
+  }
+
+  @Override
+  public void initIndex(String name) throws Exception {
+    IndexWriter writer = getGlobalState().getIndexOrThrow(name).getShard(0).writer;
+    // try to create multiple segments to validate the implement across different leaves
+    writer.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
+
+    List<Integer> idList = new ArrayList<>();
+    for (int i = 0; i < NUM_DOCS; ++i) {
+      idList.add(i);
+    }
+    Collections.shuffle(idList);
+
+    List<AddDocumentRequest> requestChunk = new ArrayList<>();
+    for (Integer id : idList) {
+      requestChunk.add(
+          AddDocumentRequest.newBuilder()
+              .setIndexName(name)
+              .putFields(
+                  "doc_id",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(id))
+                      .build())
+              .putFields(
+                  "int_score",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(NUM_DOCS - id))
+                      .build())
+              .putFields(
+                  "int_field",
+                  AddDocumentRequest.MultiValuedField.newBuilder()
+                      .addValue(String.valueOf(id))
+                      .build())
+              .build());
+
+      if (requestChunk.size() == SEGMENT_CHUNK) {
+        addDocuments(requestChunk.stream());
+        requestChunk.clear();
+        writer.commit();
+      }
+    }
+  }
+
+  // -- helpers --
+
+  private SearchRequest.Builder baseRequest(int lower, int upper) {
+    return SearchRequest.newBuilder()
+        .setTopHits(10)
+        .setStartHit(0)
+        .setIndexName(DEFAULT_TEST_INDEX)
+        .addRetrieveFields("int_score")
+        .setQuery(
+            Query.newBuilder()
+                .setRangeQuery(
+                    RangeQuery.newBuilder()
+                        .setField("int_field")
+                        .setLower(String.valueOf(lower))
+                        .setUpper(String.valueOf(upper))
+                        .build())
+                .build());
+  }
+
+  private Script jsScript(String source) {
+    return Script.newBuilder().setLang("js").setSource(source).build();
+  }
+
+  // -- tests --
+
+  @Test
+  public void testScriptRescoreReplacesScore() {
+    // Script always returns 42.0 — all rescored hits should have that score.
+    SearchRequest request =
+        baseRequest(5, 15)
+            .addRescorers(
+                Rescorer.newBuilder()
+                    .setWindowSize(10)
+                    .setScriptRescorer(
+                        ScriptRescorer.newBuilder().setScript(jsScript("42.0")).build())
+                    .build())
+            .build();
+
+    SearchResponse response = getGrpcServer().getBlockingStub().search(request);
+    assertEquals(10, response.getHitsCount());
+    for (SearchResponse.Hit hit : response.getHitsList()) {
+      assertEquals(42.0f, hit.getScore(), 0.001f);
+    }
+  }
+
+  @Test
+  public void testScriptRescoreUsingGetScore() {
+    // Script doubles the previous score (_score is the Lucene expression variable for query score).
+    SearchRequest withoutRescore = baseRequest(10, 20).setTopHits(5).build();
+    SearchRequest withRescore =
+        baseRequest(10, 20)
+            .setTopHits(5)
+            .addRescorers(
+                Rescorer.newBuilder()
+                    .setWindowSize(5)
+                    .setScriptRescorer(
+                        ScriptRescorer.newBuilder().setScript(jsScript("_score * 2.0")).build())
+                    .build())
+            .build();
+
+    SearchResponse base = getGrpcServer().getBlockingStub().search(withoutRescore);
+    SearchResponse rescored = getGrpcServer().getBlockingStub().search(withRescore);
+
+    assertEquals(base.getHitsCount(), rescored.getHitsCount());
+    for (int i = 0; i < base.getHitsCount(); i++) {
+      assertEquals(base.getHits(i).getScore() * 2.0f, rescored.getHits(i).getScore(), 0.001f);
+    }
+  }
+
+  @Test
+  public void testScriptRescoreUsingDocValue() {
+    // Script returns the int_score doc value; hits should be ranked by int_score descending.
+    // int_score = 100 - int_field, so lower int_field → higher int_score.
+    SearchRequest request =
+        baseRequest(50, 60)
+            .addRescorers(
+                Rescorer.newBuilder()
+                    .setWindowSize(10)
+                    .setScriptRescorer(
+                        ScriptRescorer.newBuilder()
+                            .setScript(jsScript("doc['int_score'].value"))
+                            .build())
+                    .build())
+            .build();
+
+    SearchResponse response = getGrpcServer().getBlockingStub().search(request);
+    assertTrue(response.getHitsCount() > 0);
+
+    // Scores should be descending and equal to int_score field values.
+    float prevScore = Float.MAX_VALUE;
+    for (SearchResponse.Hit hit : response.getHitsList()) {
+      float score = (float) hit.getScore();
+      assertTrue(score <= prevScore);
+      int intScore = hit.getFieldsOrThrow("int_score").getFieldValue(0).getIntValue();
+      assertEquals((float) intScore, score, 0.001f);
+      prevScore = score;
+    }
+  }
+
+  @Test
+  public void testScriptRescoreWithParam() {
+    // Script multiplies int_score by a param supplied in the request.
+    Script script =
+        Script.newBuilder()
+            .setLang("js")
+            .setSource("doc['int_score'].value * multiplier")
+            .putParams("multiplier", Script.ParamValue.newBuilder().setDoubleValue(3.0).build())
+            .build();
+
+    SearchRequest request =
+        baseRequest(50, 60)
+            .addRescorers(
+                Rescorer.newBuilder()
+                    .setWindowSize(10)
+                    .setScriptRescorer(ScriptRescorer.newBuilder().setScript(script).build())
+                    .build())
+            .build();
+
+    SearchResponse response = getGrpcServer().getBlockingStub().search(request);
+    assertTrue(response.getHitsCount() > 0);
+
+    for (SearchResponse.Hit hit : response.getHitsList()) {
+      int intScore = hit.getFieldsOrThrow("int_score").getFieldValue(0).getIntValue();
+      assertEquals(intScore * 3.0f, hit.getScore(), 0.01f);
+    }
+  }
+
+  @Test
+  public void testScriptRescoreWindowSizeLimitsRescored() {
+    // Window size 3: only top 3 from first pass are rescored and returned.
+    SearchRequest request =
+        baseRequest(0, 50)
+            .addRescorers(
+                Rescorer.newBuilder()
+                    .setWindowSize(3)
+                    .setScriptRescorer(
+                        ScriptRescorer.newBuilder().setScript(jsScript("42.0")).build())
+                    .build())
+            .build();
+
+    SearchResponse response = getGrpcServer().getBlockingStub().search(request);
+    assertEquals(3, response.getHitsCount());
+    for (SearchResponse.Hit hit : response.getHitsList()) {
+      assertEquals(42.0f, hit.getScore(), 0.001f);
+    }
+  }
+
+  @Test
+  public void testInvalidScriptThrows() {
+    SearchRequest request =
+        baseRequest(0, 10)
+            .addRescorers(
+                Rescorer.newBuilder()
+                    .setWindowSize(5)
+                    .setScriptRescorer(
+                        ScriptRescorer.newBuilder()
+                            .setScript(jsScript("@@@not valid js@@@"))
+                            .build())
+                    .build())
+            .build();
+
+    try {
+      getGrpcServer().getBlockingStub().search(request);
+      fail("Expected StatusRuntimeException for invalid script");
+    } catch (StatusRuntimeException e) {
+      // expected
+    }
+  }
+}


### PR DESCRIPTION
RP-15336

Add support for script rescorer to enable static or dynamic tweak on scores.
This is enabled by adapting Lucene DoubleValuesSource (core of script) to the RescoreOperation.
Theoretically, any double value script can be used immediately.

Test locally with JS script:
test code: https://fluffy.yelpcorp.com/i/pVwrqJv3J7xPJWbJ13k1FGrqhWTGfdLn.html
result: https://fluffy.yelpcorp.com/i/MDwpfQmLxkJNktXzbfBPHf3vx6sKCJK0.html