### PR TITLE
Add s3 upload file batching

### DIFF
--- a/docs/server_configuration.rst
+++ b/docs/server_configuration.rst
@@ -610,6 +610,11 @@ Example server configuration
      - Maximum number of index files downloaded concurrently in a single batch during bootstrap. When set to ``0``, the server's ``defaultParallelism`` value is used.
      - 0
 
+   * - uploadBatchSize
+     - int
+     - Maximum number of index files uploaded concurrently in a single batch. When set to ``0``, the server's ``defaultParallelism`` value is used.
+     - 0
+
 .. list-table:: `S3 Java Async Client Configuration <https://github.com/Yelp/nrtsearch/blob/master/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Util.java>`_ (``remoteConfig.s3.java.*``)
    :widths: 25 10 50 25
    :header-rows: 1

--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
@@ -86,7 +86,7 @@ public class S3Backend implements RemoteBackend {
   static final String DATA = "data";
   static final String WARMING = "warming";
   public static final String CURRENT_VERSION = "_current";
-  public static final S3BackendConfig DEFAULT_CONFIG = new S3BackendConfig(false, 0, 1, 0);
+  public static final S3BackendConfig DEFAULT_CONFIG = new S3BackendConfig(false, 0, 1, 0, 0);
 
   private static final Logger logger = LoggerFactory.getLogger(S3Backend.class);
   private static final String ZIP_EXTENSION = ".zip";
@@ -94,6 +94,7 @@ public class S3Backend implements RemoteBackend {
 
   private final int defaultParallelism;
   private final int downloadBatchSize;
+  private final int uploadBatchSize;
   private final boolean saveBeforeUnzip;
   private final S3Client s3;
   private final S3AsyncClient s3Async;
@@ -122,6 +123,7 @@ public class S3Backend implements RemoteBackend {
     private final long rateLimitBytes;
     private final int rateLimitWindowSeconds;
     private final int downloadBatchSize;
+    private final int uploadBatchSize;
 
     /**
      * Create S3BackendConfig from NrtsearchConfig.
@@ -137,9 +139,10 @@ public class S3Backend implements RemoteBackend {
       int rateLimitWindowSeconds =
           configReader.getInteger(CONFIG_PREFIX + "rateLimitWindowSeconds", 1);
       int downloadBatchSize = configReader.getInteger(CONFIG_PREFIX + "downloadBatchSize", 0);
+      int uploadBatchSize = configReader.getInteger(CONFIG_PREFIX + "uploadBatchSize", 0);
 
       return new S3BackendConfig(
-          metrics, rateLimitBytes, rateLimitWindowSeconds, downloadBatchSize);
+          metrics, rateLimitBytes, rateLimitWindowSeconds, downloadBatchSize, uploadBatchSize);
     }
 
     /**
@@ -150,10 +153,15 @@ public class S3Backend implements RemoteBackend {
      * @param rateLimitWindowSeconds rate limit window in seconds
      * @param downloadBatchSize max concurrent file downloads per batch (0 means use
      *     defaultParallelism)
+     * @param uploadBatchSize max concurrent file uploads per batch (0 means use defaultParallelism)
      * @throws IllegalArgumentException if rateLimitBytes < 0 or rateLimitWindowSeconds <= 0
      */
     public S3BackendConfig(
-        boolean metrics, long rateLimitBytes, int rateLimitWindowSeconds, int downloadBatchSize) {
+        boolean metrics,
+        long rateLimitBytes,
+        int rateLimitWindowSeconds,
+        int downloadBatchSize,
+        int uploadBatchSize) {
       if (rateLimitBytes < 0) {
         throw new IllegalArgumentException("rateLimitBytes must be >= 0");
       }
@@ -163,10 +171,14 @@ public class S3Backend implements RemoteBackend {
       if (downloadBatchSize < 0) {
         throw new IllegalArgumentException("downloadBatchSize must be >= 0");
       }
+      if (uploadBatchSize < 0) {
+        throw new IllegalArgumentException("uploadBatchSize must be >= 0");
+      }
       this.metrics = metrics;
       this.rateLimitBytes = rateLimitBytes;
       this.rateLimitWindowSeconds = rateLimitWindowSeconds;
       this.downloadBatchSize = downloadBatchSize;
+      this.uploadBatchSize = uploadBatchSize;
     }
 
     /**
@@ -203,6 +215,15 @@ public class S3Backend implements RemoteBackend {
      */
     public int getDownloadBatchSize() {
       return downloadBatchSize;
+    }
+
+    /**
+     * Get the upload batch size.
+     *
+     * @return max concurrent file uploads per batch (0 means use defaultParallelism)
+     */
+    public int getUploadBatchSize() {
+      return uploadBatchSize;
     }
 
     @VisibleForTesting
@@ -297,6 +318,7 @@ public class S3Backend implements RemoteBackend {
             : null;
     this.defaultParallelism = defaultParallelism;
     this.downloadBatchSize = s3BackendConfig.getDownloadBatchSize();
+    this.uploadBatchSize = s3BackendConfig.getUploadBatchSize();
     this.saveBeforeUnzip = savePluginBeforeUnzip;
     this.serviceBucket = serviceBucket;
 
@@ -334,6 +356,11 @@ public class S3Backend implements RemoteBackend {
   @VisibleForTesting
   int getDownloadBatchSize() {
     return downloadBatchSize;
+  }
+
+  @VisibleForTesting
+  int getUploadBatchSize() {
+    return uploadBatchSize;
   }
 
   @Override
@@ -602,57 +629,77 @@ public class S3Backend implements RemoteBackend {
   public void uploadIndexFiles(
       String service, String indexIdentifier, Path indexDir, Map<String, NrtFileMetaData> files)
       throws IOException {
+    if (transferManager == null) {
+      throw new IllegalStateException(
+          "TransferManager is not available. Ensure S3Client is properly configured.");
+    }
     List<FileNamePair> fileList = getFileNamePairs(files);
     String backendPrefix = getIndexDataPrefix(service, indexIdentifier);
+    int effectiveBatchSize = uploadBatchSize > 0 ? uploadBatchSize : defaultParallelism;
+    int totalFiles = fileList.size();
+    int batchStart = 0;
     long totalUploadBytes = files.values().stream().mapToLong(m -> m.length).sum();
     S3ProgressListenerImpl uploadProgressListener =
         new S3ProgressListenerImpl(
             service, indexIdentifier, "upload_index_files", totalUploadBytes);
-    List<FileUpload> uploadList = new LinkedList<>();
-    boolean hasFailure = false;
-    Throwable failureCause = null;
-    for (FileNamePair pair : fileList) {
-      String backendKey = backendPrefix + pair.backendFileName;
-      Path localFile = indexDir.resolve(pair.fileName);
-      UploadFileRequest request =
-          UploadFileRequest.builder()
-              .putObjectRequest(
-                  PutObjectRequest.builder().bucket(serviceBucket).key(backendKey).build())
-              .source(localFile)
-              .addTransferListener(uploadProgressListener)
-              .build();
-      try {
-        if (transferManager == null) {
-          throw new IllegalStateException(
-              "TransferManager is not available. Ensure S3Client is properly configured.");
-        }
-        FileUpload upload = transferManager.uploadFile(request);
-        uploadList.add(upload);
-      } catch (Throwable t) {
-        hasFailure = true;
-        failureCause = t;
-        break;
-      }
-    }
 
-    for (FileUpload upload : uploadList) {
-      if (hasFailure) {
-        // SDK v2 doesn't have an abort method on FileUpload, just let it complete or fail
+    while (batchStart < totalFiles) {
+      int batchEnd = Math.min(batchStart + effectiveBatchSize, totalFiles);
+      List<FileNamePair> batch = fileList.subList(batchStart, batchEnd);
+      logger.info(
+          "Uploading index files batch {}-{} of {} for {}/{}",
+          batchStart + 1,
+          batchEnd,
+          totalFiles,
+          service,
+          indexIdentifier);
+
+      List<FileUpload> uploadList = new LinkedList<>();
+      boolean hasFailure = false;
+      Throwable failureCause = null;
+
+      for (FileNamePair pair : batch) {
+        String backendKey = backendPrefix + pair.backendFileName;
+        Path localFile = indexDir.resolve(pair.fileName);
+        UploadFileRequest request =
+            UploadFileRequest.builder()
+                .putObjectRequest(
+                    PutObjectRequest.builder().bucket(serviceBucket).key(backendKey).build())
+                .source(localFile)
+                .addTransferListener(uploadProgressListener)
+                .build();
         try {
-          upload.completionFuture().cancel(true);
-        } catch (Exception ignored) {
-        }
-      } else {
-        try {
-          upload.completionFuture().join();
+          FileUpload upload = transferManager.uploadFile(request);
+          uploadList.add(upload);
         } catch (Throwable t) {
           hasFailure = true;
           failureCause = t;
+          break;
         }
       }
-    }
-    if (hasFailure) {
-      throw new IOException("Error while uploading index files to s3. ", failureCause);
+
+      for (FileUpload upload : uploadList) {
+        if (hasFailure) {
+          // SDK v2 doesn't have an abort method on FileUpload, just let it complete or fail
+          try {
+            upload.completionFuture().cancel(true);
+          } catch (Exception ignored) {
+          }
+        } else {
+          try {
+            upload.completionFuture().join();
+          } catch (Throwable t) {
+            hasFailure = true;
+            failureCause = t;
+          }
+        }
+      }
+
+      if (hasFailure) {
+        throw new IOException("Error while uploading index files to s3. ", failureCause);
+      }
+
+      batchStart = batchEnd;
     }
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendConfigTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendConfigTest.java
@@ -31,7 +31,7 @@ public class S3BackendConfigTest {
     long bytesPerSecond = 1024 * 1024; // 1MB
     int windowSeconds = 5;
     boolean metrics = true;
-    S3BackendConfig config = new S3BackendConfig(metrics, bytesPerSecond, windowSeconds, 0);
+    S3BackendConfig config = new S3BackendConfig(metrics, bytesPerSecond, windowSeconds, 0, 0);
 
     // Verify getters return expected values
     assertEquals(bytesPerSecond, config.getRateLimitBytes());
@@ -165,7 +165,7 @@ public class S3BackendConfigTest {
   public void testInvalidRateLimit() {
     // Test negative rate limit throws IllegalArgumentException
     try {
-      new S3BackendConfig(true, -1024, 5, 0);
+      new S3BackendConfig(true, -1024, 5, 0, 0);
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       // Expected
@@ -183,7 +183,7 @@ public class S3BackendConfigTest {
   public void testInvalidWindowSeconds() {
     // Test zero or negative window seconds throws IllegalArgumentException
     try {
-      new S3BackendConfig(true, 1024, 0, 0);
+      new S3BackendConfig(true, 1024, 0, 0, 0);
       fail("Expected IllegalArgumentException for zero window seconds");
     } catch (IllegalArgumentException e) {
       // Expected
@@ -191,7 +191,7 @@ public class S3BackendConfigTest {
     }
 
     try {
-      new S3BackendConfig(true, 1024, -5, 0);
+      new S3BackendConfig(true, 1024, -5, 0, 0);
       fail("Expected IllegalArgumentException for negative window seconds");
     } catch (IllegalArgumentException e) {
       // Expected

--- a/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendRateLimitTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendRateLimitTest.java
@@ -160,7 +160,7 @@ public class S3BackendRateLimitTest {
     // Create a custom S3BackendConfig
     S3BackendConfig customConfig =
         new S3BackendConfig(
-            false, 2 * 1024 * 1024, 10, 0); // 2MB/s, 10 second window, metrics disabled
+            false, 2 * 1024 * 1024, 10, 0, 0); // 2MB/s, 10 second window, metrics disabled
 
     // Create S3Backend with custom config
     S3Backend s3Backend =
@@ -196,7 +196,7 @@ public class S3BackendRateLimitTest {
   public void testMetricsConfig() throws Exception {
     // Create a custom S3BackendConfig with metrics enabled
     S3BackendConfig customConfig =
-        new S3BackendConfig(true, 0, 1, 0); // No rate limit, metrics enabled
+        new S3BackendConfig(true, 0, 1, 0, 0); // No rate limit, metrics enabled
 
     // Create S3Backend with custom config
     S3Backend s3Backend =

--- a/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendTest.java
@@ -986,7 +986,7 @@ public class S3BackendTest {
         new S3Backend(
             BUCKET_NAME,
             false,
-            new S3Backend.S3BackendConfig(false, 0, 1, 2),
+            new S3Backend.S3BackendConfig(false, 0, 1, 2, 0),
             new S3Util.S3ClientBundle(s3, S3_PROVIDER.getS3AsyncClient()));
 
     batchedBackend.downloadIndexFiles(
@@ -1004,7 +1004,7 @@ public class S3BackendTest {
 
   @Test
   public void testS3BackendConfigDefaults() {
-    S3Backend.S3BackendConfig config = new S3Backend.S3BackendConfig(false, 0, 1, 0);
+    S3Backend.S3BackendConfig config = new S3Backend.S3BackendConfig(false, 0, 1, 0, 0);
     assertEquals(0, config.getDownloadBatchSize());
     assertFalse(config.getMetrics());
     assertEquals(0, config.getRateLimitBytes());
@@ -1013,14 +1013,14 @@ public class S3BackendTest {
 
   @Test
   public void testS3BackendConfigDownloadBatchSize() {
-    S3Backend.S3BackendConfig config = new S3Backend.S3BackendConfig(false, 0, 1, 10);
+    S3Backend.S3BackendConfig config = new S3Backend.S3BackendConfig(false, 0, 1, 10, 0);
     assertEquals(10, config.getDownloadBatchSize());
   }
 
   @Test
   public void testS3BackendConfigDownloadBatchSizeNegative() {
     try {
-      new S3Backend.S3BackendConfig(false, 0, 1, -1);
+      new S3Backend.S3BackendConfig(false, 0, 1, -1, 0);
       fail("Expected IllegalArgumentException for negative downloadBatchSize");
     } catch (IllegalArgumentException e) {
       assertEquals("downloadBatchSize must be >= 0", e.getMessage());
@@ -1033,9 +1033,37 @@ public class S3BackendTest {
         new S3Backend(
             BUCKET_NAME,
             false,
-            new S3Backend.S3BackendConfig(false, 0, 1, 5),
+            new S3Backend.S3BackendConfig(false, 0, 1, 5, 0),
             new S3Util.S3ClientBundle(mock(S3Client.class), null))) {
       assertEquals(5, backend.getDownloadBatchSize());
+    }
+  }
+
+  @Test
+  public void testS3BackendConfigUploadBatchSize() {
+    S3Backend.S3BackendConfig config = new S3Backend.S3BackendConfig(false, 0, 1, 0, 10);
+    assertEquals(10, config.getUploadBatchSize());
+  }
+
+  @Test
+  public void testS3BackendConfigUploadBatchSizeNegative() {
+    try {
+      new S3Backend.S3BackendConfig(false, 0, 1, 0, -1);
+      fail("Expected IllegalArgumentException for negative uploadBatchSize");
+    } catch (IllegalArgumentException e) {
+      assertEquals("uploadBatchSize must be >= 0", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testUploadBatchSizeGetter() {
+    try (S3Backend backend =
+        new S3Backend(
+            BUCKET_NAME,
+            false,
+            new S3Backend.S3BackendConfig(false, 0, 1, 0, 7),
+            new S3Util.S3ClientBundle(mock(S3Client.class), null))) {
+      assertEquals(7, backend.getUploadBatchSize());
     }
   }
 


### PR DESCRIPTION
Add batching when uploading index files to s3.

We already have batching when bulk downloading index files to allow for better control of resource usage. This branch adds similar config for uploading. Bulk uploading is done by the primary during an index commit.

The `remoteConfig.s3.uploadBatchSize` config key controls this options, with the default being `defaultParallelism` (20).