### PR TITLE
Log uncaught exceptions from executors

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/concurrent/ExecutorFactory.java
+++ b/src/main/java/com/yelp/nrtsearch/server/concurrent/ExecutorFactory.java
@@ -82,7 +82,12 @@ public class ExecutorFactory implements Closeable {
         threadPoolConfiguration.getThreadPoolSettings(executorType);
     if (threadPoolSettings.useVirtualThreads()) {
       logger.info("Creating virtual thread executor for {}", threadPoolSettings.threadNamePrefix());
-      ExecutorService virtualThreadExecutor = Executors.newVirtualThreadPerTaskExecutor();
+      ExecutorService virtualThreadExecutor =
+          Executors.newThreadPerTaskExecutor(
+              new LoggingThreadFactory(
+                  Thread.ofVirtual()
+                      .name(threadPoolSettings.threadNamePrefix() + "-", 0)
+                      .factory()));
       ExecutorServiceStatsWrapper executorServiceStatsWrapper =
           new ExecutorServiceStatsWrapper(virtualThreadExecutor);
       ThreadPoolCollector.addVirtualPool(executorType.name(), executorServiceStatsWrapper);
@@ -101,7 +106,8 @@ public class ExecutorFactory implements Closeable {
               0L,
               TimeUnit.SECONDS,
               queue,
-              new NamedThreadFactory(threadPoolSettings.threadNamePrefix()));
+              new LoggingThreadFactory(
+                  new NamedThreadFactory(threadPoolSettings.threadNamePrefix())));
       ThreadPoolCollector.addPool(executorType.name(), threadPoolExecutor);
       return threadPoolExecutor;
     }

