### PR TITLE
Make polygon field geo queryable

### DIFF
--- a/docs/field_types/polygon.rst
+++ b/docs/field_types/polygon.rst
@@ -18,6 +18,15 @@ Field used for closed geo polygons represented as a list of geo points. The firs
 
 This field is always searchable.
 
+Supported Queries
+-----------------
+The POLYGON field type supports the following query types. All geo queries use ``INTERSECTS`` semantics — a document matches if the indexed polygon intersects the query shape.
+
+- :doc:`/queries/geo_point` — find indexed polygons that **contain** the given point
+- :doc:`/queries/geo_radius` — find indexed polygons that intersect a circle (center point + radius)
+- :doc:`/queries/geo_bounding_box` — find indexed polygons that intersect a bounding box
+- :doc:`/queries/geo_polygon` — find indexed polygons that intersect the given query polygon(s)
+
 Example
 -------
 .. code-block:: json

--- a/docs/queries/geo_bounding_box.rst
+++ b/docs/queries/geo_bounding_box.rst
@@ -1,7 +1,10 @@
 Geo-Bounding Box Query
 ==========================
 
-A query that matches documents with a geopoint within the geo box defined by topLeft and bottomRight latitude-longitude coordinates.
+A query that matches documents within the geo box defined by topLeft and bottomRight latitude-longitude coordinates. The behavior depends on the field type:
+
+- **LAT_LON**: matches documents whose indexed *point* falls within the box.
+- **POLYGON**: matches documents whose indexed *polygon* intersects the box.
 
 Proto definition:
 
@@ -12,3 +15,5 @@ Proto definition:
        google.type.LatLng topLeft = 2; // top left corner of the geo box
        google.type.LatLng bottomRight = 3; // bottom right corner of the geo box
    }
+
+Supported field types: ``LAT_LON``, ``POLYGON``

--- a/docs/queries/geo_point.rst
+++ b/docs/queries/geo_point.rst
@@ -1,7 +1,7 @@
 Geo-Point Query
 ==========================
 
-A query that matches documents with a polygon that contains the provided geo point.
+A query that matches documents with an indexed polygon that **contains** the provided geo point.
 
 Proto definition:
 
@@ -11,3 +11,5 @@ Proto definition:
        string field = 1; // Field in the document to query
        google.type.LatLng point = 2; // point used to query whether the polygon contains it.
    }
+
+Supported field types: ``POLYGON``

--- a/docs/queries/geo_polygon.rst
+++ b/docs/queries/geo_polygon.rst
@@ -1,9 +1,12 @@
 Geo-Polygon Query
 ==========================
 
-A query that matches documents with geo point within a defined set of polygons.
+A query that matches documents based on a defined set of query polygons. The behavior depends on the field type:
 
-Polygon definitions must conform to the `GeoJson <https://geojson.org/>`_ standard.
+- **LAT_LON**: matches documents whose indexed *point* falls within the query polygon(s).
+- **POLYGON**: matches documents whose indexed *polygon* intersects the query polygon(s).
+
+Query polygon definitions must conform to the `GeoJson <https://geojson.org/>`_ standard.
 Polygons must not be self-crossing, otherwise may result in unexpected behavior.
 Polygons cannot cross the 180th meridian. Instead, use two polygons: one on each side.
 
@@ -17,3 +20,5 @@ Proto definition:
        // Geo polygons to search for containing points
        repeated Polygon polygons = 2;
    }
+
+Supported field types: ``LAT_LON``, ``POLYGON``

--- a/docs/queries/geo_radius.rst
+++ b/docs/queries/geo_radius.rst
@@ -1,7 +1,10 @@
 Geo-Radius Query
 ==========================
 
-A query that matches documents with geo point within the radius of provided geo point.
+A query that finds documents within a given radius of a center point. The behavior depends on the field type:
+
+- **LAT_LON**: matches documents whose indexed *point* falls within the circle.
+- **POLYGON**: matches documents whose indexed *polygon* intersects the circle.
 
 Proto definition:
 
