### PR TITLE
Nrtsearch configurable s3 upload with refresh

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java
@@ -112,6 +112,7 @@ public class NrtsearchConfig {
   private final boolean useKeepAliveForReplication;
   private final DirectoryFactory.MMapGrouping mmapGrouping;
   private final boolean requireIdField;
+  private final boolean s3RefreshUpload;
   private final IsolatedReplicaConfig isolatedReplicaConfig;
 
   @Inject
@@ -191,6 +192,7 @@ public class NrtsearchConfig {
             DirectoryFactory.MMapGrouping.SEGMENT);
     useSeparateCommitExecutor = configReader.getBoolean("useSeparateCommitExecutor", false);
     requireIdField = configReader.getBoolean("requireIdField", false);
+    s3RefreshUpload = configReader.getBoolean("s3RefreshUpload", false);
     isolatedReplicaConfig = IsolatedReplicaConfig.fromConfig(configReader);
 
     List<String> indicesWithOverrides = configReader.getKeysOrEmpty("indexLiveSettingsOverrides");
@@ -387,6 +389,10 @@ public class NrtsearchConfig {
 
   public boolean getRequireIdField() {
     return requireIdField;
+  }
+
+  public boolean getS3RefreshUpload() {
+    return s3RefreshUpload;
   }
 
   public IsolatedReplicaConfig getIsolatedReplicaConfig() {

--- a/src/main/java/com/yelp/nrtsearch/server/index/StartIndexProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/StartIndexProcessor.java
@@ -41,6 +41,7 @@ public class StartIndexProcessor {
   private final RemoteBackend remoteBackend;
   private final IndexStateManager indexStateManager;
   private final boolean remoteCommit;
+  private final boolean s3RefreshUpload;
   private final int discoveryFileUpdateIntervalMs;
   private final boolean requireIdField;
   private static final Logger logger = LoggerFactory.getLogger(StartIndexProcessor.class);
@@ -53,6 +54,7 @@ public class StartIndexProcessor {
    * @param remoteBackend remote state backend
    * @param indexStateManager index state manager
    * @param remoteCommit whether to commit to remote state
+   * @param s3RefreshUpload whether to upload index data to S3 on every refresh
    * @param discoveryFileUpdateIntervalMs interval to update backends from discovery file
    * @param requireIdField whether the index must have an _ID field defined
    */
@@ -62,6 +64,7 @@ public class StartIndexProcessor {
       RemoteBackend remoteBackend,
       IndexStateManager indexStateManager,
       boolean remoteCommit,
+      boolean s3RefreshUpload,
       int discoveryFileUpdateIntervalMs,
       boolean requireIdField) {
     this.serviceName = serviceName;
@@ -69,6 +72,7 @@ public class StartIndexProcessor {
     this.remoteBackend = remoteBackend;
     this.indexStateManager = indexStateManager;
     this.remoteCommit = remoteCommit;
+    this.s3RefreshUpload = s3RefreshUpload;
     this.discoveryFileUpdateIntervalMs = discoveryFileUpdateIntervalMs;
     this.requireIdField = requireIdField;
   }
@@ -122,7 +126,8 @@ public class StartIndexProcessor {
             ephemeralId,
             remoteBackend,
             restoreIndex,
-            remoteCommit);
+            remoteCommit,
+            s3RefreshUpload);
     if (mode.equals(Mode.PRIMARY)) {
       primaryGen = startIndexRequest.getPrimaryGen();
       primaryClient = null;

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NRTPrimaryNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NRTPrimaryNode.java
@@ -304,8 +304,7 @@ public class NRTPrimaryNode extends PrimaryNode {
       boolean uploadQueued = false;
       try {
         if (primary.flushAndRefresh()) {
-          if (!watchers.isEmpty()) {
-            // queue the index upload if there are watchers waiting for a durable refresh
+          if (!watchers.isEmpty() || primary.getNrtDataManager().doS3RefreshUpload()) {
             queueIndexUpload(watchers);
             uploadQueued = true;
           }

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NrtDataManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NrtDataManager.java
@@ -65,6 +65,7 @@ public class NrtDataManager implements Closeable {
   private final RemoteBackend remoteBackend;
   private final RestoreIndex restoreIndex;
   private final boolean remoteCommit;
+  private final boolean s3RefreshUpload;
 
   // Set during startUploadManager
   private NRTPrimaryNode primaryNode;
@@ -100,6 +101,7 @@ public class NrtDataManager implements Closeable {
    * @param remoteBackend Remote backend to use for uploading and downloading index files
    * @param restoreIndex RestoreIndex object to use for restoring index files, or null if no restore
    * @param remoteCommit Whether to commit to the remote backend
+   * @param s3RefreshUpload Whether to upload index data to S3 on every refresh
    */
   public NrtDataManager(
       String serviceName,
@@ -107,13 +109,15 @@ public class NrtDataManager implements Closeable {
       String ephemeralId,
       RemoteBackend remoteBackend,
       RestoreIndex restoreIndex,
-      boolean remoteCommit) {
+      boolean remoteCommit,
+      boolean s3RefreshUpload) {
     this.serviceName = serviceName;
     this.ephemeralId = ephemeralId;
     this.indexIdentifier = indexIdentifier;
     this.remoteBackend = remoteBackend;
     this.restoreIndex = restoreIndex;
     this.remoteCommit = remoteCommit;
+    this.s3RefreshUpload = s3RefreshUpload;
   }
 
   /**
@@ -197,6 +201,15 @@ public class NrtDataManager implements Closeable {
    */
   public boolean doRemoteCommit() {
     return remoteCommit;
+  }
+
+  /**
+   * Check if index data should be uploaded to S3 on every refresh.
+   *
+   * @return true if S3 refresh upload is enabled, false otherwise
+   */
+  public boolean doS3RefreshUpload() {
+    return s3RefreshUpload;
   }
 
   /**
@@ -346,8 +359,9 @@ public class NrtDataManager implements Closeable {
    * @param watchers List of RefreshUploadFuture objects to notify when the upload is complete
    */
   public synchronized void enqueueUpload(CopyState copyState, List<RefreshUploadFuture> watchers) {
-    if (!remoteCommit) {
-      throw new IllegalStateException("Remote commit is not available for this configuration");
+    if (!remoteCommit && !s3RefreshUpload) {
+      throw new IllegalStateException(
+          "Neither remoteCommit nor s3RefreshUpload is enabled for this configuration");
     }
     if (closed) {
       throw new IllegalStateException("NrtDataManager is closed");

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NrtDataManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NrtDataManager.java
@@ -111,6 +111,9 @@ public class NrtDataManager implements Closeable {
       RestoreIndex restoreIndex,
       boolean remoteCommit,
       boolean s3RefreshUpload) {
+    if (s3RefreshUpload && !remoteCommit) {
+      throw new IllegalArgumentException("s3RefreshUpload requires remoteCommit to be enabled");
+    }
     this.serviceName = serviceName;
     this.ephemeralId = ephemeralId;
     this.indexIdentifier = indexIdentifier;
@@ -359,9 +362,8 @@ public class NrtDataManager implements Closeable {
    * @param watchers List of RefreshUploadFuture objects to notify when the upload is complete
    */
   public synchronized void enqueueUpload(CopyState copyState, List<RefreshUploadFuture> watchers) {
-    if (!remoteCommit && !s3RefreshUpload) {
-      throw new IllegalStateException(
-          "Neither remoteCommit nor s3RefreshUpload is enabled for this configuration");
+    if (!remoteCommit) {
+      throw new IllegalStateException("Remote commit is not available for this configuration");
     }
     if (closed) {
       throw new IllegalStateException("NrtDataManager is closed");

--- a/src/main/java/com/yelp/nrtsearch/server/state/BackendGlobalState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/state/BackendGlobalState.java
@@ -453,6 +453,7 @@ public class BackendGlobalState extends GlobalState {
                 .getIndexStartConfig()
                 .getDataLocationType()
                 .equals(IndexDataLocationType.REMOTE),
+            getConfiguration().getS3RefreshUpload(),
             getConfiguration().getDiscoveryFileUpdateIntervalMs(),
             getConfiguration().getRequireIdField());
     try {

--- a/src/test/java/com/yelp/nrtsearch/server/config/NrtsearchConfigTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/NrtsearchConfigTest.java
@@ -234,6 +234,20 @@ public class NrtsearchConfigTest {
   }
 
   @Test
+  public void testS3RefreshUpload_default() {
+    String config = "nodeName: \"server_foo\"";
+    NrtsearchConfig luceneConfig = getForConfig(config);
+    assertFalse(luceneConfig.getS3RefreshUpload());
+  }
+
+  @Test
+  public void testS3RefreshUpload_set() {
+    String config = "s3RefreshUpload: true";
+    NrtsearchConfig luceneConfig = getForConfig(config);
+    assertTrue(luceneConfig.getS3RefreshUpload());
+  }
+
+  @Test
   public void testGetIngestionPluginConfigs() {
     String config =
         String.join(

--- a/src/test/java/com/yelp/nrtsearch/server/nrt/NrtDataManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/nrt/NrtDataManagerTest.java
@@ -863,7 +863,7 @@ public class NrtDataManagerTest {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
         new NrtDataManager(
-            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, true);
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true, true);
     assertTrue(nrtDataManager.doS3RefreshUpload());
   }
 
@@ -877,18 +877,15 @@ public class NrtDataManagerTest {
   }
 
   @Test
-  public void testEnqueueUpload_s3RefreshUploadOnly() {
+  public void testS3RefreshUpload_requiresRemoteCommit() {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
-    NrtDataManager nrtDataManager =
-        new NrtDataManager(
-            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, true);
-    CopyState mockCopyState = mock(CopyState.class);
-    List<RefreshUploadFuture> refreshUploadFutures = List.of(mock(RefreshUploadFuture.class));
-    nrtDataManager.enqueueUpload(mockCopyState, refreshUploadFutures);
-
-    assertSame(mockCopyState, nrtDataManager.getCurrentUploadTask().copyState());
-    assertSame(refreshUploadFutures, nrtDataManager.getCurrentUploadTask().watchers());
-    assertNull(nrtDataManager.getNextUploadTask());
+    try {
+      new NrtDataManager(
+          SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, true);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("s3RefreshUpload requires remoteCommit to be enabled", e.getMessage());
+    }
   }
 
   @Test
@@ -901,9 +898,7 @@ public class NrtDataManagerTest {
       nrtDataManager.enqueueUpload(mock(CopyState.class), List.of());
       fail();
     } catch (IllegalStateException e) {
-      assertEquals(
-          "Neither remoteCommit nor s3RefreshUpload is enabled for this configuration",
-          e.getMessage());
+      assertEquals("Remote commit is not available for this configuration", e.getMessage());
     }
   }
 

--- a/src/test/java/com/yelp/nrtsearch/server/nrt/NrtDataManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/nrt/NrtDataManagerTest.java
@@ -859,6 +859,39 @@ public class NrtDataManagerTest {
   }
 
   @Test
+  public void testDoS3RefreshUpload_true() {
+    RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
+    NrtDataManager nrtDataManager =
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, true);
+    assertTrue(nrtDataManager.doS3RefreshUpload());
+  }
+
+  @Test
+  public void testDoS3RefreshUpload_false() {
+    RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
+    NrtDataManager nrtDataManager =
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, false);
+    assertFalse(nrtDataManager.doS3RefreshUpload());
+  }
+
+  @Test
+  public void testEnqueueUpload_s3RefreshUploadOnly() {
+    RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
+    NrtDataManager nrtDataManager =
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, true);
+    CopyState mockCopyState = mock(CopyState.class);
+    List<RefreshUploadFuture> refreshUploadFutures = List.of(mock(RefreshUploadFuture.class));
+    nrtDataManager.enqueueUpload(mockCopyState, refreshUploadFutures);
+
+    assertSame(mockCopyState, nrtDataManager.getCurrentUploadTask().copyState());
+    assertSame(refreshUploadFutures, nrtDataManager.getCurrentUploadTask().watchers());
+    assertNull(nrtDataManager.getNextUploadTask());
+  }
+
+  @Test
   public void testEnqueueNoRemoteCommit() {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =

--- a/src/test/java/com/yelp/nrtsearch/server/nrt/NrtDataManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/nrt/NrtDataManagerTest.java
@@ -69,7 +69,8 @@ public class NrtDataManagerTest {
   public void testHasRestoreData_noRestoreIndex() throws IOException {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, false);
     assertFalse(nrtDataManager.hasRestoreData());
   }
 
@@ -83,7 +84,7 @@ public class NrtDataManagerTest {
         RestoreIndex.newBuilder().setServiceName(SERVICE_NAME).setResourceName(INDEX_NAME).build();
     NrtDataManager nrtDataManager =
         new NrtDataManager(
-            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, restoreIndex, false);
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, restoreIndex, false, false);
     assertFalse(nrtDataManager.hasRestoreData());
   }
 
@@ -97,7 +98,7 @@ public class NrtDataManagerTest {
         RestoreIndex.newBuilder().setServiceName(SERVICE_NAME).setResourceName(INDEX_NAME).build();
     NrtDataManager nrtDataManager =
         new NrtDataManager(
-            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, restoreIndex, false);
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, restoreIndex, false, false);
     assertTrue(nrtDataManager.hasRestoreData());
   }
 
@@ -105,7 +106,8 @@ public class NrtDataManagerTest {
   public void testDoRemoteCommit_true() {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true, false);
     assertTrue(nrtDataManager.doRemoteCommit());
   }
 
@@ -113,7 +115,8 @@ public class NrtDataManagerTest {
   public void testDoRemoteCommit_false() {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, false);
     assertFalse(nrtDataManager.doRemoteCommit());
   }
 
@@ -121,7 +124,8 @@ public class NrtDataManagerTest {
   public void testAlreadyStarted() {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true, false);
     nrtDataManager.startUploadManager(mock(NRTPrimaryNode.class), folder.getRoot().toPath());
 
     try {
@@ -136,7 +140,8 @@ public class NrtDataManagerTest {
   public void testRestoreIfNeeded_noRestoreIndex() throws IOException {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true, false);
     folder.newFile("test_file");
     nrtDataManager.restoreIfNeeded(folder.getRoot().toPath());
     assertArrayEquals(new String[] {"test_file"}, folder.getRoot().list());
@@ -157,7 +162,7 @@ public class NrtDataManagerTest {
             .build();
     NrtDataManager nrtDataManager =
         new NrtDataManager(
-            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, restoreIndex, true);
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, restoreIndex, true, false);
     folder.newFile("test_file");
     nrtDataManager.restoreIfNeeded(folder.getRoot().toPath());
     assertArrayEquals(new String[0], folder.getRoot().list());
@@ -178,7 +183,7 @@ public class NrtDataManagerTest {
             .build();
     NrtDataManager nrtDataManager =
         new NrtDataManager(
-            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, restoreIndex, true);
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, restoreIndex, true, false);
     folder.newFile("test_file");
     nrtDataManager.restoreIfNeeded(folder.getRoot().toPath());
     assertArrayEquals(new String[] {"test_file"}, folder.getRoot().list());
@@ -220,7 +225,7 @@ public class NrtDataManagerTest {
             .build();
     NrtDataManager nrtDataManager =
         new NrtDataManager(
-            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, restoreIndex, true);
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, restoreIndex, true, false);
     folder.newFile("test_file");
     nrtDataManager.restoreIfNeeded(folder.getRoot().toPath());
     assertArrayEquals(new String[] {"segments_6"}, folder.getRoot().list());
@@ -268,7 +273,7 @@ public class NrtDataManagerTest {
             .build();
     NrtDataManager nrtDataManager =
         new NrtDataManager(
-            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, restoreIndex, true);
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, restoreIndex, true, false);
     folder.newFile("test_file");
     nrtDataManager.restoreIfNeeded(folder.getRoot().toPath());
     Set<String> expectedFiles = Set.of("test_file", "segments_6");
@@ -295,7 +300,8 @@ public class NrtDataManagerTest {
   public void testEnqueueUpload_closed() throws IOException {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true, false);
     nrtDataManager.close();
 
     try {
@@ -310,7 +316,8 @@ public class NrtDataManagerTest {
   public void testEnqueueUpload_noCurrentTask() {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true, false);
     CopyState mockCopyState = mock(CopyState.class);
     List<RefreshUploadFuture> refreshUploadFutures = List.of(mock(RefreshUploadFuture.class));
     nrtDataManager.enqueueUpload(mockCopyState, refreshUploadFutures);
@@ -324,7 +331,8 @@ public class NrtDataManagerTest {
   public void testEnqueueUpload_noNextTask() {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true, false);
     CopyState mockCopyState = mock(CopyState.class);
     List<RefreshUploadFuture> refreshUploadFutures = List.of(mock(RefreshUploadFuture.class));
     nrtDataManager.enqueueUpload(mockCopyState, refreshUploadFutures);
@@ -343,7 +351,8 @@ public class NrtDataManagerTest {
   public void testEnqueueUpload_mergeTasks() throws IOException {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true, false);
     NRTPrimaryNode mockPrimaryNode = mock(NRTPrimaryNode.class);
     nrtDataManager.startWithoutThread(mockPrimaryNode, folder.getRoot().toPath());
 
@@ -445,7 +454,8 @@ public class NrtDataManagerTest {
   public void testClose_noThread() throws IOException {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true, false);
     NRTPrimaryNode mockPrimaryNode = mock(NRTPrimaryNode.class);
     nrtDataManager.startWithoutThread(mockPrimaryNode, folder.getRoot().toPath());
     nrtDataManager.close();
@@ -457,7 +467,8 @@ public class NrtDataManagerTest {
   public void testClose_withThread() throws IOException {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true, false);
     NRTPrimaryNode mockPrimaryNode = mock(NRTPrimaryNode.class);
     nrtDataManager.startUploadManager(mockPrimaryNode, folder.getRoot().toPath());
     nrtDataManager.close();
@@ -469,7 +480,8 @@ public class NrtDataManagerTest {
   public void testClose_cleansUpTasks() throws IOException {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true, false);
     NRTPrimaryNode mockPrimaryNode = mock(NRTPrimaryNode.class);
     nrtDataManager.startWithoutThread(mockPrimaryNode, folder.getRoot().toPath());
 
@@ -497,7 +509,8 @@ public class NrtDataManagerTest {
       throws ExecutionException, InterruptedException, TimeoutException, IOException {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true, false);
     NRTPrimaryNode mockPrimaryNode = mock(NRTPrimaryNode.class);
     nrtDataManager.startUploadManager(mockPrimaryNode, folder.getRoot().toPath());
 
@@ -553,7 +566,8 @@ public class NrtDataManagerTest {
       throws ExecutionException, InterruptedException, TimeoutException, IOException {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true, false);
     NRTPrimaryNode mockPrimaryNode = mock(NRTPrimaryNode.class);
     nrtDataManager.startUploadManager(mockPrimaryNode, folder.getRoot().toPath());
 
@@ -637,7 +651,8 @@ public class NrtDataManagerTest {
       throws ExecutionException, InterruptedException, TimeoutException, IOException {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true, false);
     NRTPrimaryNode mockPrimaryNode = mock(NRTPrimaryNode.class);
     nrtDataManager.startUploadManager(mockPrimaryNode, folder.getRoot().toPath());
 
@@ -696,7 +711,8 @@ public class NrtDataManagerTest {
       throws ExecutionException, InterruptedException, TimeoutException, IOException {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true, false);
     NRTPrimaryNode mockPrimaryNode = mock(NRTPrimaryNode.class);
     nrtDataManager.startUploadManager(mockPrimaryNode, folder.getRoot().toPath());
 
@@ -771,7 +787,8 @@ public class NrtDataManagerTest {
         .uploadPointState(
             eq(SERVICE_NAME), eq(INDEX_NAME), any(NrtPointState.class), any(byte[].class));
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true, false);
     NRTPrimaryNode mockPrimaryNode = mock(NRTPrimaryNode.class);
     nrtDataManager.startUploadManager(mockPrimaryNode, folder.getRoot().toPath());
 
@@ -845,12 +862,15 @@ public class NrtDataManagerTest {
   public void testEnqueueNoRemoteCommit() {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, false);
     try {
       nrtDataManager.enqueueUpload(mock(CopyState.class), List.of());
       fail();
     } catch (IllegalStateException e) {
-      assertEquals("Remote commit is not available for this configuration", e.getMessage());
+      assertEquals(
+          "Neither remoteCommit nor s3RefreshUpload is enabled for this configuration",
+          e.getMessage());
     }
   }
 
@@ -963,7 +983,7 @@ public class NrtDataManagerTest {
             .build();
     NrtDataManager nrtDataManager =
         new NrtDataManager(
-            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, restoreIndex, true);
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, restoreIndex, true, false);
     folder.newFile("test_file");
     IsolatedReplicaConfig config = new IsolatedReplicaConfig(true, 60, 120, 0);
     nrtDataManager.restoreIfNeeded(folder.getRoot().toPath(), config);
@@ -1037,7 +1057,8 @@ public class NrtDataManagerTest {
                 new ByteArrayInputStream(pointStateBytes), testTimestamp));
 
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, false);
 
     // Test the method
     NrtDataManager.PointStateWithTimestamp result = nrtDataManager.getTargetPointState(null);
@@ -1058,7 +1079,8 @@ public class NrtDataManagerTest {
         .thenThrow(new IOException("Download failed"));
 
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, false);
 
     try {
       nrtDataManager.getTargetPointState(null);
@@ -1074,7 +1096,8 @@ public class NrtDataManagerTest {
   public void testSetLastPointState_newPointState() {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, false);
 
     // Create test data
     FileMetaData fileMetaData = new FileMetaData(new byte[] {1, 2}, new byte[] {3, 4}, 100, 12345);
@@ -1107,7 +1130,8 @@ public class NrtDataManagerTest {
   public void testSetLastPointState_higherVersion() {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, false);
 
     // Create initial point state with version 1
     FileMetaData fileMetaData1 = new FileMetaData(new byte[] {1, 2}, new byte[] {3, 4}, 100, 12345);
@@ -1156,7 +1180,8 @@ public class NrtDataManagerTest {
   public void testSetLastPointState_lowerVersion() {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, false);
 
     // Create initial point state with version 2
     FileMetaData fileMetaData2 = new FileMetaData(new byte[] {5, 6}, new byte[] {7, 8}, 200, 67890);
@@ -1206,7 +1231,8 @@ public class NrtDataManagerTest {
   public void testSetLastPointState_sameVersion() {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, false);
 
     // Create first point state with version 1
     FileMetaData fileMetaData1 = new FileMetaData(new byte[] {1, 2}, new byte[] {3, 4}, 100, 12345);
@@ -1257,7 +1283,8 @@ public class NrtDataManagerTest {
     // Create mock RemoteBackend
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, true, false);
 
     // Create test data
     String fileName = "test_file.dat";
@@ -1289,7 +1316,8 @@ public class NrtDataManagerTest {
     // Create mock RemoteBackend
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, false);
 
     // Create initial point state
     FileMetaData fileMetaData = new FileMetaData(new byte[] {1, 2}, new byte[] {3, 4}, 100, 12345);
@@ -1343,7 +1371,8 @@ public class NrtDataManagerTest {
   public void testGetLastPointTimestamp_initiallyNull() {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, false);
 
     // Initially should be null
     assertNull(nrtDataManager.getLastPointTimestamp());
@@ -1385,7 +1414,7 @@ public class NrtDataManagerTest {
             .build();
     NrtDataManager nrtDataManager =
         new NrtDataManager(
-            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, restoreIndex, true);
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, restoreIndex, true, false);
 
     // Initially should be null
     assertNull(nrtDataManager.getLastPointTimestamp());
@@ -1400,7 +1429,8 @@ public class NrtDataManagerTest {
   public void testGetLastPointTimestamp_afterSetLastPointState() {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, false);
 
     // Create test data
     FileMetaData fileMetaData = new FileMetaData(new byte[] {1, 2}, new byte[] {3, 4}, 100, 12345);
@@ -1433,7 +1463,8 @@ public class NrtDataManagerTest {
   public void testGetLastPointTimestamp_multipleSetLastPointState_higherVersion() {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, false);
 
     // Create initial point state with version 1
     FileMetaData fileMetaData1 = new FileMetaData(new byte[] {1, 2}, new byte[] {3, 4}, 100, 12345);
@@ -1482,7 +1513,8 @@ public class NrtDataManagerTest {
   public void testGetLastPointTimestamp_multipleSetLastPointState_lowerVersion() {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, false);
 
     // Create initial point state with version 2
     FileMetaData fileMetaData2 = new FileMetaData(new byte[] {5, 6}, new byte[] {7, 8}, 200, 67890);
@@ -1532,7 +1564,8 @@ public class NrtDataManagerTest {
   public void testGetLastPointTimestamp_multipleSetLastPointState_sameVersion() {
     RemoteBackend mockRemoteBackend = mock(RemoteBackend.class);
     NrtDataManager nrtDataManager =
-        new NrtDataManager(SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false);
+        new NrtDataManager(
+            SERVICE_NAME, INDEX_NAME, PRIMARY_ID, mockRemoteBackend, null, false, false);
 
     // Create first point state with version 1
     FileMetaData fileMetaData1 = new FileMetaData(new byte[] {1, 2}, new byte[] {3, 4}, 100, 12345);

--- a/src/test/java/com/yelp/nrtsearch/server/nrt/PrimaryNodeReferenceManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/nrt/PrimaryNodeReferenceManagerTest.java
@@ -83,6 +83,87 @@ public class PrimaryNodeReferenceManagerTest {
   }
 
   @Test
+  public void testRefreshIfNeeded_s3RefreshUploadTriggersUpload() throws IOException {
+    NRTPrimaryNode mockPrimaryNode = mock(NRTPrimaryNode.class);
+    ReferenceManager<IndexSearcher> mockReferenceManager = mock(ReferenceManager.class);
+    IndexSearcher mockSearcher = mock(IndexSearcher.class);
+    IndexReader mockIndexReader = mock(StandardDirectoryReader.class);
+    when(mockSearcher.getIndexReader()).thenReturn(mockIndexReader);
+    when(mockReferenceManager.acquire()).thenReturn(mockSearcher);
+    when(mockPrimaryNode.getSearcherManager()).thenReturn(mockReferenceManager);
+    SearcherFactory mockSearcherFactory = mock(SearcherFactory.class);
+    when(mockSearcherFactory.newSearcher(eq(mockIndexReader), any())).thenReturn(mockSearcher);
+
+    CopyState mockCopyState = mock(CopyState.class);
+    NrtDataManager mockNrtDataManager = mock(NrtDataManager.class);
+    when(mockNrtDataManager.doS3RefreshUpload()).thenReturn(true);
+    when(mockPrimaryNode.getNrtDataManager()).thenReturn(mockNrtDataManager);
+    when(mockPrimaryNode.getCopyState()).thenReturn(mockCopyState);
+    when(mockPrimaryNode.flushAndRefresh()).thenReturn(true);
+
+    NRTPrimaryNode.PrimaryNodeReferenceManager primaryNodeReferenceManager =
+        new NRTPrimaryNode.PrimaryNodeReferenceManager(mockPrimaryNode, mockSearcherFactory);
+    IndexSearcher indexSearcher = primaryNodeReferenceManager.refreshIfNeeded(mockSearcher);
+    assertEquals(mockSearcher, indexSearcher);
+
+    verify(mockPrimaryNode, times(2)).getSearcherManager();
+    verify(mockPrimaryNode, times(1)).flushAndRefresh();
+    verify(mockPrimaryNode, times(1)).sendNewNRTPointToReplicas();
+    verify(mockPrimaryNode, times(2)).getNrtDataManager();
+    verify(mockPrimaryNode, times(1)).getCopyState();
+    verify(mockNrtDataManager, times(1)).doS3RefreshUpload();
+    verify(mockNrtDataManager, times(1)).enqueueUpload(mockCopyState, List.of());
+    verify(mockReferenceManager, times(2)).acquire();
+    verify(mockSearcherFactory, times(1)).newSearcher(mockIndexReader, null);
+    verify(mockSearcherFactory, times(1)).newSearcher(mockIndexReader, mockIndexReader);
+    verify(mockSearcher, times(5)).getIndexReader();
+    verifyNoMoreInteractions(
+        mockPrimaryNode,
+        mockReferenceManager,
+        mockSearcher,
+        mockIndexReader,
+        mockSearcherFactory,
+        mockNrtDataManager,
+        mockCopyState);
+  }
+
+  @Test
+  public void testRefreshIfNeeded_noopFlush_s3RefreshUpload_noWatchers() throws IOException {
+    NRTPrimaryNode mockPrimaryNode = mock(NRTPrimaryNode.class);
+    ReferenceManager<IndexSearcher> mockReferenceManager = mock(ReferenceManager.class);
+    IndexSearcher mockSearcher = mock(IndexSearcher.class);
+    IndexReader mockIndexReader = mock(StandardDirectoryReader.class);
+    when(mockSearcher.getIndexReader()).thenReturn(mockIndexReader);
+    when(mockReferenceManager.acquire()).thenReturn(mockSearcher);
+    when(mockPrimaryNode.getSearcherManager()).thenReturn(mockReferenceManager);
+    SearcherFactory mockSearcherFactory = mock(SearcherFactory.class);
+    when(mockSearcherFactory.newSearcher(eq(mockIndexReader), any())).thenReturn(mockSearcher);
+
+    NrtDataManager mockNrtDataManager = mock(NrtDataManager.class);
+    when(mockNrtDataManager.doS3RefreshUpload()).thenReturn(true);
+    when(mockPrimaryNode.getNrtDataManager()).thenReturn(mockNrtDataManager);
+    when(mockPrimaryNode.flushAndRefresh()).thenReturn(false);
+
+    NRTPrimaryNode.PrimaryNodeReferenceManager primaryNodeReferenceManager =
+        new NRTPrimaryNode.PrimaryNodeReferenceManager(mockPrimaryNode, mockSearcherFactory);
+    IndexSearcher indexSearcher = primaryNodeReferenceManager.refreshIfNeeded(mockSearcher);
+    assertNull(indexSearcher);
+
+    verify(mockPrimaryNode, times(1)).getSearcherManager();
+    verify(mockPrimaryNode, times(1)).flushAndRefresh();
+    verify(mockReferenceManager, times(1)).acquire();
+    verify(mockSearcherFactory, times(1)).newSearcher(mockIndexReader, null);
+    verify(mockSearcher, times(2)).getIndexReader();
+    verifyNoMoreInteractions(
+        mockPrimaryNode,
+        mockReferenceManager,
+        mockSearcher,
+        mockIndexReader,
+        mockSearcherFactory,
+        mockNrtDataManager);
+  }
+
+  @Test
   public void testRefreshIfNeeded_noopFlush() throws IOException {
     NRTPrimaryNode mockPrimaryNode = mock(NRTPrimaryNode.class);
     ReferenceManager<IndexSearcher> mockReferenceManager = mock(ReferenceManager.class);

--- a/src/test/java/com/yelp/nrtsearch/server/nrt/PrimaryNodeReferenceManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/nrt/PrimaryNodeReferenceManagerTest.java
@@ -54,6 +54,9 @@ public class PrimaryNodeReferenceManagerTest {
     SearcherFactory mockSearcherFactory = mock(SearcherFactory.class);
     when(mockSearcherFactory.newSearcher(eq(mockIndexReader), any())).thenReturn(mockSearcher);
 
+    NrtDataManager mockNrtDataManager = mock(NrtDataManager.class);
+    when(mockNrtDataManager.doS3RefreshUpload()).thenReturn(false);
+    when(mockPrimaryNode.getNrtDataManager()).thenReturn(mockNrtDataManager);
     when(mockPrimaryNode.flushAndRefresh()).thenReturn(true);
 
     NRTPrimaryNode.PrimaryNodeReferenceManager primaryNodeReferenceManager =
@@ -64,12 +67,19 @@ public class PrimaryNodeReferenceManagerTest {
     verify(mockPrimaryNode, times(2)).getSearcherManager();
     verify(mockPrimaryNode, times(1)).flushAndRefresh();
     verify(mockPrimaryNode, times(1)).sendNewNRTPointToReplicas();
+    verify(mockPrimaryNode, times(1)).getNrtDataManager();
+    verify(mockNrtDataManager, times(1)).doS3RefreshUpload();
     verify(mockReferenceManager, times(2)).acquire();
     verify(mockSearcherFactory, times(1)).newSearcher(mockIndexReader, null);
     verify(mockSearcherFactory, times(1)).newSearcher(mockIndexReader, mockIndexReader);
     verify(mockSearcher, times(5)).getIndexReader();
     verifyNoMoreInteractions(
-        mockPrimaryNode, mockReferenceManager, mockSearcher, mockIndexReader, mockSearcherFactory);
+        mockPrimaryNode,
+        mockReferenceManager,
+        mockSearcher,
+        mockIndexReader,
+        mockSearcherFactory,
+        mockNrtDataManager);
   }
 
   @Test


### PR DESCRIPTION
Created a new boolean config s3RefreshUpload with default false
when s3RefreshUpload is true, primary would upload to s3 in parallel with grpc data replication.
Replicas stay the same, only getting refresh updates from grpc for now.
Isolated replicas may get refresh updates during commits.