### PR TITLE
Rolling batch concurrency

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
@@ -41,12 +41,15 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,6 +69,7 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.CompletedFileUpload;
 import software.amazon.awssdk.transfer.s3.model.Download;
 import software.amazon.awssdk.transfer.s3.model.DownloadRequest;
 import software.amazon.awssdk.transfer.s3.model.FileUpload;
@@ -635,71 +639,76 @@ public class S3Backend implements RemoteBackend {
     }
     List<FileNamePair> fileList = getFileNamePairs(files);
     String backendPrefix = getIndexDataPrefix(service, indexIdentifier);
-    int effectiveBatchSize = uploadBatchSize > 0 ? uploadBatchSize : defaultParallelism;
+    int maxConcurrency = uploadBatchSize > 0 ? uploadBatchSize : defaultParallelism;
     int totalFiles = fileList.size();
-    int batchStart = 0;
     long totalUploadBytes = files.values().stream().mapToLong(m -> m.length).sum();
     S3ProgressListenerImpl uploadProgressListener =
         new S3ProgressListenerImpl(
             service, indexIdentifier, "upload_index_files", totalUploadBytes);
+    logger.info(
+        "Uploading {} index files with max concurrency {} for {}/{}",
+        totalFiles,
+        maxConcurrency,
+        service,
+        indexIdentifier);
 