@@ -12,3 +15,5 @@ Proto definition:
        google.type.LatLng center = 2; // target center geo point to calculate distance
        string radius = 3; // distance radius  like "12 km". supports m, km and mi, default to m
    }
+
+Supported field types: ``LAT_LON``, ``POLYGON``

--- a/src/main/java/com/yelp/nrtsearch/server/field/PolygonfieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/PolygonfieldDef.java
@@ -19,15 +19,21 @@ import static com.yelp.nrtsearch.server.analysis.AnalyzerCreator.hasAnalyzer;
 
 import com.google.protobuf.Struct;
 import com.yelp.nrtsearch.server.doc.LoadedDocValues;
+import com.yelp.nrtsearch.server.field.properties.GeoQueryable;
 import com.yelp.nrtsearch.server.field.properties.PolygonQueryable;
+import com.yelp.nrtsearch.server.geo.GeoUtils;
 import com.yelp.nrtsearch.server.grpc.Field;
+import com.yelp.nrtsearch.server.grpc.GeoBoundingBoxQuery;
 import com.yelp.nrtsearch.server.grpc.GeoPointQuery;
+import com.yelp.nrtsearch.server.grpc.GeoPolygonQuery;
+import com.yelp.nrtsearch.server.grpc.GeoRadiusQuery;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.lucene.document.*;
+import org.apache.lucene.geo.Circle;
 import org.apache.lucene.geo.Polygon;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
