### PR TITLE
Simplify multi-retriever result handling in executeMultiRetriever

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
@@ -537,10 +537,9 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
     LinkedHashMap<String, RetrieverContext> retrieverContexts =
         new LinkedHashMap<>(multiRetrieverContext.getRetrieverContextMap());
 
-    record RetrieverMetrics(TopDocs topDocs, double searchTimeMs, double rescoreTimeMs) {}
+    record RetrieverResult(TopDocs topDocs, double searchTimeMs, double rescoreTimeMs) {}
 
-    ConcurrentHashMap<String, RetrieverMetrics> retrieverResults = new ConcurrentHashMap<>();
-    LinkedHashMap<String, Future<TopDocs>> retrieverFutures = new LinkedHashMap<>();
+    LinkedHashMap<String, Future<RetrieverResult>> retrieverFutures = new LinkedHashMap<>();
     for (Map.Entry<String, RetrieverContext> entry : retrieverContexts.entrySet()) {
       String name = entry.getKey();
       RetrieverContext retrieverContext = entry.getValue();
@@ -562,9 +561,7 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
                   topDocs = retrieverContext.getRescoreTask().rescore(topDocs, searchContext);
                   rescoreTimeMs = (System.nanoTime() - rescoreStart) / 1_000_000.0;
                 }
-                retrieverResults.put(
-                    name, new RetrieverMetrics(topDocs, searchTimeMs, rescoreTimeMs));
-                return topDocs;
+                return new RetrieverResult(topDocs, searchTimeMs, rescoreTimeMs);
               }));
     }
 
@@ -577,19 +574,33 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
             searchContext.getHitsToLog(),
             searchContext.getRescorers());
 
+    LinkedHashMap<String, RetrieverResult> retrieverResults = new LinkedHashMap<>();
+    for (Map.Entry<String, Future<RetrieverResult>> entry : retrieverFutures.entrySet()) {
+      String name = entry.getKey();
+      try {
+        retrieverResults.put(name, entry.getValue().get());
+      } catch (ExecutionException e) {
+        Throwable cause = e.getCause() != null ? e.getCause() : e;
+        throw new RuntimeException("Retriever '" + name + "' failed: " + cause.getMessage(), cause);
+      }
+    }
+
+    LinkedHashMap<String, TopDocs> retrieverTopDocs = new LinkedHashMap<>();
+    retrieverResults.forEach((name, result) -> retrieverTopDocs.put(name, result.topDocs()));
+
     long blendStartTime = System.nanoTime();
     TopDocs blendedHits =
         multiRetrieverContext
             .getBlenderOperation()
-            .blend(retrieverFutures, retrieverContexts, 0, blendTopHits);
+            .blend(retrieverTopDocs, retrieverContexts, 0, blendTopHits);
     double blenderTimeMs = (System.nanoTime() - blendStartTime) / 1_000_000.0;
 
     // Populate per-retriever diagnostics
     SearchResponse.Diagnostics.MultiRetrieverDiagnostics.Builder multiRetrieverDiagnosticsBuilder =
         diagnostics.getMultiRetrieverDiagnosticsBuilder();
