### PR TITLE
Add option to use adaptive concurrency for bootstrapping index download

### DIFF
--- a/docs/server_configuration.rst
+++ b/docs/server_configuration.rst
@@ -615,6 +615,85 @@ Example server configuration
      - Maximum number of index files uploaded concurrently in a single batch. When set to ``0``, the server's ``defaultParallelism`` value is used.
      - 0
 
+   * - downloadRetryMaxAttempts
+     - int
+     - Maximum total download attempts per file including the initial attempt. Set to ``1`` to disable retries.
+     - 3
+
+   * - downloadRetryBaseDelayMs
+     - long
+     - Base delay in milliseconds for exponential backoff between retry rounds.
+     - 1000
+
+   * - downloadRetryMaxDelayMs
+     - long
+     - Maximum delay cap in milliseconds for exponential backoff between retry rounds.
+     - 30000
+
+   * - downloadRetryReduceConcurrency
+     - bool
+     - If enabled, the download concurrency limit is halved on each retry round. Has no effect when ``adaptiveConcurrency.enabled`` is true, since the adaptive limiter manages its own concurrency.
+     - true
+
+.. list-table:: `S3 Adaptive Concurrency Configuration <https://github.com/Yelp/nrtsearch/blob/master/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java>`_ (``remoteConfig.s3.adaptiveConcurrency.*``)
+   :widths: 25 10 50 25
+   :header-rows: 1
+
+   * - Property
+     - Type
+     - Description
+     - Default
+
+   * - enabled
+     - bool
+     - Enables the adaptive concurrency limiter for index file downloads. When enabled, the limiter starts at ``initialLimit`` concurrent downloads and continuously adjusts based on observed aggregate throughput. The ``downloadBatchSize`` setting is ignored as a concurrency cap; only ``maxLimit`` applies. Recommended for IO-limited nodes or when ``downloadBatchSize`` is set higher than the number of files, which would otherwise submit all files simultaneously and cause heap pressure.
+     - false
+
+   * - initialLimit
+     - int
+     - Starting concurrency when the limiter is first created for a download batch.
+     - 16
+
+   * - minLimit
+     - int
+     - Minimum concurrency the limiter will ever decrease to.
+     - 1
+
+   * - maxLimit
+     - int
+     - Hard ceiling on concurrency. The limiter will never exceed this value regardless of throughput signals. Acts as a safety net against GC pressure from too many simultaneous in-flight transfers.
+     - 100
+
+   * - shortAlpha
+     - double
+     - Smoothing factor for the fast (short-window) EMA of aggregate throughput. Higher values make the EMA respond more quickly to recent changes.
+     - 0.3
+
+   * - longAlpha
+     - double
+     - Smoothing factor for the slow (long-window) EMA of aggregate throughput. This EMA tracks the baseline throughput against which the short EMA is compared.
+     - 0.1
+
+   * - decreaseThreshold
+     - double
+     - Gradient ratio (``shortEma / longEma``) below which the concurrency limit is decreased. A value of ``0.85`` means a 15% throughput drop triggers a decrease.
+     - 0.85
+
+   * - decreaseFactor
+     - double
+     - Multiplicative factor applied to the current limit when a decrease is triggered. Must be in (0, 1). A value of ``0.75`` reduces the limit by 25%.
+     - 0.75
+
+   * - windowDurationMs
+     - int
+     - Duration in milliseconds of each throughput measurement window. Throughput is computed as total bytes received across all concurrent transfers in the window divided by the elapsed time. Shorter windows produce faster but noisier gradient signals.
+     - 2000
+
+   * - warmupWindows
+     - int
+     - Number of initial measurement windows during which only increases are allowed. This prevents premature decreases during connection pool warm-up at the start of a download batch.
+     - 3
+
 .. list-table:: `S3 Java Async Client Configuration <https://github.com/Yelp/nrtsearch/blob/master/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Util.java>`_ (``remoteConfig.s3.java.*``)
    :widths: 25 10 50 25
    :header-rows: 1

