### PR TITLE
Aggregations and Facets Support for Multi-Retriever

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -1120,7 +1120,7 @@ message SearchResponse {
             // Vector diagnostics, only populated for KNN retrievers
             VectorDiagnostics vectorDiagnostics = 4;
             // Whether collection for this retriever was cut short by a timeout
-            bool hadTimeout = 5;
+            bool hitTimeout = 5;
             // Whether collection for this retriever terminated early (terminateAfter reached)
             bool terminatedEarly = 6;
         }

--- a/clientlib/src/main/proto/yelp/nrtsearch/search.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/search.proto
@@ -1119,6 +1119,10 @@ message SearchResponse {
             TotalHits totalHits = 3;
             // Vector diagnostics, only populated for KNN retrievers
             VectorDiagnostics vectorDiagnostics = 4;
+            // Whether collection for this retriever was cut short by a timeout
+            bool hadTimeout = 5;
+            // Whether collection for this retriever terminated early (terminateAfter reached)
+            bool terminatedEarly = 6;
         }
         // Diagnostics specific to multi-retriever search
         message MultiRetrieverDiagnostics {
@@ -1430,6 +1434,8 @@ message ProfileResult {
     message MultiRetrieverProfileResult {
         // Per-retriever profile results keyed by retriever name
         map<string, ProfileResult> retrieverProfileResults = 1;
+        // Profile result for the aggregation pass (facets + collectors) run after blending
+        ProfileResult aggregationProfileResult = 2;
     }
 
     // Stats for search phase

--- a/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
@@ -93,6 +93,10 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
   private final ExecutorService searchExecutor;
   private final boolean warming;
 
+  /** Return value of {@link #executeMultiRetriever}. */
+  private record MultiRetrieverResult(
+      TopDocs topDocs, boolean hadTimeout, boolean terminatedEarly) {}
+
   public SearchHandler(GlobalState globalState) {
     super(globalState);
     this.searchExecutor = globalState.getSearchExecutor();
@@ -181,10 +185,16 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
 
       TopDocs hits;
       if (searchContext.getMultiRetrieverContext() != null) {
-        hits =
+        MultiRetrieverResult multiRetrieverResult =
             executeMultiRetriever(searchContext, s.searcher(), diagnostics, profileResultBuilder);
+        hits = multiRetrieverResult.topDocs();
+        DeadlineUtils.checkDeadline(
+            "SearchHandler: post multi-retriever recall", diagnostics, "SEARCH");
         // Run aggregations (facets + collectors) against the union query after blending.
-        // The union query already covers all retriever matches, so counts are not double-counted.
+        // Note: facet counts reflect the full match set of the union query, not the recalled
+        // top-K per retriever. For KNN retrievers this is equivalent (KnnFloatVectorQuery is
+        // inherently bounded to k). For text retrievers, counts may include documents beyond
+        // the topHits recall window if the underlying query matches more docs than topHits.
         if (!searchRequest.getFacetsList().isEmpty()) {
           SearcherResult searcherResult =
               runDrillSidewaysSearch(
@@ -198,14 +208,30 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
               .getResponseBuilder()
               .putAllCollectorResults(searcherResult.getCollectorResults());
         }
+
+        searchContext
+            .getResponseBuilder()
+            .setHitTimeout(
+                multiRetrieverResult.hadTimeout() || searchContext.getCollector().hadTimeout());
+        searchContext
+            .getResponseBuilder()
+            .setTerminatedEarly(
+                multiRetrieverResult.terminatedEarly()
+                    || searchContext.getCollector().terminatedEarly());
+
+        if (profileResultBuilder != null
+            && (!searchRequest.getFacetsList().isEmpty()
+                || searchRequest.getCollectorsCount() > 0)) {
+          searchContext
+              .getCollector()
+              .maybeAddProfiling(
+                  profileResultBuilder
+                      .getMultiRetrieverProfileResultBuilder()
+                      .getAggregationProfileResultBuilder());
+        }
       } else {
         SearcherResult searcherResult;
         if (!searchRequest.getFacetsList().isEmpty()) {
-          // Run the drill sideways search on the direct executor to run subtasks in the
-          // current (grpc) thread. If we use the search thread pool for this, it can cause a
-          // deadlock trying to execute the dependent parallel search tasks. Since we do not
-          // currently add additional drill down definitions, there will only be one drill
-          // sideways task per query.
           searcherResult =
               runDrillSidewaysSearch(
                   s, indexState, shardState, searchContext, searchRequest, diagnostics, null);
@@ -214,7 +240,6 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
         }
         hits = searcherResult.getTopDocs();
 
-        // add results from any extra collectors
         searchContext
             .getResponseBuilder()
             .putAllCollectorResults(searcherResult.getCollectorResults());
@@ -229,8 +254,7 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
 
       DeadlineUtils.checkDeadline("SearchHandler: post recall", diagnostics, "SEARCH");
 
-      // add detailed timing metrics for query execution
-      if (profileResultBuilder != null) {
+      if (profileResultBuilder != null && searchContext.getMultiRetrieverContext() == null) {
         searchContext.getCollector().maybeAddProfiling(profileResultBuilder);
       }
 
@@ -493,7 +517,7 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
    * Execute per-retriever searches in parallel, apply optional per-retriever L1 rescoring, then
    * blend the results into a single ranked TopDocs.
    */
-  private TopDocs executeMultiRetriever(
+  private MultiRetrieverResult executeMultiRetriever(
       SearchContext searchContext,
       IndexSearcher searcher,
       SearchResponse.Diagnostics.Builder diagnostics,
@@ -503,7 +527,12 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
     LinkedHashMap<String, RetrieverContext> retrieverContexts =
         new LinkedHashMap<>(multiRetrieverContext.getRetrieverContextMap());
 
-    record RetrieverResult(TopDocs topDocs, double searchTimeMs, double rescoreTimeMs) {}
+    record RetrieverResult(
+        TopDocs topDocs,
+        double searchTimeMs,
+        double rescoreTimeMs,
+        boolean hadTimeout,
+        boolean terminatedEarly) {}
 
     LinkedHashMap<String, Future<RetrieverResult>> retrieverFutures = new LinkedHashMap<>();
     for (Map.Entry<String, RetrieverContext> entry : retrieverContexts.entrySet()) {
@@ -513,11 +542,10 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
           name,
           searchExecutor.submit(
               () -> {
+                DocCollector docCollector = retrieverContext.getDocCollector();
                 long searchStart = System.nanoTime();
                 SearcherResult result =
-                    searcher.search(
-                        retrieverContext.getQuery(),
-                        retrieverContext.getDocCollector().getWrappedManager());
+                    searcher.search(retrieverContext.getQuery(), docCollector.getWrappedManager());
                 TopDocs topDocs = result.getTopDocs();
                 double searchTimeMs = (System.nanoTime() - searchStart) / 1_000_000.0;
 
@@ -527,7 +555,12 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
                   topDocs = retrieverContext.getRescoreTask().rescore(topDocs, searchContext);
                   rescoreTimeMs = (System.nanoTime() - rescoreStart) / 1_000_000.0;
                 }
-                return new RetrieverResult(topDocs, searchTimeMs, rescoreTimeMs);
+                return new RetrieverResult(
+                    topDocs,
+                    searchTimeMs,
+                    rescoreTimeMs,
+                    docCollector.hadTimeout(),
+                    docCollector.terminatedEarly());
               }));
     }
 
@@ -541,15 +574,22 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
             searchContext.getRescorers());
 
     LinkedHashMap<String, RetrieverResult> retrieverResults = new LinkedHashMap<>();
+    boolean anyRetrieverHadTimeout = false;
+    boolean anyRetrieverTerminatedEarly = false;
     for (Map.Entry<String, Future<RetrieverResult>> entry : retrieverFutures.entrySet()) {
       String name = entry.getKey();
       try {
-        retrieverResults.put(name, entry.getValue().get());
+        RetrieverResult result = entry.getValue().get();
+        retrieverResults.put(name, result);
+        anyRetrieverHadTimeout |= result.hadTimeout();
+        anyRetrieverTerminatedEarly |= result.terminatedEarly();
       } catch (ExecutionException e) {
         Throwable cause = e.getCause() != null ? e.getCause() : e;
         throw new RuntimeException("Retriever '" + name + "' failed: " + cause.getMessage(), cause);
       }
     }
+
+    DeadlineUtils.checkDeadline("SearchHandler: post retriever recall", diagnostics, "SEARCH");
 
     LinkedHashMap<String, TopDocs> retrieverTopDocs = new LinkedHashMap<>();
     retrieverResults.forEach((name, result) -> retrieverTopDocs.put(name, result.topDocs()));
@@ -592,6 +632,8 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
         retrieverDiagBuilder.setRescoreTimeMs(retrieverResult.rescoreTimeMs());
       }
       retrieverDiagBuilder.setTotalHits(totalHits);
+      retrieverDiagBuilder.setHadTimeout(retrieverResult.hadTimeout());
+      retrieverDiagBuilder.setTerminatedEarly(retrieverResult.terminatedEarly());
       multiRetrieverDiagnosticsBuilder.putRetrieverDiagnostics(name, retrieverDiagBuilder.build());
     }
     multiRetrieverDiagnosticsBuilder.setBlenderTimeMs(blenderTimeMs);
@@ -611,7 +653,8 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
       }
     }
 
-    return blendedHits;
+    return new MultiRetrieverResult(
+        blendedHits, anyRetrieverHadTimeout, anyRetrieverTerminatedEarly);
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
@@ -1413,6 +1413,11 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
       throws IOException {
     DrillDownQuery ddq = (DrillDownQuery) searchContext.getQuery();
     List<FacetResult> grpcFacetResults = new ArrayList<>();
+    // Run the drill sideways search on the direct executor to run subtasks in the
+    // current (grpc) thread. If we use the search thread pool for this, it can cause a
+    // deadlock trying to execute the dependent parallel search tasks. Since we do not
+    // currently add additional drill down definitions, there will only be one drill
+    // sideways task per query.
     DrillSideways drillS =
         new DrillSidewaysImpl(
             s.searcher(),

--- a/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
@@ -183,68 +183,34 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
       if (searchContext.getMultiRetrieverContext() != null) {
         hits =
             executeMultiRetriever(searchContext, s.searcher(), diagnostics, profileResultBuilder);
+        // Run aggregations (facets + collectors) against the union query after blending.
+        // The union query already covers all retriever matches, so counts are not double-counted.
+        if (!searchRequest.getFacetsList().isEmpty()) {
+          SearcherResult searcherResult =
+              runDrillSidewaysSearch(
+                  s, indexState, shardState, searchContext, searchRequest, diagnostics, hits);
+          searchContext
+              .getResponseBuilder()
+              .putAllCollectorResults(searcherResult.getCollectorResults());
+        } else if (searchRequest.getCollectorsCount() > 0) {
+          SearcherResult searcherResult = executeSearch(s.searcher(), searchContext);
+          searchContext
+              .getResponseBuilder()
+              .putAllCollectorResults(searcherResult.getCollectorResults());
+        }
       } else {
         SearcherResult searcherResult;
         if (!searchRequest.getFacetsList().isEmpty()) {
-          DrillDownQuery ddq = (DrillDownQuery) searchContext.getQuery();
-
-          List<FacetResult> grpcFacetResults = new ArrayList<>();
           // Run the drill sideways search on the direct executor to run subtasks in the
           // current (grpc) thread. If we use the search thread pool for this, it can cause a
           // deadlock trying to execute the dependent parallel search tasks. Since we do not
           // currently add additional drill down definitions, there will only be one drill
           // sideways task per query.
-          DrillSideways drillS =
-              new DrillSidewaysImpl(
-                  s.searcher(),
-                  indexState.getFacetsConfig(),
-                  s.taxonomyReader(),
-                  searchRequest.getFacetsList(),
-                  s,
-                  indexState,
-                  shardState,
-                  searchContext.getQueryFields(),
-                  grpcFacetResults,
-                  DIRECT_EXECUTOR,
-                  diagnostics);
-          DrillSideways.ConcurrentDrillSidewaysResult<SearcherResult> concurrentDrillSidewaysResult;
-          try {
-            concurrentDrillSidewaysResult =
-                drillS.search(ddq, searchContext.getCollector().getWrappedManager());
-          } catch (RuntimeException e) {
-            // Searching with DrillSideways wraps exceptions in a few layers.
-            // Try to find if this was caused by a timeout, if so, re-wrap
-            // so that the top level exception is the same as when not using facets.
-            CollectionTimeoutException timeoutException = findTimeoutException(e);
-            if (timeoutException != null) {
-              throw new CollectionTimeoutException(timeoutException.getMessage(), e);
-            }
-            throw e;
-          }
-          searcherResult = concurrentDrillSidewaysResult.collectorResult;
-          searchContext.getResponseBuilder().addAllFacetResult(grpcFacetResults);
-          searchContext
-              .getResponseBuilder()
-              .addAllFacetResult(
-                  FacetTopDocs.facetTopDocsSample(
-                      searcherResult.getTopDocs(),
-                      searchRequest.getFacetsList(),
-                      indexState,
-                      s.searcher(),
-                      diagnostics));
+          searcherResult =
+              runDrillSidewaysSearch(
+                  s, indexState, shardState, searchContext, searchRequest, diagnostics, null);
         } else {
-          try {
-            searcherResult =
-                s.searcher()
-                    .search(
-                        searchContext.getQuery(), searchContext.getCollector().getWrappedManager());
-          } catch (RuntimeException e) {
-            CollectionTimeoutException timeoutException = findTimeoutException(e);
-            if (timeoutException != null) {
-              throw new CollectionTimeoutException(timeoutException.getMessage(), e);
-            }
-            throw e;
-          }
+          searcherResult = executeSearch(s.searcher(), searchContext);
         }
         hits = searcherResult.getTopDocs();
 
@@ -1364,6 +1330,83 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
     public SearchHandlerException(String message, Throwable err) {
       super(message, err);
     }
+  }
+
+  /**
+   * Runs {@link org.apache.lucene.search.IndexSearcher#search} against the search context query and
+   * collector, unwrapping any {@link CollectionTimeoutException} from the call stack.
+   */
+  private static SearcherResult executeSearch(
+      org.apache.lucene.search.IndexSearcher searcher, SearchContext searchContext)
+      throws IOException {
+    try {
+      return searcher.search(
+          searchContext.getQuery(), searchContext.getCollector().getWrappedManager());
+    } catch (RuntimeException e) {
+      CollectionTimeoutException timeoutException = findTimeoutException(e);
+      if (timeoutException != null) {
+        throw new CollectionTimeoutException(timeoutException.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Builds a {@link DrillSidewaysImpl}, executes the search, writes facet results to the response
+   * builder, and returns the {@link SearcherResult} from the drill sideways pass.
+   *
+   * @param topDocsForSample top docs to use for {@link FacetTopDocs#facetTopDocsSample}. Pass the
+   *     pre-blended hits for multi-retriever queries (where ranking is already determined), or
+   *     {@code null} to use the top docs produced by this search (single-retriever path).
+   */
+  private SearcherResult runDrillSidewaysSearch(
+      SearcherTaxonomyManager.SearcherAndTaxonomy s,
+      IndexState indexState,
+      ShardState shardState,
+      SearchContext searchContext,
+      SearchRequest searchRequest,
+      SearchResponse.Diagnostics.Builder diagnostics,
+      TopDocs topDocsForSample)
+      throws IOException {
+    DrillDownQuery ddq = (DrillDownQuery) searchContext.getQuery();
+    List<FacetResult> grpcFacetResults = new ArrayList<>();
+    DrillSideways drillS =
+        new DrillSidewaysImpl(
+            s.searcher(),
+            indexState.getFacetsConfig(),
+            s.taxonomyReader(),
+            searchRequest.getFacetsList(),
+            s,
+            indexState,
+            shardState,
+            searchContext.getQueryFields(),
+            grpcFacetResults,
+            DIRECT_EXECUTOR,
+            diagnostics);
+    DrillSideways.ConcurrentDrillSidewaysResult<SearcherResult> drillResult;
+    try {
+      drillResult = drillS.search(ddq, searchContext.getCollector().getWrappedManager());
+    } catch (RuntimeException e) {
+      // DrillSideways wraps exceptions in a few layers; unwrap timeouts so the top-level
+      // exception type is consistent with the non-facets path.
+      CollectionTimeoutException timeoutException = findTimeoutException(e);
+      if (timeoutException != null) {
+        throw new CollectionTimeoutException(timeoutException.getMessage(), e);
+      }
+      throw e;
+    }
+    SearcherResult searcherResult = drillResult.collectorResult;
+    searchContext.getResponseBuilder().addAllFacetResult(grpcFacetResults);
+    searchContext
+        .getResponseBuilder()
+        .addAllFacetResult(
+            FacetTopDocs.facetTopDocsSample(
+                topDocsForSample != null ? topDocsForSample : searcherResult.getTopDocs(),
+                searchRequest.getFacetsList(),
+                indexState,
+                s.searcher(),
+                diagnostics));
+    return searcherResult;
   }
 
   /**

--- a/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
@@ -632,7 +632,7 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
         retrieverDiagBuilder.setRescoreTimeMs(retrieverResult.rescoreTimeMs());
       }
       retrieverDiagBuilder.setTotalHits(totalHits);
-      retrieverDiagBuilder.setHadTimeout(retrieverResult.hadTimeout());
+      retrieverDiagBuilder.setHitTimeout(retrieverResult.hadTimeout());
       retrieverDiagBuilder.setTerminatedEarly(retrieverResult.terminatedEarly());
       multiRetrieverDiagnosticsBuilder.putRetrieverDiagnostics(name, retrieverDiagBuilder.build());
     }

--- a/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
@@ -661,13 +661,6 @@ public class SearchRequestProcessor {
     if (searchRequest.hasQuerySort()) {
       throw new IllegalArgumentException("QuerySort is not supported with MultiRetriever requests");
     }
-    if (searchRequest.getFacetsCount() > 0) {
-      throw new IllegalArgumentException("Facets are not supported with MultiRetriever requests");
-    }
-    if (searchRequest.getCollectorsCount() > 0) {
-      throw new IllegalArgumentException(
-          "Collectors are not supported with MultiRetriever requests");
-    }
   }
 
   private static Query buildMultiRetrieverContextAndUnionQuery(

--- a/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
@@ -181,16 +181,6 @@ public class SearchRequestProcessor {
               profileResult,
               indexState.getGlobalState().getRetrieverExecutor());
 
-      // Top-level collector for union query aggregations only (no ranking)
-      CollectorCreatorContext collectorCreatorContext =
-          CollectorCreatorContext.newBuilder(indexState)
-              .withShardState(shardState)
-              .withQueryFields(queryFields)
-              .withSearcherAndTaxonomy(searcherAndTaxonomy)
-              .withRequest(searchRequest)
-              .withNumHitsToCollect(0)
-              .build();
-      contextBuilder.setCollector(buildDocCollector(collectorCreatorContext));
     } else {
       query =
           extractQuery(
@@ -239,21 +229,21 @@ public class SearchRequestProcessor {
         }
         query = queryBuilder.build();
       }
-
-      CollectorCreatorContext collectorCreatorContext =
-          CollectorCreatorContext.newBuilder(indexState)
-              .withShardState(shardState)
-              .withQueryFields(queryFields)
-              .withSearcherAndTaxonomy(searcherAndTaxonomy)
-              .withRequest(searchRequest)
-              .build();
-      contextBuilder.setCollector(buildDocCollector(collectorCreatorContext));
     }
 
-    // Facets are applied on the union query for multi-retriever requests. Counts reflect the full
-    // match set of each retriever's query, not the recalled top-K — text retrievers may count
-    // beyond their topHits window. KNN retrievers are unaffected (KnnFloatVectorQuery is bounded).
-    // Fetch tasks (highlights, innerHits, hitsLogger) run on the final top N hits during fetch.
+    CollectorCreatorContext.Builder collectorContextBuilder =
+        CollectorCreatorContext.newBuilder(indexState)
+            .withShardState(shardState)
+            .withQueryFields(queryFields)
+            .withSearcherAndTaxonomy(searcherAndTaxonomy)
+            .withRequest(searchRequest);
+    if (searchRequest.hasMultiRetriever()) {
+      // Override to 0 — ranking is done by the blender; this pass is aggregation-only.
+      collectorContextBuilder.withNumHitsToCollect(0);
+    }
+    contextBuilder.setCollector(buildDocCollector(collectorContextBuilder.build()));
+
+    // Facets are applied on the union query for multi-retriever requests.
     if (searchRequest.getFacetsCount() > 0) {
       query = addDrillDowns(indexState, query);
       if (profileResult != null) {

--- a/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
@@ -250,7 +250,9 @@ public class SearchRequestProcessor {
       contextBuilder.setCollector(buildDocCollector(collectorCreatorContext));
     }
 
-    // Facets are applied on the union query (all matching docs) for multi-retriever requests.
+    // Facets are applied on the union query for multi-retriever requests. Counts reflect the full
+    // match set of each retriever's query, not the recalled top-K — text retrievers may count
+    // beyond their topHits window. KNN retrievers are unaffected (KnnFloatVectorQuery is bounded).
     // Fetch tasks (highlights, innerHits, hitsLogger) run on the final top N hits during fetch.
     if (searchRequest.getFacetsCount() > 0) {
       query = addDrillDowns(indexState, query);

--- a/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
@@ -135,6 +135,30 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
         .build();
   }
 
+  /** Two-retriever (text + KNN, k=10) request with WeightedRRF blending at rankConstant=60. */
+  private MultiRetrieverRequest twoRetrieverRrf() {
+    return MultiRetrieverRequest.newBuilder()
+        .addRetrievers(textRetriever(10))
+        .addRetrievers(knnRetriever(10))
+        .setBlender(
+            Blender.newBuilder()
+                .setWeightedRrf(WeightedRrfBlender.newBuilder().setRankConstant(60).build())
+                .build())
+        .build();
+  }
+
+  /** Facet over the "category" field, returning up to {@code topN} labels. */
+  private static Facet categoryFacet(int topN) {
+    return Facet.newBuilder().setName("category_facet").setDim("category").setTopN(topN).build();
+  }
+
+  /** Terms collector over the "category" field returning up to {@code size} buckets. */
+  private static Collector categoryTermsCollector(int size) {
+    return Collector.newBuilder()
+        .setTerms(TermsCollector.newBuilder().setField("category").setSize(size).build())
+        .build();
+  }
+
   /**
    * Rescorer that replaces every hit's score with {@code constant} (queryWeight=0 drops original).
    */
@@ -232,24 +256,13 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
 
   @Test
   public void testFacetsWithMultiRetriever() {
-    MultiRetrieverRequest twoRetrievers =
-        MultiRetrieverRequest.newBuilder()
-            .addRetrievers(textRetriever(10))
-            .addRetrievers(knnRetriever(10))
-            .setBlender(
-                Blender.newBuilder()
-                    .setWeightedRrf(WeightedRrfBlender.newBuilder().setRankConstant(60).build())
-                    .build())
-            .build();
-
     SearchResponse response =
         getGrpcServer()
             .getBlockingStub()
             .search(
                 baseRequest()
-                    .setMultiRetriever(twoRetrievers)
-                    .addFacets(
-                        Facet.newBuilder().setName("category_facet").setDim("category").setTopN(5))
+                    .setMultiRetriever(twoRetrieverRrf())
+                    .addFacets(categoryFacet(5))
                     .build());
 
     assertEquals(1, response.getFacetResultCount());
@@ -260,31 +273,13 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
 
   @Test
   public void testCollectorsWithMultiRetriever() {
-    MultiRetrieverRequest twoRetrievers =
-        MultiRetrieverRequest.newBuilder()
-            .addRetrievers(textRetriever(10))
-            .addRetrievers(knnRetriever(10))
-            .setBlender(
-                Blender.newBuilder()
-                    .setWeightedRrf(WeightedRrfBlender.newBuilder().setRankConstant(60).build())
-                    .build())
-            .build();
-
     SearchResponse response =
         getGrpcServer()
             .getBlockingStub()
             .search(
                 baseRequest()
-                    .setMultiRetriever(twoRetrievers)
-                    .putCollectors(
-                        "category_terms",
-                        Collector.newBuilder()
-                            .setTerms(
-                                TermsCollector.newBuilder()
-                                    .setField("category")
-                                    .setSize(10)
-                                    .build())
-                            .build())
+                    .setMultiRetriever(twoRetrieverRrf())
+                    .putCollectors("category_terms", categoryTermsCollector(10))
                     .build());
 
     assertTrue(response.getCollectorResultsMap().containsKey("category_terms"));
@@ -300,29 +295,14 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
 
   @Test
   public void testFacetsAndCollectorsTogetherWithMultiRetriever() {
-    MultiRetrieverRequest twoRetrievers =
-        MultiRetrieverRequest.newBuilder()
-            .addRetrievers(textRetriever(10))
-            .addRetrievers(knnRetriever(10))
-            .setBlender(
-                Blender.newBuilder()
-                    .setWeightedRrf(WeightedRrfBlender.newBuilder().setRankConstant(60).build())
-                    .build())
-            .build();
-
     SearchResponse response =
         getGrpcServer()
             .getBlockingStub()
             .search(
                 baseRequest()
-                    .setMultiRetriever(twoRetrievers)
-                    .addFacets(
-                        Facet.newBuilder().setName("category_facet").setDim("category").setTopN(5))
-                    .putCollectors(
-                        "category_terms",
-                        Collector.newBuilder()
-                            .setTerms(TermsCollector.newBuilder().setField("category").setSize(10))
-                            .build())
+                    .setMultiRetriever(twoRetrieverRrf())
+                    .addFacets(categoryFacet(5))
+                    .putCollectors("category_terms", categoryTermsCollector(10))
                     .build());
 
     // Facets populated
@@ -342,16 +322,6 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
 
   @Test
   public void testFacetsWithSampleTopDocsWithMultiRetriever() {
-    MultiRetrieverRequest twoRetrievers =
-        MultiRetrieverRequest.newBuilder()
-            .addRetrievers(textRetriever(10))
-            .addRetrievers(knnRetriever(10))
-            .setBlender(
-                Blender.newBuilder()
-                    .setWeightedRrf(WeightedRrfBlender.newBuilder().setRankConstant(60).build())
-                    .build())
-            .build();
-
     // sampleTopDocs=10 covers all blended hits; both categories ("odd" for docs 1-5, "even" for
     // docs 6-10) appear. This confirms counts are drawn from the blended TopDocs, not the full
     // index (which would still yield 2 labels, but via DrillSideways rather than
@@ -362,7 +332,7 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
             .search(
                 baseRequest()
                     .setTopHits(10)
-                    .setMultiRetriever(twoRetrievers)
+                    .setMultiRetriever(twoRetrieverRrf())
                     .addFacets(
                         Facet.newBuilder()
                             .setName("category_facet")
@@ -382,7 +352,7 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
             .search(
                 baseRequest()
                     .setTopHits(10)
-                    .setMultiRetriever(twoRetrievers)
+                    .setMultiRetriever(twoRetrieverRrf())
                     .addFacets(
                         Facet.newBuilder()
                             .setName("category_facet")
@@ -400,20 +370,10 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
     // A profiled multi-retriever request with no facets and no collectors must not produce an
     // aggregationProfileResult sub-message — calling getAggregationProfileResultBuilder()
     // unconditionally would stamp an empty proto message into the serialized response.
-    MultiRetrieverRequest twoRetrievers =
-        MultiRetrieverRequest.newBuilder()
-            .addRetrievers(textRetriever(10))
-            .addRetrievers(knnRetriever(10))
-            .setBlender(
-                Blender.newBuilder()
-                    .setWeightedRrf(WeightedRrfBlender.newBuilder().setRankConstant(60).build())
-                    .build())
-            .build();
-
     SearchResponse response =
         getGrpcServer()
             .getBlockingStub()
-            .search(baseRequest().setMultiRetriever(twoRetrievers).setProfile(true).build());
+            .search(baseRequest().setMultiRetriever(twoRetrieverRrf()).setProfile(true).build());
 
     assertTrue(response.hasProfileResult());
     assertTrue(response.getProfileResult().hasMultiRetrieverProfileResult());

--- a/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
@@ -352,11 +352,11 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
                     .build())
             .build();
 
-    // sampleTopDocs=5 restricts counting to the top 5 blended hits only (computed via
-    // facetTopDocsSample against the pre-blended TopDocs, not via DrillSideways).
-    // The KNN query ranks docs i=1..5 (nearest vectors) at the top, all in category "odd",
-    // so only 1 label appears in the sample window.
-    SearchResponse response =
+    // sampleTopDocs=10 covers all blended hits; both categories ("odd" for docs 1-5, "even" for
+    // docs 6-10) appear. This confirms counts are drawn from the blended TopDocs, not the full
+    // index (which would still yield 2 labels, but via DrillSideways rather than
+    // facetTopDocsSample).
+    SearchResponse fullSampleResponse =
         getGrpcServer()
             .getBlockingStub()
             .search(
@@ -368,14 +368,57 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
                             .setName("category_facet")
                             .setDim("category")
                             .setTopN(5)
-                            .setSampleTopDocs(5))
+                            .setSampleTopDocs(10))
                     .build());
+    assertEquals(1, fullSampleResponse.getFacetResultCount());
+    assertEquals("category_facet", fullSampleResponse.getFacetResult(0).getName());
+    assertEquals(2, fullSampleResponse.getFacetResult(0).getLabelValuesCount());
 
-    assertEquals(1, response.getFacetResultCount());
-    assertEquals("category_facet", response.getFacetResult(0).getName());
-    // Only the top 5 blended hits are sampled, all from category "odd"
-    assertEquals(1, response.getFacetResult(0).getLabelValuesCount());
-    assertEquals("odd", response.getFacetResult(0).getLabelValues(0).getLabel());
+    // sampleTopDocs=1 restricts counting to a single blended hit, so only 1 label can appear,
+    // regardless of which doc ranks first. This confirms the sample window is actually bounded.
+    SearchResponse singleSampleResponse =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                baseRequest()
+                    .setTopHits(10)
+                    .setMultiRetriever(twoRetrievers)
+                    .addFacets(
+                        Facet.newBuilder()
+                            .setName("category_facet")
+                            .setDim("category")
+                            .setTopN(5)
+                            .setSampleTopDocs(1))
+                    .build());
+    assertEquals(1, singleSampleResponse.getFacetResultCount());
+    assertEquals("category_facet", singleSampleResponse.getFacetResult(0).getName());
+    assertEquals(1, singleSampleResponse.getFacetResult(0).getLabelValuesCount());
+  }
+
+  @Test
+  public void testProfilingWithNoAggregationDoesNotEmitAggregationProfileResult() {
+    // A profiled multi-retriever request with no facets and no collectors must not produce an
+    // aggregationProfileResult sub-message — calling getAggregationProfileResultBuilder()
+    // unconditionally would stamp an empty proto message into the serialized response.
+    MultiRetrieverRequest twoRetrievers =
+        MultiRetrieverRequest.newBuilder()
+            .addRetrievers(textRetriever(10))
+            .addRetrievers(knnRetriever(10))
+            .setBlender(
+                Blender.newBuilder()
+                    .setWeightedRrf(WeightedRrfBlender.newBuilder().setRankConstant(60).build())
+                    .build())
+            .build();
+
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(baseRequest().setMultiRetriever(twoRetrievers).setProfile(true).build());
+
+    assertTrue(response.hasProfileResult());
+    assertTrue(response.getProfileResult().hasMultiRetrieverProfileResult());
+    assertFalse(
+        response.getProfileResult().getMultiRetrieverProfileResult().hasAggregationProfileResult());
   }
 
   /**

--- a/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
@@ -90,8 +90,7 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
                       .addValue(String.format("[%f, %f, %f]", i * 0.1f, i * 0.2f, i * 0.3f))
                       .build())
               .putFields(
-                  "category",
-                  MultiValuedField.newBuilder().addValue(i <= 5 ? "odd" : "even").build())
+                  "category", MultiValuedField.newBuilder().addValue(i <= 5 ? "a" : "b").build())
               .build());
     }
     addDocuments(docs.stream());
@@ -267,8 +266,10 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
 
     assertEquals(1, response.getFacetResultCount());
     assertEquals("category_facet", response.getFacetResult(0).getName());
-    // All 10 docs matched (union of both retrievers), split into two categories
+    // All 10 docs matched (union of both retrievers), 5 each in category "a" and "b"
     assertEquals(2, response.getFacetResult(0).getLabelValuesCount());
+    assertEquals(5, response.getFacetResult(0).getLabelValues(0).getValue(), 0);
+    assertEquals(5, response.getFacetResult(0).getLabelValues(1).getValue(), 0);
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
@@ -89,6 +89,9 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
                   MultiValuedField.newBuilder()
                       .addValue(String.format("[%f, %f, %f]", i * 0.1f, i * 0.2f, i * 0.3f))
                       .build())
+              .putFields(
+                  "category",
+                  MultiValuedField.newBuilder().addValue(i <= 5 ? "odd" : "even").build())
               .build());
     }
     addDocuments(docs.stream());
@@ -227,31 +230,152 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
         "Unsupported blender type");
   }
 
-  // TODO: Remove after adding Facets and Collectors support
   @Test
-  public void testAggregationsNotSupported() {
+  public void testFacetsWithMultiRetriever() {
     MultiRetrieverRequest twoRetrievers =
         MultiRetrieverRequest.newBuilder()
-            .addRetrievers(textRetriever(5))
-            .addRetrievers(knnRetriever(5))
+            .addRetrievers(textRetriever(10))
+            .addRetrievers(knnRetriever(10))
+            .setBlender(
+                Blender.newBuilder()
+                    .setWeightedRrf(WeightedRrfBlender.newBuilder().setRankConstant(60).build())
+                    .build())
             .build();
 
-    assertSearchError(
-        baseRequest()
-            .setMultiRetriever(twoRetrievers)
-            .addFacets(Facet.newBuilder().setName("doc_id").setTopN(5).build())
-            .build(),
-        "Facets are not supported with MultiRetriever requests");
-    assertSearchError(
-        baseRequest()
-            .setMultiRetriever(twoRetrievers)
-            .putCollectors(
-                "terms",
-                Collector.newBuilder()
-                    .setTerms(TermsCollector.newBuilder().setField("doc_id").setSize(5).build())
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                baseRequest()
+                    .setMultiRetriever(twoRetrievers)
+                    .addFacets(
+                        Facet.newBuilder().setName("category_facet").setDim("category").setTopN(5))
+                    .build());
+
+    assertEquals(1, response.getFacetResultCount());
+    assertEquals("category_facet", response.getFacetResult(0).getName());
+    // All 10 docs matched (union of both retrievers), split into two categories
+    assertEquals(2, response.getFacetResult(0).getLabelValuesCount());
+  }
+
+  @Test
+  public void testCollectorsWithMultiRetriever() {
+    MultiRetrieverRequest twoRetrievers =
+        MultiRetrieverRequest.newBuilder()
+            .addRetrievers(textRetriever(10))
+            .addRetrievers(knnRetriever(10))
+            .setBlender(
+                Blender.newBuilder()
+                    .setWeightedRrf(WeightedRrfBlender.newBuilder().setRankConstant(60).build())
                     .build())
-            .build(),
-        "Collectors are not supported with MultiRetriever requests");
+            .build();
+
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                baseRequest()
+                    .setMultiRetriever(twoRetrievers)
+                    .putCollectors(
+                        "category_terms",
+                        Collector.newBuilder()
+                            .setTerms(
+                                TermsCollector.newBuilder()
+                                    .setField("category")
+                                    .setSize(10)
+                                    .build())
+                            .build())
+                    .build());
+
+    assertTrue(response.getCollectorResultsMap().containsKey("category_terms"));
+    // Both categories should appear across all 10 docs
+    assertEquals(
+        2,
+        response
+            .getCollectorResultsMap()
+            .get("category_terms")
+            .getBucketResult()
+            .getBucketsCount());
+  }
+
+  @Test
+  public void testFacetsAndCollectorsTogetherWithMultiRetriever() {
+    MultiRetrieverRequest twoRetrievers =
+        MultiRetrieverRequest.newBuilder()
+            .addRetrievers(textRetriever(10))
+            .addRetrievers(knnRetriever(10))
+            .setBlender(
+                Blender.newBuilder()
+                    .setWeightedRrf(WeightedRrfBlender.newBuilder().setRankConstant(60).build())
+                    .build())
+            .build();
+
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                baseRequest()
+                    .setMultiRetriever(twoRetrievers)
+                    .addFacets(
+                        Facet.newBuilder().setName("category_facet").setDim("category").setTopN(5))
+                    .putCollectors(
+                        "category_terms",
+                        Collector.newBuilder()
+                            .setTerms(TermsCollector.newBuilder().setField("category").setSize(10))
+                            .build())
+                    .build());
+
+    // Facets populated
+    assertEquals(1, response.getFacetResultCount());
+    assertEquals("category_facet", response.getFacetResult(0).getName());
+    assertEquals(2, response.getFacetResult(0).getLabelValuesCount());
+    // Collectors populated in the same pass
+    assertTrue(response.getCollectorResultsMap().containsKey("category_terms"));
+    assertEquals(
+        2,
+        response
+            .getCollectorResultsMap()
+            .get("category_terms")
+            .getBucketResult()
+            .getBucketsCount());
+  }
+
+  @Test
+  public void testFacetsWithSampleTopDocsWithMultiRetriever() {
+    MultiRetrieverRequest twoRetrievers =
+        MultiRetrieverRequest.newBuilder()
+            .addRetrievers(textRetriever(10))
+            .addRetrievers(knnRetriever(10))
+            .setBlender(
+                Blender.newBuilder()
+                    .setWeightedRrf(WeightedRrfBlender.newBuilder().setRankConstant(60).build())
+                    .build())
+            .build();
+
+    // sampleTopDocs=5 restricts counting to the top 5 blended hits only (computed via
+    // facetTopDocsSample against the pre-blended TopDocs, not via DrillSideways).
+    // The KNN query ranks docs i=1..5 (nearest vectors) at the top, all in category "odd",
+    // so only 1 label appears in the sample window.
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                baseRequest()
+                    .setTopHits(10)
+                    .setMultiRetriever(twoRetrievers)
+                    .addFacets(
+                        Facet.newBuilder()
+                            .setName("category_facet")
+                            .setDim("category")
+                            .setTopN(5)
+                            .setSampleTopDocs(5))
+                    .build());
+
+    assertEquals(1, response.getFacetResultCount());
+    assertEquals("category_facet", response.getFacetResult(0).getName());
+    // Only the top 5 blended hits are sampled, all from category "odd"
+    assertEquals(1, response.getFacetResult(0).getLabelValuesCount());
+    assertEquals("odd", response.getFacetResult(0).getLabelValues(0).getLabel());
   }
 
   /**

--- a/src/test/resources/search/registerFieldsMultiRetriever.json
+++ b/src/test/resources/search/registerFieldsMultiRetriever.json
@@ -21,6 +21,13 @@
       "search": true,
       "vectorDimensions": 3,
       "vectorSimilarity": "cosine"
+    },
+    {
+      "name": "category",
+      "type": "ATOM",
+      "search": true,
+      "storeDocValues": true,
+      "facet": "SORTED_SET_DOC_VALUES"
     }
   ]
 }


### PR DESCRIPTION
Removes the validation that blocked facets and collectors on multi-retriever requests, and implements aggregation execution as a second pass against the union query after blending.

  - **SearchRequestProcessor:** Removed IllegalArgumentException guards for getFacetsCount() and getCollectorsCount() on the multi-retriever path. The union query is already built from all retriever queries; addDrillDowns wraps it in a DrillDownQuery when facets are present, covering both paths.
  - **SearchHandler:** After executeMultiRetriever returns blended hits, runs a second aggregation pass against the union query — via DrillSideways if facets are present (collecting facet counts and custom collectors in one pass), or a plain searcher.search if only collectors are requested. Blended hits are passed as the topDocsForSample source for sampleTopDocs facets so sampling reflects the final ranked order.
  - **Refactor:** Extracted runDrillSidewaysSearch and executeSearch helpers to eliminate duplicated DrillSideways construction, timeout unwrapping, and search logic between the multi-retriever and single-search paths. No behavior change to the single-search path.

### Tests

Added category field (ATOM, SORTED_SET_DOC_VALUES) to the multi-retriever test index and added four new tests: facets only, collectors only, facets + collectors together, and facets with sampleTopDocs.