-    while (batchStart < totalFiles) {
-      int batchEnd = Math.min(batchStart + effectiveBatchSize, totalFiles);
-      List<FileNamePair> batch = fileList.subList(batchStart, batchEnd);
-      logger.info(
-          "Uploading index files batch {}-{} of {} for {}/{}",
-          batchStart + 1,
-          batchEnd,
-          totalFiles,
-          service,
-          indexIdentifier);
+    Semaphore semaphore = new Semaphore(maxConcurrency);
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    List<CompletableFuture<CompletedFileUpload>> futures = new ArrayList<>();
 
-      List<FileUpload> uploadList = new LinkedList<>();
-      boolean hasFailure = false;
-      Throwable failureCause = null;
-
-      for (FileNamePair pair : batch) {
-        String backendKey = backendPrefix + pair.backendFileName;
-        Path localFile = indexDir.resolve(pair.fileName);
-        UploadFileRequest request =
-            UploadFileRequest.builder()
-                .putObjectRequest(
-                    PutObjectRequest.builder().bucket(serviceBucket).key(backendKey).build())
-                .source(localFile)
-                .addTransferListener(uploadProgressListener)
-                .build();
-        try {
-          FileUpload upload = transferManager.uploadFile(request);
-          uploadList.add(upload);
-        } catch (Throwable t) {
-          hasFailure = true;
-          failureCause = t;
-          break;
-        }
+    for (FileNamePair pair : fileList) {
+      if (failure.get() != null) {
+        break;
       }
-
-      for (FileUpload upload : uploadList) {
-        if (hasFailure) {
-          // SDK v2 doesn't have an abort method on FileUpload, just let it complete or fail
-          try {
-            upload.completionFuture().cancel(true);
-          } catch (Exception ignored) {
-          }
-        } else {
-          try {
-            upload.completionFuture().join();
-          } catch (Throwable t) {
-            hasFailure = true;
-            failureCause = t;
-          }
-        }
+      try {
+        semaphore.acquire();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IOException("Interrupted while waiting to upload index files to s3", e);
       }
-
-      if (hasFailure) {
-        throw new IOException("Error while uploading index files to s3. ", failureCause);
+      if (failure.get() != null) {
+        semaphore.release();
+        break;
       }
+      String backendKey = backendPrefix + pair.backendFileName;
+      Path localFile = indexDir.resolve(pair.fileName);
+      UploadFileRequest request =
+          UploadFileRequest.builder()
+              .putObjectRequest(
+                  PutObjectRequest.builder().bucket(serviceBucket).key(backendKey).build())
+              .source(localFile)
+              .addTransferListener(uploadProgressListener)
+              .build();
+      try {
+        FileUpload upload = transferManager.uploadFile(request);
+        CompletableFuture<CompletedFileUpload> future =
+            upload
+                .completionFuture()
+                .whenComplete(
+                    (result, t) -> {
+                      semaphore.release();
+                      if (t != null) {
+                        failure.compareAndSet(null, t);
+                      }
+                    });
+        futures.add(future);
+      } catch (Throwable t) {
+        semaphore.release();
+        failure.compareAndSet(null, t);
+        break;
+      }
+    }
 
-      batchStart = batchEnd;
+    for (CompletableFuture<CompletedFileUpload> future : futures) {
+      try {
+        future.join();
+      } catch (Exception ignored) {
+        // failure already captured in AtomicReference
+      }
+    }
+
+    if (failure.get() != null) {
+      throw new IOException("Error while uploading index files to s3. ", failure.get());
     }
   }
 
@@ -713,70 +722,76 @@ public class S3Backend implements RemoteBackend {
     }
     List<FileNamePair> fileList = getFileNamePairs(files);
     String backendPrefix = getIndexDataPrefix(service, indexIdentifier);
-    int effectiveBatchSize = downloadBatchSize > 0 ? downloadBatchSize : defaultParallelism;
+    int maxConcurrency = downloadBatchSize > 0 ? downloadBatchSize : defaultParallelism;
     int totalFiles = fileList.size();
-    int batchStart = 0;
     long totalExpectedBytes = files.values().stream().mapToLong(m -> m.length).sum();
     S3ProgressListenerImpl downloadProgressListener =
         new S3ProgressListenerImpl(
             service, indexIdentifier, "download_index_files", totalExpectedBytes);
+    logger.info(
+        "Downloading {} index files with max concurrency {} for {}/{}",
+        totalFiles,
+        maxConcurrency,
+        service,
+        indexIdentifier);
 
-    while (batchStart < totalFiles) {
-      int batchEnd = Math.min(batchStart + effectiveBatchSize, totalFiles);
-      List<FileNamePair> batch = fileList.subList(batchStart, batchEnd);
-      logger.info(
-          "Downloading index files batch {}-{} of {} for {}/{}",
-          batchStart + 1,
-          batchEnd,
-          totalFiles,
-          service,
-          indexIdentifier);
+    Semaphore semaphore = new Semaphore(maxConcurrency);
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    List<CompletableFuture<?>> futures = new ArrayList<>();
 
-      List<Download<GetObjectResponse>> downloadList = new LinkedList<>();
-      boolean hasFailure = false;
-      Throwable failureCause = null;
-
-      for (FileNamePair pair : batch) {
-        String backendKey = backendPrefix + pair.backendFileName;
-        Path localFile = indexDir.resolve(pair.fileName);
-        DownloadRequest<GetObjectResponse> request =
-            DownloadRequest.builder()
-                .getObjectRequest(
-                    GetObjectRequest.builder().bucket(serviceBucket).key(backendKey).build())
-                .responseTransformer(AsyncResponseTransformer.toFile(localFile))
-                .addTransferListener(downloadProgressListener)
-                .build();
-        try {
-          Download<GetObjectResponse> download = transferManager.download(request);
-          downloadList.add(download);
-        } catch (Throwable t) {
-          hasFailure = true;
-          failureCause = t;
-          break;
-        }
+    for (FileNamePair pair : fileList) {
+      if (failure.get() != null) {
+        break;
       }
-
-      for (Download<GetObjectResponse> download : downloadList) {
-        if (hasFailure) {
-          try {
-            download.completionFuture().cancel(true);
-          } catch (Exception ignored) {
-          }
-        } else {
-          try {
-            download.completionFuture().join();
-          } catch (Throwable t) {
-            hasFailure = true;
-            failureCause = t;
-          }
-        }
+      try {
+        semaphore.acquire();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IOException("Interrupted while waiting to download index files from s3", e);
       }
-
-      if (hasFailure) {
-        throw new IOException("Error while downloading index files from s3. ", failureCause);
+      if (failure.get() != null) {
+        semaphore.release();
+        break;
       }
+      String backendKey = backendPrefix + pair.backendFileName;
+      Path localFile = indexDir.resolve(pair.fileName);
+      DownloadRequest<GetObjectResponse> request =
+          DownloadRequest.builder()
+              .getObjectRequest(
+                  GetObjectRequest.builder().bucket(serviceBucket).key(backendKey).build())
+              .responseTransformer(AsyncResponseTransformer.toFile(localFile))
+              .addTransferListener(downloadProgressListener)
+              .build();
+      try {
+        Download<GetObjectResponse> download = transferManager.download(request);
+        CompletableFuture<?> future =
+            download
+                .completionFuture()
+                .whenComplete(
+                    (result, t) -> {
+                      semaphore.release();
+                      if (t != null) {
+                        failure.compareAndSet(null, t);
+                      }
+                    });
+        futures.add(future);
+      } catch (Throwable t) {
+        semaphore.release();
+        failure.compareAndSet(null, t);
+        break;
+      }
+    }
 
-      batchStart = batchEnd;
+    for (CompletableFuture<?> future : futures) {
+      try {
+        future.join();
+      } catch (Exception ignored) {
+        // failure already captured in AtomicReference
+      }
+    }
+
+    if (failure.get() != null) {
+      throw new IOException("Error while downloading index files from s3. ", failure.get());
     }
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendTest.java
@@ -867,6 +867,137 @@ public class S3BackendTest {
   }
 
   @Test
+  public void testUploadIndexFiles_batched() throws IOException {
+    File indexDir = folder.newFolder("index_dir_upload_batched");
+
+    NrtFileMetaData meta1 = new NrtFileMetaData(new byte[0], new byte[0], 1, 0, "pid1", "ts1");
+    NrtFileMetaData meta2 = new NrtFileMetaData(new byte[0], new byte[0], 1, 0, "pid2", "ts2");
+    NrtFileMetaData meta3 = new NrtFileMetaData(new byte[0], new byte[0], 1, 0, "pid3", "ts3");
+    NrtFileMetaData meta4 = new NrtFileMetaData(new byte[0], new byte[0], 1, 0, "pid4", "ts4");
+    NrtFileMetaData meta5 = new NrtFileMetaData(new byte[0], new byte[0], 1, 0, "pid5", "ts5");
+
+    File f1 = new File(indexDir, "uf1");
+    File f2 = new File(indexDir, "uf2");
+    File f3 = new File(indexDir, "uf3");
+    File f4 = new File(indexDir, "uf4");
+    File f5 = new File(indexDir, "uf5");
+    Files.write(f1.toPath(), "udata1".getBytes());
+    Files.write(f2.toPath(), "udata2".getBytes());
+    Files.write(f3.toPath(), "udata3".getBytes());
+    Files.write(f4.toPath(), "udata4".getBytes());
+    Files.write(f5.toPath(), "udata5".getBytes());
+
+    // Use an uploadBatchSize of 2, smaller than the file count of 5
+    S3Backend batchedBackend =
+        new S3Backend(
+            BUCKET_NAME,
+            false,
+            new S3Backend.S3BackendConfig(false, 0, 1, 0, 2),
+            new S3Util.S3ClientBundle(s3, S3_PROVIDER.getS3AsyncClient()));
+
+    batchedBackend.uploadIndexFiles(
+        "upload_batch_service",
+        "upload_batch_index",
+        indexDir.toPath(),
+        Map.of("uf1", meta1, "uf2", meta2, "uf3", meta3, "uf4", meta4, "uf5", meta5));
+
+    String keyPrefix = S3Backend.getIndexDataPrefix("upload_batch_service", "upload_batch_index");
+    assertEquals(
+        "udata1",
+        convertToString(
+            s3.getObject(
+                GetObjectRequest.builder()
+                    .bucket(BUCKET_NAME)
+                    .key(keyPrefix + S3Backend.getIndexBackendFileName("uf1", meta1))
+                    .build(),
+                ResponseTransformer.toInputStream())));
+    assertEquals(
+        "udata2",
+        convertToString(
+            s3.getObject(
+                GetObjectRequest.builder()
+                    .bucket(BUCKET_NAME)
+                    .key(keyPrefix + S3Backend.getIndexBackendFileName("uf2", meta2))
+                    .build(),
+                ResponseTransformer.toInputStream())));
+    assertEquals(
+        "udata3",
+        convertToString(
+            s3.getObject(
+                GetObjectRequest.builder()
+                    .bucket(BUCKET_NAME)
+                    .key(keyPrefix + S3Backend.getIndexBackendFileName("uf3", meta3))
+                    .build(),
+                ResponseTransformer.toInputStream())));
+    assertEquals(
+        "udata4",
+        convertToString(
+            s3.getObject(
+                GetObjectRequest.builder()
+                    .bucket(BUCKET_NAME)
+                    .key(keyPrefix + S3Backend.getIndexBackendFileName("uf4", meta4))
+                    .build(),
+                ResponseTransformer.toInputStream())));
+    assertEquals(
+        "udata5",
+        convertToString(
+            s3.getObject(
+                GetObjectRequest.builder()
+                    .bucket(BUCKET_NAME)
+                    .key(keyPrefix + S3Backend.getIndexBackendFileName("uf5", meta5))
+                    .build(),
+                ResponseTransformer.toInputStream())));
+  }
+
+  @Test
+  public void testUploadIndexFiles_stopAfterFailure() throws IOException {
+    File indexDir = folder.newFolder("index_dir_upload_fail");
+
+    NrtFileMetaData meta1 = new NrtFileMetaData(new byte[0], new byte[0], 1, 0, "pid1", "ts1");
+    NrtFileMetaData meta2 = new NrtFileMetaData(new byte[0], new byte[0], 1, 0, "pid2", "ts2");
+    NrtFileMetaData meta3 = new NrtFileMetaData(new byte[0], new byte[0], 1, 0, "pid3", "ts3");
+    NrtFileMetaData meta4 = new NrtFileMetaData(new byte[0], new byte[0], 1, 0, "pid4", "ts4");
+    NrtFileMetaData meta5 = new NrtFileMetaData(new byte[0], new byte[0], 1, 0, "pid5", "ts5");
+
+    // Only write files 1 and 3–5; file 2 ("uf_fail2") does not exist on disk
+    File f1 = new File(indexDir, "uf_fail1");
+    File f3 = new File(indexDir, "uf_fail3");
+    File f4 = new File(indexDir, "uf_fail4");
+    File f5 = new File(indexDir, "uf_fail5");
+    Files.write(f1.toPath(), "fdata1".getBytes());
+    Files.write(f3.toPath(), "fdata3".getBytes());
+    Files.write(f4.toPath(), "fdata4".getBytes());
+    Files.write(f5.toPath(), "fdata5".getBytes());
+
+    // uploadBatchSize of 1 so the missing file is encountered before others can be submitted
+    S3Backend failBackend =
+        new S3Backend(
+            BUCKET_NAME,
+            false,
+            new S3Backend.S3BackendConfig(false, 0, 1, 0, 1),
+            new S3Util.S3ClientBundle(s3, S3_PROVIDER.getS3AsyncClient()));
+
+    try {
+      failBackend.uploadIndexFiles(
+          "upload_fail_service",
+          "upload_fail_index",
+          indexDir.toPath(),
+          Map.of(
+              "uf_fail1", meta1,
+              "uf_fail2", meta2,
+              "uf_fail3", meta3,
+              "uf_fail4", meta4,
+              "uf_fail5", meta5));
+      fail("Expected IOException due to missing file");
+    } catch (IOException e) {
+      // Verify that the method propagated the failure correctly
+      assertTrue(
+          "Expected IOException about uploading index files",
+          e.getMessage().contains("Error while uploading index files to s3"));
+    }
+  }
+
+  @Test
   public void testDownloadIndexFiles() throws IOException {
     File indexDir = folder.newFolder("index_dir");
 


### PR DESCRIPTION
---
This is being applied to the `development` branch.

  Summary

  Replace the fixed-batch loop pattern in S3Backend.uploadIndexFiles and downloadIndexFiles with a semaphore-based sliding window concurrency model.

  Previously, files were uploaded/downloaded in discrete batches of size N — the next batch wouldn't start until the entire previous batch completed, leaving slots idle whenever transfers within a batch finished at different times.

  The new approach uses a Semaphore to keep up to maxConcurrency transfers in-flight at all times. As soon as any transfer completes, its semaphore permit is released and the next file begins immediately, maximizing throughput.

  Key changes:
  - uploadIndexFiles and downloadIndexFiles now use Semaphore + AtomicReference<Throwable> instead of a batch-start/batch-end loop
  - Failures are propagated via AtomicReference and short-circuit further submissions
  - Added testUploadIndexFiles_batched — verifies sliding window works correctly with uploadBatchSize=2 over 5 files
  - Added testUploadIndexFiles_stopAfterFailure — verifies that a missing source file propagates as IOException

  Test plan

  - testUploadIndexFiles_batched — uploads 5 files with concurrency 2, verifies all arrive in S3
  - testUploadIndexFiles_stopAfterFailure — missing file triggers IOException with correct message
  - Existing testDownloadIndexFiles_batched and testDownloadIndexFiles_stopAfterFailure continue to pass (same pattern already applied to downloads)