@@ -36,7 +42,8 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 
-public class PolygonfieldDef extends IndexableFieldDef<Struct> implements PolygonQueryable {
+public class PolygonfieldDef extends IndexableFieldDef<Struct>
+    implements PolygonQueryable, GeoQueryable {
 
   protected PolygonfieldDef(
       String name, Field requestField, FieldDefCreator.FieldDefCreatorContext context) {
@@ -145,5 +152,90 @@ public class PolygonfieldDef extends IndexableFieldDef<Struct> implements Polygo
         geoPointQuery.getPoint().getLatitude(),
         geoPointQuery.getPoint().getLongitude(),
         geoPointQuery.getPoint().getLongitude());
+  }
+
+  @Override
+  public Query getGeoRadiusQuery(GeoRadiusQuery geoRadiusQuery) {
+    if (!this.isSearchable()) {
+      throw new IllegalArgumentException(
+          String.format("field %s is not searchable", this.getName()));
+    }
+    double radius = GeoUtils.getDistance(geoRadiusQuery.getRadius());
+    return LatLonShape.newDistanceQuery(
+        geoRadiusQuery.getField(),
+        ShapeField.QueryRelation.INTERSECTS,
+        new Circle(
+            geoRadiusQuery.getCenter().getLatitude(),
+            geoRadiusQuery.getCenter().getLongitude(),
+            radius));
+  }
+
+  @Override
+  public Query getGeoBoundingBoxQuery(GeoBoundingBoxQuery geoBoundingBoxQuery) {
+    if (!this.isSearchable()) {
+      throw new IllegalArgumentException(
+          String.format("field %s is not searchable", this.getName()));
+    }
+    return LatLonShape.newBoxQuery(
+        geoBoundingBoxQuery.getField(),
+        ShapeField.QueryRelation.INTERSECTS,
+        geoBoundingBoxQuery.getBottomRight().getLatitude(),
+        geoBoundingBoxQuery.getTopLeft().getLatitude(),
+        geoBoundingBoxQuery.getTopLeft().getLongitude(),
+        geoBoundingBoxQuery.getBottomRight().getLongitude());
+  }
+
+  @Override
+  public Query getGeoPolygonQuery(GeoPolygonQuery geoPolygonQuery) {
+    if (!this.isSearchable()) {
+      throw new IllegalArgumentException(
+          String.format("field %s is not searchable", this.getName()));
+    }
+    if (geoPolygonQuery.getPolygonsCount() == 0) {
+      throw new IllegalArgumentException("GeoPolygonQuery must contain at least one polygon");
+    }
+    Polygon[] polygons = new Polygon[geoPolygonQuery.getPolygonsCount()];
+    for (int i = 0; i < geoPolygonQuery.getPolygonsCount(); ++i) {
+      polygons[i] = toLucenePolygon(geoPolygonQuery.getPolygons(i));
+    }
+    return LatLonShape.newPolygonQuery(
+        geoPolygonQuery.getField(), ShapeField.QueryRelation.INTERSECTS, polygons);
+  }
+
+  private static Polygon toLucenePolygon(com.yelp.nrtsearch.server.grpc.Polygon grpcPolygon) {
+    int pointsCount = grpcPolygon.getPointsCount();
+    if (pointsCount < 3) {
+      throw new IllegalArgumentException("Polygon must have at least three points");
+    }
+
+    boolean closedShape =
+        grpcPolygon.getPoints(0).equals(grpcPolygon.getPoints(grpcPolygon.getPointsCount() - 1));
+    int pointsArraySize;
+    if (closedShape) {
+      if (pointsCount < 4) {
+        throw new IllegalArgumentException("Closed Polygon must have at least four points");
+      }
+      pointsArraySize = pointsCount;
+    } else {
+      pointsArraySize = pointsCount + 1;
+    }
+
+    double[] latValues = new double[pointsArraySize];
+    double[] lonValues = new double[pointsArraySize];
+    for (int i = 0; i < grpcPolygon.getPointsCount(); ++i) {
+      latValues[i] = grpcPolygon.getPoints(i).getLatitude();
+      lonValues[i] = grpcPolygon.getPoints(i).getLongitude();
+    }
+
+    if (!closedShape) {
+      latValues[pointsCount] = grpcPolygon.getPoints(0).getLatitude();
+      lonValues[pointsCount] = grpcPolygon.getPoints(0).getLongitude();
+    }
+
+    Polygon[] holes = new Polygon[grpcPolygon.getHolesCount()];
+    for (int i = 0; i < grpcPolygon.getHolesCount(); ++i) {
+      holes[i] = toLucenePolygon(grpcPolygon.getHoles(i));
+    }
+    return new Polygon(latValues, lonValues, holes);
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/field/PolygonFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/PolygonFieldDefTest.java
@@ -55,8 +55,11 @@ public class PolygonFieldDefTest extends ServerTestCase {
 
   protected void initIndex(String name) throws Exception {
     List<AddDocumentRequest> docs = new ArrayList<>();
-    Map<String, Object> doc = new HashMap<>();
-    doc.put("type", "Polygon"); // Cannot be polygon...
+    Gson gson = new Gson();
+
+    // Doc "1": polygon at lat 0-1, lon 100-101 (with a hole), used by existing tests
+    Map<String, Object> doc1 = new HashMap<>();
+    doc1.put("type", "Polygon");
     List<List<Double>> outer = new ArrayList<>();
     outer.add(List.of(100.0, 0.0));
     outer.add(List.of(101.0, 0.0));
@@ -69,18 +72,19 @@ public class PolygonFieldDefTest extends ServerTestCase {
     hole.add(List.of(100.8, 0.8));
     hole.add(List.of(100.2, 0.8));
     hole.add(List.of(100.2, 0.2));
-    List<List<List<Double>>> coordinates = List.of(outer, hole);
-    doc.put("coordinates", coordinates);
-    Gson gson = new Gson();
-    AddDocumentRequest docRequest =
+    doc1.put("coordinates", List.of(outer, hole));
+    docs.add(
         AddDocumentRequest.newBuilder()
             .setIndexName(name)
             .putFields("doc_id", MultiValuedField.newBuilder().addValue("1").build())
-            .putFields("polygon", MultiValuedField.newBuilder().addValue(gson.toJson(doc)).build())
+            .putFields("polygon", MultiValuedField.newBuilder().addValue(gson.toJson(doc1)).build())
             .putFields(
-                "single_stored", MultiValuedField.newBuilder().addValue(gson.toJson(doc)).build())
-            .build();
-    docs.add(docRequest);
+                "single_stored", MultiValuedField.newBuilder().addValue(gson.toJson(doc1)).build())
+            .build());
+
+    // Doc "2": polygon at lat 40-41, lon -75 to -74 (roughly New Jersey), used by geo query tests
+    docs.add(buildPolygonDoc(name, "2", buildRectPolygon(40.0, -75.0, 41.0, -74.0)));
+
     addDocuments(docs.stream());
   }
 
@@ -97,7 +101,22 @@ public class PolygonFieldDefTest extends ServerTestCase {
                     .addRetrieveFields("single_none_stored")
                     .setQuery(Query.newBuilder().build())
                     .build());
-    assertEquals(1, response.getHitsCount());
+    assertEquals(2, response.getHitsCount());
+
+    // Find the hit for doc "1" which has the stored polygon
+    SearchResponse.Hit doc1Hit =
+        response.getHitsList().stream()
+            .filter(
+                h ->
+                    h.getFieldsOrThrow("single_stored").getFieldValueCount() > 0
+                        && h.getFieldsOrThrow("single_stored")
+                            .getFieldValue(0)
+                            .getStructValue()
+                            .getFieldsOrThrow("type")
+                            .getStringValue()
+                            .equals("Polygon"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("No hit with single_stored polygon found"));
 
     Struct expectedStruct =
         Struct.newBuilder()
@@ -263,12 +282,11 @@ public class PolygonFieldDefTest extends ServerTestCase {
             .putFields("type", Value.newBuilder().setStringValue("Polygon").build())
             .build();
 
-    assertEquals(1, response.getHits(0).getFieldsOrThrow("single_stored").getFieldValueCount());
+    assertEquals(1, doc1Hit.getFieldsOrThrow("single_stored").getFieldValueCount());
     assertEquals(
         expectedStruct,
-        response.getHits(0).getFieldsOrThrow("single_stored").getFieldValue(0).getStructValue());
-    assertEquals(
-        0, response.getHits(0).getFieldsOrThrow("single_none_stored").getFieldValueCount());
+        doc1Hit.getFieldsOrThrow("single_stored").getFieldValue(0).getStructValue());
+    assertEquals(0, doc1Hit.getFieldsOrThrow("single_none_stored").getFieldValueCount());
   }
 
   @Test
@@ -331,6 +349,145 @@ public class PolygonFieldDefTest extends ServerTestCase {
 
   private void queryAndVerifyIds(GeoPointQuery geoPolygonQuery, String... expectedIds) {
     Query query = Query.newBuilder().setGeoPointQuery(geoPolygonQuery).build();
+    SearchResponse response = doQuery(query, "doc_id");
+    List<String> idList = Arrays.asList(expectedIds);
+    assertEquals(idList.size(), response.getHitsCount());
+    for (SearchResponse.Hit hit : response.getHitsList()) {
+      assertTrue(idList.contains(hit.getFieldsOrThrow("doc_id").getFieldValue(0).getTextValue()));
+    }
+  }
+
+  // Builds a simple rectangular GeoJSON polygon from (lat1,lon1) to (lat2,lon2)
+  private String buildRectPolygon(double lat1, double lon1, double lat2, double lon2) {
+    Map<String, Object> doc = new HashMap<>();
+    doc.put("type", "Polygon");
+    List<List<Double>> ring = new ArrayList<>();
+    ring.add(List.of(lon1, lat1));
+    ring.add(List.of(lon2, lat1));
+    ring.add(List.of(lon2, lat2));
+    ring.add(List.of(lon1, lat2));
+    ring.add(List.of(lon1, lat1));
+    doc.put("coordinates", List.of(ring));
+    return new Gson().toJson(doc);
+  }
+
+  private AddDocumentRequest buildPolygonDoc(String name, String id, String polygonJson) {
+    return AddDocumentRequest.newBuilder()
+        .setIndexName(name)
+        .putFields("doc_id", MultiValuedField.newBuilder().addValue(id).build())
+        .putFields("polygon", MultiValuedField.newBuilder().addValue(polygonJson).build())
+        .build();
+  }
+
+  @Test
+  public void testGeoRadiusQuery() {
+    // Query centered at (0.5, 100.5) with 100km radius — should intersect doc "1"
+    GeoRadiusQuery nearDoc1 =
+        GeoRadiusQuery.newBuilder()
+            .setField("polygon")
+            .setCenter(LatLng.newBuilder().setLatitude(0.5).setLongitude(100.5).build())
+            .setRadius("100 km")
+            .build();
+    queryAndVerifyGeoRadiusIds(nearDoc1, "1");
+
+    // Query centered at (40.5, -74.5) with 100km radius — should intersect doc "2"
+    GeoRadiusQuery nearDoc2 =
+        GeoRadiusQuery.newBuilder()
+            .setField("polygon")
+            .setCenter(LatLng.newBuilder().setLatitude(40.5).setLongitude(-74.5).build())
+            .setRadius("100 km")
+            .build();
+    queryAndVerifyGeoRadiusIds(nearDoc2, "2");
+  }
+
+  @Test
+  public void testGeoRadiusQueryNoIntersection() {
+    // Query centered over the Pacific Ocean, far from the test polygon
+    GeoRadiusQuery noMatch =
+        GeoRadiusQuery.newBuilder()
+            .setField("polygon")
+            .setCenter(LatLng.newBuilder().setLatitude(0.0).setLongitude(-150.0).build())
+            .setRadius("100 km")
+            .build();
+    queryAndVerifyGeoRadiusIds(noMatch);
+  }
+
+  @Test
+  public void testGeoRadiusQueryPartialOverlap() {
+    // Query circle centered just outside the polygon's east edge (lon=101.1) but large enough
+    // to reach back into the polygon (which extends to lon=101.0), verifying INTERSECTS semantics.
+    GeoRadiusQuery partialOverlap =
+        GeoRadiusQuery.newBuilder()
+            .setField("polygon")
+            .setCenter(LatLng.newBuilder().setLatitude(0.5).setLongitude(101.1).build())
+            .setRadius("50 km")
+            .build();
+    queryAndVerifyGeoRadiusIds(partialOverlap, "1");
+  }
+
+  @Test
+  public void testGeoBoundingBoxQueryOnPolygon() {
+    // Bounding box that overlaps doc "1" (lat 0-1, lon 100-101)
+    GeoBoundingBoxQuery boxForDoc1 =
+        GeoBoundingBoxQuery.newBuilder()
+            .setField("polygon")
+            .setTopLeft(LatLng.newBuilder().setLatitude(2.0).setLongitude(99.0).build())
+            .setBottomRight(LatLng.newBuilder().setLatitude(-1.0).setLongitude(102.0).build())
+            .build();
+    Query q1 = Query.newBuilder().setGeoBoundingBoxQuery(boxForDoc1).build();
+    SearchResponse r1 = doQuery(q1, "doc_id");
+    assertEquals(1, r1.getHitsCount());
+    assertEquals("1", r1.getHits(0).getFieldsOrThrow("doc_id").getFieldValue(0).getTextValue());
+
+    // Bounding box that does not overlap either polygon
+    GeoBoundingBoxQuery noOverlapBox =
+        GeoBoundingBoxQuery.newBuilder()
+            .setField("polygon")
+            .setTopLeft(LatLng.newBuilder().setLatitude(50.0).setLongitude(50.0).build())
+            .setBottomRight(LatLng.newBuilder().setLatitude(45.0).setLongitude(60.0).build())
+            .build();
+    Query qNone = Query.newBuilder().setGeoBoundingBoxQuery(noOverlapBox).build();
+    SearchResponse rNone = doQuery(qNone, "doc_id");
+    assertEquals(0, rNone.getHitsCount());
+  }
+
+  @Test
+  public void testGeoPolygonQueryOnPolygon() {
+    // Query polygon that intersects doc "1"
+    com.yelp.nrtsearch.server.grpc.Polygon queryPolygon =
+        com.yelp.nrtsearch.server.grpc.Polygon.newBuilder()
+            .addPoints(LatLng.newBuilder().setLatitude(2.0).setLongitude(99.0).build())
+            .addPoints(LatLng.newBuilder().setLatitude(2.0).setLongitude(102.0).build())
+            .addPoints(LatLng.newBuilder().setLatitude(-1.0).setLongitude(102.0).build())
+            .addPoints(LatLng.newBuilder().setLatitude(-1.0).setLongitude(99.0).build())
+            .build();
+    GeoPolygonQuery geoPolygonQuery =
+        GeoPolygonQuery.newBuilder().setField("polygon").addPolygons(queryPolygon).build();
+    Query q = Query.newBuilder().setGeoPolygonQuery(geoPolygonQuery).build();
+    SearchResponse r = doQuery(q, "doc_id");
+    assertEquals(1, r.getHitsCount());
+    assertEquals("1", r.getHits(0).getFieldsOrThrow("doc_id").getFieldValue(0).getTextValue());
+  }
+
+  @Test
+  public void testGeoRadiusQueryNotSearchable() {
+    // "doc_id" is ATOM type, not GeoQueryable — should throw
+    GeoRadiusQuery query =
+        GeoRadiusQuery.newBuilder()
+            .setField("doc_id")
+            .setCenter(LatLng.newBuilder().setLatitude(0.5).setLongitude(100.5).build())
+            .setRadius("100 km")
+            .build();
+    try {
+      doQuery(Query.newBuilder().setGeoRadiusQuery(query).build(), "doc_id");
+      org.junit.Assert.fail("Expected exception");
+    } catch (io.grpc.StatusRuntimeException e) {
+      assertTrue(e.getMessage().contains("does not support GeoRadiusQuery"));
+    }
+  }
+
+  private void queryAndVerifyGeoRadiusIds(GeoRadiusQuery geoRadiusQuery, String... expectedIds) {
+    Query query = Query.newBuilder().setGeoRadiusQuery(geoRadiusQuery).build();
     SearchResponse response = doQuery(query, "doc_id");
     List<String> idList = Arrays.asList(expectedIds);
     assertEquals(idList.size(), response.getHitsCount());

--- a/src/test/java/com/yelp/nrtsearch/server/field/PolygonFieldDefTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/field/PolygonFieldDefTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 import com.google.gson.Gson;
@@ -29,6 +30,7 @@ import com.google.type.LatLng;
 import com.yelp.nrtsearch.server.ServerTestCase;
 import com.yelp.nrtsearch.server.grpc.*;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest.MultiValuedField;
+import com.yelp.nrtsearch.server.grpc.Polygon;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.IOException;
 import java.util.*;
@@ -39,6 +41,8 @@ import org.junit.Test;
 public class PolygonFieldDefTest extends ServerTestCase {
 
   @ClassRule public static final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private static final Gson GSON = new Gson();
 
   private PolygonfieldDef createFieldDef(Field field) {
     return new PolygonfieldDef(
@@ -55,7 +59,6 @@ public class PolygonFieldDefTest extends ServerTestCase {
 
   protected void initIndex(String name) throws Exception {
     List<AddDocumentRequest> docs = new ArrayList<>();
-    Gson gson = new Gson();
 
     // Doc "1": polygon at lat 0-1, lon 100-101 (with a hole), used by existing tests
     Map<String, Object> doc1 = new HashMap<>();
@@ -77,9 +80,9 @@ public class PolygonFieldDefTest extends ServerTestCase {
         AddDocumentRequest.newBuilder()
             .setIndexName(name)
             .putFields("doc_id", MultiValuedField.newBuilder().addValue("1").build())
-            .putFields("polygon", MultiValuedField.newBuilder().addValue(gson.toJson(doc1)).build())
+            .putFields("polygon", MultiValuedField.newBuilder().addValue(GSON.toJson(doc1)).build())
             .putFields(
-                "single_stored", MultiValuedField.newBuilder().addValue(gson.toJson(doc1)).build())
+                "single_stored", MultiValuedField.newBuilder().addValue(GSON.toJson(doc1)).build())
             .build());
 
     // Doc "2": polygon at lat 40-41, lon -75 to -74 (roughly New Jersey), used by geo query tests
@@ -99,24 +102,15 @@ public class PolygonFieldDefTest extends ServerTestCase {
                     .setTopHits(3)
                     .addRetrieveFields("single_stored")
                     .addRetrieveFields("single_none_stored")
-                    .setQuery(Query.newBuilder().build())
+                    .setQuery(
+                        Query.newBuilder()
+                            .setTermQuery(
+                                TermQuery.newBuilder().setField("doc_id").setTextValue("1").build())
+                            .build())
                     .build());
-    assertEquals(2, response.getHitsCount());
+    assertEquals(1, response.getHitsCount());
 
-    // Find the hit for doc "1" which has the stored polygon
-    SearchResponse.Hit doc1Hit =
-        response.getHitsList().stream()
-            .filter(
-                h ->
-                    h.getFieldsOrThrow("single_stored").getFieldValueCount() > 0
-                        && h.getFieldsOrThrow("single_stored")
-                            .getFieldValue(0)
-                            .getStructValue()
-                            .getFieldsOrThrow("type")
-                            .getStringValue()
-                            .equals("Polygon"))
-            .findFirst()
-            .orElseThrow(() -> new AssertionError("No hit with single_stored polygon found"));
+    SearchResponse.Hit doc1Hit = response.getHits(0);
 
     Struct expectedStruct =
         Struct.newBuilder()
@@ -368,7 +362,7 @@ public class PolygonFieldDefTest extends ServerTestCase {
     ring.add(List.of(lon1, lat2));
     ring.add(List.of(lon1, lat1));
     doc.put("coordinates", List.of(ring));
-    return new Gson().toJson(doc);
+    return GSON.toJson(doc);
   }
 
   private AddDocumentRequest buildPolygonDoc(String name, String id, String polygonJson) {
@@ -454,8 +448,8 @@ public class PolygonFieldDefTest extends ServerTestCase {
   @Test
   public void testGeoPolygonQueryOnPolygon() {
     // Query polygon that intersects doc "1"
-    com.yelp.nrtsearch.server.grpc.Polygon queryPolygon =
-        com.yelp.nrtsearch.server.grpc.Polygon.newBuilder()
+    Polygon queryPolygon =
+        Polygon.newBuilder()
             .addPoints(LatLng.newBuilder().setLatitude(2.0).setLongitude(99.0).build())
             .addPoints(LatLng.newBuilder().setLatitude(2.0).setLongitude(102.0).build())
             .addPoints(LatLng.newBuilder().setLatitude(-1.0).setLongitude(102.0).build())
@@ -480,7 +474,7 @@ public class PolygonFieldDefTest extends ServerTestCase {
             .build();
     try {
       doQuery(Query.newBuilder().setGeoRadiusQuery(query).build(), "doc_id");
-      org.junit.Assert.fail("Expected exception");
+      fail("Expected exception");
     } catch (io.grpc.StatusRuntimeException e) {
       assertTrue(e.getMessage().contains("does not support GeoRadiusQuery"));
     }


### PR DESCRIPTION
Extend the `POLYGON` field type to be `GeoQueryable`. This allows use of the geo radius/bounding box/polygon query types.