### PR TITLE
Create scriptFactoryContext to wrap all related scoreScript.factory params, including a new one - sharedDocCotext

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
@@ -20,6 +20,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat.Printer;
 import com.yelp.nrtsearch.server.doc.LoadedDocValues;
+import com.yelp.nrtsearch.server.doc.SharedDocContext;
 import com.yelp.nrtsearch.server.facet.DrillSidewaysImpl;
 import com.yelp.nrtsearch.server.facet.FacetTopDocs;
 import com.yelp.nrtsearch.server.field.DateTimeFieldDef;
@@ -183,6 +184,7 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
       if (searchContext.getMultiRetrieverContext() != null) {
         hits =
             executeMultiRetriever(searchContext, s.searcher(), diagnostics, profileResultBuilder);
+        populateRetrieverScores(hits, searchContext.getSharedDocContext());
       } else {
         SearcherResult searcherResult;
         if (!searchRequest.getFacetsList().isEmpty()) {
@@ -646,6 +648,23 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
     }
 
     return blendedHits;
+  }
+
+  /**
+   * Write per-retriever scores from blended hits into the shared doc context. For retriever {@code
+   * "text"}, the key {@code "retriever_text"} is set on each document's context map, accessible in
+   * JS scripts as {@code _shared_retriever_text} and in ScoreScript subclasses via {@code
+   * get_shared_double("retriever_text", defaultValue)}.
+   */
+  static void populateRetrieverScores(TopDocs hits, SharedDocContext sharedDocContext) {
+    for (ScoreDoc scoreDoc : hits.scoreDocs) {
+      if (scoreDoc instanceof BlendedScoreDoc blended) {
+        Map<String, Object> ctx = sharedDocContext.getContext(scoreDoc.doc);
+        for (Map.Entry<String, ScoreDoc> entry : blended.getScoreDocs().entrySet()) {
+          ctx.put("retriever_" + entry.getKey(), (double) entry.getValue().score);
+        }
+      }
+    }
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
@@ -86,6 +86,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
+  public static final String RETRIEVER_KEY_PREFIX = "retriever_";
   private static final ExecutorService DIRECT_EXECUTOR = MoreExecutors.newDirectExecutorService();
   private static final Printer protoMessagePrinter =
       ProtoMessagePrinter.omittingInsignificantWhitespace();
@@ -661,7 +662,7 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
       if (scoreDoc instanceof BlendedScoreDoc blended) {
         Map<String, Object> ctx = sharedDocContext.getContext(scoreDoc.doc);
         for (Map.Entry<String, ScoreDoc> entry : blended.getScoreDocs().entrySet()) {
-          ctx.put("retriever_" + entry.getKey(), (double) entry.getValue().score);
+          ctx.put(RETRIEVER_KEY_PREFIX + entry.getKey(), (double) entry.getValue().score);
         }
       }
     }

--- a/src/main/java/com/yelp/nrtsearch/server/index/FieldUpdateUtils.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/FieldUpdateUtils.java
@@ -23,6 +23,7 @@ import com.yelp.nrtsearch.server.field.VirtualFieldDef;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.FieldType;
 import com.yelp.nrtsearch.server.script.ScoreScript;
+import com.yelp.nrtsearch.server.script.ScriptFactoryContext;
 import com.yelp.nrtsearch.server.script.ScriptService;
 import com.yelp.nrtsearch.server.utils.ScriptParamsUtils;
 import java.util.ArrayList;
@@ -168,9 +169,13 @@ public class FieldUpdateUtils {
     Map<String, Object> params = ScriptParamsUtils.decodeParams(field.getScript().getParamsMap());
     DoubleValuesSource values =
         factory.newFactory(
-            params,
-            new DocLookup(
-                fieldStateBuilder.getFields()::get, fieldStateBuilder.getFields()::keySet, null));
+            ScriptFactoryContext.builder(
+                    params,
+                    new DocLookup(
+                        fieldStateBuilder.getFields()::get,
+                        fieldStateBuilder.getFields()::keySet,
+                        null))
+                .build());
 
     FieldDef virtualFieldDef = new VirtualFieldDef(field.getName(), values);
     fieldStateBuilder.addField(virtualFieldDef, field);

--- a/src/main/java/com/yelp/nrtsearch/server/query/QueryContext.java
+++ b/src/main/java/com/yelp/nrtsearch/server/query/QueryContext.java
@@ -16,12 +16,17 @@
 package com.yelp.nrtsearch.server.query;
 
 import com.yelp.nrtsearch.server.doc.DocLookup;
+import com.yelp.nrtsearch.server.doc.SharedDocContext;
 import com.yelp.nrtsearch.server.state.GlobalState;
 import javax.annotation.Nullable;
 
 /**
  * Context for query building. Bundles {@link DocLookup} (for field resolution and doc values) with
  * optional {@link GlobalState} (needed for cross-index queries like {@link
- * com.yelp.nrtsearch.server.grpc.CrossIndexQuery}).
+ * com.yelp.nrtsearch.server.grpc.CrossIndexQuery}) and optional {@link SharedDocContext} (for
+ * scripts that access per-document shared values).
  */
-public record QueryContext(DocLookup docLookup, @Nullable GlobalState globalState) {}
+public record QueryContext(
+    DocLookup docLookup,
+    @Nullable GlobalState globalState,
+    @Nullable SharedDocContext sharedDocContext) {}

--- a/src/main/java/com/yelp/nrtsearch/server/query/QueryNodeMapper.java
+++ b/src/main/java/com/yelp/nrtsearch/server/query/QueryNodeMapper.java
@@ -44,6 +44,7 @@ import com.yelp.nrtsearch.server.index.IndexState;
 import com.yelp.nrtsearch.server.index.ShardState;
 import com.yelp.nrtsearch.server.query.multifunction.MultiFunctionScoreQuery;
 import com.yelp.nrtsearch.server.script.ScoreScript;
+import com.yelp.nrtsearch.server.script.ScriptFactoryContext;
 import com.yelp.nrtsearch.server.script.ScriptService;
 import com.yelp.nrtsearch.server.utils.ScriptParamsUtils;
 import java.io.IOException;
