### PR TITLE
Add DocIdSet cache to speed up multiretriever aggregation

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/SearchHandler.java
@@ -52,6 +52,8 @@ import com.yelp.nrtsearch.server.search.SearchCutoffWrapper.CollectionTimeoutExc
 import com.yelp.nrtsearch.server.search.SearchRequestProcessor;
 import com.yelp.nrtsearch.server.search.SearcherResult;
 import com.yelp.nrtsearch.server.search.collectors.DocCollector;
+import com.yelp.nrtsearch.server.search.multiretriever.DocIdSetCache;
+import com.yelp.nrtsearch.server.search.multiretriever.MultiRetrieverAggregationQuery;
 import com.yelp.nrtsearch.server.search.multiretriever.MultiRetrieverContext;
 import com.yelp.nrtsearch.server.search.multiretriever.RetrieverContext;
 import com.yelp.nrtsearch.server.search.multiretriever.blender.score.BlendedScoreDoc;
@@ -92,12 +94,21 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
       ProtoMessagePrinter.omittingInsignificantWhitespace();
 
   private static final Logger logger = LoggerFactory.getLogger(SearchHandler.class);
+
+  /**
+   * Per-retriever threshold for the DocIdSetCache. If any single retriever collects more than this
+   * many docs, the cache is invalidated and the aggregation pass falls back to re-executing the
+   * union query. 10k covers typical hybrid KNN+text queries where each retriever is naturally
+   * bounded.
+   */
+  static final int DOC_ID_SET_CACHE_MAX_HITS = 7_000;
+
   private final ExecutorService searchExecutor;
   private final boolean warming;
 
   /** Return value of {@link #executeMultiRetriever}. */
   private record MultiRetrieverResult(
-      TopDocs topDocs, boolean hadTimeout, boolean terminatedEarly) {}
+      TopDocs topDocs, boolean hadTimeout, boolean terminatedEarly, DocIdSetCache docIdSetCache) {}
 
   public SearchHandler(GlobalState globalState) {
     super(globalState);
@@ -188,7 +199,8 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
       TopDocs hits;
       if (searchContext.getMultiRetrieverContext() != null) {
         MultiRetrieverResult multiRetrieverResult =
-            executeMultiRetriever(searchContext, s.searcher(), diagnostics, profileResultBuilder);
+            executeMultiRetriever(
+                searchContext, s.searcher(), searchRequest, diagnostics, profileResultBuilder);
         hits = multiRetrieverResult.topDocs();
 
         DeadlineUtils.checkDeadline(
@@ -196,21 +208,27 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
 
         populateRetrieverScores(hits, searchContext.getSharedDocContext());
 
-        // Run aggregations (facets + collectors) against the union query after blending.
-        // Note: facet counts reflect the full match set of the union query, not the recalled
-        // top-K per retriever. For KNN retrievers this is equivalent (KnnFloatVectorQuery is
-        // inherently bounded to k). For text retrievers, counts may include documents beyond
-        // the topHits recall window if the underlying query matches more docs than topHits.
-        if (!searchRequest.getFacetsList().isEmpty()) {
-          SearcherResult searcherResult =
-              runDrillSidewaysSearch(
-                  s, indexState, shardState, searchContext, searchRequest, diagnostics, hits);
-          searchContext
-              .getResponseBuilder()
-              .putAllCollectorResults(searcherResult.getCollectorResults());
-          hits = new TopDocs(searcherResult.getTopDocs().totalHits, hits.scoreDocs);
-        } else if (searchRequest.getCollectorsCount() > 0) {
-          SearcherResult searcherResult = executeSearch(s.searcher(), searchContext);
+        // Run aggregations (facets + collectors). Uses the cached bitset query when valid,
+        // otherwise rewrites transparently to the union query.
+        if (!searchRequest.getFacetsList().isEmpty() || searchRequest.getCollectorsCount() > 0) {
+          Query aggregationQuery =
+              new MultiRetrieverAggregationQuery(
+                  multiRetrieverResult.docIdSetCache(), searchContext.getQuery());
+          SearcherResult searcherResult;
+          if (!searchRequest.getFacetsList().isEmpty()) {
+            searcherResult =
+                runDrillSidewaysSearchWithQuery(
+                    s,
+                    indexState,
+                    shardState,
+                    searchContext,
+                    searchRequest,
+                    diagnostics,
+                    hits,
+                    aggregationQuery);
+          } else {
+            searcherResult = executeSearchWithQuery(s.searcher(), searchContext, aggregationQuery);
+          }
           searchContext
               .getResponseBuilder()
               .putAllCollectorResults(searcherResult.getCollectorResults());
@@ -528,6 +546,7 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
   private MultiRetrieverResult executeMultiRetriever(
       SearchContext searchContext,
       IndexSearcher searcher,
+      SearchRequest searchRequest,
       SearchResponse.Diagnostics.Builder diagnostics,
       ProfileResult.Builder profileResultBuilder)
       throws InterruptedException {
@@ -542,6 +561,12 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
         boolean hadTimeout,
         boolean terminatedEarly) {}
 
+    boolean needsAggregation =
+        !searchRequest.getFacetsList().isEmpty() || searchRequest.getCollectorsCount() > 0;
+    // Create DocIdSetCache when aggregations are needed. This is a request level object
+    DocIdSetCache docIdSetCache =
+        needsAggregation ? new DocIdSetCache(DOC_ID_SET_CACHE_MAX_HITS) : null;
+
     LinkedHashMap<String, Future<RetrieverResult>> retrieverFutures = new LinkedHashMap<>();
     for (Map.Entry<String, RetrieverContext> entry : retrieverContexts.entrySet()) {
       String name = entry.getKey();
@@ -551,9 +576,13 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
           searchExecutor.submit(
               () -> {
                 DocCollector docCollector = retrieverContext.getDocCollector();
+                CollectorManager<? extends Collector, SearcherResult> manager =
+                    docCollector.getWrappedManager();
+                if (docIdSetCache != null) {
+                  manager = docIdSetCache.wrapWithCaching(manager);
+                }
                 long searchStart = System.nanoTime();
-                SearcherResult result =
-                    searcher.search(retrieverContext.getQuery(), docCollector.getWrappedManager());
+                SearcherResult result = searcher.search(retrieverContext.getQuery(), manager);
                 TopDocs topDocs = result.getTopDocs();
                 double searchTimeMs = (System.nanoTime() - searchStart) / 1_000_000.0;
 
@@ -662,7 +691,7 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
     }
 
     return new MultiRetrieverResult(
-        blendedHits, anyRetrieverHadTimeout, anyRetrieverTerminatedEarly);
+        blendedHits, anyRetrieverHadTimeout, anyRetrieverTerminatedEarly, docIdSetCache);
   }
 
   /**
@@ -1420,6 +1449,26 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
   }
 
   /**
+   * Like {@link #executeSearch} but uses an explicit query instead of the one stored in the search
+   * context. Used when the DocIdSetCache provides a lightweight cached query for aggregation.
+   */
+  private static SearcherResult executeSearchWithQuery(
+      org.apache.lucene.search.IndexSearcher searcher,
+      SearchContext searchContext,
+      org.apache.lucene.search.Query query)
+      throws IOException {
+    try {
+      return searcher.search(query, searchContext.getCollector().getWrappedManager());
+    } catch (RuntimeException e) {
+      CollectionTimeoutException timeoutException = findTimeoutException(e);
+      if (timeoutException != null) {
+        throw new CollectionTimeoutException(timeoutException.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  /**
    * Builds a {@link DrillSidewaysImpl}, executes the search, writes facet results to the response
    * builder, and returns the {@link SearcherResult} from the drill sideways pass.
    *
@@ -1462,6 +1511,59 @@ public class SearchHandler extends Handler<SearchRequest, SearchResponse> {
     } catch (RuntimeException e) {
       // DrillSideways wraps exceptions in a few layers; unwrap timeouts so the top-level
       // exception type is consistent with the non-facets path.
+      CollectionTimeoutException timeoutException = findTimeoutException(e);
+      if (timeoutException != null) {
+        throw new CollectionTimeoutException(timeoutException.getMessage(), e);
+      }
+      throw e;
+    }
+    SearcherResult searcherResult = drillResult.collectorResult;
+    searchContext.getResponseBuilder().addAllFacetResult(grpcFacetResults);
+    searchContext
+        .getResponseBuilder()
+        .addAllFacetResult(
+            FacetTopDocs.facetTopDocsSample(
+                topDocsForSample != null ? topDocsForSample : searcherResult.getTopDocs(),
+                searchRequest.getFacetsList(),
+                indexState,
+                s.searcher(),
+                diagnostics));
+    return searcherResult;
+  }
+
+  /**
+   * Like {@link #runDrillSidewaysSearch} but uses an explicit base query (e.g. a cached DocIdSet
+   * query) instead of the drill-down query stored in the search context.
+   */
+  private SearcherResult runDrillSidewaysSearchWithQuery(
+      SearcherTaxonomyManager.SearcherAndTaxonomy s,
+      IndexState indexState,
+      ShardState shardState,
+      SearchContext searchContext,
+      SearchRequest searchRequest,
+      SearchResponse.Diagnostics.Builder diagnostics,
+      TopDocs topDocsForSample,
+      org.apache.lucene.search.Query baseQuery)
+      throws IOException {
+    DrillDownQuery ddq = new DrillDownQuery(indexState.getFacetsConfig(), baseQuery);
+    List<FacetResult> grpcFacetResults = new ArrayList<>();
+    DrillSideways drillS =
+        new DrillSidewaysImpl(
+            s.searcher(),
+            indexState.getFacetsConfig(),
+            s.taxonomyReader(),
+            searchRequest.getFacetsList(),
+            s,
+            indexState,
+            shardState,
+            searchContext.getQueryFields(),
+            grpcFacetResults,
+            DIRECT_EXECUTOR,
+            diagnostics);
+    DrillSideways.ConcurrentDrillSidewaysResult<SearcherResult> drillResult;
+    try {
+      drillResult = drillS.search(ddq, searchContext.getCollector().getWrappedManager());
+    } catch (RuntimeException e) {
       CollectionTimeoutException timeoutException = findTimeoutException(e);
       if (timeoutException != null) {
         throw new CollectionTimeoutException(timeoutException.getMessage(), e);

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/DocIdSetCache.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/DocIdSetCache.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever;
+
+import com.yelp.nrtsearch.server.search.SearcherResult;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
+import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.BitSetIterator;
+import org.apache.lucene.util.SparseFixedBitSet;
+
+/**
+ * Captures document IDs from multiple retriever searches into per-retriever, per-segment {@link
+ * SparseFixedBitSet}s, then merges them (OR) into a union view for the aggregation pass.
+ *
+ * <p>Uses {@link SparseFixedBitSet} for collection. Each retriever tracks its own hit count and
+ * stops recording once its per-retriever threshold is breached (plain int, no cross-thread
+ * contention). After all retrievers complete, run {@link #merge} ORs the per-retriever bitsets
+ * together into the union view.
+ */
+public class DocIdSetCache {
+
+  private final int perRetrieverMaxHits;
+  private final AtomicBoolean exceeded = new AtomicBoolean(false);
+  private final List<Map<Integer, SparseFixedBitSet>> retrieverBitSets;
+  private Map<Integer, BitSet> mergedBitSets;
+
+  /**
+   * @param perRetrieverMaxHits per-retriever threshold — if any single retriever collects more than
+   *     this many docs, the cache is invalidated immediately during collection
+   */
+  public DocIdSetCache(int perRetrieverMaxHits) {
+    this.perRetrieverMaxHits = perRetrieverMaxHits;
+    this.retrieverBitSets = new ArrayList<>();
+  }
+
+  /**
+   * Wraps the given collector manager with caching. Each call creates a new per-retriever bitset
+   * collection and returns a wrapping manager that captures doc IDs during collection.
+   */
+  public synchronized CollectorManager<? extends Collector, SearcherResult> wrapWithCaching(
+      CollectorManager<? extends Collector, SearcherResult> delegate) {
+    return new DocIdSetCacheCollectorManager(delegate, newRetrieverBitSets());
+  }
+
+  /** Creates a new per-retriever bitset collection for direct use in tests. */
+  synchronized RetrieverBitSets newRetrieverBitSets() {
+    ConcurrentHashMap<Integer, SparseFixedBitSet> map = new ConcurrentHashMap<>();
+    retrieverBitSets.add(map);
+    return new RetrieverBitSets(map, perRetrieverMaxHits, exceeded);
+  }
+
+  /**
+   * True once any retriever has tripped the threshold. Collectors check this to skip bitset writes.
+   */
+  public boolean isExceeded() {
+    return exceeded.get();
+  }
+
+  /**
+   * Merges all per-retriever bitsets via OR into the union view. Must be called after all
+   * retrievers have completed (single-threaded). Idempotent — subsequent calls are no-ops.
+   *
+   * <p>If the exceeded flag was already set during collection, the merge is skipped (bitsets are
+   * incomplete and must not be used).
+   */
+  public void merge() {
+    if (mergedBitSets != null) {
+      return;
+    }
+    if (exceeded.get()) {
+      retrieverBitSets.clear();
+      return;
+    }
+
+    Map<Integer, BitSet> tempMergedBitSets = new HashMap<>();
+
+    for (Map<Integer, SparseFixedBitSet> retrieverMap : retrieverBitSets) {
+      for (Map.Entry<Integer, SparseFixedBitSet> entry : retrieverMap.entrySet()) {
+        int segmentOrd = entry.getKey();
+        SparseFixedBitSet bits = entry.getValue();
+        tempMergedBitSets.merge(
+            segmentOrd,
+            bits,
+            (existing, incoming) -> {
+              try {
+                // Using iterator for OR as the underlying bitSet are not guaranteed to be
+                // fixedBitSet
+                // that supports bitwise operations
+                existing.or(new BitSetIterator(incoming, incoming.approximateCardinality()));
+              } catch (IOException e) {
+                throw new RuntimeException("Failed to merge bitsets for segment " + segmentOrd, e);
+              }
+              return existing;
+            });
+      }
+    }
+
+    retrieverBitSets.clear();
+    // Set the mergedBitSets only after the merge is complete.
+    this.mergedBitSets = tempMergedBitSets;
+  }
+
+  /** Whether {@link #merge} has been called successfully. */
+  public boolean isMerged() {
+    return mergedBitSets != null;
+  }
+
+  /** Gets the merged bitset for a given segment. Only valid after {@link #merge}. */
+  public BitSet getBitSet(int segmentOrd) {
+    return mergedBitSets != null ? mergedBitSets.get(segmentOrd) : null;
+  }
+
+  /**
+   * Per-retriever handle for recording hits. Each instance is owned by a single retriever.
+   *
+   * <p>The underlying map is a {@link ConcurrentHashMap} so that multiple search slices (each
+   * handling disjoint segments) can safely create entries concurrently. Each {@link
+   * SparseFixedBitSet} is only written by the single slice thread that owns that segment.
+   *
+   * <p>Tracks a per-retriever hit count (plain int, incremented only by the slice thread that owns
+   * the segment). Once the count exceeds the threshold, sets the cache-wide exceeded flag and stops
+   * recording. No atomic operations on the hot path.
+   */
+  public static class RetrieverBitSets {
+    private final ConcurrentHashMap<Integer, SparseFixedBitSet> segmentBitSets;
+    private final int maxHits;
+    private final AtomicBoolean exceeded;
+    private int hitCount;
+
+    RetrieverBitSets(
+        ConcurrentHashMap<Integer, SparseFixedBitSet> segmentBitSets,
+        int maxHits,
+        AtomicBoolean exceeded) {
+      this.segmentBitSets = segmentBitSets;
+      this.maxHits = maxHits;
+      this.exceeded = exceeded;
+    }
+
+    /**
+     * Gets or creates the bitset for the given segment.
+     *
+     * @param segmentOrd segment ordinal from LeafReaderContext.ord
+     * @param maxDoc the segment's maxDoc (sizes the bitset)
+     */
+    public SparseFixedBitSet getOrCreateBitSet(int segmentOrd, int maxDoc) {
+      return segmentBitSets.computeIfAbsent(segmentOrd, k -> new SparseFixedBitSet(maxDoc));
+    }
+
+    /**
+     * Records a hit. Call from the collector after setting a bit. Once the per-retriever count
+     * exceeds the threshold, sets the shared exceeded flag.
+     */
+    public void recordHit() {
+      if (++hitCount > maxHits) {
+        exceeded.set(true);
+      }
+    }
+
+    /** Whether any retriever has exceeded the threshold. */
+    public boolean isExceeded() {
+      return exceeded.get();
+    }
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/DocIdSetCacheCollectorManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/DocIdSetCacheCollectorManager.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever;
+
+import com.yelp.nrtsearch.server.search.SearcherResult;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.util.SparseFixedBitSet;
+
+/**
+ * A {@link CollectorManager} wrapper that intercepts document collection to capture doc IDs into a
+ * per-retriever {@link DocIdSetCache.RetrieverBitSets}, while delegating all actual ranking and
+ * collection to the wrapped manager.
+ *
+ * <p>Supports early exit: once the per-retriever hit count exceeds the threshold, the collector
+ * stops writing to the bitset (just delegates). No atomic operations on the hot path — each leaf
+ * collector holds a plain int counter via its {@link DocIdSetCache.RetrieverBitSets}.
+ */
+public class DocIdSetCacheCollectorManager
+    implements CollectorManager<DocIdSetCacheCollectorManager.CachingCollector, SearcherResult> {
+
+  private final CollectorManager<? extends Collector, SearcherResult> delegate;
+  private final DocIdSetCache.RetrieverBitSets retrieverBitSets;
+
+  public DocIdSetCacheCollectorManager(
+      CollectorManager<? extends Collector, SearcherResult> delegate,
+      DocIdSetCache.RetrieverBitSets retrieverBitSets) {
+    this.delegate = delegate;
+    this.retrieverBitSets = retrieverBitSets;
+  }
+
+  @Override
+  public CachingCollector newCollector() throws IOException {
+    Collector delegateCollector = delegate.newCollector();
+    return new CachingCollector(delegateCollector);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SearcherResult reduce(Collection<CachingCollector> collectors) throws IOException {
+    ArrayList<Collector> delegateCollectors = new ArrayList<>(collectors.size());
+    for (CachingCollector cachingCollector : collectors) {
+      delegateCollectors.add(cachingCollector.getDelegate());
+    }
+    return ((CollectorManager<Collector, SearcherResult>) delegate).reduce(delegateCollectors);
+  }
+
+  /** Wraps a delegate collector and records collected doc IDs into the retriever's bitsets. */
+  public class CachingCollector implements Collector {
+
+    private final Collector delegate;
+
+    CachingCollector(Collector delegate) {
+      this.delegate = delegate;
+    }
+
+    public Collector getDelegate() {
+      return delegate;
+    }
+
+    @Override
+    public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+      LeafCollector delegateLeafCollector = delegate.getLeafCollector(context);
+      if (retrieverBitSets.isExceeded()) {
+        return delegateLeafCollector;
+      }
+      SparseFixedBitSet bitSet =
+          retrieverBitSets.getOrCreateBitSet(context.ord, context.reader().maxDoc());
+      return new CachingLeafCollector(delegateLeafCollector, bitSet);
+    }
+
+    @Override
+    public ScoreMode scoreMode() {
+      return delegate.scoreMode();
+    }
+  }
+
+  private class CachingLeafCollector implements LeafCollector {
+
+    private final LeafCollector delegate;
+    private final SparseFixedBitSet bitSet;
+
+    CachingLeafCollector(LeafCollector delegate, SparseFixedBitSet bitSet) {
+      this.delegate = delegate;
+      this.bitSet = bitSet;
+    }
+
+    @Override
+    public void collect(int doc) throws IOException {
+      if (!retrieverBitSets.isExceeded()) {
+        bitSet.set(doc);
+        retrieverBitSets.recordHit();
+      }
+      delegate.collect(doc);
+    }
+
+    @Override
+    public void setScorer(Scorable scorer) throws IOException {
+      delegate.setScorer(scorer);
+    }
+  }
+}

--- a/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/MultiRetrieverAggregationQuery.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/multiretriever/MultiRetrieverAggregationQuery.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever;
+
+import java.io.IOException;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.BitSetIterator;
+
+/**
+ * Query used for the multi-retriever aggregation pass. Wraps a {@link DocIdSetCache} and a fallback
+ * union query. If the cache is valid (not exceeded), iterates the cached per-segment bitsets
+ * directly — avoiding re-execution of the union query. If the cache was invalidated during
+ * collection, rewrites to the fallback query transparently.
+ *
+ * <p>All matched docs receive a constant score of 0.0f since aggregation does not use scores.
+ */
+public class MultiRetrieverAggregationQuery extends Query {
+  private final DocIdSetCache cache;
+  private final Query fallback;
+
+  /**
+   * @param cache the doc ID cache populated during retriever collection (may be exceeded)
+   * @param fallback the union query to use when the cache is invalid
+   */
+  public MultiRetrieverAggregationQuery(DocIdSetCache cache, Query fallback) {
+    this.cache = cache;
+    this.fallback = fallback;
+  }
+
+  @Override
+  public Query rewrite(IndexSearcher indexSearcher) throws IOException {
+    if (cache.isExceeded()) {
+      return fallback.rewrite(indexSearcher);
+    }
+    cache.merge();
+    return this;
+  }
+
+  @Override
+  public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
+      throws IOException {
+    assert cache.isMerged() && !cache.isExceeded()
+        : "createWeight called without rewrite(); cache must be merged and not exceeded";
+
+    // If scores are needed, delegate to the fallback query — the cached bitset has no scores.
+    if (scoreMode.needsScores()) {
+      return fallback.createWeight(searcher, scoreMode, boost);
+    }
+
+    return new ConstantScoreWeight(this, 0f) {
+      @Override
+      public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+        BitSet bitSet = cache.getBitSet(context.ord);
+        if (bitSet == null || bitSet.cardinality() == 0) {
+          return null;
+        }
+        return new ScorerSupplier() {
+          @Override
+          public Scorer get(long leadCost) throws IOException {
+            DocIdSetIterator iterator = new BitSetIterator(bitSet, bitSet.cardinality());
+            return new ConstantScoreScorer(score(), scoreMode, iterator);
+          }
+
+          @Override
+          public long cost() {
+            return bitSet.cardinality();
+          }
+        };
+      }
+
+      @Override
+      public boolean isCacheable(LeafReaderContext ctx) {
+        return false;
+      }
+    };
+  }
+
+  @Override
+  public String toString(String field) {
+    return "MultiRetrieverAggregationQuery(fallback=" + fallback.toString(field) + ")";
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (!(other instanceof MultiRetrieverAggregationQuery o)) {
+      return false;
+    }
+    return cache == o.cache && fallback.equals(o.fallback);
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * System.identityHashCode(cache) + fallback.hashCode();
+  }
+
+  @Override
+  public void visit(QueryVisitor visitor) {
+    visitor.visitLeaf(this);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/MultiRetrieverSearchTest.java
@@ -732,4 +732,75 @@ public class MultiRetrieverSearchTest extends ServerTestCase {
     for (int i = 0; i < 5; i++) assertTrue(hits.get(i).getScore() > RRF_RANK1_K60);
     for (int i = 5; i < 10; i++) assertTrue(hits.get(i).getScore() <= RRF_RANK1_K60);
   }
+
+  // --- DocIdSetCache tests ---
+  // The cache is always active (threshold = 10k). These tests verify it produces correct results.
+  // With only 10 docs in the test index, the cache is always within threshold.
+
+  @Test
+  public void testDocIdSetCacheCollectorsProduceSameResults() {
+    // Cache is active under the hood; verify collectors produce correct results
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                baseRequest()
+                    .setMultiRetriever(twoRetrieverRrf())
+                    .putCollectors("category_terms", categoryTermsCollector(10))
+                    .build());
+
+    assertEquals(10, response.getTotalHits().getValue());
+    assertEquals(TotalHits.Relation.EQUAL_TO, response.getTotalHits().getRelation());
+    assertTrue(response.getCollectorResultsMap().containsKey("category_terms"));
+    assertEquals(
+        2,
+        response
+            .getCollectorResultsMap()
+            .get("category_terms")
+            .getBucketResult()
+            .getBucketsCount());
+  }
+
+  @Test
+  public void testDocIdSetCacheFacetsProduceSameResults() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                baseRequest()
+                    .setMultiRetriever(twoRetrieverRrf())
+                    .addFacets(categoryFacet(5))
+                    .build());
+
+    assertEquals(10, response.getTotalHits().getValue());
+    assertEquals(1, response.getFacetResultCount());
+    assertEquals("category_facet", response.getFacetResult(0).getName());
+    assertEquals(2, response.getFacetResult(0).getLabelValuesCount());
+    assertEquals(5, response.getFacetResult(0).getLabelValues(0).getValue(), 0);
+    assertEquals(5, response.getFacetResult(0).getLabelValues(1).getValue(), 0);
+  }
+
+  @Test
+  public void testDocIdSetCacheFacetsAndCollectorsTogether() {
+    SearchResponse response =
+        getGrpcServer()
+            .getBlockingStub()
+            .search(
+                baseRequest()
+                    .setMultiRetriever(twoRetrieverRrf())
+                    .addFacets(categoryFacet(5))
+                    .putCollectors("category_terms", categoryTermsCollector(10))
+                    .build());
+
+    assertEquals(10, response.getTotalHits().getValue());
+    assertEquals(1, response.getFacetResultCount());
+    assertTrue(response.getCollectorResultsMap().containsKey("category_terms"));
+    assertEquals(
+        2,
+        response
+            .getCollectorResultsMap()
+            .get("category_terms")
+            .getBucketResult()
+            .getBucketsCount());
+  }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/DocIdSetCacheTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/multiretriever/DocIdSetCacheTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.search.multiretriever;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.SparseFixedBitSet;
+import org.junit.Test;
+
+public class DocIdSetCacheTest {
+
+  @Test
+  public void testSingleRetrieverMerge() {
+    DocIdSetCache cache = new DocIdSetCache(100);
+    DocIdSetCache.RetrieverBitSets rbs = cache.newRetrieverBitSets();
+
+    SparseFixedBitSet bitSet = rbs.getOrCreateBitSet(0, 1000);
+    assertNotNull(bitSet);
+
+    bitSet.set(5);
+    rbs.recordHit();
+    bitSet.set(10);
+    rbs.recordHit();
+
+    cache.merge();
+    assertFalse(cache.isExceeded());
+
+    BitSet merged = cache.getBitSet(0);
+    assertNotNull(merged);
+    assertTrue(merged.get(5));
+    assertTrue(merged.get(10));
+  }
+
+  @Test
+  public void testMultipleRetrieversMergeWithOverlap() {
+    DocIdSetCache cache = new DocIdSetCache(100);
+
+    DocIdSetCache.RetrieverBitSets rbs1 = cache.newRetrieverBitSets();
+    DocIdSetCache.RetrieverBitSets rbs2 = cache.newRetrieverBitSets();
+
+    SparseFixedBitSet bs1 = rbs1.getOrCreateBitSet(0, 100);
+    bs1.set(5);
+    rbs1.recordHit();
+    bs1.set(10);
+    rbs1.recordHit();
+
+    SparseFixedBitSet bs2 = rbs2.getOrCreateBitSet(0, 100);
+    bs2.set(10);
+    rbs2.recordHit();
+    bs2.set(20);
+    rbs2.recordHit();
+
+    cache.merge();
+
+    BitSet merged = cache.getBitSet(0);
+    assertTrue(merged.get(5));
+    assertTrue(merged.get(10));
+    assertTrue(merged.get(20));
+    assertFalse(merged.get(0));
+  }
+
+  @Test
+  public void testMultipleSegments() {
+    DocIdSetCache cache = new DocIdSetCache(100);
+    DocIdSetCache.RetrieverBitSets rbs = cache.newRetrieverBitSets();
+
+    rbs.getOrCreateBitSet(0, 500).set(1);
+    rbs.recordHit();
+    rbs.getOrCreateBitSet(1, 300).set(2);
+    rbs.recordHit();
+
+    cache.merge();
+
+    assertNotNull(cache.getBitSet(0));
+    assertNotNull(cache.getBitSet(1));
+    assertTrue(cache.getBitSet(0).get(1));
+    assertTrue(cache.getBitSet(1).get(2));
+  }
+
+  @Test
+  public void testPerRetrieverThresholdTripsEarlyExit() {
+    // perRetrieverMaxHits=3 — exceeds at >3, i.e. 4th hit trips it
+    DocIdSetCache cache = new DocIdSetCache(3);
+    DocIdSetCache.RetrieverBitSets rbs = cache.newRetrieverBitSets();
+
+    SparseFixedBitSet bitSet = rbs.getOrCreateBitSet(0, 100);
+
+    for (int i = 0; i < 4; i++) {
+      bitSet.set(i);
+      rbs.recordHit();
+    }
+
+    assertTrue(rbs.isExceeded());
+    assertTrue(cache.isExceeded());
+    cache.merge();
+  }
+
+  @Test
+  public void testExactlyAtPerRetrieverThreshold() {
+    // perRetrieverMaxHits=4 — 4 hits is NOT > 4, so no early exit
+    DocIdSetCache cache = new DocIdSetCache(4);
+    DocIdSetCache.RetrieverBitSets rbs = cache.newRetrieverBitSets();
+
+    SparseFixedBitSet bitSet = rbs.getOrCreateBitSet(0, 100);
+    for (int i = 1; i <= 4; i++) {
+      bitSet.set(i);
+      rbs.recordHit();
+    }
+
+    assertFalse(rbs.isExceeded());
+    cache.merge();
+    assertFalse(cache.isExceeded());
+  }
+
+  @Test
+  public void testGetBitSetReturnsNullForUnknownSegment() {
+    DocIdSetCache cache = new DocIdSetCache(100);
+    DocIdSetCache.RetrieverBitSets rbs = cache.newRetrieverBitSets();
+    rbs.getOrCreateBitSet(0, 100).set(1);
+    rbs.recordHit();
+    cache.merge();
+
+    assertNull(cache.getBitSet(1));
+    assertNull(cache.getBitSet(99));
+  }
+
+  @Test
+  public void testSecondRetrieverSeesExceededFromFirst() {
+    DocIdSetCache cache = new DocIdSetCache(2);
+
+    DocIdSetCache.RetrieverBitSets rbs1 = cache.newRetrieverBitSets();
+    DocIdSetCache.RetrieverBitSets rbs2 = cache.newRetrieverBitSets();
+
+    SparseFixedBitSet bs1 = rbs1.getOrCreateBitSet(0, 100);
+    for (int i = 0; i < 5; i++) {
+      bs1.set(i);
+      rbs1.recordHit();
+    }
+
+    assertTrue(rbs2.isExceeded());
+  }
+}


### PR DESCRIPTION
https://jira.yelpcorp.com/browse/RP-16311
https://docs.google.com/document/d/1lvGjNSzzYJ8CHHXb8qxS3yMx-iLQW_qRZK7Z-WHBt-0/edit?tab=t.5443g0bbb9aw#heading=h.u9nrgnw9ioas
Add a new internal MultiRetrieverAggregationQuery backed by a docId cache to record hit docId without scores. Use this query to avoid second-pass for union query during the aggregation.

Under either condition, the query will fallback to the union query during the rewrite:
- Early exit (stop caching) when any leaf hit > 7k ()
- The aggregation collector need score