--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/AdaptiveConcurrencyLimiter.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/AdaptiveConcurrencyLimiter.java
@@ -290,17 +290,20 @@ public class AdaptiveConcurrencyLimiter implements ConcurrencyLimiter {
   /** Release a permit, absorbing it against outstanding debt if any exists. */
   private void releasePermit() {
     inflight.decrementAndGet();
-    while (true) {
-      int debt = permitDebt.get();
-      if (debt <= 0) {
-        semaphore.release();
-        return;
-      }
-      if (permitDebt.compareAndSet(debt, debt - 1)) {
+    // Fast path: no debt, release immediately without acquiring the lock.
+    if (permitDebt.get() <= 0) {
+      semaphore.release();
+      return;
+    }
+    // Slow path: acquire the lock so the absorption is atomic with respect to
+    // applyLimitChange, which also modifies permitDebt under the same lock.
+    synchronized (this) {
+      if (permitDebt.get() > 0) {
+        permitDebt.decrementAndGet();
         // Permit absorbed — do not release to the semaphore.
-        return;
+      } else {
+        semaphore.release();
       }
-      // CAS missed; retry.
     }
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/AdaptiveConcurrencyLimiter.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/AdaptiveConcurrencyLimiter.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.remote.s3;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link ConcurrencyLimiter} that dynamically adjusts the concurrency limit using a
+ * throughput-gradient algorithm driven by a sliding time window.
+ *
+ * <p>Throughput is measured as total bytes received across <em>all</em> concurrent transfers in the
+ * current time window, fed continuously via {@link #recordBytes(long)} from a {@link
+ * software.amazon.awssdk.transfer.s3.progress.TransferListener}. This is intentionally aggregate
+ * rather than per-file: the CRT S3 client downloads large files as many parallel parts, so a
+ * per-file sample conflates internal part-level parallelism with actual IO saturation. The
+ * time-window approach averages cleanly across files of any size.
+ *
+ * <p>Every {@code windowDurationMs} a new throughput sample is computed (bytes / elapsed seconds)
+ * and fed into two EMAs:
+ *
+ * <ul>
+ *   <li>Short EMA (higher {@code shortAlpha}): tracks recent throughput.
+ *   <li>Long EMA (lower {@code longAlpha}): tracks baseline throughput.
+ * </ul>
+ *
+ * <p>The gradient {@code shortEma / longEma} drives limit adjustments:
+ *
+ * <ul>
+ *   <li>Ratio {@code >= 1.0}: throughput stable or improving — increase the limit.
+ *   <li>Ratio {@code < decreaseThreshold}: throughput degrading — decrease the limit.
+ *   <li>Otherwise: hold.
+ * </ul>
+ *
+ * <p>Errors (failed downloads) are treated as an immediate congestion signal and decrease the limit
+ * multiplicatively regardless of the window schedule.
+ *
+ * <p>During a configurable warmup period (measured in windows) the limit only increases, giving the
+ * system time to ramp up without being penalised by cold-start effects.
+ *
+ * <p>A hard {@code maxLimit} cap prevents the GC death spiral that occurs when too many in-flight
+ * transfers accumulate on the heap simultaneously.
+ *
+ * <p>Permit management uses a {@link Semaphore} combined with an {@code AtomicInteger} "permit
+ * debt" counter:
+ *
+ * <ul>
+ *   <li>Limit increase: release extra permits to the semaphore immediately.
+ *   <li>Limit decrease: accumulate debt; completion callbacks absorb permits against the debt
+ *       rather than releasing them, gracefully draining in-flight operations to the new limit.
+ * </ul>
+ */
+public class AdaptiveConcurrencyLimiter implements ConcurrencyLimiter {
+
+  private static final Logger logger = LoggerFactory.getLogger(AdaptiveConcurrencyLimiter.class);
+
+  private final int minLimit;
+  private final int maxLimit;
+  private final double shortAlpha;
+  private final double longAlpha;
+  private final double decreaseThreshold;
+  private final double decreaseFactor;
+  private final long windowDurationNanos;
+  private final int warmupWindows;
+
+  private final AtomicInteger currentLimit;
+  private final AtomicInteger inflight = new AtomicInteger(0);
+  private final AtomicInteger permitDebt = new AtomicInteger(0);
+
+  // Bytes accumulated in the current window; updated by recordBytes() on EventLoop threads.
+  private final AtomicLong windowBytes = new AtomicLong(0);
+
+  // Guarded by `this`
+  private double shortEma = 0;
+  private double longEma = 0;
+  private long windowStartNanos;
+  private int windowsObserved = 0;
+  private final Semaphore semaphore;
+
+  /**
+   * @param initialLimit starting concurrency
+   * @param minLimit minimum concurrency (floor)
+   * @param maxLimit maximum concurrency (hard ceiling — safety net against GC death spiral)
+   * @param shortAlpha fast EMA smoothing factor (higher = more responsive, e.g. 0.3)
+   * @param longAlpha slow EMA smoothing factor (e.g. 0.1)
+   * @param decreaseThreshold gradient ratio below which the limit is decreased (e.g. 0.85)
+   * @param decreaseFactor multiplicative factor applied on decrease (e.g. 0.75)
+   * @param windowDurationMs duration of each throughput measurement window in milliseconds
+   * @param warmupWindows number of initial windows during which only increases are allowed
+   */
+  public AdaptiveConcurrencyLimiter(
+      int initialLimit,
+      int minLimit,
+      int maxLimit,
+      double shortAlpha,
+      double longAlpha,
+      double decreaseThreshold,
+      double decreaseFactor,
+      int windowDurationMs,
+      int warmupWindows) {
+    if (initialLimit <= 0) throw new IllegalArgumentException("initialLimit must be > 0");
+    if (minLimit <= 0) throw new IllegalArgumentException("minLimit must be > 0");
+    if (maxLimit < minLimit) throw new IllegalArgumentException("maxLimit must be >= minLimit");
+    if (shortAlpha <= 0 || shortAlpha > 1)
+      throw new IllegalArgumentException("shortAlpha must be in (0, 1]");
+    if (longAlpha <= 0 || longAlpha > 1)
+      throw new IllegalArgumentException("longAlpha must be in (0, 1]");
+    if (decreaseFactor <= 0 || decreaseFactor >= 1)
+      throw new IllegalArgumentException("decreaseFactor must be in (0, 1)");
+    if (windowDurationMs < 1) throw new IllegalArgumentException("windowDurationMs must be >= 1");
+    if (warmupWindows < 0) throw new IllegalArgumentException("warmupWindows must be >= 0");
+
+    this.minLimit = minLimit;
+    this.maxLimit = maxLimit;
+    this.shortAlpha = shortAlpha;
+    this.longAlpha = longAlpha;
+    this.decreaseThreshold = decreaseThreshold;
+    this.decreaseFactor = decreaseFactor;
+    this.windowDurationNanos = windowDurationMs * 1_000_000L;
+    this.warmupWindows = warmupWindows;
+
+    int clamped = Math.max(minLimit, Math.min(maxLimit, initialLimit));
+    this.currentLimit = new AtomicInteger(clamped);
+    this.semaphore = new Semaphore(clamped);
+    this.windowStartNanos = System.nanoTime();
+  }
+
+  @Override
+  public void acquire() throws InterruptedException {
+    semaphore.acquire();
+    inflight.incrementAndGet();
+  }
+
+  @Override
+  public void onSuccess() {
+    releasePermit();
+  }
+
+  @Override
+  public void onError() {
+    // Treat error as strong congestion: decrease immediately without waiting for the next window.
+    synchronized (this) {
+      int oldLimit = currentLimit.get();
+      int newLimit = Math.max((int) (oldLimit * decreaseFactor), minLimit);
+      if (newLimit < oldLimit) {
+        applyLimitChange(oldLimit, newLimit);
+        logger.info(
+            "Adaptive concurrency: error signal, limit {} -> {} (inflight={})",
+            oldLimit,
+            newLimit,
+            inflight.get());
+      }
+      // Reset short EMA toward long EMA to clear short-term optimism.
+      if (longEma > 0) {
+        shortEma = longEma;
+      }
+    }
+    releasePermit();
+  }
+
+  /**
+   * Record bytes transferred since the last callback, as reported by a {@link
+   * software.amazon.awssdk.transfer.s3.progress.TransferListener}. Rolls the measurement window
+   * when sufficient time has elapsed and triggers a limit adjustment if warranted.
+   *
+   * <p>Must be non-blocking; called on AwsEventLoop threads.
+   */
+  @Override
+  public void recordBytes(long delta) {
+    windowBytes.addAndGet(delta);
+    long now = System.nanoTime();
+
+    // Fast path: still inside the current window.
+    // Read windowStartNanos without the lock first to avoid contention on every byte callback.
+    if (now - windowStartNanos < windowDurationNanos) {
+      return;
+    }
+
+    // Window has elapsed — try to become the thread that closes it.
+    synchronized (this) {
+      long elapsed = now - windowStartNanos;
+      if (elapsed < windowDurationNanos) {
+        // Another thread already rolled the window.
+        return;
+      }
+
+      // Claim the accumulated bytes and reset for the next window.
+      long bytes = windowBytes.getAndSet(0);
+      windowStartNanos = now;
+      windowsObserved++;
+
+      double throughput = bytes / (elapsed / 1e9);
+
+      // Bootstrap EMAs from the first real window.
+      if (shortEma == 0) {
+        shortEma = throughput;
+        longEma = throughput;
+      } else {
+        shortEma = shortAlpha * throughput + (1 - shortAlpha) * shortEma;
+        longEma = longAlpha * throughput + (1 - longAlpha) * longEma;
+      }
+
+      if (longEma == 0) {
+        return;
+      }
+
+      double gradient = shortEma / longEma;
+      boolean inWarmup = windowsObserved <= warmupWindows;
+      int oldLimit = currentLimit.get();
+      int newLimit;
+
+      if (gradient >= 1.0) {
+        int increase = Math.max(1, oldLimit / 10);
+        newLimit = Math.min(oldLimit + increase, maxLimit);
+      } else if (!inWarmup && gradient < decreaseThreshold) {
+        newLimit = Math.max((int) (oldLimit * decreaseFactor), minLimit);
+      } else {
+        return;
+      }
+
+      if (newLimit == oldLimit) {
+        return;
+      }
+
+      applyLimitChange(oldLimit, newLimit);
+      logger.info(
+          "Adaptive concurrency: limit {} -> {} (gradient={}, shortEma={} MB/s, longEma={} MB/s)",
+          oldLimit,
+          newLimit,
+          String.format("%.3f", gradient),
+          String.format("%.1f", shortEma / (1024.0 * 1024.0)),
+          String.format("%.1f", longEma / (1024.0 * 1024.0)));
+    }
+  }
+
+  @Override
+  public int getLimit() {
+    return currentLimit.get();
+  }
+
+  @Override
+  public int getInflight() {
+    return inflight.get();
+  }
+
+  @com.google.common.annotations.VisibleForTesting
+  public int getMaxLimit() {
+    return maxLimit;
+  }
+
+  /**
+   * Apply a limit change. Must be called while holding {@code this} lock so that the limit and
+   * semaphore state are updated atomically with respect to other adjustments.
+   */
+  private void applyLimitChange(int oldLimit, int newLimit) {
+    currentLimit.set(newLimit);
+    int delta = newLimit - oldLimit;
+    if (delta > 0) {
+      // Pay off any outstanding debt first; release the remainder to the semaphore.
+      int debtPayoff = Math.min(delta, permitDebt.get());
+      if (debtPayoff > 0) {
+        permitDebt.addAndGet(-debtPayoff);
+      }
+      int toRelease = delta - debtPayoff;
+      if (toRelease > 0) {
+        semaphore.release(toRelease);
+      }
+    } else {
+      // Accumulate debt; completion callbacks will absorb permits rather than releasing them.
+      permitDebt.addAndGet(-delta);
+    }
+  }
+
+  /** Release a permit, absorbing it against outstanding debt if any exists. */
+  private void releasePermit() {
+    inflight.decrementAndGet();
+    while (true) {
+      int debt = permitDebt.get();
+      if (debt <= 0) {
+        semaphore.release();
+        return;
+      }
+      if (permitDebt.compareAndSet(debt, debt - 1)) {
+        // Permit absorbed — do not release to the semaphore.
+        return;
+      }
+      // CAS missed; retry.
+    }
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/ConcurrencyLimiter.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/ConcurrencyLimiter.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.remote.s3;
+
+/**
+ * Controls the number of concurrent in-flight operations, optionally adjusting the limit
+ * dynamically based on observed performance signals.
+ *
+ * <p>{@link #acquire()} is called by the submitter thread before starting each operation. {@link
+ * #onSuccess} and {@link #onError} are called by completion callbacks (which may run on different
+ * threads) and must therefore be non-blocking.
+ */
+public interface ConcurrencyLimiter {
+
+  /**
+   * Acquire a permit to start an operation. Blocks until a permit is available.
+   *
+   * @throws InterruptedException if the thread is interrupted while waiting
+   */
+  void acquire() throws InterruptedException;
+
+  /**
+   * Report that an operation completed successfully. Releases the permit acquired via {@link
+   * #acquire()}. Must be non-blocking.
+   */
+  void onSuccess();
+
+  /**
+   * Record that {@code delta} bytes were transferred since the last call. Called continuously by a
+   * {@link software.amazon.awssdk.transfer.s3.progress.TransferListener} as parts arrive, giving
+   * implementations a real-time throughput signal that is unaffected by file-size variance.
+   *
+   * <p>The default implementation is a no-op; only adaptive implementations need to override it.
+   * Must be non-blocking.
+   *
+   * @param delta bytes transferred since the last call (already computed as a delta, not
+   *     cumulative)
+   */
+  default void recordBytes(long delta) {}
+
+  /**
+   * Report that an operation failed. Implementations should treat this as a congestion signal and
+   * may decrease the concurrency limit. Must be non-blocking.
+   */
+  void onError();
+
+  /** Returns the current concurrency limit. */
+  int getLimit();
+
+  /** Returns the number of permits currently in use (in-flight operations). */
+  int getInflight();
+}

--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
@@ -76,6 +77,7 @@ import software.amazon.awssdk.transfer.s3.model.Download;
 import software.amazon.awssdk.transfer.s3.model.DownloadRequest;
 import software.amazon.awssdk.transfer.s3.model.FileUpload;
 import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
+import software.amazon.awssdk.transfer.s3.progress.TransferListener;
 
 /** Backend implementation that stored data in amazon s3 object storage. */
 public class S3Backend implements RemoteBackend {
@@ -107,6 +109,7 @@ public class S3Backend implements RemoteBackend {
   private final long downloadRetryBaseDelayMs;
   private final long downloadRetryMaxDelayMs;
   private final boolean downloadRetryReduceConcurrency;
+  private final AdaptiveConcurrencyConfig adaptiveConcurrencyConfig;
   private final S3Client s3;
   private final S3AsyncClient s3Async;
   private final String serviceBucket;
@@ -121,6 +124,113 @@ public class S3Backend implements RemoteBackend {
    * @param backendFileName backend file name
    */
   record FileNamePair(String fileName, String backendFileName, long length) {}
+
+  /** Configuration for the adaptive concurrency limiter. */
+  public static class AdaptiveConcurrencyConfig {
+    private static final String CONFIG_PREFIX = "remoteConfig.s3.adaptiveConcurrency.";
+
+    public static final AdaptiveConcurrencyConfig DISABLED =
+        new AdaptiveConcurrencyConfig(false, 16, 1, 100, 0.3, 0.1, 0.85, 0.75, 2000, 3);
+
+    private final boolean enabled;
+    private final int initialLimit;
+    private final int minLimit;
+    private final int maxLimit;
+    private final double shortAlpha;
+    private final double longAlpha;
+    private final double decreaseThreshold;
+    private final double decreaseFactor;
+    private final int windowDurationMs;
+    private final int warmupWindows;
+
+    public static AdaptiveConcurrencyConfig fromConfig(NrtsearchConfig configuration) {
+      YamlConfigReader configReader = configuration.getConfigReader();
+      boolean enabled = configReader.getBoolean(CONFIG_PREFIX + "enabled", false);
+      int initialLimit = configReader.getInteger(CONFIG_PREFIX + "initialLimit", 16);
+      int minLimit = configReader.getInteger(CONFIG_PREFIX + "minLimit", 1);
+      int maxLimit = configReader.getInteger(CONFIG_PREFIX + "maxLimit", 100);
+      double shortAlpha = configReader.getDouble(CONFIG_PREFIX + "shortAlpha", 0.3);
+      double longAlpha = configReader.getDouble(CONFIG_PREFIX + "longAlpha", 0.1);
+      double decreaseThreshold = configReader.getDouble(CONFIG_PREFIX + "decreaseThreshold", 0.85);
+      double decreaseFactor = configReader.getDouble(CONFIG_PREFIX + "decreaseFactor", 0.75);
+      int windowDurationMs = configReader.getInteger(CONFIG_PREFIX + "windowDurationMs", 2000);
+      int warmupWindows = configReader.getInteger(CONFIG_PREFIX + "warmupWindows", 3);
+      return new AdaptiveConcurrencyConfig(
+          enabled,
+          initialLimit,
+          minLimit,
+          maxLimit,
+          shortAlpha,
+          longAlpha,
+          decreaseThreshold,
+          decreaseFactor,
+          windowDurationMs,
+          warmupWindows);
+    }
+
+    public AdaptiveConcurrencyConfig(
+        boolean enabled,
+        int initialLimit,
+        int minLimit,
+        int maxLimit,
+        double shortAlpha,
+        double longAlpha,
+        double decreaseThreshold,
+        double decreaseFactor,
+        int windowDurationMs,
+        int warmupWindows) {
+      this.enabled = enabled;
+      this.initialLimit = initialLimit;
+      this.minLimit = minLimit;
+      this.maxLimit = maxLimit;
+      this.shortAlpha = shortAlpha;
+      this.longAlpha = longAlpha;
+      this.decreaseThreshold = decreaseThreshold;
+      this.decreaseFactor = decreaseFactor;
+      this.windowDurationMs = windowDurationMs;
+      this.warmupWindows = warmupWindows;
+    }
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public int getInitialLimit() {
+      return initialLimit;
+    }
+
+    public int getMinLimit() {
+      return minLimit;
+    }
+
+    public int getMaxLimit() {
+      return maxLimit;
+    }
+
+    public double getShortAlpha() {
+      return shortAlpha;
+    }
+
+    public double getLongAlpha() {
+      return longAlpha;
+    }
+
+    public double getDecreaseThreshold() {
+      return decreaseThreshold;
+    }
+
+    public double getDecreaseFactor() {
+      return decreaseFactor;
+    }
+
+    public int getWindowDurationMs() {
+      return windowDurationMs;
+    }
+
+    public int getWarmupWindows() {
+      return warmupWindows;
+    }
+  }
 
   /**
    * Configuration for S3 backend.
@@ -139,6 +249,7 @@ public class S3Backend implements RemoteBackend {
     private final long downloadRetryBaseDelayMs;
     private final long downloadRetryMaxDelayMs;
     private final boolean downloadRetryReduceConcurrency;
+    private final AdaptiveConcurrencyConfig adaptiveConcurrencyConfig;
 
     /**
      * Create S3BackendConfig from NrtsearchConfig.
@@ -163,6 +274,8 @@ public class S3Backend implements RemoteBackend {
           configReader.getLong(CONFIG_PREFIX + "downloadRetryMaxDelayMs", 30000L);
       boolean downloadRetryReduceConcurrency =
           configReader.getBoolean(CONFIG_PREFIX + "downloadRetryReduceConcurrency", true);
+      AdaptiveConcurrencyConfig adaptiveConcurrencyConfig =
+          AdaptiveConcurrencyConfig.fromConfig(configuration);
 
       return new S3BackendConfig(
           metrics,
@@ -173,7 +286,35 @@ public class S3Backend implements RemoteBackend {
           downloadRetryMaxAttempts,
           downloadRetryBaseDelayMs,
           downloadRetryMaxDelayMs,
-          downloadRetryReduceConcurrency);
+          downloadRetryReduceConcurrency,
+          adaptiveConcurrencyConfig);
+    }
+
+    /**
+     * Convenience constructor with adaptive concurrency disabled. Adaptive parameters are set to
+     * their defaults.
+     */
+    public S3BackendConfig(
+        boolean metrics,
+        long rateLimitBytes,
+        int rateLimitWindowSeconds,
+        int downloadBatchSize,
+        int uploadBatchSize,
+        int downloadRetryMaxAttempts,
+        long downloadRetryBaseDelayMs,
+        long downloadRetryMaxDelayMs,
+        boolean downloadRetryReduceConcurrency) {
+      this(
+          metrics,
+          rateLimitBytes,
+          rateLimitWindowSeconds,
+          downloadBatchSize,
+          uploadBatchSize,
+          downloadRetryMaxAttempts,
+          downloadRetryBaseDelayMs,
+          downloadRetryMaxDelayMs,
+          downloadRetryReduceConcurrency,
+          AdaptiveConcurrencyConfig.DISABLED);
     }
 
     /**
@@ -190,6 +331,7 @@ public class S3Backend implements RemoteBackend {
      * @param downloadRetryBaseDelayMs base delay in ms for exponential backoff between retry rounds
      * @param downloadRetryMaxDelayMs max delay cap in ms for exponential backoff
      * @param downloadRetryReduceConcurrency whether to halve concurrency on each retry round
+     * @param adaptiveConcurrencyConfig adaptive concurrency configuration
      * @throws IllegalArgumentException if parameters are invalid
      */
     public S3BackendConfig(
@@ -201,7 +343,8 @@ public class S3Backend implements RemoteBackend {
         int downloadRetryMaxAttempts,
         long downloadRetryBaseDelayMs,
         long downloadRetryMaxDelayMs,
-        boolean downloadRetryReduceConcurrency) {
+        boolean downloadRetryReduceConcurrency,
+        AdaptiveConcurrencyConfig adaptiveConcurrencyConfig) {
       if (rateLimitBytes < 0) {
         throw new IllegalArgumentException("rateLimitBytes must be >= 0");
       }
@@ -232,6 +375,10 @@ public class S3Backend implements RemoteBackend {
       this.downloadRetryBaseDelayMs = downloadRetryBaseDelayMs;
       this.downloadRetryMaxDelayMs = downloadRetryMaxDelayMs;
       this.downloadRetryReduceConcurrency = downloadRetryReduceConcurrency;
+      this.adaptiveConcurrencyConfig =
+          adaptiveConcurrencyConfig != null
+              ? adaptiveConcurrencyConfig
+              : AdaptiveConcurrencyConfig.DISABLED;
     }
 
     /**
@@ -313,6 +460,10 @@ public class S3Backend implements RemoteBackend {
      */
     public boolean getDownloadRetryReduceConcurrency() {
       return downloadRetryReduceConcurrency;
+    }
+
+    public AdaptiveConcurrencyConfig getAdaptiveConcurrencyConfig() {
+      return adaptiveConcurrencyConfig;
     }
 
     @VisibleForTesting
@@ -413,6 +564,7 @@ public class S3Backend implements RemoteBackend {
     this.downloadRetryBaseDelayMs = s3BackendConfig.getDownloadRetryBaseDelayMs();
     this.downloadRetryMaxDelayMs = s3BackendConfig.getDownloadRetryMaxDelayMs();
     this.downloadRetryReduceConcurrency = s3BackendConfig.getDownloadRetryReduceConcurrency();
+    this.adaptiveConcurrencyConfig = s3BackendConfig.getAdaptiveConcurrencyConfig();
     this.serviceBucket = serviceBucket;
 
     this.s3Metrics = s3BackendConfig.metrics;
@@ -867,6 +1019,41 @@ public class S3Backend implements RemoteBackend {
     }
   }
 
+  private TransferListener createThroughputListener(ConcurrencyLimiter limiter) {
+    // lastSeenBytes tracks the last cumulative snapshot per request, same as
+    // S3ProgressListenerImpl,
+    // so we can compute the delta on each bytesTransferred callback.
+    ConcurrentHashMap<Object, Long> lastSeenBytes = new ConcurrentHashMap<>();
+    return new TransferListener() {
+      @Override
+      public void bytesTransferred(TransferListener.Context.BytesTransferred context) {
+        long current = context.progressSnapshot().transferredBytes();
+        Long prev = lastSeenBytes.put(context.request(), current);
+        long delta = prev == null ? current : current - prev;
+        if (delta > 0) {
+          limiter.recordBytes(delta);
+        }
+      }
+    };
+  }
+
+  @VisibleForTesting
+  ConcurrencyLimiter createConcurrencyLimiter(int maxConcurrency) {
+    if (adaptiveConcurrencyConfig.isEnabled()) {
+      return new AdaptiveConcurrencyLimiter(
+          adaptiveConcurrencyConfig.getInitialLimit(),
+          adaptiveConcurrencyConfig.getMinLimit(),
+          adaptiveConcurrencyConfig.getMaxLimit(),
+          adaptiveConcurrencyConfig.getShortAlpha(),
+          adaptiveConcurrencyConfig.getLongAlpha(),
+          adaptiveConcurrencyConfig.getDecreaseThreshold(),
+          adaptiveConcurrencyConfig.getDecreaseFactor(),
+          adaptiveConcurrencyConfig.getWindowDurationMs(),
+          adaptiveConcurrencyConfig.getWarmupWindows());
+    }
+    return new StaticConcurrencyLimiter(maxConcurrency);
+  }
+
   /**
    * Download a batch of files concurrently and return any that failed.
    *
@@ -876,7 +1063,7 @@ public class S3Backend implements RemoteBackend {
    * @param maxConcurrency max number of concurrent downloads
    * @param progressListener listener for download progress
    * @return list of files that failed to download (empty if all succeeded)
-   * @throws IOException if interrupted while acquiring the semaphore
+   * @throws IOException if interrupted while waiting to acquire a concurrency permit
    */
   private List<FailedDownload> downloadBatch(
       List<FileNamePair> files,
@@ -885,13 +1072,14 @@ public class S3Backend implements RemoteBackend {
       int maxConcurrency,
       S3ProgressListenerImpl progressListener)
       throws IOException {
-    Semaphore semaphore = new Semaphore(maxConcurrency);
+    ConcurrencyLimiter limiter = createConcurrencyLimiter(maxConcurrency);
+    TransferListener throughputListener = createThroughputListener(limiter);
     ConcurrentLinkedQueue<FailedDownload> failures = new ConcurrentLinkedQueue<>();
     List<CompletableFuture<?>> futures = new ArrayList<>();
 
     for (FileNamePair pair : files) {
       try {
-        semaphore.acquire();
+        limiter.acquire();
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new IOException("Interrupted while waiting to download index files from s3", e);
@@ -910,6 +1098,7 @@ public class S3Backend implements RemoteBackend {
                   GetObjectRequest.builder().bucket(serviceBucket).key(backendKey).build())
               .responseTransformer(AsyncResponseTransformer.toFile(localFile))
               .addTransferListener(progressListener)
+              .addTransferListener(throughputListener)
               .build();
       try {
         Download<GetObjectResponse> download = transferManager.download(request);
@@ -918,14 +1107,16 @@ public class S3Backend implements RemoteBackend {
                 .completionFuture()
                 .whenComplete(
                     (result, t) -> {
-                      semaphore.release();
                       if (t != null) {
+                        limiter.onError();
                         failures.add(new FailedDownload(pair, t));
+                      } else {
+                        limiter.onSuccess();
                       }
                     });
         futures.add(future);
       } catch (Throwable t) {
-        semaphore.release();
+        limiter.onError();
         failures.add(new FailedDownload(pair, t));
       }
     }

--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3Backend.java
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
@@ -77,7 +76,6 @@ import software.amazon.awssdk.transfer.s3.model.Download;
 import software.amazon.awssdk.transfer.s3.model.DownloadRequest;
 import software.amazon.awssdk.transfer.s3.model.FileUpload;
 import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
-import software.amazon.awssdk.transfer.s3.progress.TransferListener;
 
 /** Backend implementation that stored data in amazon s3 object storage. */
 public class S3Backend implements RemoteBackend {
@@ -1019,24 +1017,6 @@ public class S3Backend implements RemoteBackend {
     }
   }
 
-  private TransferListener createThroughputListener(ConcurrencyLimiter limiter) {
-    // lastSeenBytes tracks the last cumulative snapshot per request, same as
-    // S3ProgressListenerImpl,
-    // so we can compute the delta on each bytesTransferred callback.
-    ConcurrentHashMap<Object, Long> lastSeenBytes = new ConcurrentHashMap<>();
-    return new TransferListener() {
-      @Override
-      public void bytesTransferred(TransferListener.Context.BytesTransferred context) {
-        long current = context.progressSnapshot().transferredBytes();
-        Long prev = lastSeenBytes.put(context.request(), current);
-        long delta = prev == null ? current : current - prev;
-        if (delta > 0) {
-          limiter.recordBytes(delta);
-        }
-      }
-    };
-  }
-
   @VisibleForTesting
   ConcurrencyLimiter createConcurrencyLimiter(int maxConcurrency) {
     if (adaptiveConcurrencyConfig.isEnabled()) {
@@ -1073,7 +1053,7 @@ public class S3Backend implements RemoteBackend {
       S3ProgressListenerImpl progressListener)
       throws IOException {
     ConcurrencyLimiter limiter = createConcurrencyLimiter(maxConcurrency);
-    TransferListener throughputListener = createThroughputListener(limiter);
+    progressListener.setDeltaCallback(limiter::recordBytes);
     ConcurrentLinkedQueue<FailedDownload> failures = new ConcurrentLinkedQueue<>();
     List<CompletableFuture<?>> futures = new ArrayList<>();
 
@@ -1098,7 +1078,6 @@ public class S3Backend implements RemoteBackend {
                   GetObjectRequest.builder().bucket(serviceBucket).key(backendKey).build())
               .responseTransformer(AsyncResponseTransformer.toFile(localFile))
               .addTransferListener(progressListener)
-              .addTransferListener(throughputListener)
               .build();
       try {
         Download<GetObjectResponse> download = transferManager.download(request);

--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3ProgressListenerImpl.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/S3ProgressListenerImpl.java
@@ -18,6 +18,7 @@ package com.yelp.nrtsearch.server.remote.s3;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.transfer.s3.progress.TransferListener;
@@ -45,6 +46,9 @@ public class S3ProgressListenerImpl implements TransferListener {
   private final ConcurrentHashMap<Object, Long> lastSeenBytes = new ConcurrentHashMap<>();
   private final AtomicLong totalBytesTransferred = new AtomicLong();
   private final AtomicLong lastLoggedNanos = new AtomicLong(System.nanoTime());
+  // Optional callback invoked with each computed delta, allowing other listeners to piggyback
+  // on this class's cumulative-to-delta computation rather than duplicating the map.
+  private volatile LongConsumer deltaCallback = null;
 
   /**
    * Constructor.
@@ -63,6 +67,14 @@ public class S3ProgressListenerImpl implements TransferListener {
     this.totalExpectedBytes = totalExpectedBytes;
   }
 
+  /**
+   * Register a callback to be invoked with each computed byte delta. Allows other listeners to
+   * piggyback on this class's cumulative-to-delta conversion without maintaining a separate map.
+   */
+  public void setDeltaCallback(LongConsumer callback) {
+    this.deltaCallback = callback;
+  }
+
   @Override
   public void bytesTransferred(Context.BytesTransferred context) {
     // transferredBytes() is cumulative for this individual file transfer; compute the delta.
@@ -70,6 +82,10 @@ public class S3ProgressListenerImpl implements TransferListener {
     Long prev = lastSeenBytes.put(context.request(), current);
     long delta = prev == null ? current : current - prev;
     long total = totalBytesTransferred.addAndGet(delta);
+    LongConsumer cb = deltaCallback;
+    if (cb != null && delta > 0) {
+      cb.accept(delta);
+    }
 
     long now = System.nanoTime();
     long last = lastLoggedNanos.get();

--- a/src/main/java/com/yelp/nrtsearch/server/remote/s3/StaticConcurrencyLimiter.java
+++ b/src/main/java/com/yelp/nrtsearch/server/remote/s3/StaticConcurrencyLimiter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.remote.s3;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** A {@link ConcurrencyLimiter} that enforces a fixed maximum concurrency. */
+public class StaticConcurrencyLimiter implements ConcurrencyLimiter {
+
+  private final Semaphore semaphore;
+  private final int limit;
+  private final AtomicInteger inflight = new AtomicInteger(0);
+
+  public StaticConcurrencyLimiter(int maxConcurrency) {
+    if (maxConcurrency <= 0) {
+      throw new IllegalArgumentException("maxConcurrency must be > 0");
+    }
+    this.limit = maxConcurrency;
+    this.semaphore = new Semaphore(maxConcurrency);
+  }
+
+  @Override
+  public void acquire() throws InterruptedException {
+    semaphore.acquire();
+    inflight.incrementAndGet();
+  }
+
+  @Override
+  public void onSuccess() {
+    inflight.decrementAndGet();
+    semaphore.release();
+  }
+
+  @Override
+  public void onError() {
+    inflight.decrementAndGet();
+    semaphore.release();
+  }
+
+  @Override
+  public int getLimit() {
+    return limit;
+  }
+
+  @Override
+  public int getInflight() {
+    return inflight.get();
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/remote/s3/AdaptiveConcurrencyLimiterTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/remote/s3/AdaptiveConcurrencyLimiterTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.remote.s3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class AdaptiveConcurrencyLimiterTest {
+
+  /**
+   * Build a limiter with a very short window (1 ms) so tests can drive adjustments without real
+   * wall-clock delays. warmupWindows=0 lets decrease fire immediately.
+   */
+  private AdaptiveConcurrencyLimiter fastLimiter(int initial, int min, int max) {
+    return new AdaptiveConcurrencyLimiter(
+        initial,
+        min,
+        max,
+        0.3,
+        0.1, // shortAlpha, longAlpha
+        0.85,
+        0.75, // decreaseThreshold, decreaseFactor
+        1, // windowDurationMs — 1 ms so tests can cross boundaries easily
+        0 // warmupWindows — no warmup so both increase and decrease can fire
+        );
+  }
+
+  /** Same as fastLimiter but with a warmup period. */
+  private AdaptiveConcurrencyLimiter fastLimiterWithWarmup(
+      int initial, int min, int max, int warmupWindows) {
+    return new AdaptiveConcurrencyLimiter(
+        initial, min, max, 0.3, 0.1, 0.85, 0.75, 1, warmupWindows);
+  }
+
+  // ---- Construction ----
+
+  @Test
+  public void testInvalidArguments() {
+    try {
+      new AdaptiveConcurrencyLimiter(0, 1, 100, 0.3, 0.1, 0.85, 0.75, 1000, 3);
+      fail();
+    } catch (IllegalArgumentException e) {
+      /* expected */
+    }
+
+    try {
+      new AdaptiveConcurrencyLimiter(5, 0, 100, 0.3, 0.1, 0.85, 0.75, 1000, 3);
+      fail();
+    } catch (IllegalArgumentException e) {
+      /* expected */
+    }
+
+    try {
+      // maxLimit < minLimit
+      new AdaptiveConcurrencyLimiter(5, 10, 5, 0.3, 0.1, 0.85, 0.75, 1000, 3);
+      fail();
+    } catch (IllegalArgumentException e) {
+      /* expected */
+    }
+
+    try {
+      new AdaptiveConcurrencyLimiter(5, 1, 100, 0.0, 0.1, 0.85, 0.75, 1000, 3);
+      fail();
+    } catch (IllegalArgumentException e) {
+      /* expected */
+    }
+
+    try {
+      // decreaseFactor >= 1
+      new AdaptiveConcurrencyLimiter(5, 1, 100, 0.3, 0.1, 0.85, 1.0, 1000, 3);
+      fail();
+    } catch (IllegalArgumentException e) {
+      /* expected */
+    }
+
+    try {
+      // windowDurationMs < 1
+      new AdaptiveConcurrencyLimiter(5, 1, 100, 0.3, 0.1, 0.85, 0.75, 0, 3);
+      fail();
+    } catch (IllegalArgumentException e) {
+      /* expected */
+    }
+  }
+
+  @Test
+  public void testInitialState() {
+    AdaptiveConcurrencyLimiter limiter = fastLimiter(16, 1, 100);
+    assertEquals(16, limiter.getLimit());
+    assertEquals(0, limiter.getInflight());
+  }
+
+  @Test
+  public void testInitialLimitClampedToMaxLimit() {
+    AdaptiveConcurrencyLimiter limiter = fastLimiter(200, 1, 100);
+    assertEquals(100, limiter.getLimit());
+  }
+
+  @Test
+  public void testInitialLimitClampedToMinLimit() {
+    AdaptiveConcurrencyLimiter limiter = fastLimiter(1, 5, 100);
+    assertEquals(5, limiter.getLimit());
+  }
+
+  // ---- Inflight tracking ----
+
+  @Test
+  public void testInflightTracking() throws InterruptedException {
+    AdaptiveConcurrencyLimiter limiter = fastLimiter(4, 1, 10);
+    assertEquals(0, limiter.getInflight());
+    limiter.acquire();
+    assertEquals(1, limiter.getInflight());
+    limiter.acquire();
+    assertEquals(2, limiter.getInflight());
+    limiter.onSuccess();
+    assertEquals(1, limiter.getInflight());
+    limiter.onError();
+    assertEquals(0, limiter.getInflight());
+  }
+
+  // ---- recordBytes drives window adjustments ----
+
+  /**
+   * Helper: sleep past the window boundary, then feed a burst of bytes so the window closes and an
+   * EMA sample is recorded.
+   */
+  private void feedWindow(AdaptiveConcurrencyLimiter limiter, long bytesPerWindow)
+      throws InterruptedException {
+    Thread.sleep(2); // ensure at least one 1 ms window has elapsed
+    limiter.recordBytes(bytesPerWindow);
+  }
+
+  @Test
+  public void testLimitIncreasesWithStableThroughput() throws InterruptedException {
+    AdaptiveConcurrencyLimiter limiter = fastLimiter(10, 1, 100);
+    int initialLimit = limiter.getLimit();
+
+    // Drive many windows at constant throughput — gradient stays at 1.0, should increase.
+    for (int i = 0; i < 20; i++) {
+      feedWindow(limiter, 10_000_000L); // 10 MB per window
+    }
+
+    assertTrue(
+        "Limit should increase with stable throughput, was " + limiter.getLimit(),
+        limiter.getLimit() > initialLimit);
+  }
+
+  @Test
+  public void testLimitDoesNotExceedMaxLimit() throws InterruptedException {
+    AdaptiveConcurrencyLimiter limiter = fastLimiter(20, 1, 25);
+
+    for (int i = 0; i < 100; i++) {
+      feedWindow(limiter, 10_000_000L);
+    }
+
+    assertTrue(
+        "Limit must not exceed maxLimit, was " + limiter.getLimit(), limiter.getLimit() <= 25);
+  }
+
+  @Test
+  public void testLimitDecreasesWithDegradingThroughput() throws InterruptedException {
+    AdaptiveConcurrencyLimiter limiter = fastLimiter(20, 1, 100);
+
+    // Bootstrap with high throughput so long EMA is high.
+    for (int i = 0; i < 10; i++) {
+      feedWindow(limiter, 100_000_000L);
+    }
+    int limitAfterRamp = limiter.getLimit();
+
+    // Now drop to near-zero throughput — short EMA collapses below threshold.
+    for (int i = 0; i < 20; i++) {
+      feedWindow(limiter, 1L);
+    }
+
+    assertTrue(
+        "Limit should decrease with degrading throughput; before="
+            + limitAfterRamp
+            + ", after="
+            + limiter.getLimit(),
+        limiter.getLimit() < limitAfterRamp);
+  }
+
+  @Test
+  public void testLimitDoesNotGoBelowMinLimit() throws InterruptedException {
+    AdaptiveConcurrencyLimiter limiter = fastLimiter(5, 3, 100);
+
+    for (int i = 0; i < 100; i++) {
+      feedWindow(limiter, 1L);
+    }
+
+    assertTrue(
+        "Limit must not go below minLimit, was " + limiter.getLimit(), limiter.getLimit() >= 3);
+  }
+
+  // ---- Warmup: no decrease allowed ----
+
+  @Test
+  public void testNoDecreaseInWarmup() throws InterruptedException {
+    // warmupWindows=5 — decreases blocked for the first 5 windows.
+    AdaptiveConcurrencyLimiter limiter = fastLimiterWithWarmup(16, 1, 100, 5);
+    int initialLimit = limiter.getLimit();
+
+    // Feed 3 windows with collapsing throughput — still within warmup.
+    feedWindow(limiter, 100_000_000L); // bootstrap EMA high
+    feedWindow(limiter, 1L); // near zero
+    feedWindow(limiter, 1L); // near zero
+
+    assertTrue(
+        "Limit should not decrease during warmup, was " + limiter.getLimit(),
+        limiter.getLimit() >= initialLimit);
+  }
+
+  // ---- Error signal ----
+
+  @Test
+  public void testErrorDecreasesLimit() {
+    AdaptiveConcurrencyLimiter limiter = fastLimiter(20, 1, 100);
+    int before = limiter.getLimit();
+
+    limiter.onError();
+
+    int after = limiter.getLimit();
+    assertTrue(
+        "Error should decrease limit, before=" + before + ", after=" + after, after < before);
+  }
+
+  @Test
+  public void testErrorHonorsMinLimit() {
+    AdaptiveConcurrencyLimiter limiter = fastLimiter(2, 2, 100);
+    limiter.onError();
+    assertTrue(limiter.getLimit() >= 2);
+  }
+
+  // ---- Hard bounds with effective cap ----
+
+  @Test
+  public void testEffectiveMaxLimitCap() throws InterruptedException {
+    // Simulates createConcurrencyLimiter capping adaptiveMaxLimit at maxConcurrency.
+    int effectiveMax = Math.min(100, 15);
+    AdaptiveConcurrencyLimiter limiter = fastLimiter(8, 1, effectiveMax);
+
+    for (int i = 0; i < 100; i++) {
+      feedWindow(limiter, 10_000_000L);
+    }
+    assertTrue(limiter.getLimit() <= 15);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/remote/s3/S3BackendTest.java
@@ -1173,6 +1173,38 @@ public class S3BackendTest {
   }
 
   @Test
+  public void testCreateConcurrencyLimiterStatic() {
+    // adaptiveConcurrency=false → StaticConcurrencyLimiter capped at maxConcurrency
+    try (S3Backend backend =
+        new S3Backend(
+            BUCKET_NAME,
+            false,
+            new S3Backend.S3BackendConfig(false, 0, 1, 30, 0, 1, 0, 0, false),
+            new S3Util.S3ClientBundle(mock(S3Client.class), null))) {
+      ConcurrencyLimiter limiter = backend.createConcurrencyLimiter(30);
+      assertTrue(limiter instanceof StaticConcurrencyLimiter);
+      assertEquals(30, limiter.getLimit());
+    }
+  }
+
+  @Test
+  public void testCreateConcurrencyLimiterAdaptive() {
+    // enabled=true → AdaptiveConcurrencyLimiter using maxLimit from config regardless of
+    // maxConcurrency argument (which comes from downloadBatchSize or defaultParallelism).
+    S3Backend.AdaptiveConcurrencyConfig adaptive =
+        new S3Backend.AdaptiveConcurrencyConfig(true, 16, 1, 50, 0.3, 0.1, 0.85, 0.75, 2000, 3);
+    S3Backend.S3BackendConfig config =
+        new S3Backend.S3BackendConfig(false, 0, 1, 0, 0, 1, 0, 0, false, adaptive);
+    try (S3Backend backend =
+        new S3Backend(
+            BUCKET_NAME, false, config, new S3Util.S3ClientBundle(mock(S3Client.class), null))) {
+      ConcurrencyLimiter limiter = backend.createConcurrencyLimiter(20);
+      assertTrue(limiter instanceof AdaptiveConcurrencyLimiter);
+      assertEquals(50, ((AdaptiveConcurrencyLimiter) limiter).getMaxLimit());
+    }
+  }
+
+  @Test
   public void testS3BackendConfigUploadBatchSize() {
     S3Backend.S3BackendConfig config =
         new S3Backend.S3BackendConfig(false, 0, 1, 0, 10, 1, 0, 0, false);

--- a/src/test/java/com/yelp/nrtsearch/server/remote/s3/StaticConcurrencyLimiterTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/remote/s3/StaticConcurrencyLimiterTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.remote.s3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+public class StaticConcurrencyLimiterTest {
+
+  @Test
+  public void testInvalidConcurrency() {
+    try {
+      new StaticConcurrencyLimiter(0);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      new StaticConcurrencyLimiter(-1);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testLimitIsFixed() {
+    StaticConcurrencyLimiter limiter = new StaticConcurrencyLimiter(5);
+    assertEquals(5, limiter.getLimit());
+    limiter.onSuccess();
+    assertEquals(5, limiter.getLimit());
+    limiter.onError();
+    assertEquals(5, limiter.getLimit());
+  }
+
+  @Test
+  public void testAcquireAndRelease() throws InterruptedException {
+    StaticConcurrencyLimiter limiter = new StaticConcurrencyLimiter(2);
+    assertEquals(0, limiter.getInflight());
+    limiter.acquire();
+    assertEquals(1, limiter.getInflight());
+    limiter.acquire();
+    assertEquals(2, limiter.getInflight());
+    limiter.onSuccess();
+    assertEquals(1, limiter.getInflight());
+    limiter.onError();
+    assertEquals(0, limiter.getInflight());
+  }
+
+  @Test
+  public void testConcurrencyCapEnforced() throws InterruptedException {
+    int limit = 3;
+    StaticConcurrencyLimiter limiter = new StaticConcurrencyLimiter(limit);
+    AtomicInteger maxObservedInflight = new AtomicInteger(0);
+    AtomicInteger currentInflight = new AtomicInteger(0);
+    int totalTasks = 20;
+    CountDownLatch done = new CountDownLatch(totalTasks);
+    ExecutorService executor = Executors.newFixedThreadPool(10);
+
+    for (int i = 0; i < totalTasks; i++) {
+      executor.submit(
+          () -> {
+            try {
+              limiter.acquire();
+              int current = currentInflight.incrementAndGet();
+              maxObservedInflight.updateAndGet(m -> Math.max(m, current));
+              Thread.sleep(5);
+              currentInflight.decrementAndGet();
+              limiter.onSuccess();
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            } finally {
+              done.countDown();
+            }
+          });
+    }
+
+    assertTrue(done.await(10, TimeUnit.SECONDS));
+    executor.shutdown();
+    assertTrue(maxObservedInflight.get() <= limit);
+    assertEquals(0, limiter.getInflight());
+  }
+}


### PR DESCRIPTION
# Problem
Infrastructure for a cluster is not always homogeneous. Due to differences in resource limits (network bandwidth, disk io, etc) it is hard to use a single value to tune the index download during bootstrapping. Additionally, resources are shared by other services running of the same host. Can we provide a means to dynamically adjust the download concurrency based on the resources available.

My hope is that this will avoid resource issues when using the crt async client.

# Solution

  Replaces the raw Semaphore in downloadBatch with a ConcurrencyLimiter interface, with two implementations:

  - StaticConcurrencyLimiter — wraps the existing Semaphore behavior; default when adaptiveConcurrency.enabled is false.
  - AdaptiveConcurrencyLimiter — dynamically adjusts concurrency based on observed throughput.

## Algorithm

  The adaptive limiter uses a dual-EMA throughput gradient over a sliding time window:

  1. Bytes transferred are fed continuously via a TransferListener attached to each download request. This gives an aggregate signal across all concurrent transfers and all CRT multipart parts — avoiding the per-file sampling bias where large files (split into many parts internally) would skew measurements.
  2. Every windowDurationMs (default 2s), the accumulated bytes are converted to a throughput sample (bytes/sec).
  3. Two exponential moving averages are updated: a fast short EMA (α=0.3) and a slow long EMA (α=0.1).
  4. The gradient shortEma / longEma drives concurrency adjustments:
    - ≥ 1.0 — throughput stable or improving → increase by 10% (additive)
    - < 0.85 — throughput degrading → decrease by 25% (multiplicative)
    - otherwise → hold
  5. Download errors trigger an immediate multiplicative decrease regardless of the window schedule.
  6. A configurable warmup period (default 3 windows) allows increases only, preventing cold-start penalties during connection pool warm-up.
  6. A configurable warmup period (default 3 windows) allows increases only, preventing cold-start penalties during connection pool warm-up.
  7. maxLimit (default 100) is a hard ceiling that acts as a safety net regardless of gradient signals.

## Changes

  - ConcurrencyLimiter — new interface (acquire, onSuccess, onError, recordBytes)
  - StaticConcurrencyLimiter — fixed-limit implementation
  - AdaptiveConcurrencyLimiter — throughput-gradient implementation
  - S3Backend.AdaptiveConcurrencyConfig — new nested config class at remoteConfig.s3.adaptiveConcurrency.*
  - S3Backend.downloadBatch — uses ConcurrencyLimiter + attaches a TransferListener to feed byte deltas to the limiter
  - docs/server_configuration.rst — documents the new remoteConfig.s3.adaptiveConcurrency.* settings and the previously undocumented retry settings

## Configuration
```
  remoteConfig:
    s3:
      adaptiveConcurrency:
        enabled: true
        initialLimit: 16   # starting concurrency
        minLimit: 1
        maxLimit: 100      # hard ceiling — prevents GC death spiral
        windowDurationMs: 2000
        warmupWindows: 3
```

  All other parameters (shortAlpha, longAlpha, decreaseThreshold, decreaseFactor) have sensible defaults and should not need tuning in most cases. The feature is opt-in; existing behavior is unchanged when
  enabled: false.