--- a/src/main/java/com/yelp/nrtsearch/server/concurrent/LoggingThreadFactory.java
+++ b/src/main/java/com/yelp/nrtsearch/server/concurrent/LoggingThreadFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.concurrent;
+
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * Delegates thread creation to another {@link ThreadFactory} and sets a {@link
+ * LoggingUncaughtExceptionHandler} on each created thread.
+ */
+public class LoggingThreadFactory implements ThreadFactory {
+  private final ThreadFactory delegate;
+
+  public LoggingThreadFactory(ThreadFactory delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Thread newThread(Runnable r) {
+    Thread thread = delegate.newThread(r);
+    thread.setUncaughtExceptionHandler(LoggingUncaughtExceptionHandler.getInstance());
+    return thread;
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/concurrent/LoggingUncaughtExceptionHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/concurrent/LoggingUncaughtExceptionHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.concurrent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Routes uncaught thread exceptions through SLF4J so they appear in structured log output rather
+ * than only on stderr via the JVM default handler. The singleton instance is pre-allocated to
+ * minimize heap pressure at the point of an OOM.
+ */
+public class LoggingUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+  private static final Logger logger =
+      LoggerFactory.getLogger(LoggingUncaughtExceptionHandler.class);
+
+  private static final LoggingUncaughtExceptionHandler INSTANCE =
+      new LoggingUncaughtExceptionHandler();
+
+  private LoggingUncaughtExceptionHandler() {}
+
+  public static LoggingUncaughtExceptionHandler getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public void uncaughtException(Thread t, Throwable e) {
+    logger.error("Uncaught exception on thread [{}]", t.getName(), e);
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/NrtsearchServer.java
@@ -27,6 +27,7 @@ import com.google.protobuf.Empty;
 import com.google.protobuf.util.JsonFormat;
 import com.yelp.nrtsearch.server.analysis.AnalyzerCreator;
 import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
+import com.yelp.nrtsearch.server.concurrent.LoggingUncaughtExceptionHandler;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.config.QueryCacheConfig;
 import com.yelp.nrtsearch.server.custom.request.CustomRequestProcessor;
@@ -303,6 +304,7 @@ public class NrtsearchServer {
 
     @Override
     public Integer call() throws Exception {
+      Thread.setDefaultUncaughtExceptionHandler(LoggingUncaughtExceptionHandler.getInstance());
       NrtsearchServer server;
       try {
         Injector injector = Guice.createInjector(new NrtsearchModule(this));

--- a/src/test/java/com/yelp/nrtsearch/server/concurrent/ExecutorFactoryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/concurrent/ExecutorFactoryTest.java
@@ -24,6 +24,7 @@ import com.yelp.nrtsearch.server.config.ThreadPoolConfiguration;
 import java.io.ByteArrayInputStream;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Test;
 
@@ -350,5 +351,18 @@ public class ExecutorFactoryTest {
     init(String.join("\n", "threadPoolConfiguration:", "  search:", "    useVirtualThreads: true"));
     ExecutorService executor = executorFactory.getExecutor(ExecutorFactory.ExecutorType.SEARCH);
     assertTrue(executor instanceof ExecutorServiceStatsWrapper);
+  }
+
+  @Test
+  public void testThreadsHaveLoggingUncaughtExceptionHandler() throws InterruptedException {
+    init();
+    ThreadPoolExecutor executor =
+        (ThreadPoolExecutor) executorFactory.getExecutor(ExecutorFactory.ExecutorType.SEARCH);
+    AtomicReference<Thread.UncaughtExceptionHandler> capturedHandler = new AtomicReference<>();
+    executor.execute(
+        () -> capturedHandler.set(Thread.currentThread().getUncaughtExceptionHandler()));
+    executor.shutdown();
+    executor.awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS);
+    assertSame(LoggingUncaughtExceptionHandler.getInstance(), capturedHandler.get());
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/concurrent/LoggingThreadFactoryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/concurrent/LoggingThreadFactoryTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.concurrent;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.lucene.util.NamedThreadFactory;
+import org.junit.Test;
+
+public class LoggingThreadFactoryTest {
+
+  @Test
+  public void testCreatedThreadHasLoggingHandler() {
+    LoggingThreadFactory factory = new LoggingThreadFactory(new NamedThreadFactory("test"));
+    Thread thread = factory.newThread(() -> {});
+    assertSame(LoggingUncaughtExceptionHandler.getInstance(), thread.getUncaughtExceptionHandler());
+  }
+
+  @Test
+  public void testCreatedThreadHasNameFromDelegate() {
+    LoggingThreadFactory factory = new LoggingThreadFactory(new NamedThreadFactory("mypool"));
+    Thread thread = factory.newThread(() -> {});
+    assertTrue(thread.getName().startsWith("mypool-"));
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/concurrent/LoggingUncaughtExceptionHandlerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/concurrent/LoggingUncaughtExceptionHandlerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.concurrent;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+public class LoggingUncaughtExceptionHandlerTest {
+
+  @Test
+  public void testGetInstanceReturnsSingleton() {
+    assertSame(
+        LoggingUncaughtExceptionHandler.getInstance(),
+        LoggingUncaughtExceptionHandler.getInstance());
+  }
+
+  @Test
+  public void testGetInstanceNotNull() {
+    assertNotNull(LoggingUncaughtExceptionHandler.getInstance());
+  }
+
+  @Test
+  public void testUncaughtExceptionDoesNotThrow() {
+    Thread thread = new Thread(() -> {}, "test-thread");
+    // Should not throw even for severe errors like OOME
+    LoggingUncaughtExceptionHandler.getInstance()
+        .uncaughtException(thread, new RuntimeException("test"));
+    LoggingUncaughtExceptionHandler.getInstance()
+        .uncaughtException(thread, new OutOfMemoryError("simulated OOM"));
+  }
+}


### PR DESCRIPTION
I noticed there were some `OutOfMemoryError` notifications that went to stderr, but did not end up in the logs. This change creates a `LoggingUncaughtExceptionHandler` and registers it as the default handler. It also creates the `LoggingThreadFactory`, which wraps creation of all threads and sets the handler.