### PR TITLE
Fix thread safety issue with ordinal terms collector

### DIFF
--- a/src/main/java/com/yelp/nrtsearch/server/search/GlobalOrdinalLookup.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/GlobalOrdinalLookup.java
@@ -16,17 +16,23 @@
 package com.yelp.nrtsearch.server.search;
 
 import java.io.IOException;
+import java.util.List;
+import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.MultiDocValues;
 import org.apache.lucene.index.MultiDocValues.MultiSortedDocValues;
 import org.apache.lucene.index.MultiDocValues.MultiSortedSetDocValues;
+import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.LongValues;
 
 /**
  * Class to manage global ordinal lookup operations. Provides lookup to convert segment ordinals to
- * global ordinals, and to convert global ordinals to term strings.
+ * global ordinals. Instances are cached and shared across concurrent requests, so they must be
+ * thread-safe. Use {@link #createTermLookup(IndexReader)} to obtain a per-request {@link
+ * TermLookup} for converting global ordinals back to term strings.
  */
 public abstract class GlobalOrdinalLookup {
   static final LongValues IDENTITY_MAPPING = new IdentityMapping();
@@ -38,78 +44,187 @@ public abstract class GlobalOrdinalLookup {
    */
   public abstract LongValues getSegmentMapping(int segmentIndex);
 
-  /**
-   * Look up term value for a given global ordinal.
-   *
-   * @param ord global ordinal
-   * @throws IOException on error loading term value
-   */
-  public abstract String lookupGlobalOrdinal(long ord) throws IOException;
-
   /** Get the total number of global ordinals. */
   public abstract long getNumOrdinals();
 
+  /**
+   * Create a per-request {@link TermLookup} that can resolve global ordinals to term strings. The
+   * returned instance is NOT thread-safe and must not be shared across threads or requests.
+   *
+   * @param reader index reader for the current request
+   * @throws IOException on error loading doc values
+   */
+  public abstract TermLookup createTermLookup(IndexReader reader) throws IOException;
+
+  /**
+   * Per-request object for resolving global ordinals to term strings. NOT thread-safe — each
+   * request must obtain its own instance via {@link GlobalOrdinalLookup#createTermLookup}.
+   */
+  public abstract static class TermLookup {
+
+    /**
+     * Look up term value for a given global ordinal.
+     *
+     * @param ord global ordinal
+     * @throws IOException on error loading term value
+     */
+    public abstract String lookupGlobalOrdinal(long ord) throws IOException;
+  }
+
   /** Implementation for field using {@link SortedDocValues}. */
   public static class SortedLookup extends GlobalOrdinalLookup {
-    private final SortedDocValues sortedDocValues;
+    private final OrdinalMap ordinalMap;
+    private final long numOrdinals;
     private final String field;
 
     public SortedLookup(IndexReader reader, String field) throws IOException {
       this.field = field;
-      sortedDocValues = MultiDocValues.getSortedValues(reader, field);
+      SortedDocValues dv = MultiDocValues.getSortedValues(reader, field);
+      if (dv instanceof MultiSortedDocValues) {
+        ordinalMap = ((MultiSortedDocValues) dv).mapping;
+        numOrdinals = dv.getValueCount();
+      } else if (dv != null) {
+        // single segment — no OrdinalMap needed, identity mapping
+        ordinalMap = null;
+        numOrdinals = dv.getValueCount();
+      } else {
+        ordinalMap = null;
+        numOrdinals = 0;
+      }
     }
 
     @Override
     public LongValues getSegmentMapping(int segmentIndex) {
-      if (sortedDocValues == null || !(sortedDocValues instanceof MultiSortedDocValues)) {
+      if (ordinalMap == null) {
         return IDENTITY_MAPPING;
       }
-      return ((MultiSortedDocValues) sortedDocValues).mapping.getGlobalOrds(segmentIndex);
-    }
-
-    @Override
-    public String lookupGlobalOrdinal(long ord) throws IOException {
-      if (sortedDocValues == null) {
-        throw new IllegalStateException("No ordinals for field: " + field);
-      }
-      return sortedDocValues.lookupOrd((int) ord).utf8ToString();
+      return ordinalMap.getGlobalOrds(segmentIndex);
     }
 
     @Override
     public long getNumOrdinals() {
-      return sortedDocValues == null ? 0 : sortedDocValues.getValueCount();
+      return numOrdinals;
+    }
+
+    @Override
+    public TermLookup createTermLookup(IndexReader reader) throws IOException {
+      if (numOrdinals == 0) {
+        return new EmptyTermLookup(field);
+      }
+      List<LeafReaderContext> leaves = reader.leaves();
+      SortedDocValues[] segmentValues = new SortedDocValues[leaves.size()];
+      for (LeafReaderContext leaf : leaves) {
+        segmentValues[leaf.ord] = DocValues.getSorted(leaf.reader(), field);
+      }
+      return new SortedTermLookup(segmentValues, ordinalMap);
     }
   }
 
   /** Implementation for field using {@link SortedSetDocValues}. */
   public static class SortedSetLookup extends GlobalOrdinalLookup {
-    private final SortedSetDocValues sortedSetDocValues;
+    private final OrdinalMap ordinalMap;
+    private final long numOrdinals;
     private final String field;
 
     public SortedSetLookup(IndexReader reader, String field) throws IOException {
       this.field = field;
-      sortedSetDocValues = MultiDocValues.getSortedSetValues(reader, field);
+      SortedSetDocValues dv = MultiDocValues.getSortedSetValues(reader, field);
+      if (dv instanceof MultiSortedSetDocValues) {
+        ordinalMap = ((MultiSortedSetDocValues) dv).mapping;
+        numOrdinals = dv.getValueCount();
+      } else if (dv != null) {
+        ordinalMap = null;
+        numOrdinals = dv.getValueCount();
+      } else {
+        ordinalMap = null;
+        numOrdinals = 0;
+      }
     }
 
     @Override
     public LongValues getSegmentMapping(int segmentIndex) {
-      if (sortedSetDocValues == null || !(sortedSetDocValues instanceof MultiSortedSetDocValues)) {
+      if (ordinalMap == null) {
         return IDENTITY_MAPPING;
       }
-      return ((MultiSortedSetDocValues) sortedSetDocValues).mapping.getGlobalOrds(segmentIndex);
-    }
-
-    @Override
-    public String lookupGlobalOrdinal(long ord) throws IOException {
-      if (sortedSetDocValues == null) {
-        throw new IllegalStateException("No ordinals for field: " + field);
-      }
-      return sortedSetDocValues.lookupOrd(ord).utf8ToString();
+      return ordinalMap.getGlobalOrds(segmentIndex);
     }
 
     @Override
     public long getNumOrdinals() {
-      return sortedSetDocValues == null ? 0 : sortedSetDocValues.getValueCount();
+      return numOrdinals;
+    }
+
+    @Override
+    public TermLookup createTermLookup(IndexReader reader) throws IOException {
+      if (numOrdinals == 0) {
+        return new EmptyTermLookup(field);
+      }
+      List<LeafReaderContext> leaves = reader.leaves();
+      SortedSetDocValues[] segmentValues = new SortedSetDocValues[leaves.size()];
+      for (LeafReaderContext leaf : leaves) {
+        segmentValues[leaf.ord] = DocValues.getSortedSet(leaf.reader(), field);
+      }
+      return new SortedSetTermLookup(segmentValues, ordinalMap);
+    }
+  }
+
+  /** TermLookup for a field with no values. */
+  private static class EmptyTermLookup extends TermLookup {
+    private final String field;
+
+    EmptyTermLookup(String field) {
+      this.field = field;
+    }
+
+    @Override
+    public String lookupGlobalOrdinal(long ord) {
+      throw new IllegalStateException("No ordinals for field: " + field);
+    }
+  }
+
+  /**
+   * TermLookup for SORTED doc values. Routes global ordinal → segment → local ordinal using the
+   * cached OrdinalMap, then delegates to per-request segment doc values for the actual term lookup.
+   */
+  private static class SortedTermLookup extends TermLookup {
+    private final SortedDocValues[] segmentValues;
+    private final OrdinalMap ordinalMap;
+
+    SortedTermLookup(SortedDocValues[] segmentValues, OrdinalMap ordinalMap) {
+      this.segmentValues = segmentValues;
+      this.ordinalMap = ordinalMap;
+    }
+
+    @Override
+    public String lookupGlobalOrdinal(long ord) throws IOException {
+      if (ordinalMap == null) {
+        // single segment — global ord == local ord
+        return segmentValues[0].lookupOrd((int) ord).utf8ToString();
+      }
+      int segmentIndex = ordinalMap.getFirstSegmentNumber(ord);
+      int localOrd = (int) ordinalMap.getFirstSegmentOrd(ord);
+      return segmentValues[segmentIndex].lookupOrd(localOrd).utf8ToString();
+    }
+  }
+
+  /** TermLookup for SORTED_SET doc values. */
+  private static class SortedSetTermLookup extends TermLookup {
+    private final SortedSetDocValues[] segmentValues;
+    private final OrdinalMap ordinalMap;
+
+    SortedSetTermLookup(SortedSetDocValues[] segmentValues, OrdinalMap ordinalMap) {
+      this.segmentValues = segmentValues;
+      this.ordinalMap = ordinalMap;
+    }
+
+    @Override
+    public String lookupGlobalOrdinal(long ord) throws IOException {
+      if (ordinalMap == null) {
+        return segmentValues[0].lookupOrd(ord).utf8ToString();
+      }
+      int segmentIndex = ordinalMap.getFirstSegmentNumber(ord);
+      long localOrd = ordinalMap.getFirstSegmentOrd(ord);
+      return segmentValues[segmentIndex].lookupOrd(localOrd).utf8ToString();
     }
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/search/collectors/additional/OrdinalTermsCollectorManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/collectors/additional/OrdinalTermsCollectorManager.java
@@ -37,6 +37,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
@@ -51,6 +52,7 @@ public class OrdinalTermsCollectorManager extends TermsCollectorManager {
 
   private final IndexableFieldDef<?> fieldDef;
   private final GlobalOrdinalLookup globalOrdinalLookup;
+  private final IndexReader indexReader;
 
   /**
    * Constructor.
@@ -74,10 +76,9 @@ public class OrdinalTermsCollectorManager extends TermsCollectorManager {
       BucketOrder bucketOrder) {
     super(name, grpcTermsCollector.getSize(), nestedCollectorSuppliers, bucketOrder);
     fieldDef = indexableFieldDef;
+    indexReader = context.getSearcherAndTaxonomy().searcher().getIndexReader();
     try {
-      globalOrdinalLookup =
-          globalOrdinalable.getOrdinalLookup(
-              context.getSearcherAndTaxonomy().searcher().getIndexReader());
+      globalOrdinalLookup = globalOrdinalable.getOrdinalLookup(indexReader);
     } catch (IOException e) {
       throw new RuntimeException("Error getting ordinal map");
     }
@@ -99,7 +100,8 @@ public class OrdinalTermsCollectorManager extends TermsCollectorManager {
     } else {
       nestedCollectors = Collections.emptyList();
     }
-    fillBucketResult(bucketBuilder, combinedCounts, globalOrdinalLookup, nestedCollectors);
+    GlobalOrdinalLookup.TermLookup termLookup = globalOrdinalLookup.createTermLookup(indexReader);
+    fillBucketResult(bucketBuilder, combinedCounts, termLookup, nestedCollectors);
 
     return CollectorResult.newBuilder().setBucketResult(bucketBuilder.build()).build();
   }

--- a/src/main/java/com/yelp/nrtsearch/server/search/collectors/additional/TermsCollectorManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/search/collectors/additional/TermsCollectorManager.java
@@ -796,18 +796,18 @@ public abstract class TermsCollectorManager
    *
    * @param bucketBuilder bucket result builder
    * @param counts map containing doc counts for keys
-   * @param ordinalLookup global ordinal lookup object
+   * @param termLookup per-request term lookup for resolving global ordinals to strings
    * @param nestedCollectors collectors for nested aggregations
    */
   void fillBucketResult(
       BucketResult.Builder bucketBuilder,
       Long2IntMap counts,
-      GlobalOrdinalLookup ordinalLookup,
+      GlobalOrdinalLookup.TermLookup termLookup,
       Collection<NestedCollectorManagers.NestedCollectors> nestedCollectors)
       throws IOException {
     switch (bucketOrder.getValueType()) {
       case COUNT:
-        fillBucketResultByCount(bucketBuilder, counts, ordinalLookup, nestedCollectors);
+        fillBucketResultByCount(bucketBuilder, counts, termLookup, nestedCollectors);
         return;
       case NESTED_COLLECTOR:
         fillBucketResultByNestedOrder(
@@ -815,7 +815,7 @@ public abstract class TermsCollectorManager
             counts,
             o -> {
               try {
-                return ordinalLookup.lookupGlobalOrdinal(o);
+                return termLookup.lookupGlobalOrdinal(o);
               } catch (IOException e) {
                 throw new RuntimeException(e);
               }
@@ -833,13 +833,13 @@ public abstract class TermsCollectorManager
    *
    * @param bucketBuilder bucket result builder
    * @param counts map containing doc counts for keys
-   * @param ordinalLookup global ordinal lookup object
+   * @param termLookup per-request term lookup for resolving global ordinals to strings
    * @param nestedCollectors collectors for nested aggregations
    */
   void fillBucketResultByCount(
       BucketResult.Builder bucketBuilder,
       Long2IntMap counts,
-      GlobalOrdinalLookup ordinalLookup,
+      GlobalOrdinalLookup.TermLookup termLookup,
       Collection<NestedCollectorManagers.NestedCollectors> nestedCollectors)
       throws IOException {
     int size = getSize();
@@ -878,7 +878,7 @@ public abstract class TermsCollectorManager
         LongBucketEntry entry = priorityQueue.poll();
         Bucket.Builder builder =
             Bucket.newBuilder()
-                .setKey(ordinalLookup.lookupGlobalOrdinal(entry.key))
+                .setKey(termLookup.lookupGlobalOrdinal(entry.key))
                 .setCount(entry.count);
         if (nestedCollectorManagers != null) {
           builder.putAllNestedCollectorResults(

--- a/src/test/java/com/yelp/nrtsearch/server/search/GlobalOrdinalLookupTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/search/GlobalOrdinalLookupTest.java
@@ -31,6 +31,13 @@ import com.yelp.nrtsearch.server.index.IndexState;
 import com.yelp.nrtsearch.server.index.ShardState;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager;
 import org.apache.lucene.index.IndexReader;
@@ -87,8 +94,9 @@ public class GlobalOrdinalLookupTest extends ServerTestCase {
     assertNotNull(ordinalLookup);
     assertEquals(0, ordinalLookup.getNumOrdinals());
     assertSame(GlobalOrdinalLookup.IDENTITY_MAPPING, ordinalLookup.getSegmentMapping(0));
+    GlobalOrdinalLookup.TermLookup termLookup = ordinalLookup.createTermLookup(reader);
     try {
-      ordinalLookup.lookupGlobalOrdinal(0);
+      termLookup.lookupGlobalOrdinal(0);
       fail();
     } catch (IllegalStateException e) {
       assertEquals("No ordinals for field: " + fieldDef.getName(), e.getMessage());
@@ -120,7 +128,8 @@ public class GlobalOrdinalLookupTest extends ServerTestCase {
     assertNotNull(ordinalLookup);
     assertEquals(1, ordinalLookup.getNumOrdinals());
     assertSame(GlobalOrdinalLookup.IDENTITY_MAPPING, ordinalLookup.getSegmentMapping(0));
-    assertEquals("1", ordinalLookup.lookupGlobalOrdinal(0));
+    GlobalOrdinalLookup.TermLookup termLookup = ordinalLookup.createTermLookup(reader);
+    assertEquals("1", termLookup.lookupGlobalOrdinal(0));
   }
 
   @Test
@@ -154,8 +163,70 @@ public class GlobalOrdinalLookupTest extends ServerTestCase {
     assertEquals(0, mapping.get(0));
     mapping = ordinalLookup.getSegmentMapping(1);
     assertEquals(1, mapping.get(0));
-    assertEquals("1", ordinalLookup.lookupGlobalOrdinal(0));
-    assertEquals("3", ordinalLookup.lookupGlobalOrdinal(1));
+    GlobalOrdinalLookup.TermLookup termLookup = ordinalLookup.createTermLookup(reader);
+    assertEquals("1", termLookup.lookupGlobalOrdinal(0));
+    assertEquals("3", termLookup.lookupGlobalOrdinal(1));
+  }
+
+  /**
+   * Verifies that concurrent TermLookup instances created from the same cached GlobalOrdinalLookup
+   * do not interfere with each other's LZ4 decompression state.
+   */
+  @Test
+  public void testConcurrentTermLookup() throws Exception {
+    addData("1");
+    addData("3");
+
+    SearcherTaxonomyManager.SearcherAndTaxonomy s = null;
+    IndexState indexState = getGlobalState().getIndexOrThrow(DEFAULT_TEST_INDEX);
+    ShardState shardState = indexState.getShard(0);
+    try {
+      s = shardState.acquire();
+      final IndexReader reader = s.searcher().getIndexReader();
+      final GlobalOrdinalLookup ordinalLookup =
+          ((GlobalOrdinalable) indexState.getFieldOrThrow(VALUE_FIELD)).getOrdinalLookup(reader);
+
+      int threadCount = 8;
+      int iterations = 500;
+      ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+      CountDownLatch startLatch = new CountDownLatch(1);
+      AtomicInteger errorCount = new AtomicInteger(0);
+
+      List<Future<?>> futures = new ArrayList<>();
+      for (int t = 0; t < threadCount; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  try {
+                    startLatch.await();
+                    for (int i = 0; i < iterations; i++) {
+                      // each thread gets its own TermLookup — this is the correct usage
+                      GlobalOrdinalLookup.TermLookup termLookup =
+                          ordinalLookup.createTermLookup(reader);
+                      String v0 = termLookup.lookupGlobalOrdinal(0);
+                      String v1 = termLookup.lookupGlobalOrdinal(1);
+                      if (!"1".equals(v0) || !"3".equals(v1)) {
+                        errorCount.incrementAndGet();
+                      }
+                    }
+                  } catch (Exception e) {
+                    errorCount.incrementAndGet();
+                  }
+                  return null;
+                }));
+      }
+
+      startLatch.countDown();
+      for (Future<?> f : futures) {
+        f.get();
+      }
+      executor.shutdown();
+      assertEquals("Concurrent term lookups produced errors", 0, errorCount.get());
+    } finally {
+      if (s != null) {
+        shardState.release(s);
+      }
+    }
   }
 
   private void addData(String value) throws Exception {


### PR DESCRIPTION
## Problem

`GlobalOrdinalLookup` instances are cached per `IndexReader` and shared across all concurrent search requests. The cached object held a single `SortedDocValues` / `SortedSetDocValues` instance, which is **not thread-safe** — Lucene's term dictionary uses mutable LZ4 decompression buffers internally (`blockBuffer`, `blockInput`, `currentCompressedBlockStart/End`).

 When two requests both reach the `reduce()` phase of an `OrdinalTermsCollectorManager` at the same time, their `lookupGlobalOrdinal` calls operate on the same `TermsDict` decompression state simultaneously. One thread's `decompressBlock()` corrupts the buffers the other is reading, producing:

```
  java.lang.ArrayIndexOutOfBoundsException: arraycopy: source index -59 out of bounds for byte[259]
      at org.apache.lucene.util.compress.LZ4.decompress(LZ4.java:135)
      at org.apache.lucene.codecs.lucene90.Lucene90DocValuesProducer$TermsDict.decompressBlock(...)
      at org.apache.lucene.index.MultiDocValues$MultiSortedDocValues.lookupOrd(...)
      at com.yelp.nrtsearch.server.search.GlobalOrdinalLookup$SortedLookup.lookupGlobalOrdinal(...)
      at com.yelp.nrtsearch.server.search.collectors.additional.TermsCollectorManager.fillBucketResult(...)
```

The `OrdinalMap` (used for segment-to-global ordinal mapping during collection) is thread-safe — it is backed by read-only packed integer arrays. Only the term lookup path is affected.

## Fix

Separate the thread-safe part (`OrdinalMap`) from the non-thread-safe part (`SortedDocValues` / `SortedSetDocValues`):

  - `GlobalOrdinalLookup` (cached, shared) now holds only the `OrdinalMap` and value count. `getSegmentMapping()` is unchanged.
  - A new `createTermLookup(IndexReader)` method returns a lightweight per-request `TermLookup` that holds its own private array of segment-level doc values. It uses the cached `OrdinalMap` to route `lookupGlobalOrdinal(ord)` to the correct segment and local ordinal.
  - `OrdinalTermsCollectorManager.reduce()` now calls `createTermLookup` to get a fresh, request-private `TermLookup` before resolving ordinals to strings.

Getting per-segment `SortedDocValues` via `DocValues.getSorted(leafReader, field)` is cheap (a pointer into already-loaded segment data). The expensive `OrdinalMap.build()` call remains cached as before.

## Testing

  - All existing `GlobalOrdinalLookupTest` and `OrdinalTermsCollectorManagerTest` tests pass unchanged.
  - Added `testConcurrentTermLookup`: 8 threads × 500 iterations each calling `createTermLookup` and resolving ordinals concurrently from the same cached `GlobalOrdinalLookup`, asserting no errors or incorrect results.