### PR TITLE
fix the bug the exact vector search will fail when candidates has no …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ java {
 }
 
 allprojects {
-    version = '1.4.0'
+    version = '1.4.1'
     group = 'com.yelp.nrtsearch'
 }
 

--- a/src/main/java/com/yelp/nrtsearch/server/query/vector/ExactVectorQuery.java
+++ b/src/main/java/com/yelp/nrtsearch/server/query/vector/ExactVectorQuery.java
@@ -186,7 +186,12 @@ public abstract class ExactVectorQuery extends Query {
      * @param queryVector the query vector
      */
     public ExactFloatVectorQuery(String field, float[] queryVector) {
-      super(field, reader -> reader.getFloatVectorValues(field).scorer(queryVector));
+      super(
+          field,
+          reader -> {
+            var vectorValues = reader.getFloatVectorValues(field);
+            return vectorValues == null ? null : vectorValues.scorer(queryVector);
+          });
       this.queryVector = queryVector;
     }
 
@@ -232,7 +237,12 @@ public abstract class ExactVectorQuery extends Query {
      * @param queryVector the query vector
      */
     public ExactByteVectorQuery(String field, byte[] queryVector) {
-      super(field, reader -> reader.getByteVectorValues(field).scorer(queryVector));
+      super(
+          field,
+          reader -> {
+            var vectorValues = reader.getByteVectorValues(field);
+            return vectorValues == null ? null : vectorValues.scorer(queryVector);
+          });
       this.queryVector = queryVector;
     }
 

--- a/src/test/java/com/yelp/nrtsearch/server/field/VectorFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/VectorFieldDefTest.java
@@ -2231,6 +2231,53 @@ public class VectorFieldDefTest extends ServerTestCase {
     }
   }
 
+  @Test
+  public void testFloatExactSearch_noData() {
+    List<Float> queryVector = List.of(0.25f, 0.5f, 0.75f);
+    String field = "vector_no_data";
+    SearchResponse searchResponse =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(VECTOR_SEARCH_INDEX_NAME)
+                    .setStartHit(0)
+                    .setTopHits(5)
+                    .setQuery(
+                        Query.newBuilder()
+                            .setExactVectorQuery(
+                                ExactVectorQuery.newBuilder()
+                                    .setField(field)
+                                    .addAllQueryFloatVector(queryVector)
+                                    .build())
+                            .build())
+                    .build());
+    assertEquals(0, searchResponse.getHitsCount());
+  }
+
+  @Test
+  public void testByteExactSearch_noData() {
+    String field = "byte_vector_no_data";
+    SearchResponse searchResponse =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                SearchRequest.newBuilder()
+                    .setIndexName(VECTOR_SEARCH_INDEX_NAME)
+                    .setStartHit(0)
+                    .setTopHits(5)
+                    .setQuery(
+                        Query.newBuilder()
+                            .setExactVectorQuery(
+                                ExactVectorQuery.newBuilder()
+                                    .setField(field)
+                                    .setQueryByteVector(ByteString.copyFrom(new byte[] {1, 2, 3}))
+                                    .build())
+                            .build())
+                    .build());
+    assertEquals(0, searchResponse.getHitsCount());
+  }
+
   record VectorSearchResult(int docId, float score) {}
 
   private List<VectorSearchResult> getTrueFloatTopHits(


### PR DESCRIPTION
https://yelp.slack.com/archives/CFV0F14CC/p1781413926906099?thread_ts=1781411109.978799&cid=CFV0F14CC

Exact vector search assumes that the vector field always has the data indexed, otherwise it will throw NPE.
Based on the Lucene docstring `Returns FloatVectorValues for this field, or null if no FloatVectorValues were indexed`, we shall add null-check when creating scorer to prevent exceptions, and keep the parity of the behavior with HNSW knn.