### PR TITLE
Fix L1 quality for multi-retriever

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
@@ -562,6 +562,12 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
                   long rescoreStart = System.nanoTime();
                   topDocs = retrieverContext.getRescoreTask().rescore(topDocs, searchContext);
                   rescoreTimeMs = (System.nanoTime() - rescoreStart) / 1_000_000.0;
+                  int topHits = retrieverContext.getTopHits();
+                  if (topDocs.scoreDocs.length > topHits) {
+                    ScoreDoc[] truncated = new ScoreDoc[topHits];
+                    System.arraycopy(topDocs.scoreDocs, 0, truncated, 0, topHits);
+                    topDocs = new TopDocs(topDocs.totalHits, truncated);
+                  }
                 }
                 return new RetrieverResult(
                     topDocs,

--- a/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
@@ -562,12 +562,7 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
                   long rescoreStart = System.nanoTime();
                   topDocs = retrieverContext.getRescoreTask().rescore(topDocs, searchContext);
                   rescoreTimeMs = (System.nanoTime() - rescoreStart) / 1_000_000.0;
-                  int topHits = retrieverContext.getTopHits();
-                  if (topDocs.scoreDocs.length > topHits) {
-                    ScoreDoc[] truncated = new ScoreDoc[topHits];
-                    System.arraycopy(topDocs.scoreDocs, 0, truncated, 0, topHits);
-                    topDocs = new TopDocs(topDocs.totalHits, truncated);
-                  }
+                  topDocs = getHitsFromOffset(topDocs, 0, retrieverContext.getTopHits());
                 }
                 return new RetrieverResult(
                     topDocs,

--- a/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
@@ -784,7 +784,7 @@ public class SearchRequestProcessor {
 
     for (Retriever retriever : searchRequest.getMultiRetriever().getRetrieversList()) {
       Query query;
-      int numHitsToCollect;
+      int topHits;
       ProfileResult.Builder retrieverProfileResult = doProfile ? ProfileResult.newBuilder() : null;
       RetrieverContext.Builder retrieverContextBuilder =
           RetrieverContext.newBuilder(retriever.getName()).boost(retriever.getBoost());
@@ -814,7 +814,7 @@ public class SearchRequestProcessor {
           if (textRetriever.getTopHits() <= 0) {
             throw new IllegalArgumentException("TextRetriever topHits must be > 0");
           }
-          numHitsToCollect = textRetriever.getTopHits();
+          topHits = textRetriever.getTopHits();
         }
         case KNNRETRIEVER -> {
           retrieverContextBuilder.retrieverType(RetrieverContext.RetrieverType.KNN);
@@ -832,15 +832,16 @@ public class SearchRequestProcessor {
               SearchResponse.Diagnostics.RetrieverDiagnostics.newBuilder()
                   .setVectorDiagnostics(result.vectorDiagnostics())
                   .build());
-          numHitsToCollect = retriever.getKnnRetriever().getKnnQuery().getK();
+          topHits = retriever.getKnnRetriever().getKnnQuery().getK();
         }
         default ->
             throw new IllegalArgumentException(
                 "Unsupported Retriever Type: " + retriever.getRetrieverTypeCase());
       }
 
-      retrieverContextBuilder.query(query);
+      retrieverContextBuilder.query(query).topHits(topHits);
       unionQueryBuilder.add(query, BooleanClause.Occur.SHOULD);
+      int numHitsToCollect = topHits;
       if (retriever.hasRescorer()) {
         retrieverContextBuilder.rescoreTask(
             buildRescoreTask(
@@ -849,6 +850,10 @@ public class SearchRequestProcessor {
                 retriever.getRescorer(),
                 retriever.getName() + "_rescorer",
                 sharedDocContext));
+        int windowSize = retriever.getRescorer().getWindowSize();
+        if (windowSize > numHitsToCollect) {
+          numHitsToCollect = windowSize;
+        }
       }
 
       CollectorCreatorContext collectorCreatorContext =

--- a/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/SearchRequestProcessor.java
@@ -841,7 +841,7 @@ public class SearchRequestProcessor {
 
       retrieverContextBuilder.query(query).topHits(topHits);
       unionQueryBuilder.add(query, BooleanClause.Occur.SHOULD);
-      int numHitsToCollect = topHits;
+      int numHitsToCollect = computeRetrieverNumHitsToCollect(topHits, retriever);
       if (retriever.hasRescorer()) {
         retrieverContextBuilder.rescoreTask(
             buildRescoreTask(
@@ -850,10 +850,6 @@ public class SearchRequestProcessor {
                 retriever.getRescorer(),
                 retriever.getName() + "_rescorer",
                 sharedDocContext));
-        int windowSize = retriever.getRescorer().getWindowSize();
-        if (windowSize > numHitsToCollect) {
-          numHitsToCollect = windowSize;
-        }
       }
 
       CollectorCreatorContext collectorCreatorContext =
@@ -920,5 +916,15 @@ public class SearchRequestProcessor {
       userChildFilters.put(path, filterQuery);
     }
     return userChildFilters;
+  }
+
+  static int computeRetrieverNumHitsToCollect(int topHits, Retriever retriever) {
+    if (retriever.hasRescorer()) {
+      int windowSize = retriever.getRescorer().getWindowSize();
+      if (windowSize > topHits) {
+        return windowSize;
+      }
+    }
+    return topHits;
   }
 }

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/RetrieverContext.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/RetrieverContext.java
@@ -34,6 +34,7 @@ public class RetrieverContext {
   private final Query query;
   private final DocCollector docCollector;
   private final RescoreTask rescoreTask;
+  private final int topHits;
 
   private RetrieverContext(Builder builder) {
     this.name = builder.name;
@@ -42,6 +43,7 @@ public class RetrieverContext {
     this.query = builder.query;
     this.docCollector = builder.docCollector;
     this.rescoreTask = builder.rescoreTask;
+    this.topHits = builder.topHits;
   }
 
   public static Builder newBuilder(String name) {
@@ -56,6 +58,7 @@ public class RetrieverContext {
     private Query query;
     private DocCollector docCollector;
     private RescoreTask rescoreTask;
+    private int topHits;
 
     private Builder(String name) {
       this.name = name;
@@ -86,6 +89,11 @@ public class RetrieverContext {
       return this;
     }
 
+    public Builder topHits(int topHits) {
+      this.topHits = topHits;
+      return this;
+    }
+
     public RetrieverContext build() {
       return new RetrieverContext(this);
     }
@@ -113,5 +121,9 @@ public class RetrieverContext {
 
   public RescoreTask getRescoreTask() {
     return rescoreTask;
+  }
+
+  public int getTopHits() {
+    return topHits;
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
@@ -714,44 +714,31 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
   }
 
   @Test
-  public void testL1RescorerWindowSize() {
-    // topHits=3 but rescorer windowSize=10: all 10 docs should be rescored
-    Retriever textWithLargeWindow =
-        textRetriever(3).toBuilder()
-            .setRescorer(constantScoreRescorer(7.0, 10, "l1_large_window"))
-            .build();
+  public void testComputeRetrieverNumHitsToCollect() {
+    Retriever noRescorer = textRetriever(500);
+    assertEquals(500, SearchRequestProcessor.computeRetrieverNumHitsToCollect(500, noRescorer));
 
-    SearchResponse response =
-        getGrpcServer()
-            .getBlockingStub()
-            .search(
-                baseRequest()
-                    .setMultiRetriever(
-                        MultiRetrieverRequest.newBuilder()
-                            .addRetrievers(textWithLargeWindow)
-                            .setBlender(
-                                Blender.newBuilder()
-                                    .setWeightedScoreOrder(
-                                        WeightedScoreOrderBlender.newBuilder()
-                                            .setScoreMode(WeightedScoreOrderBlender.ScoreMode.MAX)
-                                            .build())
-                                    .build())
-                            .build())
-                    .build());
+    // Rescorer windowSize > topHits: numHitsToCollect = windowSize
+    Retriever withLargeWindow =
+        textRetriever(500).toBuilder().setRescorer(constantScoreRescorer(7.0, 15000, "l1")).build();
+    assertEquals(
+        15000, SearchRequestProcessor.computeRetrieverNumHitsToCollect(500, withLargeWindow));
 
-    // Only 3 docs fed to blender (truncated after rescore), all with score 7.0
-    assertEquals(3, response.getHitsCount());
-    for (Hit hit : response.getHitsList()) {
-      assertEquals(7.0, hit.getScore(), SCORE_DELTA);
-    }
+    // Rescorer windowSize <= topHits: numHitsToCollect = topHits
+    Retriever withSmallWindow =
+        textRetriever(500).toBuilder().setRescorer(constantScoreRescorer(7.0, 100, "l1")).build();
+    assertEquals(
+        500, SearchRequestProcessor.computeRetrieverNumHitsToCollect(500, withSmallWindow));
   }
 
   @Test
   public void testL1RescorerTruncatesToTopHitsBeforeBlend() {
-    // topHits=5 with rescorer windowSize=10 and only one retriever:
-    // all 10 docs get rescored but only 5 are fed to blender
+    // topHits=3, rescorer windowSize=10
+    // truncate to topHits=3 before blending
     Retriever textWithLargeWindow =
-        textRetriever(5).toBuilder().setRescorer(constantScoreRescorer(7.0, 10, "l1_text")).build();
+        textRetriever(3).toBuilder()
+            .setRescorer(constantScoreRescorer(7.0, 10, "l1_large_window"))
+            .build();
 
     SearchResponse response =
         getGrpcServer()
@@ -772,11 +759,7 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
                             .build())
                     .build());
 
-    // Only 5 docs returned despite requesting topHits=10, because truncation limits to 5
-    assertEquals(5, response.getHitsCount());
-    for (Hit hit : response.getHitsList()) {
-      assertEquals(7.0, hit.getScore(), SCORE_DELTA);
-    }
+    assertEquals(3, response.getHitsCount());
   }
 
   @Test

--- a/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
@@ -714,6 +714,72 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
   }
 
   @Test
+  public void testL1RescorerWindowSize() {
+    // topHits=3 but rescorer windowSize=10: all 10 docs should be rescored
+    Retriever textWithLargeWindow =
+        textRetriever(3).toBuilder()
+            .setRescorer(constantScoreRescorer(7.0, 10, "l1_large_window"))
+            .build();
+
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                baseRequest()
+                    .setMultiRetriever(
+                        MultiRetrieverRequest.newBuilder()
+                            .addRetrievers(textWithLargeWindow)
+                            .setBlender(
+                                Blender.newBuilder()
+                                    .setWeightedScoreOrder(
+                                        WeightedScoreOrderBlender.newBuilder()
+                                            .setScoreMode(WeightedScoreOrderBlender.ScoreMode.MAX)
+                                            .build())
+                                    .build())
+                            .build())
+                    .build());
+
+    // Only 3 docs fed to blender (truncated after rescore), all with score 7.0
+    assertEquals(3, response.getHitsCount());
+    for (Hit hit : response.getHitsList()) {
+      assertEquals(7.0, hit.getScore(), SCORE_DELTA);
+    }
+  }
+
+  @Test
+  public void testL1RescorerTruncatesToTopHitsBeforeBlend() {
+    // topHits=5 with rescorer windowSize=10 and only one retriever:
+    // all 10 docs get rescored but only 5 are fed to blender
+    Retriever textWithLargeWindow =
+        textRetriever(5).toBuilder().setRescorer(constantScoreRescorer(7.0, 10, "l1_text")).build();
+
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                baseRequest()
+                    .setTopHits(10)
+                    .setMultiRetriever(
+                        MultiRetrieverRequest.newBuilder()
+                            .addRetrievers(textWithLargeWindow)
+                            .setBlender(
+                                Blender.newBuilder()
+                                    .setWeightedScoreOrder(
+                                        WeightedScoreOrderBlender.newBuilder()
+                                            .setScoreMode(WeightedScoreOrderBlender.ScoreMode.MAX)
+                                            .build())
+                                    .build())
+                            .build())
+                    .build());
+
+    // Only 5 docs returned despite requesting topHits=10, because truncation limits to 5
+    assertEquals(5, response.getHitsCount());
+    for (Hit hit : response.getHitsList()) {
+      assertEquals(7.0, hit.getScore(), SCORE_DELTA);
+    }
+  }
+
+  @Test
   public void testJsonMultiRetrieverRrfRequest() throws Exception {
     SearchResponse response =
         getGrpcServer()


### PR DESCRIPTION
When a multi-retriever has an L1 rescorer with windowSize > topHits, expand collection to windowSize so the rescorer sees the full candidate pool, then truncate back to topHits after rescoring (keeping the best N by L1 score) before feeding to the blender.

  - RetrieverContext — added topHits field
  - SearchRequestProcessor — numHitsToCollect = max(topHits, rescorer.windowSize)
  - SearchHandler — truncate TopDocs to topHits after rescore