-    for (Map.Entry<String, RetrieverMetrics> entry : retrieverResults.entrySet()) {
+    for (Map.Entry<String, RetrieverResult> entry : retrieverResults.entrySet()) {
       String name = entry.getKey();
-      RetrieverMetrics retrieverResult = entry.getValue();
+      RetrieverResult retrieverResult = entry.getValue();
       RetrieverContext.RetrieverType type = retrieverContexts.get(name).getRetrieverType();
       org.apache.lucene.search.TotalHits luceneTotalHits = retrieverResult.topDocs().totalHits;
       TotalHits totalHits =

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderOperation.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderOperation.java
@@ -21,10 +21,7 @@ import com.yelp.nrtsearch.server.search.multiretriever.blender.score.BlendedScor
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.PriorityQueue;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
@@ -34,10 +31,9 @@ import org.apache.lucene.search.TotalHits;
  * Implementations are registered by name via {@link BlenderPlugin} and instantiated through {@link
  * BlenderCreator}.
  *
- * <p>The entry point is {@link #blend}, which accepts already-submitted per-retriever {@link
- * Future}s (keyed by name), collects their results, then merges, sorts, and paginates. Callers are
- * responsible for submitting retriever searches to an executor before calling {@code blend}; the
- * futures run concurrently and this method blocks until all complete.
+ * <p>The entry point is {@link #blend}, which accepts resolved per-retriever results (keyed by
+ * name), merges, sorts, and paginates them. Callers are responsible for resolving retriever futures
+ * before calling this method.
  *
  * <p>Implementations define the merge logic in {@link #mergeHits}, which operates on the raw
  * per-retriever hits before sorting and pagination are applied by the framework.
@@ -59,39 +55,24 @@ public interface BlenderOperation {
       LinkedHashMap<String, RetrieverContext> retrieverContexts);
 
   /**
-   * Collects results from already-submitted retriever futures, then merges, sorts, and paginates.
-   * Blocks until all futures complete. Callers must submit retriever searches to an executor before
-   * calling this method so that the futures run concurrently.
+   * Merges, sorts, and paginates resolved per-retriever results.
    *
-   * @param retrieverFutures per-retriever futures in declaration order, keyed by retriever name
+   * @param retrieverResults per-retriever {@link TopDocs} in declaration order, keyed by name
    * @param retrieverContexts per-retriever contexts in declaration order, keyed by retriever name
    * @param startHit 0-based offset of the first blended hit to include in the result
    * @param topHits maximum number of blended hits to return; {@code 0} returns empty; must be >= 0
    * @return blended, sorted, paginated {@link TopDocs}
-   * @throws RuntimeException wrapping any retriever {@link ExecutionException}, identified by name
-   * @throws InterruptedException if the calling thread is interrupted while waiting
    */
   default TopDocs blend(
-      LinkedHashMap<String, Future<TopDocs>> retrieverFutures,
+      LinkedHashMap<String, TopDocs> retrieverResults,
       LinkedHashMap<String, RetrieverContext> retrieverContexts,
       int startHit,
-      int topHits)
-      throws InterruptedException {
+      int topHits) {
     if (topHits == 0 || startHit > topHits) {
       return new TopDocs(
           new TotalHits(0, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO), new ScoreDoc[0]);
     }
-    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
-    for (Map.Entry<String, Future<TopDocs>> entry : retrieverFutures.entrySet()) {
-      String name = entry.getKey();
-      try {
-        results.put(name, entry.getValue().get());
-      } catch (ExecutionException e) {
-        Throwable cause = e.getCause() != null ? e.getCause() : e;
-        throw new RuntimeException("Retriever '" + name + "' failed: " + cause.getMessage(), cause);
-      }
-    }
-    Collection<BlendedScoreDoc> merged = mergeHits(results, retrieverContexts);
+    Collection<BlendedScoreDoc> merged = mergeHits(retrieverResults, retrieverContexts);
     return sortAndPaginate(merged, startHit, topHits);
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/ScorelessRawMergeBlenderOperation.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/ScorelessRawMergeBlenderOperation.java
@@ -23,8 +23,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
@@ -67,28 +65,16 @@ public class ScorelessRawMergeBlenderOperation implements BlenderOperation {
   }
 
   /**
-   * Collects results via {@link #mergeHits}, then returns them as-is without sorting or pagination.
-   * The {@code startHit} and {@code topHits} parameters are ignored.
+   * Returns all merged hits as-is without sorting or pagination. The {@code startHit} and {@code
+   * topHits} parameters are ignored.
    */
   @Override
   public TopDocs blend(
-      LinkedHashMap<String, Future<TopDocs>> retrieverFutures,
+      LinkedHashMap<String, TopDocs> retrieverResults,
       LinkedHashMap<String, RetrieverContext> retrieverContexts,
       int startHit,
-      int topHits)
-      throws InterruptedException {
-    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
-    for (Map.Entry<String, Future<TopDocs>> entry : retrieverFutures.entrySet()) {
-      String name = entry.getKey();
-      try {
-        results.put(name, entry.getValue().get());
-      } catch (ExecutionException e) {
-        Throwable cause = e.getCause() != null ? e.getCause() : e;
-        throw new RuntimeException("Retriever '" + name + "' failed: " + cause.getMessage(), cause);
-      }
-    }
-
-    Collection<BlendedScoreDoc> merged = mergeHits(results, retrieverContexts);
+      int topHits) {
+    Collection<BlendedScoreDoc> merged = mergeHits(retrieverResults, retrieverContexts);
     return new TopDocs(
         new TotalHits(merged.size(), TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO),
         merged.toArray(ScoreDoc[]::new));

--- a/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/ScorelessRawMergeBlenderOperationTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/ScorelessRawMergeBlenderOperationTest.java
@@ -22,8 +22,6 @@ import com.yelp.nrtsearch.server.search.multiretriever.blender.score.BlendedScor
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
@@ -44,10 +42,6 @@ public class ScorelessRawMergeBlenderOperationTest {
 
   private static RetrieverContext retriever(String name) {
     return RetrieverContext.newBuilder(name).build();
-  }
-
-  private static Future<TopDocs> future(TopDocs td) {
-    return CompletableFuture.completedFuture(td);
   }
 
   private static Map<Integer, BlendedScoreDoc> toDocMap(Collection<BlendedScoreDoc> docs) {
@@ -144,31 +138,30 @@ public class ScorelessRawMergeBlenderOperationTest {
   // ---- blend: no sort, no pagination ----
 
   @Test
-  public void testBlendIgnoresPagination() throws InterruptedException {
-    LinkedHashMap<String, Future<TopDocs>> futures = new LinkedHashMap<>();
-    futures.put(
-        "text", future(topDocs(new int[] {1, 2, 3, 4, 5}, new float[] {1f, 1f, 1f, 1f, 1f})));
+  public void testBlendIgnoresPagination() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(new int[] {1, 2, 3, 4, 5}, new float[] {1f, 1f, 1f, 1f, 1f}));
 
     LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
     contexts.put("text", retriever("text"));
 
-    TopDocs result = new ScorelessRawMergeBlenderOperation().blend(futures, contexts, 2, 2);
+    TopDocs result = new ScorelessRawMergeBlenderOperation().blend(results, contexts, 2, 2);
 
     // All 5 hits returned despite startHit=2 topHits=2
     assertEquals(5, result.scoreDocs.length);
   }
 
   @Test
-  public void testBlendDeduplicates() throws InterruptedException {
-    LinkedHashMap<String, Future<TopDocs>> futures = new LinkedHashMap<>();
-    futures.put("text", future(topDocs(new int[] {7}, new float[] {1f})));
-    futures.put("knn", future(topDocs(new int[] {7}, new float[] {2f})));
+  public void testBlendDeduplicates() {
+    LinkedHashMap<String, TopDocs> results = new LinkedHashMap<>();
+    results.put("text", topDocs(new int[] {7}, new float[] {1f}));
+    results.put("knn", topDocs(new int[] {7}, new float[] {2f}));
 
     LinkedHashMap<String, RetrieverContext> contexts = new LinkedHashMap<>();
     contexts.put("text", retriever("text"));
     contexts.put("knn", retriever("knn"));
 
-    TopDocs result = new ScorelessRawMergeBlenderOperation().blend(futures, contexts, 0, 10);
+    TopDocs result = new ScorelessRawMergeBlenderOperation().blend(results, contexts, 0, 10);
 
     assertEquals(1, result.scoreDocs.length);
     assertEquals(0f, result.scoreDocs[0].score, DELTA);


### PR DESCRIPTION
1.   Fix the blenderTimeMs issue that it includes retriever time
2.  Rename RetrieverMetrics to RetrieverResult so the record serves as both the future return topDocs and the diagnostics, eliminating the side-channel ConcurrentHashMap written from inside the lambda.