### PR TITLE
Add arm64 to GOARCH loop in grpc-gateway Dockerfile

### DIFF
--- a/grpc-gateway/Dockerfile
+++ b/grpc-gateway/Dockerfile
@@ -97,7 +97,7 @@ RUN cp $OUTPATH/github.com/Yelp/nrtsearch/* grpc-gateway/
 
 # build go executables for various platforms
 RUN for GOOS in darwin linux windows; do \
-    for GOARCH in 386 amd64; do \
+    for GOARCH in 386 amd64 arm64; do \
         echo "Building $GOOS-$GOARCH"; \
         export GOOS=$GOOS; \
         export GOARCH=$GOARCH; \


### PR DESCRIPTION
## Summary

- Adds `arm64` to the inner `for GOARCH` loop in `grpc-gateway/Dockerfile` (line 100), alongside the existing `386` and `amd64` targets.
- This causes the Docker build to produce three additional binaries: `http_wrapper-darwin-arm64`, `http_wrapper-linux-arm64`, and `http_wrapper-windows-arm64`.
- Enables native execution of the grpc-gateway HTTP wrapper on Apple Silicon Macs and ARM-based Linux hosts (e.g., AWS Graviton instances).

## Tests

- Ran `./gradlew clean installDist buildGrpcGateway` successfully.
- Confirmed the following new binaries were produced in `build/install/nrtsearch/bin/`:
  - `http_wrapper-darwin-arm64` (15.3 MB)
  - `http_wrapper-linux-arm64` (15.2 MB)
  - `http_wrapper-windows-arm64` (15.2 MB)
- Note: `darwin/386` is an unsupported GOOS/GOARCH pair in Go and is skipped silently — this is pre-existing behavior unaffected by this change.