### PR TITLE
replica pull from s3 during refresh with config

### DIFF
--- a/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
+++ b/clientlib/src/main/proto/yelp/nrtsearch/luceneserver.proto
@@ -1241,6 +1241,10 @@ message CopyFiles {
     FilesMetadata filesMetadata = 4;
     // Index id
     string indexId = 5;
+    // Primary node id used to locate files on remote storage
+    string primaryId = 6;
+    // Time string used to locate files on remote storage
+    string timeString = 7;
 }
 
 // Replica invokes this on a primary to let primary know it needs the CopyState

--- a/src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java
+++ b/src/main/java/com/yelp/nrtsearch/server/config/NrtsearchConfig.java
@@ -113,6 +113,7 @@ public class NrtsearchConfig {
   private final DirectoryFactory.MMapGrouping mmapGrouping;
   private final boolean requireIdField;
   private final boolean s3RefreshUpload;
+  private final boolean s3ReplicaRefreshDownload;
   private final IsolatedReplicaConfig isolatedReplicaConfig;
 
   @Inject
@@ -193,6 +194,7 @@ public class NrtsearchConfig {
     useSeparateCommitExecutor = configReader.getBoolean("useSeparateCommitExecutor", false);
     requireIdField = configReader.getBoolean("requireIdField", false);
     s3RefreshUpload = configReader.getBoolean("s3RefreshUpload", false);
+    s3ReplicaRefreshDownload = configReader.getBoolean("s3ReplicaRefreshDownload", false);
     isolatedReplicaConfig = IsolatedReplicaConfig.fromConfig(configReader);
 
     List<String> indicesWithOverrides = configReader.getKeysOrEmpty("indexLiveSettingsOverrides");
@@ -393,6 +395,10 @@ public class NrtsearchConfig {
 
   public boolean getS3RefreshUpload() {
     return s3RefreshUpload;
+  }
+
+  public boolean getS3ReplicaRefreshDownload() {
+    return s3ReplicaRefreshDownload;
   }
 
   public IsolatedReplicaConfig getIsolatedReplicaConfig() {

--- a/src/main/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClient.java
+++ b/src/main/java/com/yelp/nrtsearch/server/grpc/ReplicationServerClient.java
@@ -256,16 +256,23 @@ public class ReplicationServerClient implements Closeable {
       String indexId,
       long primaryGen,
       FilesMetadata filesMetadata,
-      Deadline deadline) {
+      Deadline deadline,
+      String primaryId,
+      String timeString) {
     CopyFiles.Builder copyFilesBuilder = CopyFiles.newBuilder();
-    CopyFiles copyFiles =
-        copyFilesBuilder
-            .setMagicNumber(BINARY_MAGIC)
-            .setIndexName(indexName)
-            .setIndexId(indexId)
-            .setPrimaryGen(primaryGen)
-            .setFilesMetadata(filesMetadata)
-            .build();
+    copyFilesBuilder
+        .setMagicNumber(BINARY_MAGIC)
+        .setIndexName(indexName)
+        .setIndexId(indexId)
+        .setPrimaryGen(primaryGen)
+        .setFilesMetadata(filesMetadata);
+    if (primaryId != null) {
+      copyFilesBuilder.setPrimaryId(primaryId);
+    }
+    if (timeString != null) {
+      copyFilesBuilder.setTimeString(timeString);
+    }
+    CopyFiles copyFiles = copyFilesBuilder.build();
     ReplicationServerBlockingStub blockingStub = this.blockingStub;
     if (deadline != null) {
       blockingStub = blockingStub.withDeadline(deadline);

--- a/src/main/java/com/yelp/nrtsearch/server/handler/CopyFilesHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/CopyFilesHandler.java
@@ -108,12 +108,18 @@ public class CopyFilesHandler extends Handler<CopyFiles, TransferStatus> {
     long primaryGen = copyFilesRequest.getPrimaryGen();
     // these are the files that the remote (primary) wants us to copy
     Map<String, FileMetaData> files = readFilesMetaData(copyFilesRequest.getFilesMetadata());
+    String primaryId =
+        copyFilesRequest.getPrimaryId().isEmpty() ? null : copyFilesRequest.getPrimaryId();
+    String timeString =
+        copyFilesRequest.getTimeString().isEmpty() ? null : copyFilesRequest.getTimeString();
 
     AtomicBoolean finished = new AtomicBoolean();
     CopyJob job;
     long startNS = System.nanoTime();
     try {
-      job = shardState.nrtReplicaNode.launchPreCopyFiles(finished, primaryGen, files);
+      job =
+          shardState.nrtReplicaNode.launchPreCopyFiles(
+              finished, primaryGen, files, primaryId, timeString);
     } catch (IOException e) {
       responseObserver.onNext(
           TransferStatus.newBuilder()

--- a/src/main/java/com/yelp/nrtsearch/server/index/ShardState.java
+++ b/src/main/java/com/yelp/nrtsearch/server/index/ShardState.java
@@ -968,7 +968,8 @@ public class ShardState implements Closeable {
               configuration.getFileCopyConfig().getAckedCopy(),
               configuration.getDecInitialCommit(),
               configuration.getFilterIncompatibleSegmentReaders(),
-              configuration.getLowPriorityCopyPercentage());
+              configuration.getLowPriorityCopyPercentage(),
+              configuration.getS3ReplicaRefreshDownload());
       if (primaryGen != -1) {
         nrtReplicaNode.start(primaryGen);
       } else {

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NRTPrimaryNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NRTPrimaryNode.java
@@ -158,17 +158,23 @@ public class NRTPrimaryNode extends PrimaryNode {
     final Set<ReplicationServerClient> connections = Collections.synchronizedSet(new HashSet<>());
     final Map<ReplicationServerClient, Iterator<TransferStatus>> clientToTransferStatusIterator;
     final Map<String, FileMetaData> files;
+    final String primaryId;
+    final String timeString;
     private final Deadline deadline;
     private boolean finished;
 
     public MergePreCopy(
         Map<String, FileMetaData> files,
         Map<ReplicationServerClient, Iterator<TransferStatus>> clientToTransferStatusIterator,
-        Deadline deadline) {
+        Deadline deadline,
+        String primaryId,
+        String timeString) {
       this.files = files;
       this.clientToTransferStatusIterator = new ConcurrentHashMap<>(clientToTransferStatusIterator);
       this.connections.addAll(clientToTransferStatusIterator.keySet());
       this.deadline = deadline;
+      this.primaryId = primaryId;
+      this.timeString = timeString;
     }
 
     public synchronized boolean tryAddConnection(
@@ -179,7 +185,8 @@ public class NRTPrimaryNode extends PrimaryNode {
         FilesMetadata filesMetadata) {
       if (!finished && (deadline == null || !deadline.isExpired())) {
         Iterator<TransferStatus> transferStatusIterator =
-            c.copyFiles(indexName, indexId, primaryGen, filesMetadata, deadline);
+            c.copyFiles(
+                indexName, indexId, primaryGen, filesMetadata, deadline, primaryId, timeString);
         clientToTransferStatusIterator.put(c, transferStatusIterator);
         connections.add(c);
         return true;
@@ -358,6 +365,16 @@ public class NRTPrimaryNode extends PrimaryNode {
       return;
     }
 
+    String mergeTimeString = null;
+    if (nrtDataManager.doS3RefreshUpload()) {
+      try {
+        mergeTimeString = nrtDataManager.uploadMergedFiles(files);
+      } catch (IOException e) {
+        logMessage("Failed to upload merged files to S3: " + e.getMessage());
+        logger.warn("Failed to upload merged files to S3 for segment {}", info, e);
+      }
+    }
+
     NrtMetrics.nrtMergeCopyStartCount.labelValues(indexName).inc();
 
     long maxMergePreCopyDurationSec = getCurrentMaxMergePreCopyDurationSec();
@@ -374,9 +391,11 @@ public class NRTPrimaryNode extends PrimaryNode {
               "Start merge precopy %s to %d replicas; localAddress=%s: files=%s",
               info, replicasInfos.size(), hostPort, files.keySet()));
 
+      String mergePrimaryId =
+          nrtDataManager.doS3RefreshUpload() ? nrtDataManager.getEphemeralId() : null;
       Map<ReplicationServerClient, Iterator<TransferStatus>> allCopyStatus =
-          callCopyFilesForPreCopy(files, deadline);
-      preCopy = new MergePreCopy(files, allCopyStatus, deadline);
+          callCopyFilesForPreCopy(files, deadline, mergePrimaryId, mergeTimeString);
+      preCopy = new MergePreCopy(files, allCopyStatus, deadline, mergePrimaryId, mergeTimeString);
       warmingSegments.add(preCopy);
     }
 
@@ -451,7 +470,10 @@ public class NRTPrimaryNode extends PrimaryNode {
   }
 
   private Map<ReplicationServerClient, Iterator<TransferStatus>> callCopyFilesForPreCopy(
-      Map<String, FileMetaData> files, Deadline deadline) {
+      Map<String, FileMetaData> files,
+      Deadline deadline,
+      String primaryId,
+      String mergeTimeString) {
     // Ask all currently known replicas to pre-copy this newly merged segment's files:
     Iterator<ReplicaDetails> replicaInfos = replicasInfos.iterator();
     ReplicaDetails replicaDetails = null;
@@ -463,7 +485,13 @@ public class NRTPrimaryNode extends PrimaryNode {
         replicaDetails = replicaInfos.next();
         Iterator<TransferStatus> copyStatus =
             replicaDetails.replicationServerClient.copyFiles(
-                indexName, indexStateManager.getIndexId(), primaryGen, filesMetadata, deadline);
+                indexName,
+                indexStateManager.getIndexId(),
+                primaryGen,
+                filesMetadata,
+                deadline,
+                primaryId,
+                mergeTimeString);
         allCopyStatus.put(replicaDetails.replicationServerClient, copyStatus);
         logMessage(
             String.format(

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NRTReplicaNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NRTReplicaNode.java
@@ -23,6 +23,7 @@ import com.yelp.nrtsearch.server.grpc.ReplicationServerClient;
 import com.yelp.nrtsearch.server.monitoring.NrtMetrics;
 import com.yelp.nrtsearch.server.nrt.jobs.CopyJobManager;
 import com.yelp.nrtsearch.server.nrt.jobs.GrpcCopyJobManager;
+import com.yelp.nrtsearch.server.nrt.jobs.NrtPushRemoteCopyJobManager;
 import com.yelp.nrtsearch.server.nrt.jobs.RemoteCopyJobManager;
 import com.yelp.nrtsearch.server.nrt.jobs.SimpleCopyJob;
 import com.yelp.nrtsearch.server.utils.HostPort;
@@ -74,7 +75,8 @@ public class NRTReplicaNode extends ReplicaNode {
       boolean ackedCopy,
       boolean decInitialCommit,
       boolean filterIncompatibleSegmentReaders,
-      int lowPriorityCopyPercentage)
+      int lowPriorityCopyPercentage,
+      boolean s3ReplicaRefreshDownload)
       throws IOException {
     // the id is always 0, the nodeName is the identifier
     super(0, indexDir, searcherFactory, printStream);
@@ -99,6 +101,8 @@ public class NRTReplicaNode extends ReplicaNode {
               nrtDataManager,
               this,
               isolatedReplicaConfig);
+    } else if (s3ReplicaRefreshDownload) {
+      copyJobManager = new NrtPushRemoteCopyJobManager(nrtDataManager, this);
     } else {
       copyJobManager =
           new GrpcCopyJobManager(indexName, indexId, primaryAddress, ackedCopy, this, id);

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NRTReplicaNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NRTReplicaNode.java
@@ -211,8 +211,13 @@ public class NRTReplicaNode extends ReplicaNode {
   }
 
   public CopyJob launchPreCopyFiles(
-      AtomicBoolean finished, long curPrimaryGen, Map<String, FileMetaData> files)
+      AtomicBoolean finished,
+      long curPrimaryGen,
+      Map<String, FileMetaData> files,
+      String primaryId,
+      String timeString)
       throws IOException {
+    copyJobManager.setMergePreCopyMetadata(primaryId, timeString);
     return launchPreCopyMerge(finished, curPrimaryGen, files);
   }
 

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NRTReplicaNode.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NRTReplicaNode.java
@@ -210,7 +210,7 @@ public class NRTReplicaNode extends ReplicaNode {
     }
   }
 
-  public CopyJob launchPreCopyFiles(
+  public synchronized CopyJob launchPreCopyFiles(
       AtomicBoolean finished,
       long curPrimaryGen,
       Map<String, FileMetaData> files,
@@ -218,7 +218,11 @@ public class NRTReplicaNode extends ReplicaNode {
       String timeString)
       throws IOException {
     copyJobManager.setMergePreCopyMetadata(primaryId, timeString);
-    return launchPreCopyMerge(finished, curPrimaryGen, files);
+    try {
+      return launchPreCopyMerge(finished, curPrimaryGen, files);
+    } finally {
+      copyJobManager.setMergePreCopyMetadata(null, null);
+    }
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NrtDataManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NrtDataManager.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.replicator.nrt.CopyState;
 import org.apache.lucene.replicator.nrt.FileMetaData;
@@ -66,6 +67,11 @@ public class NrtDataManager implements Closeable {
   private final RestoreIndex restoreIndex;
   private final boolean remoteCommit;
   private final boolean s3RefreshUpload;
+
+  // Files uploaded during merge precopy, keyed by file name. Consumed by uploadDiff to avoid
+  // re-uploading.
+  private final ConcurrentHashMap<String, NrtFileMetaData> mergePreCopyUploadedFiles =
+      new ConcurrentHashMap<>();
 
   // Set during startUploadManager
   private NRTPrimaryNode primaryNode;
@@ -356,6 +362,38 @@ public class NrtDataManager implements Closeable {
   }
 
   /**
+   * Upload merged segment files to the remote backend. This is called by the primary during merge
+   * precopy to ensure the files are available on S3 before notifying replicas.
+   *
+   * @param files map of file names to FileMetaData for the merged segment
+   * @return the time string used for the upload, needed by replicas to locate files on S3
+   * @throws IOException on error uploading files
+   */
+  public String uploadMergedFiles(Map<String, FileMetaData> files) throws IOException {
+    Map<String, NrtFileMetaData> filesToUpload = new HashMap<>();
+    String timeString = TimeStringUtils.generateTimeStringSec();
+    for (Map.Entry<String, FileMetaData> entry : files.entrySet()) {
+      String fileName = entry.getKey();
+      FileMetaData fileMetaData = entry.getValue();
+      NrtFileMetaData nrtFileMetaData = new NrtFileMetaData(fileMetaData, ephemeralId, timeString);
+      filesToUpload.put(fileName, nrtFileMetaData);
+    }
+    logger.info("Uploading merged segment files: {}", filesToUpload.keySet());
+    remoteBackend.uploadIndexFiles(serviceName, indexIdentifier, shardDataDir, filesToUpload);
+    mergePreCopyUploadedFiles.putAll(filesToUpload);
+    return timeString;
+  }
+
+  /**
+   * Get the ephemeral id for this node.
+   *
+   * @return ephemeral id
+   */
+  public String getEphemeralId() {
+    return ephemeralId;
+  }
+
+  /**
    * Enqueue an upload task to be processed by the UploadManagerThread.
    *
    * @param copyState CopyState of data to upload
@@ -541,11 +579,16 @@ public class NrtDataManager implements Closeable {
         if (lastFileMetaData != null && isSameFile(fileMetaData, lastFileMetaData)) {
           currentPointFiles.put(fileName, lastFileMetaData);
         } else {
-          String timeString = TimeStringUtils.generateTimeStringSec();
-          NrtFileMetaData nrtFileMetaData =
-              new NrtFileMetaData(fileMetaData, ephemeralId, timeString);
-          currentPointFiles.put(fileName, nrtFileMetaData);
-          filesToUpload.put(fileName, nrtFileMetaData);
+          NrtFileMetaData mergeUploaded = mergePreCopyUploadedFiles.remove(fileName);
+          if (mergeUploaded != null && isSameFile(fileMetaData, mergeUploaded)) {
+            currentPointFiles.put(fileName, mergeUploaded);
+          } else {
+            String timeString = TimeStringUtils.generateTimeStringSec();
+            NrtFileMetaData nrtFileMetaData =
+                new NrtFileMetaData(fileMetaData, ephemeralId, timeString);
+            currentPointFiles.put(fileName, nrtFileMetaData);
+            filesToUpload.put(fileName, nrtFileMetaData);
+          }
         }
       }
       logger.info("Uploading index files: {}", filesToUpload.keySet());

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/NrtDataManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/NrtDataManager.java
@@ -18,6 +18,8 @@ package com.yelp.nrtsearch.server.nrt;
 import static com.yelp.nrtsearch.server.state.BackendGlobalState.getBaseIndexName;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.yelp.nrtsearch.server.config.IsolatedReplicaConfig;
 import com.yelp.nrtsearch.server.grpc.RestoreIndex;
 import com.yelp.nrtsearch.server.monitoring.BootstrapMetrics;
@@ -40,7 +42,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.replicator.nrt.CopyState;
 import org.apache.lucene.replicator.nrt.FileMetaData;
@@ -69,9 +70,10 @@ public class NrtDataManager implements Closeable {
   private final boolean s3RefreshUpload;
 
   // Files uploaded during merge precopy, keyed by file name. Consumed by uploadDiff to avoid
-  // re-uploading.
-  private final ConcurrentHashMap<String, NrtFileMetaData> mergePreCopyUploadedFiles =
-      new ConcurrentHashMap<>();
+  // re-uploading. Size-bounded to handle cases where merged segments are re-merged before
+  // appearing in a refresh (stale entries evicted by LRU).
+  private final Cache<String, NrtFileMetaData> mergePreCopyUploadedFiles =
+      CacheBuilder.newBuilder().maximumSize(1000).build();
 
   // Set during startUploadManager
   private NRTPrimaryNode primaryNode;
@@ -380,7 +382,7 @@ public class NrtDataManager implements Closeable {
     }
     logger.info("Uploading merged segment files: {}", filesToUpload.keySet());
     remoteBackend.uploadIndexFiles(serviceName, indexIdentifier, shardDataDir, filesToUpload);
-    mergePreCopyUploadedFiles.putAll(filesToUpload);
+    filesToUpload.forEach(mergePreCopyUploadedFiles::put);
     return timeString;
   }
 
@@ -579,8 +581,9 @@ public class NrtDataManager implements Closeable {
         if (lastFileMetaData != null && isSameFile(fileMetaData, lastFileMetaData)) {
           currentPointFiles.put(fileName, lastFileMetaData);
         } else {
-          NrtFileMetaData mergeUploaded = mergePreCopyUploadedFiles.remove(fileName);
+          NrtFileMetaData mergeUploaded = mergePreCopyUploadedFiles.getIfPresent(fileName);
           if (mergeUploaded != null && isSameFile(fileMetaData, mergeUploaded)) {
+            mergePreCopyUploadedFiles.invalidate(fileName);
             currentPointFiles.put(fileName, mergeUploaded);
           } else {
             String timeString = TimeStringUtils.generateTimeStringSec();

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/CopyJobManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/CopyJobManager.java
@@ -59,4 +59,13 @@ public interface CopyJobManager extends Closeable {
    * @throws IOException on error
    */
   void finishNRTCopy(CopyJob copyJob) throws IOException;
+
+  /**
+   * Set the S3 metadata for the next merge precopy job. Called before launchPreCopyMerge so the
+   * metadata is available when newCopyJob is invoked with files != null.
+   *
+   * @param primaryId primary node id used to locate files on remote storage
+   * @param timeString time string used to locate files on remote storage
+   */
+  default void setMergePreCopyMetadata(String primaryId, String timeString) {}
 }

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/NrtPushRemoteCopyJobManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/NrtPushRemoteCopyJobManager.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.nrt.jobs;
+
+import com.yelp.nrtsearch.server.nrt.NRTReplicaNode;
+import com.yelp.nrtsearch.server.nrt.NrtDataManager;
+import com.yelp.nrtsearch.server.nrt.state.NrtPointState;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+import org.apache.lucene.replicator.nrt.CopyJob;
+import org.apache.lucene.replicator.nrt.CopyState;
+import org.apache.lucene.replicator.nrt.FileMetaData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * CopyJobManager implementation that receives NRT point notifications from the primary via gRPC but
+ * downloads index files from S3 instead of streaming them from the primary. This reduces network
+ * load on the primary while maintaining low-latency NRT point notifications.
+ */
+public class NrtPushRemoteCopyJobManager implements CopyJobManager {
+  private static final Logger logger = LoggerFactory.getLogger(NrtPushRemoteCopyJobManager.class);
+
+  private final NrtDataManager dataManager;
+  private final NRTReplicaNode replicaNode;
+
+  public NrtPushRemoteCopyJobManager(NrtDataManager dataManager, NRTReplicaNode replicaNode) {
+    this.dataManager = dataManager;
+    this.replicaNode = replicaNode;
+  }
+
+  @Override
+  public void start() throws IOException {}
+
+  @Override
+  public CopyJob newCopyJob(
+      String reason,
+      Map<String, FileMetaData> files,
+      Map<String, FileMetaData> prevFiles,
+      boolean highPriority,
+      CopyJob.OnceDone onceDone)
+      throws IOException {
+    if (files != null) {
+      throw new IllegalArgumentException(
+          "NrtPushRemoteCopyJobManager does not support merge precopy");
+    }
+
+    NrtDataManager.PointStateWithTimestamp targetPointStateWithTimestamp =
+        dataManager.getTargetPointState(null);
+    NrtPointState pointState = targetPointStateWithTimestamp.pointState();
+    if (pointState == null) {
+      throw new IOException("No point state available from S3");
+    }
+
+    CopyState copyState = pointState.toCopyState();
+    return new RemoteCopyJob(
+        reason,
+        pointState,
+        targetPointStateWithTimestamp.timestamp(),
+        copyState,
+        dataManager,
+        replicaNode,
+        copyState.files(),
+        highPriority,
+        onceDone);
+  }
+
+  @Override
+  public void finishNRTCopy(CopyJob copyJob) throws IOException {
+    if (copyJob.getFailed()) {
+      return;
+    }
+    if (copyJob instanceof RemoteCopyJob remoteCopyJob) {
+      NrtPointState pointState = remoteCopyJob.getPointState();
+      Instant pointStateTimestamp = remoteCopyJob.getPointStateTimestamp();
+      dataManager.setLastPointState(pointState, pointStateTimestamp);
+    } else {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected copyJob to be instance of RemoteCopyJob, got %s",
+              copyJob.getClass().getName()));
+    }
+  }
+
+  @Override
+  public void close() throws IOException {}
+}

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/NrtPushRemoteCopyJobManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/NrtPushRemoteCopyJobManager.java
@@ -17,9 +17,11 @@ package com.yelp.nrtsearch.server.nrt.jobs;
 
 import com.yelp.nrtsearch.server.nrt.NRTReplicaNode;
 import com.yelp.nrtsearch.server.nrt.NrtDataManager;
+import com.yelp.nrtsearch.server.nrt.state.NrtFileMetaData;
 import com.yelp.nrtsearch.server.nrt.state.NrtPointState;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.lucene.replicator.nrt.CopyJob;
 import org.apache.lucene.replicator.nrt.CopyState;
@@ -38,9 +40,18 @@ public class NrtPushRemoteCopyJobManager implements CopyJobManager {
   private final NrtDataManager dataManager;
   private final NRTReplicaNode replicaNode;
 
+  private volatile String mergePrimaryId;
+  private volatile String mergeTimeString;
+
   public NrtPushRemoteCopyJobManager(NrtDataManager dataManager, NRTReplicaNode replicaNode) {
     this.dataManager = dataManager;
     this.replicaNode = replicaNode;
+  }
+
+  @Override
+  public void setMergePreCopyMetadata(String primaryId, String timeString) {
+    this.mergePrimaryId = primaryId;
+    this.mergeTimeString = timeString;
   }
 
   @Override
@@ -55,8 +66,7 @@ public class NrtPushRemoteCopyJobManager implements CopyJobManager {
       CopyJob.OnceDone onceDone)
       throws IOException {
     if (files != null) {
-      throw new IllegalArgumentException(
-          "NrtPushRemoteCopyJobManager does not support merge precopy");
+      return newMergePreCopyJob(reason, files, highPriority, onceDone);
     }
 
     NrtDataManager.PointStateWithTimestamp targetPointStateWithTimestamp =
@@ -75,6 +85,39 @@ public class NrtPushRemoteCopyJobManager implements CopyJobManager {
         dataManager,
         replicaNode,
         copyState.files(),
+        highPriority,
+        onceDone);
+  }
+
+  private CopyJob newMergePreCopyJob(
+      String reason,
+      Map<String, FileMetaData> files,
+      boolean highPriority,
+      CopyJob.OnceDone onceDone)
+      throws IOException {
+    String primaryId = mergePrimaryId;
+    String timeString = mergeTimeString;
+    if (primaryId == null || timeString == null) {
+      throw new IOException(
+          "Missing S3 metadata for merge precopy (primaryId="
+              + primaryId
+              + ", timeString="
+              + timeString
+              + ")");
+    }
+    Map<String, NrtFileMetaData> nrtFiles = new HashMap<>();
+    for (Map.Entry<String, FileMetaData> entry : files.entrySet()) {
+      nrtFiles.put(entry.getKey(), new NrtFileMetaData(entry.getValue(), primaryId, timeString));
+    }
+    return new RemoteCopyJob(
+        reason,
+        null,
+        null,
+        null,
+        dataManager,
+        replicaNode,
+        files,
+        nrtFiles,
         highPriority,
         onceDone);
   }

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/NrtPushRemoteCopyJobManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/NrtPushRemoteCopyJobManager.java
@@ -18,13 +18,10 @@ package com.yelp.nrtsearch.server.nrt.jobs;
 import com.yelp.nrtsearch.server.nrt.NRTReplicaNode;
 import com.yelp.nrtsearch.server.nrt.NrtDataManager;
 import com.yelp.nrtsearch.server.nrt.state.NrtFileMetaData;
-import com.yelp.nrtsearch.server.nrt.state.NrtPointState;
 import java.io.IOException;
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.lucene.replicator.nrt.CopyJob;
-import org.apache.lucene.replicator.nrt.CopyState;
 import org.apache.lucene.replicator.nrt.FileMetaData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,23 +65,11 @@ public class NrtPushRemoteCopyJobManager implements CopyJobManager {
     if (files != null) {
       return newMergePreCopyJob(reason, files, highPriority, onceDone);
     }
-
-    NrtDataManager.PointStateWithTimestamp targetPointStateWithTimestamp =
-        dataManager.getTargetPointState(null);
-    NrtPointState pointState = targetPointStateWithTimestamp.pointState();
-    if (pointState == null) {
-      throw new IOException("No point state available from S3");
-    }
-
-    CopyState copyState = pointState.toCopyState();
-    return new RemoteCopyJob(
+    return RemoteCopyJob.forNrtPoint(
         reason,
-        pointState,
-        targetPointStateWithTimestamp.timestamp(),
-        copyState,
+        dataManager.getTargetPointState(null),
         dataManager,
         replicaNode,
-        copyState.files(),
         highPriority,
         onceDone);
   }
@@ -124,19 +109,7 @@ public class NrtPushRemoteCopyJobManager implements CopyJobManager {
 
   @Override
   public void finishNRTCopy(CopyJob copyJob) throws IOException {
-    if (copyJob.getFailed()) {
-      return;
-    }
-    if (copyJob instanceof RemoteCopyJob remoteCopyJob) {
-      NrtPointState pointState = remoteCopyJob.getPointState();
-      Instant pointStateTimestamp = remoteCopyJob.getPointStateTimestamp();
-      dataManager.setLastPointState(pointState, pointStateTimestamp);
-    } else {
-      throw new IllegalArgumentException(
-          String.format(
-              "Expected copyJob to be instance of RemoteCopyJob, got %s",
-              copyJob.getClass().getName()));
-    }
+    RemoteCopyJob.commitPointState(copyJob, dataManager);
   }
 
   @Override

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/RemoteCopyJob.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/RemoteCopyJob.java
@@ -16,6 +16,7 @@
 package com.yelp.nrtsearch.server.nrt.jobs;
 
 import com.yelp.nrtsearch.server.nrt.NrtDataManager;
+import com.yelp.nrtsearch.server.nrt.state.NrtFileMetaData;
 import com.yelp.nrtsearch.server.nrt.state.NrtPointState;
 import com.yelp.nrtsearch.server.remote.InputStreamDataInput;
 import java.io.IOException;
@@ -48,10 +49,11 @@ public class RemoteCopyJob extends VisitableCopyJob {
   private final Instant pointStateTimestamp;
   private final NrtDataManager dataManager;
   private final CopyState copyState;
+  private final Map<String, NrtFileMetaData> nrtFiles;
   private Iterator<Map.Entry<String, FileMetaData>> iter;
 
   /**
-   * Constructor.
+   * Constructor for NRT point copy.
    *
    * @param reason the reason for the copy
    * @param pointState the state for the nrt point index version
@@ -75,11 +77,52 @@ public class RemoteCopyJob extends VisitableCopyJob {
       boolean highPriority,
       OnceDone onceDone)
       throws IOException {
+    this(
+        reason,
+        pointState,
+        pointStateTimestamp,
+        copyState,
+        dataManager,
+        dest,
+        files,
+        pointState.files,
+        highPriority,
+        onceDone);
+  }
+
+  /**
+   * Constructor with explicit NRT file metadata map.
+   *
+   * @param reason the reason for the copy
+   * @param pointState the state for the nrt point index version, or null for merge precopy
+   * @param pointStateTimestamp timestamp of the point state, or null for merge precopy
+   * @param copyState the copy state, or null for merge precopy
+   * @param dataManager to download files from remote storage
+   * @param dest the destination replica node
+   * @param files the files to copy
+   * @param nrtFiles map of file names to NrtFileMetaData for S3 download
+   * @param highPriority if this is a high priority copy
+   * @param onceDone callback when done
+   * @throws IOException on I/O error
+   */
+  public RemoteCopyJob(
+      String reason,
+      NrtPointState pointState,
+      Instant pointStateTimestamp,
+      CopyState copyState,
+      NrtDataManager dataManager,
+      ReplicaNode dest,
+      Map<String, FileMetaData> files,
+      Map<String, NrtFileMetaData> nrtFiles,
+      boolean highPriority,
+      OnceDone onceDone)
+      throws IOException {
     super(reason, files, dest, highPriority, onceDone);
     this.pointState = pointState;
     this.pointStateTimestamp = pointStateTimestamp;
     this.copyState = copyState;
     this.dataManager = dataManager;
+    this.nrtFiles = nrtFiles;
   }
 
   /**
@@ -255,7 +298,7 @@ public class RemoteCopyJob extends VisitableCopyJob {
       FileMetaData metaData = next.getValue();
       String fileName = next.getKey();
       InputStream remoteFileInputStream =
-          dataManager.downloadIndexFile(fileName, pointState.files.get(fileName));
+          dataManager.downloadIndexFile(fileName, nrtFiles.get(fileName));
       current =
           new StreamCopyOneFile(
               new InputStreamDataInput(remoteFileInputStream),

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/RemoteCopyJob.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/RemoteCopyJob.java
@@ -143,6 +143,69 @@ public class RemoteCopyJob extends VisitableCopyJob {
     return pointStateTimestamp;
   }
 
+  /**
+   * Commits the point state from a completed copy job to the data manager. This advances the
+   * replica's tracked point state so it won't re-download the same version. Does nothing if the
+   * copy job failed.
+   *
+   * @param copyJob the completed copy job
+   * @param dataManager the data manager to update
+   * @throws IOException on error
+   * @throws IllegalArgumentException if copyJob is not a RemoteCopyJob
+   */
+  public static void commitPointState(CopyJob copyJob, NrtDataManager dataManager)
+      throws IOException {
+    if (copyJob.getFailed()) {
+      return;
+    }
+    if (copyJob instanceof RemoteCopyJob remoteCopyJob) {
+      dataManager.setLastPointState(
+          remoteCopyJob.getPointState(), remoteCopyJob.getPointStateTimestamp());
+    } else {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected copyJob to be instance of RemoteCopyJob, got %s",
+              copyJob.getClass().getName()));
+    }
+  }
+
+  /**
+   * Factory method to create a RemoteCopyJob for an NRT point refresh.
+   *
+   * @param reason the reason for the copy
+   * @param target the target point state with timestamp
+   * @param dataManager to download files from remote storage
+   * @param dest the destination replica node
+   * @param highPriority if this is a high priority copy
+   * @param onceDone callback when done
+   * @return the new copy job
+   * @throws IOException on error or if no point state is available
+   */
+  public static RemoteCopyJob forNrtPoint(
+      String reason,
+      NrtDataManager.PointStateWithTimestamp target,
+      NrtDataManager dataManager,
+      ReplicaNode dest,
+      boolean highPriority,
+      OnceDone onceDone)
+      throws IOException {
+    NrtPointState pointState = target.pointState();
+    if (pointState == null) {
+      throw new IOException("No point state available from S3");
+    }
+    CopyState copyState = pointState.toCopyState();
+    return new RemoteCopyJob(
+        reason,
+        pointState,
+        target.timestamp(),
+        copyState,
+        dataManager,
+        dest,
+        copyState.files(),
+        highPriority,
+        onceDone);
+  }
+
   @Override
   protected CopyOneFile newCopyOneFile(CopyOneFile prev) {
     // No state needs to be changed when transferring to a new job

--- a/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/RemoteCopyJobManager.java
+++ b/src/main/java/com/yelp/nrtsearch/server/nrt/jobs/RemoteCopyJobManager.java
@@ -20,10 +20,8 @@ import com.yelp.nrtsearch.server.nrt.NRTReplicaNode;
 import com.yelp.nrtsearch.server.nrt.NrtDataManager;
 import com.yelp.nrtsearch.server.nrt.state.NrtPointState;
 import java.io.IOException;
-import java.time.Instant;
 import java.util.Map;
 import org.apache.lucene.replicator.nrt.CopyJob;
-import org.apache.lucene.replicator.nrt.CopyState;
 import org.apache.lucene.replicator.nrt.FileMetaData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,39 +76,18 @@ public class RemoteCopyJobManager implements CopyJobManager {
     if (files != null) {
       throw new IllegalArgumentException("RemoteCopyJobManager does not support merge precopy");
     }
-
-    NrtDataManager.PointStateWithTimestamp targetPointStateWithTimestamp =
-        dataManager.getTargetPointState(isolatedReplicaConfig);
-
-    CopyState copyState = targetPointStateWithTimestamp.pointState().toCopyState();
-    return new RemoteCopyJob(
+    return RemoteCopyJob.forNrtPoint(
         reason,
-        targetPointStateWithTimestamp.pointState(),
-        targetPointStateWithTimestamp.timestamp(),
-        copyState,
+        dataManager.getTargetPointState(isolatedReplicaConfig),
         dataManager,
         replicaNode,
-        copyState.files(),
         highPriority,
         onceDone);
   }
 
   @Override
   public void finishNRTCopy(CopyJob copyJob) throws IOException {
-    // If the copy job failed, we do not update the last known point state
-    if (copyJob.getFailed()) {
-      return;
-    }
-    if (copyJob instanceof RemoteCopyJob remoteCopyJob) {
-      NrtPointState pointState = remoteCopyJob.getPointState();
-      Instant pointStateTimestamp = remoteCopyJob.getPointStateTimestamp();
-      dataManager.setLastPointState(pointState, pointStateTimestamp);
-    } else {
-      throw new IllegalArgumentException(
-          String.format(
-              "Expected copyJob to be instance of RemoteCopyJob, got %s",
-              copyJob.getClass().getName()));
-    }
+    RemoteCopyJob.commitPointState(copyJob, dataManager);
   }
 
   @Override

--- a/src/test/java/com/yelp/nrtsearch/server/config/NrtsearchConfigTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/config/NrtsearchConfigTest.java
@@ -248,6 +248,20 @@ public class NrtsearchConfigTest {
   }
 
   @Test
+  public void testS3ReplicaRefreshDownload_default() {
+    String config = "nodeName: \"server_foo\"";
+    NrtsearchConfig luceneConfig = getForConfig(config);
+    assertFalse(luceneConfig.getS3ReplicaRefreshDownload());
+  }
+
+  @Test
+  public void testS3ReplicaRefreshDownload_set() {
+    String config = "s3ReplicaRefreshDownload: true";
+    NrtsearchConfig luceneConfig = getForConfig(config);
+    assertTrue(luceneConfig.getS3ReplicaRefreshDownload());
+  }
+
+  @Test
   public void testGetIngestionPluginConfigs() {
     String config =
         String.join(

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/IndexStartTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/IndexStartTest.java
@@ -1041,7 +1041,8 @@ public class IndexStartTest {
       Iterator<TransferStatus> iterator =
           replica
               .getReplicationClient()
-              .copyFiles("test_index", indexId, -1, FilesMetadata.newBuilder().build(), null);
+              .copyFiles(
+                  "test_index", indexId, -1, FilesMetadata.newBuilder().build(), null, null, null);
       iterator.next();
       fail();
     } catch (StatusRuntimeException e) {

--- a/src/test/java/com/yelp/nrtsearch/server/nrt/NrtReplicaNodeTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/nrt/NrtReplicaNodeTest.java
@@ -28,6 +28,7 @@ import com.yelp.nrtsearch.server.config.IsolatedReplicaConfig;
 import com.yelp.nrtsearch.server.grpc.ReplicationServerClient;
 import com.yelp.nrtsearch.server.monitoring.NrtMetrics;
 import com.yelp.nrtsearch.server.nrt.jobs.GrpcCopyJobManager;
+import com.yelp.nrtsearch.server.nrt.jobs.NrtPushRemoteCopyJobManager;
 import com.yelp.nrtsearch.server.nrt.jobs.RemoteCopyJobManager;
 import com.yelp.nrtsearch.server.nrt.jobs.SimpleCopyJob;
 import com.yelp.nrtsearch.server.utils.HostPort;
@@ -97,7 +98,8 @@ public class NrtReplicaNodeTest {
         false,
         false,
         true,
-        0);
+        0,
+        false);
   }
 
   private NRTReplicaNode getNrtReplicaNodeWithIRConfig(
@@ -116,7 +118,8 @@ public class NrtReplicaNodeTest {
         false,
         false,
         true,
-        0);
+        0,
+        false);
   }
 
   @Test
@@ -136,7 +139,8 @@ public class NrtReplicaNodeTest {
             false,
             false,
             true,
-            0);
+            0,
+            false);
     assertTrue(replicaNode.hasPrimaryConnection());
   }
 
@@ -194,6 +198,50 @@ public class NrtReplicaNodeTest {
     }
   }
 
+  @Test
+  public void testS3ReplicaRefreshDownload_enabled() throws IOException {
+    NRTReplicaNode replicaNode =
+        new NRTReplicaNode(
+            "test_index",
+            "id",
+            mock(ReplicationServerClient.class),
+            new HostPort("host", 0),
+            "testNode",
+            mock(Directory.class),
+            null,
+            new IsolatedReplicaConfig(false, 1, 0, 0),
+            null,
+            null,
+            false,
+            false,
+            true,
+            0,
+            true);
+    assertTrue(replicaNode.getCopyJobManager() instanceof NrtPushRemoteCopyJobManager);
+  }
+
+  @Test
+  public void testS3ReplicaRefreshDownload_disabled() throws IOException {
+    NRTReplicaNode replicaNode =
+        new NRTReplicaNode(
+            "test_index",
+            "id",
+            mock(ReplicationServerClient.class),
+            new HostPort("host", 0),
+            "testNode",
+            mock(Directory.class),
+            null,
+            new IsolatedReplicaConfig(false, 1, 0, 0),
+            null,
+            null,
+            false,
+            false,
+            true,
+            0,
+            false);
+    assertTrue(replicaNode.getCopyJobManager() instanceof GrpcCopyJobManager);
+  }
+
   /**
    * Test that NrtMetrics.indexTimestampSec gets set correctly when finishNRTCopy is called with a
    * successful SimpleCopyJob that has a timestamp.
@@ -229,7 +277,8 @@ public class NrtReplicaNodeTest {
             false,
             false,
             false,
-            0);
+            0,
+            false);
 
     // Create a spy to skip the parent finishNRTCopy call
     NRTReplicaNode spyReplicaNode = spy(replicaNode);
@@ -291,7 +340,8 @@ public class NrtReplicaNodeTest {
             false,
             false,
             false,
-            0);
+            0,
+            false);
 
     // Set initial metric value to verify it doesn't change
     NrtMetrics.indexTimestampSec.labelValues(TEST_INDEX_NAME).set(999.0);
@@ -349,7 +399,8 @@ public class NrtReplicaNodeTest {
             false,
             false,
             false,
-            0);
+            0,
+            false);
 
     // Set initial metric value to verify it doesn't change
     NrtMetrics.indexTimestampSec.labelValues(TEST_INDEX_NAME).set(999.0);
@@ -413,7 +464,8 @@ public class NrtReplicaNodeTest {
             false,
             false,
             false,
-            0);
+            0,
+            false);
 
     // Set initial metric value to verify it doesn't change
     NrtMetrics.indexTimestampSec.labelValues(TEST_INDEX_NAME).set(999.0);

--- a/src/test/java/com/yelp/nrtsearch/server/nrt/jobs/NrtPushRemoteCopyJobManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/nrt/jobs/NrtPushRemoteCopyJobManagerTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2025 Yelp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yelp.nrtsearch.server.nrt.jobs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.yelp.nrtsearch.server.nrt.NRTReplicaNode;
+import com.yelp.nrtsearch.server.nrt.NrtDataManager;
+import com.yelp.nrtsearch.server.nrt.state.NrtFileMetaData;
+import com.yelp.nrtsearch.server.nrt.state.NrtPointState;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+import org.apache.lucene.replicator.nrt.CopyJob;
+import org.apache.lucene.replicator.nrt.CopyState;
+import org.apache.lucene.replicator.nrt.FileMetaData;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NrtPushRemoteCopyJobManagerTest {
+
+  @Mock private NrtDataManager mockDataManager;
+  @Mock private NRTReplicaNode mockReplicaNode;
+  @Mock private CopyJob.OnceDone mockOnceDone;
+
+  private NrtPushRemoteCopyJobManager copyJobManager;
+
+  @Before
+  public void setUp() {
+    copyJobManager = new NrtPushRemoteCopyJobManager(mockDataManager, mockReplicaNode);
+  }
+
+  @Test
+  public void testNewCopyJob_withFiles() throws IOException {
+    Map<String, FileMetaData> files =
+        Map.of("file1", new FileMetaData(new byte[0], new byte[0], 1, 0));
+
+    try {
+      copyJobManager.newCopyJob("test", files, null, false, mockOnceDone);
+      fail("Expected IllegalArgumentException when files is not null");
+    } catch (IllegalArgumentException e) {
+      assertEquals("NrtPushRemoteCopyJobManager does not support merge precopy", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testNewCopyJob_success() throws IOException {
+    NrtPointState pointState = createTestPointState();
+    Instant timestamp = Instant.now();
+    NrtDataManager.PointStateWithTimestamp pointStateWithTimestamp =
+        new NrtDataManager.PointStateWithTimestamp(pointState, timestamp);
+
+    when(mockDataManager.getTargetPointState(null)).thenReturn(pointStateWithTimestamp);
+
+    CopyJob copyJob = copyJobManager.newCopyJob("test_reason", null, null, true, mockOnceDone);
+
+    assertNotNull(copyJob);
+    assertTrue(copyJob instanceof RemoteCopyJob);
+
+    RemoteCopyJob remoteCopyJob = (RemoteCopyJob) copyJob;
+    assertEquals(pointState, remoteCopyJob.getPointState());
+    assertEquals(timestamp, remoteCopyJob.getPointStateTimestamp());
+
+    verify(mockDataManager).getTargetPointState(null);
+  }
+
+  @Test
+  public void testNewCopyJob_nullPointState() throws IOException {
+    NrtDataManager.PointStateWithTimestamp pointStateWithTimestamp =
+        new NrtDataManager.PointStateWithTimestamp(null, null);
+
+    when(mockDataManager.getTargetPointState(null)).thenReturn(pointStateWithTimestamp);
+
+    try {
+      copyJobManager.newCopyJob("test_reason", null, null, true, mockOnceDone);
+      fail("Expected IOException when point state is null");
+    } catch (IOException e) {
+      assertEquals("No point state available from S3", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testFinishNRTCopy_success() throws IOException {
+    RemoteCopyJob mockRemoteCopyJob = mock(RemoteCopyJob.class);
+    NrtPointState pointState = createTestPointState();
+    Instant timestamp = Instant.now();
+
+    when(mockRemoteCopyJob.getFailed()).thenReturn(false);
+    when(mockRemoteCopyJob.getPointState()).thenReturn(pointState);
+    when(mockRemoteCopyJob.getPointStateTimestamp()).thenReturn(timestamp);
+
+    copyJobManager.finishNRTCopy(mockRemoteCopyJob);
+
+    verify(mockDataManager).setLastPointState(pointState, timestamp);
+  }
+
+  @Test
+  public void testFinishNRTCopy_failed() throws IOException {
+    RemoteCopyJob mockRemoteCopyJob = mock(RemoteCopyJob.class);
+    when(mockRemoteCopyJob.getFailed()).thenReturn(true);
+
+    copyJobManager.finishNRTCopy(mockRemoteCopyJob);
+
+    verify(mockDataManager, never()).setLastPointState(any(), any());
+  }
+
+  @Test
+  public void testFinishNRTCopy_wrongCopyJobType() throws IOException {
+    CopyJob mockCopyJob = mock(CopyJob.class);
+    when(mockCopyJob.getFailed()).thenReturn(false);
+
+    try {
+      copyJobManager.finishNRTCopy(mockCopyJob);
+      fail("Expected IllegalArgumentException for wrong copy job type");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("Expected copyJob to be instance of RemoteCopyJob"));
+    }
+  }
+
+  private NrtPointState createTestPointState() {
+    long version = 1;
+    long gen = 3;
+    byte[] infosBytes = new byte[] {1, 2, 3, 4, 5};
+    long primaryGen = 5;
+    Set<String> completedMergeFiles = Set.of("file1");
+    String primaryId = "testPrimaryId";
+
+    FileMetaData fileMetaData =
+        new FileMetaData(new byte[] {6, 7, 8}, new byte[] {0, 10, 11}, 10, 25);
+    NrtFileMetaData nrtFileMetaData =
+        new NrtFileMetaData(
+            new byte[] {6, 7, 8}, new byte[] {0, 10, 11}, 10, 25, "primaryId2", "timeString");
+
+    CopyState copyState =
+        new CopyState(
+            Map.of("file3", fileMetaData),
+            version,
+            gen,
+            infosBytes,
+            completedMergeFiles,
+            primaryGen,
+            null);
+
+    return new NrtPointState(copyState, Map.of("file3", nrtFileMetaData), primaryId);
+  }
+}

--- a/src/test/java/com/yelp/nrtsearch/server/nrt/jobs/NrtPushRemoteCopyJobManagerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/nrt/jobs/NrtPushRemoteCopyJobManagerTest.java
@@ -57,16 +57,29 @@ public class NrtPushRemoteCopyJobManagerTest {
   }
 
   @Test
-  public void testNewCopyJob_withFiles() throws IOException {
+  public void testNewCopyJob_withFiles_noMetadata() throws IOException {
     Map<String, FileMetaData> files =
         Map.of("file1", new FileMetaData(new byte[0], new byte[0], 1, 0));
 
     try {
       copyJobManager.newCopyJob("test", files, null, false, mockOnceDone);
-      fail("Expected IllegalArgumentException when files is not null");
-    } catch (IllegalArgumentException e) {
-      assertEquals("NrtPushRemoteCopyJobManager does not support merge precopy", e.getMessage());
+      fail("Expected IOException when merge metadata is not set");
+    } catch (IOException e) {
+      assertTrue(e.getMessage().contains("Missing S3 metadata for merge precopy"));
     }
+  }
+
+  @Test
+  public void testNewCopyJob_withFiles_success() throws IOException {
+    Map<String, FileMetaData> files =
+        Map.of("file1", new FileMetaData(new byte[0], new byte[0], 1, 0));
+
+    copyJobManager.setMergePreCopyMetadata("testPrimaryId", "20260805120000");
+
+    CopyJob copyJob = copyJobManager.newCopyJob("test", files, null, false, mockOnceDone);
+
+    assertNotNull(copyJob);
+    assertTrue(copyJob instanceof RemoteCopyJob);
   }
 
   @Test


### PR DESCRIPTION
Added config s3ReplicaRefreshDownload with default false
when s3ReplicaRefreshDownload is true
During refresh or commit
1. replica receives push notification from primary
2. downloads the latest point state from s3
3. create a RemoteCopy Job that downloads file from s3
4. set the latest point state

It is a little tricky for segment merge and I'd like to get feedback here. I haven't made any changes about the code here
So 
1. primary still tries to copy merged segment files to replicas and replicas will throw errors and got skipped
2. in the next refresh, replicas will download the files from s3.
3. Since our refresh is usually every second, this is not too bad maybe?

This is a little different from isolated replicas since isolated replicas does not receive push notifications from primary and primary does not need to know the replicas so primary won't try to copy data to them at all.

I'm planning to make changes to replica to direct return success when primary trying to copy merged data to replicas if the config is true. This will avoid making primaries throw errors and then skip.

Or I can try make it more complicated to make primary aware that these replicas are s3 based replicas and do not do pre copy merge via grpc streaming for these replicas.

One other idea would be not rely on push notifications from primary.

I want to get your thoughts about the precopy merge here @aprudhomme, thanks