@@ -298,7 +299,8 @@ public class QueryNodeMapper {
         ScriptParamsUtils.decodeParams(functionScoreQuery.getScript().getParamsMap());
     return new FunctionScoreQuery(
         getQuery(functionScoreQuery.getQuery(), context),
-        scriptFactory.newFactory(params, context.docLookup()));
+        scriptFactory.newFactory(
+            ScriptFactoryContext.builder(params, context.docLookup()).build()));
   }
 
   private FunctionMatchQuery getFunctionFilterQuery(
@@ -307,7 +309,9 @@ public class QueryNodeMapper {
         ScriptService.getInstance().compile(functionFilterQuery.getScript(), ScoreScript.CONTEXT);
     Map<String, Object> params =
         ScriptParamsUtils.decodeParams(functionFilterQuery.getScript().getParamsMap());
-    return new FunctionMatchQuery(scriptFactory.newFactory(params, docLookup), score -> score > 0);
+    return new FunctionMatchQuery(
+        scriptFactory.newFactory(ScriptFactoryContext.builder(params, docLookup).build()),
+        score -> score > 0);
   }
 
   private Query getTermQuery(

--- a/src/main/java/com/yelp/nrtsearch/server/query/QueryNodeMapper.java
+++ b/src/main/java/com/yelp/nrtsearch/server/query/QueryNodeMapper.java
@@ -114,11 +114,11 @@ public class QueryNodeMapper {
               MatchOperator.MUST, BooleanClause.Occur.MUST));
 
   public Query getQuery(com.yelp.nrtsearch.server.grpc.Query query, IndexState state) {
-    return getQuery(query, new QueryContext(state.docLookup, state.getGlobalState()));
+    return getQuery(query, new QueryContext(state.docLookup, state.getGlobalState(), null));
   }
 
   public Query getQuery(com.yelp.nrtsearch.server.grpc.Query query, DocLookup docLookup) {
-    return getQuery(query, new QueryContext(docLookup, null));
+    return getQuery(query, new QueryContext(docLookup, null, null));
   }
 
   public Query getQuery(com.yelp.nrtsearch.server.grpc.Query query, QueryContext context) {
@@ -184,10 +184,10 @@ public class QueryNodeMapper {
       case NESTEDQUERY -> getNestedQuery(query.getNestedQuery(), context);
       case EXISTSQUERY -> getExistsQuery(query.getExistsQuery());
       case GEORADIUSQUERY -> getGeoRadiusQuery(query.getGeoRadiusQuery(), docLookup);
-      case FUNCTIONFILTERQUERY -> getFunctionFilterQuery(query.getFunctionFilterQuery(), docLookup);
+      case FUNCTIONFILTERQUERY -> getFunctionFilterQuery(query.getFunctionFilterQuery(), context);
       case COMPLETIONQUERY -> getCompletionQuery(query.getCompletionQuery(), docLookup);
       case MULTIFUNCTIONSCOREQUERY ->
-          MultiFunctionScoreQuery.build(query.getMultiFunctionScoreQuery(), docLookup);
+          MultiFunctionScoreQuery.build(query.getMultiFunctionScoreQuery(), context);
       case MATCHPHRASEPREFIXQUERY ->
           MatchPhrasePrefixQuery.build(query.getMatchPhrasePrefixQuery(), docLookup);
       case PREFIXQUERY -> getPrefixQuery(query.getPrefixQuery(), docLookup, false);
@@ -300,17 +300,22 @@ public class QueryNodeMapper {
     return new FunctionScoreQuery(
         getQuery(functionScoreQuery.getQuery(), context),
         scriptFactory.newFactory(
-            ScriptFactoryContext.builder(params, context.docLookup()).build()));
+            ScriptFactoryContext.builder(params, context.docLookup())
+                .sharedDocContext(context.sharedDocContext())
+                .build()));
   }
 
   private FunctionMatchQuery getFunctionFilterQuery(
-      FunctionFilterQuery functionFilterQuery, DocLookup docLookup) {
+      FunctionFilterQuery functionFilterQuery, QueryContext context) {
     ScoreScript.Factory scriptFactory =
         ScriptService.getInstance().compile(functionFilterQuery.getScript(), ScoreScript.CONTEXT);
     Map<String, Object> params =
         ScriptParamsUtils.decodeParams(functionFilterQuery.getScript().getParamsMap());
     return new FunctionMatchQuery(
-        scriptFactory.newFactory(ScriptFactoryContext.builder(params, docLookup).build()),
+        scriptFactory.newFactory(
+            ScriptFactoryContext.builder(params, context.docLookup())
+                .sharedDocContext(context.sharedDocContext())
+                .build()),
         score -> score > 0);
   }
 
@@ -870,7 +875,7 @@ public class QueryNodeMapper {
       Query innerQuery =
           getQuery(
               crossIndexQuery.getQuery(),
-              new QueryContext(secondaryIndex.docLookup, context.globalState()));
+              new QueryContext(secondaryIndex.docLookup, context.globalState(), null));
 
       int maxTerms = crossIndexQuery.getMaxTerms();
       if (maxTerms > 0) {

--- a/src/main/java/com/yelp/nrtsearch/server/query/multifunction/FilterFunction.java
+++ b/src/main/java/com/yelp/nrtsearch/server/query/multifunction/FilterFunction.java
@@ -17,6 +17,7 @@ package com.yelp.nrtsearch.server.query.multifunction;
 
 import com.yelp.nrtsearch.server.doc.DocLookup;
 import com.yelp.nrtsearch.server.grpc.MultiFunctionScoreQuery;
+import com.yelp.nrtsearch.server.query.QueryContext;
 import com.yelp.nrtsearch.server.query.QueryNodeMapper;
 import com.yelp.nrtsearch.server.script.ScoreScript;
 import com.yelp.nrtsearch.server.script.ScriptFactoryContext;
@@ -69,14 +70,15 @@ public abstract class FilterFunction {
    * Builder method to create a {@link FilterFunction} object based on its gRPC message definition.
    *
    * @param filterFunctionGrpc function gRPC definition
-   * @param docLookup lookup for document field data
+   * @param context query context with doc lookup and shared doc context
    * @return filter function object
    */
   public static FilterFunction build(
-      MultiFunctionScoreQuery.FilterFunction filterFunctionGrpc, DocLookup docLookup) {
+      MultiFunctionScoreQuery.FilterFunction filterFunctionGrpc, QueryContext context) {
+    DocLookup docLookup = context.docLookup();
     Query filterQuery =
         filterFunctionGrpc.hasFilter()
-            ? QueryNodeMapper.getInstance().getQuery(filterFunctionGrpc.getFilter(), docLookup)
+            ? QueryNodeMapper.getInstance().getQuery(filterFunctionGrpc.getFilter(), context)
             : null;
     float weight = filterFunctionGrpc.getWeight() != 0.0f ? filterFunctionGrpc.getWeight() : 1.0f;
     switch (filterFunctionGrpc.getFunctionCase()) {
@@ -90,6 +92,7 @@ public abstract class FilterFunction {
                         ScriptParamsUtils.decodeParams(
                             filterFunctionGrpc.getScript().getParamsMap()),
                         docLookup)
+                    .sharedDocContext(context.sharedDocContext())
                     .build());
         return new ScriptFilterFunction(
             filterQuery, weight, filterFunctionGrpc.getScript(), scriptSource);

--- a/src/main/java/com/yelp/nrtsearch/server/query/multifunction/FilterFunction.java
+++ b/src/main/java/com/yelp/nrtsearch/server/query/multifunction/FilterFunction.java
@@ -19,6 +19,7 @@ import com.yelp.nrtsearch.server.doc.DocLookup;
 import com.yelp.nrtsearch.server.grpc.MultiFunctionScoreQuery;
 import com.yelp.nrtsearch.server.query.QueryNodeMapper;
 import com.yelp.nrtsearch.server.script.ScoreScript;
+import com.yelp.nrtsearch.server.script.ScriptFactoryContext;
 import com.yelp.nrtsearch.server.script.ScriptService;
 import com.yelp.nrtsearch.server.utils.ScriptParamsUtils;
 import java.io.IOException;
@@ -85,8 +86,11 @@ public abstract class FilterFunction {
                 .compile(filterFunctionGrpc.getScript(), ScoreScript.CONTEXT);
         DoubleValuesSource scriptSource =
             factory.newFactory(
-                ScriptParamsUtils.decodeParams(filterFunctionGrpc.getScript().getParamsMap()),
-                docLookup);
+                ScriptFactoryContext.builder(
+                        ScriptParamsUtils.decodeParams(
+                            filterFunctionGrpc.getScript().getParamsMap()),
+                        docLookup)
+                    .build());
         return new ScriptFilterFunction(
             filterQuery, weight, filterFunctionGrpc.getScript(), scriptSource);
       case DECAYFUNCTION:

--- a/src/main/java/com/yelp/nrtsearch/server/query/multifunction/MultiFunctionScoreQuery.java
+++ b/src/main/java/com/yelp/nrtsearch/server/query/multifunction/MultiFunctionScoreQuery.java
@@ -15,9 +15,9 @@
  */
 package com.yelp.nrtsearch.server.query.multifunction;
 
-import com.yelp.nrtsearch.server.doc.DocLookup;
 import com.yelp.nrtsearch.server.grpc.MultiFunctionScoreQuery.BoostMode;
 import com.yelp.nrtsearch.server.grpc.MultiFunctionScoreQuery.FunctionScoreMode;
+import com.yelp.nrtsearch.server.query.QueryContext;
 import com.yelp.nrtsearch.server.query.QueryNodeMapper;
 import com.yelp.nrtsearch.server.query.QueryUtils;
 import com.yelp.nrtsearch.server.query.multifunction.FilterFunction.LeafFunction;
@@ -68,18 +68,18 @@ public class MultiFunctionScoreQuery extends Query {
    * Builder method that creates a {@link MultiFunctionScoreQuery} from its gRPC message definiton.
    *
    * @param multiFunctionScoreQueryGrpc grpc definition
-   * @param docLookup lookup for document field data
+   * @param context query context with doc lookup and shared doc context
    * @return multi function score query
    */
   public static MultiFunctionScoreQuery build(
       com.yelp.nrtsearch.server.grpc.MultiFunctionScoreQuery multiFunctionScoreQueryGrpc,
-      DocLookup docLookup) {
+      QueryContext context) {
     Query innerQuery =
-        QueryNodeMapper.getInstance().getQuery(multiFunctionScoreQueryGrpc.getQuery(), docLookup);
+        QueryNodeMapper.getInstance().getQuery(multiFunctionScoreQueryGrpc.getQuery(), context);
     FilterFunction[] functions =
         new FilterFunction[multiFunctionScoreQueryGrpc.getFunctionsCount()];
     for (int i = 0; i < functions.length; ++i) {
-      functions[i] = FilterFunction.build(multiFunctionScoreQueryGrpc.getFunctions(i), docLookup);
+      functions[i] = FilterFunction.build(multiFunctionScoreQueryGrpc.getFunctions(i), context);
     }
     return new MultiFunctionScoreQuery(
         innerQuery,

--- a/src/main/java/com/yelp/nrtsearch/server/rescore/RescoreTask.java
+++ b/src/main/java/com/yelp/nrtsearch/server/rescore/RescoreTask.java
@@ -15,7 +15,6 @@
  */
 package com.yelp.nrtsearch.server.rescore;
 
-import com.yelp.nrtsearch.server.handler.SearchHandler;
 import com.yelp.nrtsearch.server.search.SearchContext;
 import java.io.IOException;
 import org.apache.lucene.search.TopDocs;

--- a/src/main/java/com/yelp/nrtsearch/server/rescore/ScriptRescore.java
+++ b/src/main/java/com/yelp/nrtsearch/server/rescore/ScriptRescore.java
@@ -15,11 +15,15 @@
  */
 package com.yelp.nrtsearch.server.rescore;
 
+import com.yelp.nrtsearch.server.doc.DocLookup;
 import com.yelp.nrtsearch.server.query.QueryUtils;
+import com.yelp.nrtsearch.server.script.ScoreScript;
+import com.yelp.nrtsearch.server.script.ScriptFactoryContext;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DoubleValues;
 import org.apache.lucene.search.DoubleValuesSource;
@@ -29,18 +33,23 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 
 /**
- * {@link RescoreOperation} that re-scores each hit by evaluating a {@link DoubleValuesSource}
- * (typically compiled from a {@link com.yelp.nrtsearch.server.script.ScoreScript}). The
- * previous-pass score is passed as the {@link DoubleValues} {@code scores} argument to {@link
- * DoubleValuesSource#getValues}. How that score is surfaced to the script author depends on the
- * script engine:
+ * {@link RescoreOperation} that re-scores each hit by evaluating a compiled script. At rescore
+ * time, the factory is called with the current {@link
+ * com.yelp.nrtsearch.server.doc.SharedDocContext} from the search context, allowing the script to
+ * read per-retriever scores (and any other values contributed by earlier pipeline steps) in
+ * addition to the standard inputs.
+ *
+ * <p>Inputs available to scripts:
  *
  * <ul>
- *   <li><b>JS (Lucene expression)</b> – accessible as the {@code _score} variable, resolved via
- *       {@link com.yelp.nrtsearch.server.field.FieldDefBindings} to {@link
- *       DoubleValuesSource#SCORES}.
- *   <li><b>Custom {@link com.yelp.nrtsearch.server.script.ScoreScript} subclasses</b> – accessible
- *       via {@link com.yelp.nrtsearch.server.script.ScoreScript#get_score()}.
+ *   <li><b>{@code _score}</b> — the previous-pass blended score (JS: {@code _score} variable;
+ *       {@link com.yelp.nrtsearch.server.script.ScoreScript} subclasses: {@code get_score()}).
+ *   <li><b>Doc values</b> — index field values via {@code doc['field'].value}.
+ *   <li><b>Shared doc context values</b> — per-document values contributed by earlier pipeline
+ *       steps. For multi-retriever queries, each retriever's raw score is available under the key
+ *       {@code retriever_<name>} (JS: {@code _shared_retriever_<name>}; {@link
+ *       com.yelp.nrtsearch.server.script.ScoreScript} subclasses: {@code
+ *       get_shared_double("retriever_<name>", defaultValue)}).
  * </ul>
  */
 public class ScriptRescore implements RescoreOperation {
@@ -53,14 +62,25 @@ public class ScriptRescore implements RescoreOperation {
   private static final Comparator<ScoreDoc> BY_SCORE_DESC =
       Comparator.<ScoreDoc>comparingDouble(d -> -d.score).thenComparing(BY_DOC_ID);
 
-  private final DoubleValuesSource scriptSource;
+  private final ScoreScript.Factory factory;
+  private final Map<String, Object> params;
+  private final DocLookup docLookup;
 
-  public ScriptRescore(DoubleValuesSource scriptSource) {
-    this.scriptSource = scriptSource;
+  public ScriptRescore(
+      ScoreScript.Factory factory, Map<String, Object> params, DocLookup docLookup) {
+    this.factory = factory;
+    this.params = params;
+    this.docLookup = docLookup;
   }
 
   @Override
   public TopDocs rescore(TopDocs hits, RescoreContext context) throws IOException {
+    ScriptFactoryContext factoryContext =
+        ScriptFactoryContext.builder(params, docLookup)
+            .sharedDocContext(context.getSearchContext().getSharedDocContext())
+            .build();
+    DoubleValuesSource scriptSource = factory.newFactory(factoryContext);
+
     IndexSearcher searcher = context.getSearchContext().getSearcherAndTaxonomy().searcher();
 
     // Sort hits by doc id so we can walk leaves in one forward pass.

--- a/src/main/java/com/yelp/nrtsearch/server/rescore/ScriptRescore.java
+++ b/src/main/java/com/yelp/nrtsearch/server/rescore/ScriptRescore.java
@@ -15,7 +15,6 @@
  */
 package com.yelp.nrtsearch.server.rescore;
 
-import com.yelp.nrtsearch.server.doc.DocLookup;
 import com.yelp.nrtsearch.server.query.QueryUtils;
 import com.yelp.nrtsearch.server.script.ScoreScript;
 import com.yelp.nrtsearch.server.script.ScriptFactoryContext;
@@ -23,7 +22,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DoubleValues;
 import org.apache.lucene.search.DoubleValuesSource;
@@ -63,23 +61,16 @@ public class ScriptRescore implements RescoreOperation {
       Comparator.<ScoreDoc>comparingDouble(d -> -d.score).thenComparing(BY_DOC_ID);
 
   private final ScoreScript.Factory factory;
-  private final Map<String, Object> params;
-  private final DocLookup docLookup;
+  private final ScriptFactoryContext scriptFactoryContext;
 
-  public ScriptRescore(
-      ScoreScript.Factory factory, Map<String, Object> params, DocLookup docLookup) {
+  public ScriptRescore(ScoreScript.Factory factory, ScriptFactoryContext scriptFactoryContext) {
     this.factory = factory;
-    this.params = params;
-    this.docLookup = docLookup;
+    this.scriptFactoryContext = scriptFactoryContext;
   }
 
   @Override
   public TopDocs rescore(TopDocs hits, RescoreContext context) throws IOException {
-    ScriptFactoryContext factoryContext =
-        ScriptFactoryContext.builder(params, docLookup)
-            .sharedDocContext(context.getSearchContext().getSharedDocContext())
-            .build();
-    DoubleValuesSource scriptSource = factory.newFactory(factoryContext);
+    DoubleValuesSource scriptSource = factory.newFactory(scriptFactoryContext);
 
     IndexSearcher searcher = context.getSearchContext().getSearcherAndTaxonomy().searcher();
 

--- a/src/main/java/com/yelp/nrtsearch/server/script/ScoreScript.java
+++ b/src/main/java/com/yelp/nrtsearch/server/script/ScoreScript.java
@@ -20,6 +20,7 @@ import com.yelp.nrtsearch.server.doc.LoadedDocValues;
 import com.yelp.nrtsearch.server.doc.SegmentDocLookup;
 import com.yelp.nrtsearch.server.doc.SharedDocContext;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.lucene.index.LeafReaderContext;
@@ -147,6 +148,21 @@ public abstract class ScoreScript extends DoubleValues {
       return n.doubleValue();
     }
     return defaultValue;
+  }
+
+  /**
+   * Get the full shared doc context map for the current document. Allows script plugins to access
+   * values of any type stored in the shared context.
+   *
+   * <p>Not available through JS expressions, which are limited to {@code double} values.
+   *
+   * @return shared doc context map for the current document, or an empty map if no context exists
+   */
+  public Map<String, Object> get_shared_doc_context_map() {
+    if (sharedDocContext == null) {
+      return Collections.emptyMap();
+    }
+    return sharedDocContext.getContext(leafDocBase + docId);
   }
 
   /** Get the script parameters provided in the request. */

--- a/src/main/java/com/yelp/nrtsearch/server/script/ScoreScript.java
+++ b/src/main/java/com/yelp/nrtsearch/server/script/ScoreScript.java
@@ -18,6 +18,7 @@ package com.yelp.nrtsearch.server.script;
 import com.yelp.nrtsearch.server.doc.DocLookup;
 import com.yelp.nrtsearch.server.doc.LoadedDocValues;
 import com.yelp.nrtsearch.server.doc.SegmentDocLookup;
+import com.yelp.nrtsearch.server.doc.SharedDocContext;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
@@ -27,10 +28,21 @@ import org.apache.lucene.search.DoubleValuesSource;
 import org.apache.lucene.search.IndexSearcher;
 
 /**
- * Script to produce a double value for a given document. Implementations must have an execute
- * function. This class conforms with the script compile contract, see {@link ScriptContext}. The
- * script has access to the query parameters, the document doc values through {@link
- * SegmentDocLookup}, and the document score through get_score.
+ * Script to produce a double value for a given document. Implementations must provide an {@link
+ * #execute()} method. This class conforms with the script compile contract defined by {@link
+ * ScriptContext}.
+ *
+ * <p>Scripts have access to:
+ *
+ * <ul>
+ *   <li><b>Parameters</b> — via {@link #getParams()}, set in the {@link
+ *       com.yelp.nrtsearch.server.grpc.Script} request.
+ *   <li><b>Doc values</b> — via {@link #getDoc()}, backed by {@link SegmentDocLookup}.
+ *   <li><b>Previous-pass score</b> — via {@link #get_score()}.
+ *   <li><b>Shared doc context values</b> — per-document values contributed by earlier pipeline
+ *       steps, accessed via {@link #get_shared_double(String, double)}. For multi-retriever queries
+ *       each retriever's raw score is available under the key {@code retriever_<name>}.
+ * </ul>
  */
 public abstract class ScoreScript extends DoubleValues {
   private static final int DOC_UNSET = -1;
@@ -38,8 +50,10 @@ public abstract class ScoreScript extends DoubleValues {
   private final Map<String, Object> params;
   private final SegmentDocLookup segmentDocLookup;
   private final DoubleValues scores;
+  private final SharedDocContext sharedDocContext;
   private int docId = DOC_UNSET;
   private int scoreDocId = DOC_UNSET;
+  private int leafDocBase = 0;
 
   // names for parameters to execute
   public static final String[] PARAMETERS = new String[] {};
@@ -51,15 +65,19 @@ public abstract class ScoreScript extends DoubleValues {
    * @param docLookup index level doc values lookup
    * @param leafContext lucene segment context
    * @param scores provider of segment document scores
+   * @param sharedDocContext per-document context shared across pipeline stages, or {@code null}
    */
   public ScoreScript(
       Map<String, Object> params,
       DocLookup docLookup,
       LeafReaderContext leafContext,
-      DoubleValues scores) {
+      DoubleValues scores,
+      SharedDocContext sharedDocContext) {
     this.params = params;
     this.segmentDocLookup = docLookup.getSegmentLookup(leafContext);
     this.scores = scores;
+    this.sharedDocContext = sharedDocContext;
+    this.leafDocBase = leafContext.docBase;
   }
 
   /**
@@ -110,6 +128,27 @@ public abstract class ScoreScript extends DoubleValues {
     }
   }
 
+  /**
+   * Get a {@code double} value from the shared doc context for the current document.
+   *
+   * <p>For multi-retriever queries, each retriever's raw score is stored under {@code
+   * retriever_<name>} (e.g. {@code "retriever_text"}, {@code "retriever_knn"}).
+   *
+   * @param key shared doc context key
+   * @param defaultValue returned when no entry is present for this key and document
+   * @return stored value cast to {@code double}, or {@code defaultValue}
+   */
+  public double get_shared_double(String key, double defaultValue) {
+    if (sharedDocContext == null) {
+      return defaultValue;
+    }
+    Object value = sharedDocContext.getContext(leafDocBase + docId).get(key);
+    if (value instanceof Number n) {
+      return n.doubleValue();
+    }
+    return defaultValue;
+  }
+
   /** Get the script parameters provided in the request. */
   public Map<String, Object> getParams() {
     return params;
@@ -128,11 +167,10 @@ public abstract class ScoreScript extends DoubleValues {
     /**
      * Create request level {@link DoubleValuesSource}.
      *
-     * @param params parameters from script request
-     * @param docLookup index level doc value lookup provider
+     * @param context request-level resources available to the script factory
      * @return {@link DoubleValuesSource} to evaluate script
      */
-    DoubleValuesSource newFactory(Map<String, Object> params, DocLookup docLookup);
+    DoubleValuesSource newFactory(ScriptFactoryContext context);
   }
 
   // compile context for the ScoreScript, contains script type info
@@ -141,12 +179,13 @@ public abstract class ScoreScript extends DoubleValues {
           "score", ScoreScript.Factory.class, ScoreScript.SegmentFactory.class, ScoreScript.class);
 
   /**
-   * Simple abstract implementation of a {@link DoubleValuesSource} this can be extended for engines
-   * that need to implement a custom {@link ScoreScript}. The newInstance and needs_score must be
-   * implemented. If more state is needed, the equals/hashCode should be redefined appropriately.
+   * Abstract {@link DoubleValuesSource} that script engines extend to produce per-segment {@link
+   * ScoreScript} instances. Subclasses must implement {@link #newInstance} and {@link
+   * #needs_score}. If additional state is held, {@link #equals} and {@link #hashCode} should be
+   * overridden accordingly.
    *
    * <p>This class conforms with the script compile contract, see {@link ScriptContext}. However,
-   * Engines are also free to create there own {@link DoubleValuesSource} implementations instead.
+   * Engines are also free to create their own {@link DoubleValuesSource} implementations instead.
    */
   public abstract static class SegmentFactory extends DoubleValuesSource {
     private final Map<String, Object> params;

--- a/src/main/java/com/yelp/nrtsearch/server/script/ScriptFactoryContext.java
+++ b/src/main/java/com/yelp/nrtsearch/server/script/ScriptFactoryContext.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.script;
+
+import com.yelp.nrtsearch.server.doc.DocLookup;
+import com.yelp.nrtsearch.server.doc.SharedDocContext;
+import java.util.Map;
+
+/**
+ * Bundles all request-level resources that a {@link ScoreScript.Factory} may need to produce a
+ * {@link org.apache.lucene.search.DoubleValuesSource}. Using a single value object instead of
+ * individual parameters makes the {@link ScoreScript.Factory#newFactory} signature stable — adding
+ * resources in the future does not require changing the interface.
+ */
+public final class ScriptFactoryContext {
+
+  private final Map<String, Object> params;
+  private final DocLookup docLookup;
+  private final SharedDocContext sharedDocContext;
+
+  private ScriptFactoryContext(Builder builder) {
+    this.params = builder.params;
+    this.docLookup = builder.docLookup;
+    this.sharedDocContext = builder.sharedDocContext;
+  }
+
+  /** Script parameters from the {@link com.yelp.nrtsearch.server.grpc.Script} request. */
+  public Map<String, Object> getParams() {
+    return params;
+  }
+
+  /** Index-level doc-values lookup. */
+  public DocLookup getDocLookup() {
+    return docLookup;
+  }
+
+  /**
+   * Per-document context shared across pipeline stages. Retriever scores are stored here under the
+   * key {@code retriever_<name>} as {@code Double} values, accessible via {@link
+   * ScoreScript#get_shared_double(String, double)}.
+   */
+  public SharedDocContext getSharedDocContext() {
+    return sharedDocContext;
+  }
+
+  public static Builder builder(Map<String, Object> params, DocLookup docLookup) {
+    return new Builder(params, docLookup);
+  }
+
+  public static final class Builder {
+    private final Map<String, Object> params;
+    private final DocLookup docLookup;
+    private SharedDocContext sharedDocContext;
+
+    private Builder(Map<String, Object> params, DocLookup docLookup) {
+      this.params = params;
+      this.docLookup = docLookup;
+    }
+
+    public Builder sharedDocContext(SharedDocContext sharedDocContext) {
+      this.sharedDocContext = sharedDocContext;
+      return this;
+    }
+
+    public ScriptFactoryContext build() {
+      return new ScriptFactoryContext(this);
+    }
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/script/js/JsScriptBindings.java
+++ b/src/main/java/com/yelp/nrtsearch/server/script/js/JsScriptBindings.java
@@ -15,6 +15,8 @@
  */
 package com.yelp.nrtsearch.server.script.js;
 
+import com.yelp.nrtsearch.server.doc.SharedDocContext;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,41 +36,80 @@ import org.apache.lucene.search.IndexSearcher;
  * false being 0.0d.
  *
  * <p>Bound parameters are also cached, since the value is constant for each query.
+ *
+ * <p>Shared doc context values are accessible via the {@code _shared_<key>} variable convention
+ * (the {@code _shared_} prefix is stripped, and the remaining string is the key in the {@link
+ * SharedDocContext} map for each document). Values must be stored as {@link Number} instances.
+ * Retriever scores use the key format {@code retriever_<name>}, so the JS variable is {@code
+ * _shared_retriever_<name>}. {@code advanceExact} returns {@code false} when no entry is present
+ * for that document.
  */
 public final class JsScriptBindings extends Bindings {
+
+  static final String SHARED_CONTEXT_PREFIX = "_shared_";
 
   private final Bindings fieldDefBindings;
   private final Map<String, Object> scriptParams;
   private final Map<String, DoubleValuesSource> paramBindingsCache;
+  private final SharedDocContext sharedDocContext;
 
   /**
-   * Sole constructor.
+   * Constructor without shared doc context.
    *
-   * @param fieldDefBindings bindings for index fields, may contain fields still being registers in
-   *     a {@link com.yelp.nrtsearch.server.grpc.FieldDefRequest}
-   * @param scriptParams params from a {@link com.yelp.nrtsearch.server.grpc.Script} definition,
-   *     converted to java types
+   * @param fieldDefBindings bindings for index fields
+   * @param scriptParams params from a {@link com.yelp.nrtsearch.server.grpc.Script} definition
    * @throws NullPointerException if fieldDefBindings or scriptParams is null
    */
   public JsScriptBindings(Bindings fieldDefBindings, Map<String, Object> scriptParams) {
+    this(fieldDefBindings, scriptParams, null);
+  }
+
+  /**
+   * Constructor with shared doc context.
+   *
+   * @param fieldDefBindings bindings for index fields, may contain fields still being registered in
+   *     a {@link com.yelp.nrtsearch.server.grpc.FieldDefRequest}
+   * @param scriptParams params from a {@link com.yelp.nrtsearch.server.grpc.Script} definition,
+   *     converted to java types
+   * @param sharedDocContext per-document context shared across pipeline stages, or {@code null} if
+   *     not available
+   * @throws NullPointerException if fieldDefBindings or scriptParams is null
+   */
+  public JsScriptBindings(
+      Bindings fieldDefBindings,
+      Map<String, Object> scriptParams,
+      SharedDocContext sharedDocContext) {
     Objects.requireNonNull(fieldDefBindings);
     Objects.requireNonNull(scriptParams);
     this.fieldDefBindings = fieldDefBindings;
     this.scriptParams = scriptParams;
     this.paramBindingsCache = scriptParams.isEmpty() ? Collections.emptyMap() : new HashMap<>();
+    this.sharedDocContext = sharedDocContext;
   }
 
   /**
-   * Get value binding for an expression variable. Binds to script parameter value if present,
-   * otherwise the document field value.
+   * Get value binding for an expression variable. Resolution order:
+   *
+   * <ol>
+   *   <li>Variables prefixed with {@value SHARED_CONTEXT_PREFIX} are resolved against {@link
+   *       SharedDocContext} using the suffix as the key. Retriever scores use the key format {@code
+   *       retriever_<name>}, so the JS variable is {@code _shared_retriever_<name>}.
+   *   <li>Script parameter value (if present).
+   *   <li>Document field value via {@code fieldDefBindings}.
+   * </ol>
    *
    * @param name expression variable name
    * @return {@link DoubleValuesSource} factory to provide per segment variable evaluators.
-   * @throws IllegalArgumentException if then named script parameter exists, but is not of an
-   *     expected type
+   * @throws IllegalArgumentException if the named script parameter exists but is not of an expected
+   *     type
    */
   @Override
   public DoubleValuesSource getDoubleValuesSource(String name) {
+    if (name.startsWith(SHARED_CONTEXT_PREFIX)) {
+      String key = name.substring(SHARED_CONTEXT_PREFIX.length());
+      return new SharedContextDoubleValuesSource(sharedDocContext, key);
+    }
+
     DoubleValuesSource cachedSource = paramBindingsCache.get(name);
     if (cachedSource != null) {
       return cachedSource;
@@ -166,6 +207,92 @@ public final class JsScriptBindings extends Bindings {
     @Override
     public boolean advanceExact(int doc) {
       return true;
+    }
+  }
+
+  /**
+   * {@link DoubleValuesSource} that resolves per-document values from {@link SharedDocContext} by
+   * combining the segment leaf doc base with the segment-local doc id to form the global doc id.
+   */
+  static class SharedContextDoubleValuesSource extends DoubleValuesSource {
+
+    private final SharedDocContext sharedDocContext;
+    private final String key;
+
+    SharedContextDoubleValuesSource(SharedDocContext sharedDocContext, String key) {
+      this.sharedDocContext = sharedDocContext;
+      this.key = key;
+    }
+
+    @Override
+    public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores) throws IOException {
+      return new SharedContextDoubleValues(sharedDocContext, key, ctx.docBase);
+    }
+
+    @Override
+    public boolean needsScores() {
+      return false;
+    }
+
+    @Override
+    public DoubleValuesSource rewrite(IndexSearcher reader) {
+      return this;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(key);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj instanceof SharedContextDoubleValuesSource other) {
+        return Objects.equals(key, other.key) && sharedDocContext == other.sharedDocContext;
+      }
+      return false;
+    }
+
+    @Override
+    public String toString() {
+      return "SharedContextDoubleValuesSource(" + key + ")";
+    }
+
+    @Override
+    public boolean isCacheable(LeafReaderContext ctx) {
+      return false;
+    }
+  }
+
+  /** Resolves the shared context value for the current segment document as a double. */
+  static class SharedContextDoubleValues extends DoubleValues {
+
+    private final SharedDocContext sharedDocContext;
+    private final String key;
+    private final int leafDocBase;
+    private double currentValue;
+
+    SharedContextDoubleValues(SharedDocContext sharedDocContext, String key, int leafDocBase) {
+      this.sharedDocContext = sharedDocContext;
+      this.key = key;
+      this.leafDocBase = leafDocBase;
+    }
+
+    @Override
+    public double doubleValue() {
+      return currentValue;
+    }
+
+    @Override
+    public boolean advanceExact(int doc) {
+      if (sharedDocContext == null) {
+        return false;
+      }
+      Object value = sharedDocContext.getContext(leafDocBase + doc).get(key);
+      if (value instanceof Number n) {
+        currentValue = n.doubleValue();
+        return true;
+      }
+      return false;
     }
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/script/js/JsScriptEngine.java
+++ b/src/main/java/com/yelp/nrtsearch/server/script/js/JsScriptEngine.java
@@ -19,6 +19,7 @@ import com.yelp.nrtsearch.server.field.FieldDefBindings;
 import com.yelp.nrtsearch.server.script.ScoreScript;
 import com.yelp.nrtsearch.server.script.ScriptContext;
 import com.yelp.nrtsearch.server.script.ScriptEngine;
+import com.yelp.nrtsearch.server.script.ScriptFactoryContext;
 import java.text.ParseException;
 import org.apache.lucene.expressions.Bindings;
 import org.apache.lucene.expressions.Expression;
@@ -69,10 +70,12 @@ public class JsScriptEngine implements ScriptEngine {
           String.format("could not parse expression: %s", source), pe);
     }
     ScoreScript.Factory factory =
-        ((params, docLookup) -> {
-          Bindings fieldBindings = new FieldDefBindings(docLookup::getFieldDef);
-          return expr.getDoubleValuesSource(new JsScriptBindings(fieldBindings, params));
-        });
+        (ScriptFactoryContext factoryContext) -> {
+          Bindings fieldBindings = new FieldDefBindings(factoryContext.getDocLookup()::getFieldDef);
+          return expr.getDoubleValuesSource(
+              new JsScriptBindings(
+                  fieldBindings, factoryContext.getParams(), factoryContext.getSharedDocContext()));
+        };
     return context.factoryClazz.cast(factory);
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
@@ -21,6 +21,7 @@ import static com.yelp.nrtsearch.server.search.KnnUtils.resolveKnnQueryAndBoost;
 
 import com.yelp.nrtsearch.server.doc.DefaultSharedDocContext;
 import com.yelp.nrtsearch.server.doc.DocLookup;
+import com.yelp.nrtsearch.server.doc.SharedDocContext;
 import com.yelp.nrtsearch.server.field.FieldDef;
 import com.yelp.nrtsearch.server.field.IndexableFieldDef;
 import com.yelp.nrtsearch.server.field.RuntimeFieldDef;
@@ -126,12 +127,14 @@ public class SearchRequestProcessor {
 
     SearchContext.Builder contextBuilder = SearchContext.newBuilder();
     SearchResponse.Builder responseBuilder = SearchResponse.newBuilder();
+    SharedDocContext sharedDocContext = new DefaultSharedDocContext();
 
     contextBuilder
         .setIndexState(indexState)
         .setShardState(shardState)
         .setSearcherAndTaxonomy(searcherAndTaxonomy)
         .setResponseBuilder(responseBuilder)
+        .setSharedDocContext(sharedDocContext)
         .setTimestampSec(System.currentTimeMillis() / 1000)
         .setStartHit(searchRequest.getStartHit())
         .setTopHits(searchRequest.getTopHits())
@@ -146,7 +149,7 @@ public class SearchRequestProcessor {
         new DocLookup(
             indexState::getField, () -> indexState.getAllFields().keySet(), searcherAndTaxonomy);
     Map<String, FieldDef> queryVirtualFields =
-        getVirtualFields(indexLookupWithSearcher, searchRequest);
+        getVirtualFields(indexLookupWithSearcher, searchRequest, sharedDocContext);
     Map<String, FieldDef> queryRuntimeFields =
         getRuntimeFields(indexLookupWithSearcher, searchRequest);
 
@@ -177,6 +180,7 @@ public class SearchRequestProcessor {
               searcherAndTaxonomy,
               queryFields,
               docLookup,
+              sharedDocContext,
               contextBuilder,
               diagnostics,
               profileResult,
@@ -199,7 +203,8 @@ public class SearchRequestProcessor {
               searchRequest.getQueryText(),
               searchRequest.getQuery(),
               rootQueryNestedPath,
-              docLookup);
+              docLookup,
+              sharedDocContext);
 
       if (profileResult != null) {
         profileResult.setParsedQuery(query.toString());
@@ -303,8 +308,11 @@ public class SearchRequestProcessor {
     // Top-level rescorers are applied post-blending for multi-retriever requests
     // Each retriever has an optional L1 rescorer before blending
     contextBuilder.setRescorers(
-        getRescorers(indexState, searcherAndTaxonomy.searcher(), searchRequest.getRescorersList()));
-    contextBuilder.setSharedDocContext(new DefaultSharedDocContext());
+        getRescorers(
+            indexState,
+            searcherAndTaxonomy.searcher(),
+            searchRequest.getRescorersList(),
+            sharedDocContext));
 
     contextBuilder.setExtraContext(new ConcurrentHashMap<>());
 
@@ -320,7 +328,7 @@ public class SearchRequestProcessor {
    * @throws IllegalArgumentException if there are multiple virtual fields with the same name
    */
   private static Map<String, FieldDef> getVirtualFields(
-      DocLookup docLookup, SearchRequest searchRequest) {
+      DocLookup docLookup, SearchRequest searchRequest, SharedDocContext sharedDocContext) {
     if (searchRequest.getVirtualFieldsList().isEmpty()) {
       return new HashMap<>();
     }
@@ -337,7 +345,10 @@ public class SearchRequestProcessor {
       FieldDef virtualField =
           new VirtualFieldDef(
               vf.getName(),
-              factory.newFactory(ScriptFactoryContext.builder(params, docLookup).build()));
+              factory.newFactory(
+                  ScriptFactoryContext.builder(params, docLookup)
+                      .sharedDocContext(sharedDocContext)
+                      .build()));
       virtualFields.put(vf.getName(), virtualField);
     }
     return virtualFields;
@@ -466,7 +477,8 @@ public class SearchRequestProcessor {
       String queryText,
       com.yelp.nrtsearch.server.grpc.Query query,
       String queryNestedPath,
-      DocLookup docLookup) {
+      DocLookup docLookup,
+      SharedDocContext sharedDocContext) {
     Query q;
     if (!queryText.isEmpty()) {
       QueryBuilder queryParser = createQueryParser(state, null);
@@ -478,7 +490,8 @@ public class SearchRequestProcessor {
             String.format("could not parse queryText: %s", queryText));
       }
     } else {
-      QueryContext queryContext = new QueryContext(docLookup, state.getGlobalState());
+      QueryContext queryContext =
+          new QueryContext(docLookup, state.getGlobalState(), sharedDocContext);
       q = QUERY_NODE_MAPPER.getQuery(query, queryContext);
     }
 
@@ -554,14 +567,20 @@ public class SearchRequestProcessor {
 
   /** Builds a single RescoreTask from a Rescorer proto. */
   private static RescoreTask buildRescoreTask(
-      IndexState indexState, IndexSearcher searcher, Rescorer rescorer, String defaultRescorerName)
+      IndexState indexState,
+      IndexSearcher searcher,
+      Rescorer rescorer,
+      String defaultRescorerName,
+      SharedDocContext sharedDocContext)
       throws IOException {
     String rescorerName = rescorer.getName();
     RescoreOperation rescoreOperation;
 
     if (rescorer.hasQueryRescorer()) {
       QueryRescorer queryRescorer = rescorer.getQueryRescorer();
-      Query query = QUERY_NODE_MAPPER.getQuery(queryRescorer.getRescoreQuery(), indexState);
+      QueryContext queryContext =
+          new QueryContext(indexState.docLookup, indexState.getGlobalState(), sharedDocContext);
+      Query query = QUERY_NODE_MAPPER.getQuery(queryRescorer.getRescoreQuery(), queryContext);
       query = searcher.rewrite(query);
 
       rescoreOperation =
@@ -579,7 +598,11 @@ public class SearchRequestProcessor {
           ScriptService.getInstance().compile(script, ScoreScript.CONTEXT);
       Map<String, Object> params = ScriptParamsUtils.decodeParams(script.getParamsMap());
       DocLookup docLookup = indexState.docLookup;
-      rescoreOperation = new ScriptRescore(factory, params, docLookup);
+      ScriptFactoryContext scriptFactoryContext =
+          ScriptFactoryContext.builder(params, docLookup)
+              .sharedDocContext(sharedDocContext)
+              .build();
+      rescoreOperation = new ScriptRescore(factory, scriptFactoryContext);
     } else {
       throw new IllegalArgumentException(
           "Rescorer should define one of: QueryRescorer, PluginRescorer, ScriptRescorer");
@@ -595,13 +618,20 @@ public class SearchRequestProcessor {
 
   /** Parses rescorers defined in this search request. */
   private static List<RescoreTask> getRescorers(
-      IndexState indexState, IndexSearcher searcher, List<Rescorer> rescorerList)
+      IndexState indexState,
+      IndexSearcher searcher,
+      List<Rescorer> rescorerList,
+      SharedDocContext sharedDocContext)
       throws IOException {
     List<RescoreTask> rescorers = new ArrayList<>();
     for (int i = 0; i < rescorerList.size(); ++i) {
       rescorers.add(
           buildRescoreTask(
-              indexState, searcher, rescorerList.get(i), String.format("rescorer_%d", i)));
+              indexState,
+              searcher,
+              rescorerList.get(i),
+              String.format("rescorer_%d", i),
+              sharedDocContext));
     }
     return rescorers;
   }
@@ -619,7 +649,8 @@ public class SearchRequestProcessor {
       DocLookup docLookup) {
     // Do not apply nestedPath here. This is query is used to create a shared
     // weight.
-    Query childQuery = extractQuery(indexState, "", innerHit.getInnerQuery(), null, docLookup);
+    Query childQuery =
+        extractQuery(indexState, "", innerHit.getInnerQuery(), null, docLookup, null);
     return InnerHitContextBuilder.Builder()
         .withInnerHitName(innerHitName)
         .withQuery(childQuery)
@@ -680,6 +711,7 @@ public class SearchRequestProcessor {
       SearcherAndTaxonomy searcherAndTaxonomy,
       Map<String, FieldDef> queryFields,
       DocLookup docLookup,
+      SharedDocContext sharedDocContext,
       SearchContext.Builder searchContextBuilder,
       SearchResponse.Diagnostics.Builder diagnostics,
       ProfileResult.Builder profileResult,
@@ -723,7 +755,13 @@ public class SearchRequestProcessor {
                   : IndexState.resolveQueryNestedPath(
                       textRetriever.getQueryNestedPath(), docLookup);
           Query extractedQuery =
-              extractQuery(indexState, "", textRetriever.getQuery(), nestedQueryPath, docLookup);
+              extractQuery(
+                  indexState,
+                  "",
+                  textRetriever.getQuery(),
+                  nestedQueryPath,
+                  docLookup,
+                  sharedDocContext);
           query = searcher.rewrite(extractedQuery);
           if (doProfile) {
             retrieverProfileResult.setParsedQuery(extractedQuery.toString());
@@ -762,7 +800,11 @@ public class SearchRequestProcessor {
       if (retriever.hasRescorer()) {
         retrieverContextBuilder.rescoreTask(
             buildRescoreTask(
-                indexState, searcher, retriever.getRescorer(), retriever.getName() + "_rescorer"));
+                indexState,
+                searcher,
+                retriever.getRescorer(),
+                retriever.getName() + "_rescorer",
+                sharedDocContext));
       }
 
       CollectorCreatorContext collectorCreatorContext =

--- a/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
@@ -45,6 +45,7 @@ import com.yelp.nrtsearch.server.rescore.RescorerCreator;
 import com.yelp.nrtsearch.server.rescore.ScriptRescore;
 import com.yelp.nrtsearch.server.script.RuntimeScript;
 import com.yelp.nrtsearch.server.script.ScoreScript;
+import com.yelp.nrtsearch.server.script.ScriptFactoryContext;
 import com.yelp.nrtsearch.server.script.ScriptService;
 import com.yelp.nrtsearch.server.search.collectors.AdditionalCollectorManager;
 import com.yelp.nrtsearch.server.search.collectors.CollectorCreator;
@@ -334,7 +335,9 @@ public class SearchRequestProcessor {
           ScriptService.getInstance().compile(vf.getScript(), ScoreScript.CONTEXT);
       Map<String, Object> params = ScriptParamsUtils.decodeParams(vf.getScript().getParamsMap());
       FieldDef virtualField =
-          new VirtualFieldDef(vf.getName(), factory.newFactory(params, docLookup));
+          new VirtualFieldDef(
+              vf.getName(),
+              factory.newFactory(ScriptFactoryContext.builder(params, docLookup).build()));
       virtualFields.put(vf.getName(), virtualField);
     }
     return virtualFields;
@@ -576,7 +579,7 @@ public class SearchRequestProcessor {
           ScriptService.getInstance().compile(script, ScoreScript.CONTEXT);
       Map<String, Object> params = ScriptParamsUtils.decodeParams(script.getParamsMap());
       DocLookup docLookup = indexState.docLookup;
-      rescoreOperation = new ScriptRescore(factory.newFactory(params, docLookup));
+      rescoreOperation = new ScriptRescore(factory, params, docLookup);
     } else {
       throw new IllegalArgumentException(
           "Rescorer should define one of: QueryRescorer, PluginRescorer, ScriptRescorer");

--- a/src/main/java/com/yelp/nrtsearch/server/search/collectors/additional/ScriptValueProvider.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/collectors/additional/ScriptValueProvider.java
@@ -19,6 +19,7 @@ import com.yelp.nrtsearch.server.doc.DocLookup;
 import com.yelp.nrtsearch.server.grpc.Script;
 import com.yelp.nrtsearch.server.query.QueryUtils;
 import com.yelp.nrtsearch.server.script.ScoreScript;
+import com.yelp.nrtsearch.server.script.ScriptFactoryContext;
 import com.yelp.nrtsearch.server.script.ScriptService;
 import com.yelp.nrtsearch.server.utils.ScriptParamsUtils;
 import java.io.IOException;
@@ -41,7 +42,10 @@ class ScriptValueProvider implements ValueProvider {
   ScriptValueProvider(Script script, DocLookup lookup, double unsetValue) {
     ScoreScript.Factory factory = ScriptService.getInstance().compile(script, ScoreScript.CONTEXT);
     valuesSource =
-        factory.newFactory(ScriptParamsUtils.decodeParams(script.getParamsMap()), lookup);
+        factory.newFactory(
+            ScriptFactoryContext.builder(
+                    ScriptParamsUtils.decodeParams(script.getParamsMap()), lookup)
+                .build());
     unsetVal = unsetValue;
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderOperation.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/BlenderOperation.java
@@ -31,20 +31,28 @@ import org.apache.lucene.search.TotalHits;
  * Implementations are registered by name via {@link BlenderPlugin} and instantiated through {@link
  * BlenderCreator}.
  *
- * <p>The entry point is {@link #blend}, which accepts resolved per-retriever results (keyed by
- * name), merges, sorts, and paginates them. Callers are responsible for resolving retriever futures
- * before calling this method.
+ * <p>The pipeline is:
  *
- * <p>Implementations define the merge logic in {@link #mergeHits}, which operates on the raw
- * per-retriever hits before sorting and pagination are applied by the framework.
+ * <ol>
+ *   <li>{@link #mergeHits} — implementation-defined: deduplicate across retrievers and assign a
+ *       blended {@link BlendedScoreDoc#score}.
+ *   <li>{@link #blend} — framework default: calls {@link #mergeHits}, then {@link
+ *       #sortAndPaginate}. Implementations may override {@link #blend} to skip sorting/pagination
+ *       (e.g. {@link
+ *       com.yelp.nrtsearch.server.search.multiretriever.blender.operation.ScorelessRawMergeBlenderOperation}).
+ * </ol>
+ *
+ * <p>Each {@link BlendedScoreDoc} in the returned {@link TopDocs} preserves the raw per-retriever
+ * hits in {@link BlendedScoreDoc#getScoreDocs()}, which the caller (SearchHandler) uses to build
+ * retriever-score side values for downstream L2 rescorers.
  */
 public interface BlenderOperation {
 
   /**
    * Merge per-retriever hits into an unsorted, unpaginated flat list. Implementations deduplicate
-   * hits that appear in multiple retrievers and assign each a combined score (e.g. via RRF or a
-   * score-mode fold). The returned collection will be sorted by {@link BlendedScoreDoc#score} and
-   * paginated by the caller.
+   * hits that appear in multiple retrievers and assign each a combined {@link
+   * BlendedScoreDoc#score} (e.g. via RRF or a score-mode fold). The raw per-retriever hits must be
+   * preserved in {@link BlendedScoreDoc#getScoreDocs()} for diagnostics and side-value extraction.
    *
    * @param retrieverResults per-retriever {@link TopDocs} in declaration order, keyed by name
    * @param retrieverContexts per-retriever contexts in declaration order, keyed by name
@@ -55,7 +63,9 @@ public interface BlenderOperation {
       LinkedHashMap<String, RetrieverContext> retrieverContexts);
 
   /**
-   * Merges, sorts, and paginates resolved per-retriever results.
+   * Merges, sorts, and paginates resolved per-retriever results into a final ranked {@link
+   * TopDocs}. The returned hits are {@link BlendedScoreDoc} instances carrying per-retriever score
+   * breakdowns; the caller extracts these for response diagnostics and L2 rescore side values.
    *
    * @param retrieverResults per-retriever {@link TopDocs} in declaration order, keyed by name
    * @param retrieverContexts per-retriever contexts in declaration order, keyed by retriever name
@@ -77,13 +87,13 @@ public interface BlenderOperation {
   }
 
   /**
-   * Select and return the requested pagination window from merged hits without sorting the full
-   * list. Uses a min-heap of size {@code k = topHits} to find the top-k hits in O(n log k) time and
-   * O(k) space. The heap entries are then sorted in O(k log k) to produce the final page order.
+   * Selects the top-k window from merged hits in O(n log k) time using a min-heap, then returns
+   * them in descending score order. The heap entries are drained in O(k log k) to produce the final
+   * page without a full sort of all merged hits.
    *
    * @param merged unsorted merged hits from {@link #mergeHits}
    * @param startHit 0-based offset of the first hit to include in the returned page
-   * @param topHits maximum number of hits to return; {@code 0} returns empty; must be >= 0
+   * @param topHits maximum number of hits to return; must be >= 0
    * @return paginated {@link TopDocs}
    */
   static TopDocs sortAndPaginate(Collection<BlendedScoreDoc> merged, int startHit, int topHits) {

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/ScorelessRawMergeBlenderOperation.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/operation/ScorelessRawMergeBlenderOperation.java
@@ -28,18 +28,18 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 
 /**
- * {@link BlenderOperation} that deduplicates hits across retrievers (accumulating per-retriever
- * {@link ScoreDoc}s in a single {@link WeightedScoreDoc}) but assigns score 0 to every result and
- * skips sorting and pagination. Intended for callers that handle ranking and pagination on the
- * client side.
+ * {@link BlenderOperation} that deduplicates hits across retrievers and assigns score {@code 0} to
+ * every result without sorting or paginating. This is intended for use with an L2 {@link
+ * com.yelp.nrtsearch.server.rescore.ScriptRescore} that takes full ownership of ranking via
+ * retriever side values (e.g. {@code _side_retriever_text}, {@code _side_retriever_knn}).
  */
 public class ScorelessRawMergeBlenderOperation implements BlenderOperation {
 
   /**
-   * Deduplicates hits by doc ID across retrievers. Each unique document is represented by a {@link
-   * WeightedScoreDoc} with weight 0, so {@link BlendedScoreDoc#score} remains 0 regardless of how
-   * many retrievers contributed. All per-retriever hits for the same document are preserved in
-   * {@link BlendedScoreDoc#getScoreDocs()}.
+   * Deduplicates hits by doc ID. Each unique document is represented by a {@link WeightedScoreDoc}
+   * with weight {@code 0}, so {@link BlendedScoreDoc#score} stays {@code 0} regardless of how many
+   * retrievers contributed. All per-retriever raw hits are preserved in {@link
+   * BlendedScoreDoc#getScoreDocs()} for side-value extraction and response diagnostics.
    */
   @Override
   public Collection<BlendedScoreDoc> mergeHits(
@@ -65,8 +65,8 @@ public class ScorelessRawMergeBlenderOperation implements BlenderOperation {
   }
 
   /**
-   * Returns all merged hits as-is without sorting or pagination. The {@code startHit} and {@code
-   * topHits} parameters are ignored.
+   * Returns all merged hits without sorting or pagination. The {@code startHit} and {@code topHits}
+   * parameters are ignored; an L2 rescorer is expected to produce the final ordering.
    */
   @Override
   public TopDocs blend(

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/BlendedScoreDoc.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/blender/score/BlendedScoreDoc.java
@@ -25,8 +25,14 @@ import org.apache.lucene.search.ScoreDoc;
  * score and must be kept up to date by each {@link #add} implementation. It drives result ordering
  * directly — no separate sorting-score indirection.
  *
- * <p>The original per-retriever hits are preserved in {@link #scoreDocs}, keyed by retriever name
- * in insertion order, for diagnostics and downstream inspection.
+ * <p>The raw per-retriever hits are preserved in {@link #scoreDocs}, keyed by retriever name in
+ * insertion order. These are used by {@code SearchHandler} to:
+ *
+ * <ul>
+ *   <li>Populate {@code retrieverScores} in the search response for each hit.
+ *   <li>Populate per-retriever scores in the shared doc context so L2 rescore scripts can read them
+ *       via {@code get_shared_double("retriever_<name>", defaultValue)}.
+ * </ul>
  *
  * <p>Subclasses define their own merging semantics by implementing {@link #add(String, int, float,
  * ScoreDoc)}, which is called for every retriever hit after the first. The first hit is supplied at

--- a/src/test/java/com/yelp/nrtsearch/server/handler/BuildRetrieverSideValuesTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/handler/BuildRetrieverSideValuesTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.handler;
+
+import static org.junit.Assert.*;
+
+import com.yelp.nrtsearch.server.doc.DefaultSharedDocContext;
+import com.yelp.nrtsearch.server.doc.SharedDocContext;
+import com.yelp.nrtsearch.server.search.multiretriever.blender.score.BlendedScoreDoc;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.junit.Test;
+
+public class BuildRetrieverSideValuesTest {
+
+  /** Minimal BlendedScoreDoc subclass for testing. */
+  private static BlendedScoreDoc blended(
+      int docId, String retriever1, float score1, String retriever2, float score2) {
+    BlendedScoreDoc b =
+        new BlendedScoreDoc(retriever1, new ScoreDoc(docId, score1), score1) {
+          @Override
+          public void add(String retrieverName, int rank, float weight, ScoreDoc scoreDoc) {
+            score = score + scoreDoc.score;
+            scoreDocs.put(retrieverName, scoreDoc);
+          }
+        };
+    b.add(retriever2, 1, 1.0f, new ScoreDoc(docId, score2));
+    return b;
+  }
+
+  @Test
+  public void testEmptyHitsNoWrites() {
+    SharedDocContext ctx = new DefaultSharedDocContext();
+    TopDocs hits = new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
+    SearchHandler.populateRetrieverScores(hits, ctx);
+    // No documents were visited; nothing to assert, just verify no exception.
+  }
+
+  @Test
+  public void testPlainScoreDocsNoWrites() {
+    SharedDocContext ctx = new DefaultSharedDocContext();
+    ScoreDoc[] docs = {new ScoreDoc(0, 3.0f), new ScoreDoc(1, 2.0f)};
+    TopDocs hits = new TopDocs(new TotalHits(2, TotalHits.Relation.EQUAL_TO), docs);
+    SearchHandler.populateRetrieverScores(hits, ctx);
+    // Plain ScoreDocs carry no retriever data — context should be empty for those docs.
+    assertTrue(ctx.getContext(0).isEmpty());
+    assertTrue(ctx.getContext(1).isEmpty());
+  }
+
+  @Test
+  public void testRetrieverScoresStoredWithPrefix() {
+    SharedDocContext ctx = new DefaultSharedDocContext();
+    BlendedScoreDoc hit = blended(5, "text", 1.5f, "knn", 0.8f);
+    TopDocs hits = new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] {hit});
+    SearchHandler.populateRetrieverScores(hits, ctx);
+
+    assertEquals(1.5, (Double) ctx.getContext(5).get("retriever_text"), 0.0001);
+    assertEquals(0.8, (Double) ctx.getContext(5).get("retriever_knn"), 0.001);
+    // Raw retriever name without prefix is not present.
+    assertNull(ctx.getContext(5).get("text"));
+  }
+
+  @Test
+  public void testMultipleDocsStoredUnderSameKey() {
+    SharedDocContext ctx = new DefaultSharedDocContext();
+    BlendedScoreDoc hit0 = blended(0, "text", 2.0f, "knn", 1.0f);
+    BlendedScoreDoc hit1 = blended(1, "text", 3.0f, "knn", 0.5f);
+    TopDocs hits =
+        new TopDocs(new TotalHits(2, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] {hit0, hit1});
+    SearchHandler.populateRetrieverScores(hits, ctx);
+
+    assertEquals(2.0, (Double) ctx.getContext(0).get("retriever_text"), 0.0001);
+    assertEquals(3.0, (Double) ctx.getContext(1).get("retriever_text"), 0.0001);
+    assertEquals(1.0, (Double) ctx.getContext(0).get("retriever_knn"), 0.001);
+    assertEquals(0.5, (Double) ctx.getContext(1).get("retriever_knn"), 0.001);
+  }
+
+  @Test
+  public void testMixedPlainAndBlendedHits() {
+    SharedDocContext ctx = new DefaultSharedDocContext();
+    BlendedScoreDoc blendedHit = blended(0, "r1", 5.0f, "r2", 3.0f);
+    ScoreDoc plainHit = new ScoreDoc(1, 2.0f);
+    TopDocs hits =
+        new TopDocs(
+            new TotalHits(2, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] {blendedHit, plainHit});
+    SearchHandler.populateRetrieverScores(hits, ctx);
+
+    assertEquals(5.0, (Double) ctx.getContext(0).get("retriever_r1"), 0.0001);
+    // Plain ScoreDoc at doc 1 should have no retriever entries.
+    assertNull(ctx.getContext(1).get("retriever_r1"));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/query/NestedQueryWithParentAccessTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/query/NestedQueryWithParentAccessTest.java
@@ -29,6 +29,7 @@ import com.yelp.nrtsearch.server.plugins.ScriptPlugin;
 import com.yelp.nrtsearch.server.script.ScoreScript;
 import com.yelp.nrtsearch.server.script.ScriptContext;
 import com.yelp.nrtsearch.server.script.ScriptEngine;
+import com.yelp.nrtsearch.server.script.ScriptFactoryContext;
 import com.yelp.nrtsearch.server.script.ScriptService;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.ByteArrayInputStream;
@@ -138,7 +139,8 @@ public class NestedQueryWithParentAccessTest extends ServerTestCase {
     @Override
     public <T> T compile(String source, ScriptContext<T> context) {
       ScoreScript.Factory factory =
-          ((params, docLookup) -> new TestScriptFactory(params, docLookup, source));
+          (ScriptFactoryContext ctx) ->
+              new TestScriptFactory(ctx.getParams(), ctx.getDocLookup(), source);
       return context.factoryClazz.cast(factory);
     }
   }
@@ -180,7 +182,7 @@ public class NestedQueryWithParentAccessTest extends ServerTestCase {
         DocLookup docLookup,
         LeafReaderContext context,
         DoubleValues scores) {
-      super(params, docLookup, context, scores);
+      super(params, docLookup, context, scores, null);
     }
 
     @Override
@@ -263,7 +265,7 @@ public class NestedQueryWithParentAccessTest extends ServerTestCase {
         DocLookup docLookup,
         LeafReaderContext context,
         DoubleValues scores) {
-      super(params, docLookup, context, scores);
+      super(params, docLookup, context, scores, null);
     }
 
     @Override

--- a/src/test/java/com/yelp/nrtsearch/server/query/QueryNodeMapperTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/query/QueryNodeMapperTest.java
@@ -32,6 +32,7 @@ import com.yelp.nrtsearch.server.plugins.ScriptPlugin;
 import com.yelp.nrtsearch.server.script.ScoreScript;
 import com.yelp.nrtsearch.server.script.ScriptContext;
 import com.yelp.nrtsearch.server.script.ScriptEngine;
+import com.yelp.nrtsearch.server.script.ScriptFactoryContext;
 import com.yelp.nrtsearch.server.script.ScriptService;
 import com.yelp.nrtsearch.server.search.SearchContext;
 import com.yelp.nrtsearch.server.search.SearchRequestProcessor;
@@ -132,7 +133,8 @@ public class QueryNodeMapperTest extends ServerTestCase {
     @Override
     public <T> T compile(String source, ScriptContext<T> context) {
       ScoreScript.Factory factory =
-          ((params, docLookup) -> new TestScriptFactory(params, docLookup, source));
+          (ScriptFactoryContext ctx) ->
+              new TestScriptFactory(ctx.getParams(), ctx.getDocLookup(), source);
       return context.factoryClazz.cast(factory);
     }
   }
@@ -170,7 +172,7 @@ public class QueryNodeMapperTest extends ServerTestCase {
         DocLookup docLookup,
         LeafReaderContext context,
         DoubleValues scores) {
-      super(params, docLookup, context, scores);
+      super(params, docLookup, context, scores, null);
     }
 
     @Override

--- a/src/test/java/com/yelp/nrtsearch/server/rescore/ScriptRescoreTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/rescore/ScriptRescoreTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.yelp.nrtsearch.server.doc.DefaultSharedDocContext;
 import com.yelp.nrtsearch.server.doc.DocLookup;
 import com.yelp.nrtsearch.server.script.ScoreScript;
 import com.yelp.nrtsearch.server.script.ScriptFactoryContext;
@@ -146,7 +145,9 @@ public class ScriptRescoreTest {
   /** Wraps a pre-built DoubleValuesSource in a ScoreScript.Factory for testing. */
   private static ScriptRescore rescoreFromSource(DoubleValuesSource source) {
     ScoreScript.Factory factory = (ScriptFactoryContext ctx) -> source;
-    return new ScriptRescore(factory, Collections.emptyMap(), mock(DocLookup.class));
+    ScriptFactoryContext scriptFactoryContext =
+        ScriptFactoryContext.builder(Collections.emptyMap(), mock(DocLookup.class)).build();
+    return new ScriptRescore(factory, scriptFactoryContext);
   }
 
   private RescoreContext buildContext(IndexSearcher searcher) {
@@ -156,7 +157,6 @@ public class ScriptRescoreTest {
         mock(org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager.SearcherAndTaxonomy.class);
     when(searchContext.getSearcherAndTaxonomy()).thenReturn(sat);
     when(sat.searcher()).thenReturn(searcher);
-    when(searchContext.getSharedDocContext()).thenReturn(new DefaultSharedDocContext());
     return new RescoreContext(3, searchContext);
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/rescore/ScriptRescoreTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/rescore/ScriptRescoreTest.java
@@ -19,6 +19,10 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.yelp.nrtsearch.server.doc.DefaultSharedDocContext;
+import com.yelp.nrtsearch.server.doc.DocLookup;
+import com.yelp.nrtsearch.server.script.ScoreScript;
+import com.yelp.nrtsearch.server.script.ScriptFactoryContext;
 import java.io.IOException;
 import java.util.Collections;
 import org.apache.lucene.index.LeafReaderContext;
@@ -139,6 +143,12 @@ public class ScriptRescoreTest {
     };
   }
 
+  /** Wraps a pre-built DoubleValuesSource in a ScoreScript.Factory for testing. */
+  private static ScriptRescore rescoreFromSource(DoubleValuesSource source) {
+    ScoreScript.Factory factory = (ScriptFactoryContext ctx) -> source;
+    return new ScriptRescore(factory, Collections.emptyMap(), mock(DocLookup.class));
+  }
+
   private RescoreContext buildContext(IndexSearcher searcher) {
     com.yelp.nrtsearch.server.search.SearchContext searchContext =
         mock(com.yelp.nrtsearch.server.search.SearchContext.class);
@@ -146,6 +156,7 @@ public class ScriptRescoreTest {
         mock(org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager.SearcherAndTaxonomy.class);
     when(searchContext.getSearcherAndTaxonomy()).thenReturn(sat);
     when(sat.searcher()).thenReturn(searcher);
+    when(searchContext.getSharedDocContext()).thenReturn(new DefaultSharedDocContext());
     return new RescoreContext(3, searchContext);
   }
 
@@ -173,7 +184,7 @@ public class ScriptRescoreTest {
         ScoreDoc[] input = {new ScoreDoc(0, 3.0f), new ScoreDoc(1, 2.0f), new ScoreDoc(2, 1.0f)};
         TopDocs hits = new TopDocs(new TotalHits(3, Relation.EQUAL_TO), input);
 
-        ScriptRescore rescorer = new ScriptRescore(constantSource(5.0));
+        ScriptRescore rescorer = rescoreFromSource(constantSource(5.0));
         TopDocs result = rescorer.rescore(hits, buildContext(searcher));
 
         assertEquals(3, result.scoreDocs.length);
@@ -210,7 +221,7 @@ public class ScriptRescoreTest {
         TopDocs hits = new TopDocs(new TotalHits(3, Relation.EQUAL_TO), input);
 
         // Script doubles the previous score.
-        ScriptRescore rescorer = new ScriptRescore(multiplierOfPreviousScore(2.0));
+        ScriptRescore rescorer = rescoreFromSource(multiplierOfPreviousScore(2.0));
         TopDocs result = rescorer.rescore(hits, buildContext(searcher));
 
         assertEquals(3, result.scoreDocs.length);
@@ -249,7 +260,7 @@ public class ScriptRescoreTest {
         ScoreDoc[] input = {new ScoreDoc(0, 10.0f), new ScoreDoc(1, 5.0f), new ScoreDoc(2, 1.0f)};
         TopDocs hits = new TopDocs(new TotalHits(3, Relation.EQUAL_TO), input);
 
-        ScriptRescore rescorer = new ScriptRescore(multiplierOfPreviousScore(3.0));
+        ScriptRescore rescorer = rescoreFromSource(multiplierOfPreviousScore(3.0));
         TopDocs result = rescorer.rescore(hits, buildContext(searcher));
 
         assertEquals(3, result.scoreDocs.length);
@@ -336,7 +347,7 @@ public class ScriptRescoreTest {
               }
             };
 
-        ScriptRescore rescorer = new ScriptRescore(invertingSource);
+        ScriptRescore rescorer = rescoreFromSource(invertingSource);
         TopDocs result = rescorer.rescore(hits, buildContext(searcher));
 
         assertEquals(3, result.scoreDocs.length);
@@ -373,7 +384,7 @@ public class ScriptRescoreTest {
                 new TotalHits(999, Relation.GREATER_THAN_OR_EQUAL_TO),
                 new ScoreDoc[] {new ScoreDoc(0, 1.0f)});
 
-        ScriptRescore rescorer = new ScriptRescore(constantSource(2.0));
+        ScriptRescore rescorer = rescoreFromSource(constantSource(2.0));
         TopDocs result = rescorer.rescore(hits, buildContext(searcher));
 
         assertEquals(999, result.totalHits.value());

--- a/src/test/java/com/yelp/nrtsearch/server/script/ScoreScriptTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/script/ScoreScriptTest.java
@@ -129,7 +129,8 @@ public class ScoreScriptTest {
     @Override
     public <T> T compile(String source, ScriptContext<T> context) {
       ScoreScript.Factory factory =
-          ((params, docLookup) -> new TestScriptFactory(params, docLookup, source));
+          (ScriptFactoryContext ctx) ->
+              new TestScriptFactory(ctx.getParams(), ctx.getDocLookup(), source);
       return context.factoryClazz.cast(factory);
     }
   }
@@ -183,7 +184,7 @@ public class ScoreScriptTest {
         DocLookup docLookup,
         LeafReaderContext context,
         DoubleValues scores) {
-      super(params, docLookup, context, scores);
+      super(params, docLookup, context, scores, null);
     }
 
     @Override
@@ -345,7 +346,7 @@ public class ScoreScriptTest {
         DocLookup docLookup,
         LeafReaderContext context,
         DoubleValues scores) {
-      super(params, docLookup, context, scores);
+      super(params, docLookup, context, scores, null);
     }
 
     @Override
@@ -454,7 +455,7 @@ public class ScoreScriptTest {
         DocLookup docLookup,
         LeafReaderContext context,
         DoubleValues scores) {
-      super(params, docLookup, context, scores);
+      super(params, docLookup, context, scores, null);
     }
 
     @Override
@@ -485,7 +486,7 @@ public class ScoreScriptTest {
         DocLookup docLookup,
         LeafReaderContext context,
         DoubleValues scores) {
-      super(params, docLookup, context, scores);
+      super(params, docLookup, context, scores, null);
     }
 
     @Override
@@ -524,7 +525,7 @@ public class ScoreScriptTest {
         DocLookup docLookup,
         LeafReaderContext context,
         DoubleValues scores) {
-      super(params, docLookup, context, scores);
+      super(params, docLookup, context, scores, null);
     }
 
     @Override
@@ -553,7 +554,7 @@ public class ScoreScriptTest {
         DocLookup docLookup,
         LeafReaderContext context,
         DoubleValues scores) {
-      super(params, docLookup, context, scores);
+      super(params, docLookup, context, scores, null);
     }
 
     @Override
@@ -611,7 +612,7 @@ public class ScoreScriptTest {
         DocLookup docLookup,
         LeafReaderContext context,
         DoubleValues scores) {
-      super(params, docLookup, context, scores);
+      super(params, docLookup, context, scores, null);
     }
 
     @Override
@@ -633,7 +634,7 @@ public class ScoreScriptTest {
         DocLookup docLookup,
         LeafReaderContext context,
         DoubleValues scores) {
-      super(params, docLookup, context, scores);
+      super(params, docLookup, context, scores, null);
     }
 
     @Override
@@ -666,7 +667,7 @@ public class ScoreScriptTest {
         DocLookup docLookup,
         LeafReaderContext context,
         DoubleValues scores) {
-      super(params, docLookup, context, scores);
+      super(params, docLookup, context, scores, null);
     }
 
     @Override

--- a/src/test/java/com/yelp/nrtsearch/server/script/ScriptServiceTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/script/ScriptServiceTest.java
@@ -65,7 +65,7 @@ public class ScriptServiceTest {
 
     @Override
     public <T> T compile(String source, ScriptContext<T> context) {
-      ScoreScript.Factory factory = ((params, docLookup) -> null);
+      ScoreScript.Factory factory = ((ScriptFactoryContext ctx) -> null);
       return context.factoryClazz.cast(factory);
     }
   }

--- a/src/test/java/com/yelp/nrtsearch/server/script/js/JsScriptSideValuesTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/script/js/JsScriptSideValuesTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.script.js;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+import com.yelp.nrtsearch.server.doc.DefaultSharedDocContext;
+import com.yelp.nrtsearch.server.doc.SharedDocContext;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.lucene.expressions.Bindings;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DoubleValues;
+import org.apache.lucene.search.DoubleValuesSource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Tests for JS variable resolution of shared doc context values. Retriever scores are stored in
+ * SharedDocContext under the key {@code retriever_<name>} and accessed in JS expressions as {@code
+ * _shared_retriever_<name>}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class JsScriptSideValuesTest {
+
+  /** A no-op Bindings that throws for any lookup to confirm shared-context bypass field lookup. */
+  private static final Bindings EMPTY_BINDINGS =
+      new Bindings() {
+        @Override
+        public DoubleValuesSource getDoubleValuesSource(String name) {
+          throw new IllegalArgumentException("Unexpected field lookup: " + name);
+        }
+      };
+
+  private static LeafReaderContext leafWithBase(int docBase) {
+    LeafReaderContext ctx = mock(LeafReaderContext.class);
+    try {
+      java.lang.reflect.Field f = LeafReaderContext.class.getField("docBase");
+      f.setAccessible(true);
+      f.set(ctx, docBase);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return ctx;
+  }
+
+  @Test
+  public void testRetrieverScoreResolvesViaJsVariable() throws IOException {
+    SharedDocContext ctx = new DefaultSharedDocContext();
+    ctx.getContext(0).put("retriever_text", 7.25);
+    JsScriptBindings bindings = new JsScriptBindings(EMPTY_BINDINGS, Collections.emptyMap(), ctx);
+
+    DoubleValuesSource source = bindings.getDoubleValuesSource("_shared_retriever_text");
+    assertNotNull(source);
+
+    LeafReaderContext leaf = leafWithBase(0);
+    DoubleValues values = source.getValues(leaf, null);
+    assertTrue(values.advanceExact(0)); // doc present → true
+    assertEquals(7.25, values.doubleValue(), 0.0001);
+  }
+
+  @Test
+  public void testAdvanceExactReturnsFalseWhenDocMissing() throws IOException {
+    SharedDocContext ctx = new DefaultSharedDocContext();
+    ctx.getContext(0).put("retriever_text", 5.0); // only doc 0
+    JsScriptBindings bindings = new JsScriptBindings(EMPTY_BINDINGS, Collections.emptyMap(), ctx);
+
+    DoubleValuesSource source = bindings.getDoubleValuesSource("_shared_retriever_text");
+    LeafReaderContext leaf = leafWithBase(0);
+    DoubleValues values = source.getValues(leaf, null);
+    assertFalse(values.advanceExact(99)); // doc 99 not present → false
+  }
+
+  @Test
+  public void testSharedContextValueUsesLeafDocBase() throws IOException {
+    // globalDoc=10: leafBase=10, segmentDoc=0
+    SharedDocContext ctx = new DefaultSharedDocContext();
+    ctx.getContext(10).put("retriever_knn", 3.5);
+    JsScriptBindings bindings = new JsScriptBindings(EMPTY_BINDINGS, Collections.emptyMap(), ctx);
+
+    DoubleValuesSource source = bindings.getDoubleValuesSource("_shared_retriever_knn");
+    LeafReaderContext leaf = leafWithBase(10);
+    DoubleValues values = source.getValues(leaf, null);
+    assertTrue(values.advanceExact(0)); // segmentDoc=0 → globalDoc=10
+    assertEquals(3.5, values.doubleValue(), 0.0001);
+  }
+
+  @Test
+  public void testNonSharedPrefixDelegatesNormally() {
+    JsScriptBindings bindings =
+        new JsScriptBindings(EMPTY_BINDINGS, Map.of("multiplier", 2.0), null);
+    DoubleValuesSource source = bindings.getDoubleValuesSource("multiplier");
+    assertNotNull(source);
+  }
+
+  @Test
+  public void testSharedPrefixWithNullContextReturnsFalse() throws IOException {
+    // null sharedDocContext → advanceExact always returns false
+    JsScriptBindings bindings = new JsScriptBindings(EMPTY_BINDINGS, Collections.emptyMap(), null);
+
+    DoubleValuesSource source = bindings.getDoubleValuesSource("_shared_retriever_anything");
+    assertNotNull(source);
+    LeafReaderContext leaf = leafWithBase(0);
+    DoubleValues values = source.getValues(leaf, null);
+    assertFalse(values.advanceExact(0));
+  }
+}


### PR DESCRIPTION
⏺ RP-15633 (https://jira.yelpcorp.com/browse/RP-15633) Add retriever score side values for L2 ScriptRescorer

*Breaking Change on All Script Plugins*

- Creating scriptFactoryContext to convey all necessary contexts for script factory to avoid future changes.
- Add the retriever_score and pass to script factory through sharedDocContext, allowing easy access from the rescorers

Test passed local manual test:  https://fluffy.yelpcorp.com/i/QlQZks5Twn7rmZB6kzktnbL6VsVZJ25m.html

Once merged. Need to update the core image with migration for [all](https://sourcegraph.yelpcorp.com/search?q=repo:%5Ejava-packages/nrtsearch-plugin+scoreScript.factory&patternType=keyword&sm=0) related plugins:
- painless (to be verified)
- inference
- lucyscoring
- queryscore
- maptype (test only)