### PR TITLE
Migrate 8 direct GrpcServer users to TestServer (Phase 1)

### DIFF
--- a/src/test/java/com/yelp/nrtsearch/clientlib/NodeNameResolverAndLoadBalancingTests.java
+++ b/src/test/java/com/yelp/nrtsearch/clientlib/NodeNameResolverAndLoadBalancingTests.java
@@ -15,33 +15,29 @@
  */
 package com.yelp.nrtsearch.clientlib;
 
-import static com.yelp.nrtsearch.server.grpc.GrpcServer.TEST_INDEX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.CommitRequest;
 import com.yelp.nrtsearch.server.grpc.CreateIndexRequest;
 import com.yelp.nrtsearch.server.grpc.Field;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
 import com.yelp.nrtsearch.server.grpc.FieldType;
-import com.yelp.nrtsearch.server.grpc.GrpcServer;
 import com.yelp.nrtsearch.server.grpc.HealthCheckRequest;
 import com.yelp.nrtsearch.server.grpc.LuceneServerGrpc;
 import com.yelp.nrtsearch.server.grpc.LuceneServerStubBuilder;
-import com.yelp.nrtsearch.server.grpc.Mode;
 import com.yelp.nrtsearch.server.grpc.RefreshRequest;
 import com.yelp.nrtsearch.server.grpc.SearchRequest;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
 import com.yelp.nrtsearch.server.grpc.StartIndexRequest;
-import com.yelp.nrtsearch.server.utils.NrtsearchTestConfigurationFactory;
+import com.yelp.nrtsearch.server.grpc.TestServer;
+import com.yelp.nrtsearch.test_utils.TestDocumentHelper;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
-import io.grpc.testing.GrpcCleanupRule;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
@@ -60,6 +56,7 @@ import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 
 public class NodeNameResolverAndLoadBalancingTests {
+  private static final String TEST_INDEX = "test_index";
   private static final String FIELD_NAME = "test_field";
   private static final String NODE_ADDRESSES_FILE_NAME = "nrtsearch-addresses.json";
 
@@ -70,20 +67,11 @@ public class NodeNameResolverAndLoadBalancingTests {
   private static final int SERVER_2_ID = 2;
   private static final int SERVER_3_ID = 3;
 
-  /**
-   * This rule manages automatic graceful shutdown for the registered servers and channels at the
-   * end of test.
-   */
-  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
-
-  /**
-   * This rule ensures the temporary folder which maintains indexes are cleaned up after each test
-   */
   @Rule public final TemporaryFolder folder = new TemporaryFolder();
 
-  private GrpcServer server1;
-  private GrpcServer server2;
-  private GrpcServer server3;
+  private TestServer server1;
+  private TestServer server2;
+  private TestServer server3;
   private int port1;
   private int port2;
   private int port3;
@@ -94,13 +82,13 @@ public class NodeNameResolverAndLoadBalancingTests {
   public void setup() throws IOException, InterruptedException {
     addressesFile = folder.newFile(NODE_ADDRESSES_FILE_NAME);
 
-    server1 = createGrpcServer();
-    server2 = createGrpcServer();
-    server3 = createGrpcServer();
+    server1 = TestServer.builder(folder).build();
+    server2 = TestServer.builder(folder).build();
+    server3 = TestServer.builder(folder).build();
 
-    port1 = server1.getGlobalState().getPort();
-    port2 = server2.getGlobalState().getPort();
-    port3 = server3.getGlobalState().getPort();
+    port1 = server1.getPort();
+    port2 = server2.getPort();
+    port3 = server3.getPort();
 
     startIndexAndAddDocuments(server1, SERVER_1_ID);
     startIndexAndAddDocuments(server2, SERVER_2_ID);
@@ -110,22 +98,8 @@ public class NodeNameResolverAndLoadBalancingTests {
     luceneServerStubBuilder = new LuceneServerStubBuilder(addressesFile.toString(), OBJECT_MAPPER);
   }
 
-  private GrpcServer createGrpcServer() throws IOException {
-    NrtsearchConfig configuration =
-        NrtsearchTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
-    return new GrpcServer(
-        grpcCleanup,
-        configuration,
-        folder,
-        null,
-        configuration.getIndexDir(),
-        TEST_INDEX,
-        configuration.getPort());
-  }
-
-  private void startIndexAndAddDocuments(GrpcServer server, int id)
-      throws InterruptedException, IOException {
-    LuceneServerGrpc.LuceneServerBlockingStub stub = server.getBlockingStub();
+  private void startIndexAndAddDocuments(TestServer server, int id) {
+    LuceneServerGrpc.LuceneServerBlockingStub stub = server.getClient().getBlockingStub();
 
     stub.createIndex(CreateIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
 
@@ -152,8 +126,8 @@ public class NodeNameResolverAndLoadBalancingTests {
                     .addValue(String.valueOf(id))
                     .build())
             .build();
-    new GrpcServer.TestServer(server, false, Mode.STANDALONE)
-        .addDocumentsFromStream(Stream.of(addDocumentRequest));
+    TestDocumentHelper.addDocuments(
+        server.getClient().getAsyncStub(), Stream.of(addDocumentRequest));
     stub.commit(CommitRequest.newBuilder().setIndexName(TEST_INDEX).build());
     stub.refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
   }
@@ -163,14 +137,7 @@ public class NodeNameResolverAndLoadBalancingTests {
     luceneServerStubBuilder.close();
     luceneServerStubBuilder.waitUntilClosed(100, TimeUnit.MILLISECONDS);
     luceneServerStubBuilder = null;
-    teardownGrpcServer(server1);
-    teardownGrpcServer(server2);
-    teardownGrpcServer(server3);
-  }
-
-  private void teardownGrpcServer(GrpcServer server) throws IOException {
-    server.getGlobalState().close();
-    server.shutdown();
+    TestServer.cleanupAll();
   }
 
   @Test(timeout = 10000)
@@ -240,7 +207,7 @@ public class NodeNameResolverAndLoadBalancingTests {
     assertEquals(resultCounts.get(SERVER_3_ID).intValue(), requestsToEachServer);
 
     // Shutdown server 1
-    server1.forceShutdown();
+    server1.stop();
     Thread.sleep(50);
 
     resultCounts = performSearchAndGetResultCounts(stub, requestsToEachServer, 2);

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/CustomFieldTypeTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/CustomFieldTypeTest.java
@@ -15,10 +15,8 @@
  */
 package com.yelp.nrtsearch.server.grpc;
 
-import static com.yelp.nrtsearch.server.grpc.GrpcServer.rmDir;
 import static org.junit.Assert.assertEquals;
 
-import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.doc.LoadedDocValues;
 import com.yelp.nrtsearch.server.field.FieldDef;
 import com.yelp.nrtsearch.server.field.FieldDefCreator;
@@ -26,12 +24,10 @@ import com.yelp.nrtsearch.server.field.FieldDefProvider;
 import com.yelp.nrtsearch.server.field.IndexableFieldDef;
 import com.yelp.nrtsearch.server.plugins.FieldTypePlugin;
 import com.yelp.nrtsearch.server.plugins.Plugin;
-import com.yelp.nrtsearch.server.utils.NrtsearchTestConfigurationFactory;
+import com.yelp.nrtsearch.test_utils.TestDocumentHelper;
+import com.yelp.nrtsearch.test_utils.TestResourceHelper;
 import io.grpc.StatusRuntimeException;
-import io.grpc.testing.GrpcCleanupRule;
-import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -49,52 +45,24 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public class CustomFieldTypeTest {
-  /**
-   * This rule manages automatic graceful shutdown for the registered servers and channels at the
-   * end of test.
-   */
-  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
-  /**
-   * This rule ensure the temporary folder which maintains indexes are cleaned up after each test
-   */
+  private static final String TEST_INDEX = "test_index";
+
   @Rule public final TemporaryFolder folder = new TemporaryFolder();
 
-  private GrpcServer grpcServer;
-  private PrometheusRegistry prometheusRegistry;
+  private TestServer server;
 
   @After
-  public void tearDown() throws IOException {
-    tearDownGrpcServer();
-  }
-
-  private void tearDownGrpcServer() throws IOException {
-    grpcServer.getGlobalState().close();
-    grpcServer.shutdown();
-    rmDir(Paths.get(grpcServer.getIndexDir()).getParent());
+  public void tearDown() {
+    TestServer.cleanupAll();
   }
 
   @Before
   public void setUp() throws IOException {
-    prometheusRegistry = new PrometheusRegistry();
-    grpcServer = setUpGrpcServer(prometheusRegistry);
-  }
-
-  private GrpcServer setUpGrpcServer(PrometheusRegistry prometheusRegistry) throws IOException {
-    String testIndex = "test_index";
-    NrtsearchConfig configuration =
-        NrtsearchTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
-    return new GrpcServer(
-        prometheusRegistry,
-        grpcCleanup,
-        configuration,
-        folder,
-        null,
-        configuration.getIndexDir(),
-        testIndex,
-        configuration.getPort(),
-        null,
-        Collections.singletonList(new TestFieldTypePlugin()));
+    server =
+        TestServer.builder(folder)
+            .withPlugins(Collections.singletonList(new TestFieldTypePlugin()))
+            .build();
   }
 
   static class TestFieldDef extends IndexableFieldDef<Integer> {
@@ -140,30 +108,29 @@ public class CustomFieldTypeTest {
 
   @Test
   public void testCustomFieldDef() throws Exception {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
-    new GrpcServer.IndexAndRoleManager(grpcServer)
-        .createStartIndexAndRegisterFields(
-            Mode.STANDALONE, 0, false, "registerFieldsCustomType.json");
-    AddDocumentResponse addDocumentResponse = testAddDocs.addDocuments("addDocsCustomType.csv");
-    // manual refresh
-    grpcServer
-        .getBlockingStub()
-        .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+    LuceneServerGrpc.LuceneServerBlockingStub stub = server.getClient().getBlockingStub();
+    stub.createIndex(CreateIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    stub.startIndex(StartIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    stub.registerFields(
+        TestResourceHelper.getFieldsFromResourceFile("/registerFieldsCustomType.json").toBuilder()
+            .setIndexName(TEST_INDEX)
+            .build());
+    TestDocumentHelper.addDocuments(
+        server.getClient().getAsyncStub(),
+        TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocsCustomType.csv"));
+    stub.refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
 
     SearchResponse searchResponse =
-        grpcServer
-            .getBlockingStub()
-            .search(
-                SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
-                    .addRetrieveFields("doc_id")
-                    .addRetrieveFields("int_field")
-                    .addRetrieveFields("custom_field")
-                    .setStartHit(0)
-                    .setTopHits(10)
-                    .setQuery(Query.newBuilder().build())
-                    .build());
+        stub.search(
+            SearchRequest.newBuilder()
+                .setIndexName(TEST_INDEX)
+                .addRetrieveFields("doc_id")
+                .addRetrieveFields("int_field")
+                .addRetrieveFields("custom_field")
+                .setStartHit(0)
+                .setTopHits(10)
+                .setQuery(Query.newBuilder().build())
+                .build());
     assertEquals(2, searchResponse.getHitsCount());
     assertEquals(
         "1", searchResponse.getHits(0).getFieldsOrThrow("doc_id").getFieldValue(0).getTextValue());
@@ -185,9 +152,13 @@ public class CustomFieldTypeTest {
 
   @Test(expected = StatusRuntimeException.class)
   public void testNoTypeProperty() throws Exception {
-    new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
-    new GrpcServer.IndexAndRoleManager(grpcServer)
-        .createStartIndexAndRegisterFields(
-            Mode.STANDALONE, 0, false, "registerFieldsCustomTypeInvalid.json");
+    LuceneServerGrpc.LuceneServerBlockingStub stub = server.getClient().getBlockingStub();
+    stub.createIndex(CreateIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    stub.startIndex(StartIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    stub.registerFields(
+        TestResourceHelper.getFieldsFromResourceFile("/registerFieldsCustomTypeInvalid.json")
+            .toBuilder()
+            .setIndexName(TEST_INDEX)
+            .build());
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/MergeBehaviorTests.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/MergeBehaviorTests.java
@@ -15,22 +15,17 @@
  */
 package com.yelp.nrtsearch.server.grpc;
 
-import static com.yelp.nrtsearch.server.grpc.GrpcServer.rmDir;
 import static com.yelp.nrtsearch.server.grpc.NrtsearchServerTest.RETRIEVED_VALUES;
 import static org.junit.Assert.*;
 
 import com.google.common.collect.Sets;
-import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.state.BackendGlobalState;
-import com.yelp.nrtsearch.server.utils.NrtsearchTestConfigurationFactory;
-import io.grpc.testing.GrpcCleanupRule;
-import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import com.yelp.nrtsearch.test_utils.TestDocumentHelper;
+import com.yelp.nrtsearch.test_utils.TestResourceHelper;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.After;
@@ -49,78 +44,56 @@ import org.junit.rules.TemporaryFolder;
  * after the merge must be issued
  */
 public class MergeBehaviorTests {
-  /**
-   * This rule manages automatic graceful shutdown for the registered servers and channels at the
-   * end of test.
-   */
-  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
-  /**
-   * This rule ensure the temporary folder which maintains indexes are cleaned up after each test
-   */
+  private static final String TEST_INDEX = "test_index";
+
   @Rule public final TemporaryFolder folder = new TemporaryFolder();
 
-  private GrpcServer grpcServer;
+  private TestServer server;
 
   private final int segmentsBeforeMerge = 2;
   private final int segmentsAfterMerge = 1;
   private final int numDocs = 4;
 
   @After
-  public void tearDown() throws IOException {
-    tearDownGrpcServer();
-  }
-
-  private void tearDownGrpcServer() throws IOException {
-    grpcServer.getGlobalState().close();
-    grpcServer.shutdown();
-    rmDir(Paths.get(grpcServer.getIndexDir()).getParent());
+  public void tearDown() {
+    TestServer.cleanupAll();
   }
 
   @Before
-  public void setUp() throws IOException {
-    PrometheusRegistry prometheusRegistry = new PrometheusRegistry();
-    grpcServer = setUpGrpcServer(prometheusRegistry);
-  }
-
-  private GrpcServer setUpGrpcServer(PrometheusRegistry prometheusRegistry) throws IOException {
-    String testIndex = "test_index";
-    NrtsearchConfig configuration =
-        NrtsearchTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
-    return new GrpcServer(
-        prometheusRegistry,
-        grpcCleanup,
-        configuration,
-        folder,
-        null,
-        configuration.getIndexDir(),
-        testIndex,
-        configuration.getPort(),
-        null,
-        Collections.emptyList());
+  public void setUp() throws Exception {
+    server = TestServer.builder(folder).build();
+    server.createIndex(TEST_INDEX);
+    server
+        .getClient()
+        .getBlockingStub()
+        .registerFields(
+            TestResourceHelper.getFieldsFromResourceFile("/registerFieldsBasic.json").toBuilder()
+                .setIndexName(TEST_INDEX)
+                .build());
+    server.startStandaloneIndex(TEST_INDEX, null);
   }
 
   @Test
-  public void testForceMergeBehaviorWithoutCommitOrSnapshot()
-      throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs = addFourDocsInTwoSegments();
+  public void testForceMergeBehaviorWithoutCommitOrSnapshot() throws Exception {
+    addFourDocsInTwoSegments();
 
     // Correct number of segments and no searchers in the response other than currentSearcher
-    assertStats(segmentsBeforeMerge, List.of());
+    assertStats(segmentsBeforeMerge, java.util.List.of());
 
     doSearch();
 
     // Searcher present in the response after doing a search
-    assertStats(segmentsBeforeMerge, List.of(6L));
+    assertStats(segmentsBeforeMerge, java.util.List.of(6L));
 
     Set<String> segmentFilesBeforeMerge = getSegmentFiles();
 
     doForceMerge();
 
-    testAddDocs.refresh();
+    server.refresh(TEST_INDEX);
 
     // Only the previous searcher present
-    assertStats(segmentsAfterMerge, List.of(6L));
+    assertStats(segmentsAfterMerge, java.util.List.of(6L));
 
     // After merge we have both pre-merge segments and the new merged segments
     Set<String> segmentFilesAfterMerge = getSegmentFiles();
@@ -130,13 +103,13 @@ public class MergeBehaviorTests {
     doSearch();
 
     // After doing another search both previous and current searchers show up under searchers
-    assertStats(segmentsAfterMerge, List.of(8L, 6L));
+    assertStats(segmentsAfterMerge, java.util.List.of(8L, 6L));
 
     // Wait for 40 seconds
     sleep(40);
 
     // We still have the previous searcher
-    assertStats(segmentsAfterMerge, List.of(8L, 6L));
+    assertStats(segmentsAfterMerge, java.util.List.of(8L, 6L));
     // No change in segment files since merge
     assertEquals(segmentFilesAfterMerge, getSegmentFiles());
 
@@ -145,7 +118,7 @@ public class MergeBehaviorTests {
 
     // After waiting for 62 seconds total, the previous searcher is pruned (time when cleanup begins
     // is 60 seconds)
-    assertStats(segmentsAfterMerge, List.of(8L));
+    assertStats(segmentsAfterMerge, java.util.List.of(8L));
 
     Set<String> segmentFilesAfterMergeAndSearcherPrune = getSegmentFiles();
 
@@ -163,26 +136,26 @@ public class MergeBehaviorTests {
   }
 
   @Test
-  public void testForceMergeBehaviorWithCommit() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs = addFourDocsInTwoSegments();
+  public void testForceMergeBehaviorWithCommit() throws Exception {
+    addFourDocsInTwoSegments();
     commit();
 
     // Correct number of segments and no searchers in the response other than currentSearcher
-    assertStats(segmentsBeforeMerge, List.of());
+    assertStats(segmentsBeforeMerge, java.util.List.of());
 
     doSearch();
 
     // Searcher present in the response after doing a search
-    assertStats(segmentsBeforeMerge, List.of(6L));
+    assertStats(segmentsBeforeMerge, java.util.List.of(6L));
 
     Set<String> segmentFilesBeforeMerge = getSegmentFiles();
 
     doForceMerge();
 
-    testAddDocs.refresh();
+    server.refresh(TEST_INDEX);
 
     // Only the previous searcher present
-    assertStats(segmentsAfterMerge, List.of(6L));
+    assertStats(segmentsAfterMerge, java.util.List.of(6L));
 
     // After merge we have both pre-merge segments and the new merged segments
     Set<String> segmentFilesAfterMerge = getSegmentFiles();
@@ -192,13 +165,13 @@ public class MergeBehaviorTests {
     doSearch();
 
     // After doing another search both previous and current searchers show up under searchers
-    assertStats(segmentsAfterMerge, List.of(9L, 6L));
+    assertStats(segmentsAfterMerge, java.util.List.of(9L, 6L));
 
     // Wait for 40 seconds
     sleep(40);
 
     // We still have the previous searcher
-    assertStats(segmentsAfterMerge, List.of(9L, 6L));
+    assertStats(segmentsAfterMerge, java.util.List.of(9L, 6L));
     // No change in segment files since merge
     assertEquals(segmentFilesAfterMerge, getSegmentFiles());
 
@@ -207,7 +180,7 @@ public class MergeBehaviorTests {
 
     // After waiting for 62 seconds total, the previous searcher is pruned (time when cleanup begins
     // is 60 seconds)
-    assertStats(segmentsAfterMerge, List.of(9L));
+    assertStats(segmentsAfterMerge, java.util.List.of(9L));
 
     // Previous segments not deleted yet
     assertEquals(segmentFilesAfterMerge, getSegmentFiles());
@@ -231,31 +204,31 @@ public class MergeBehaviorTests {
   }
 
   @Test
-  public void testForceMergeBehaviorWithSnapshot() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs = addFourDocsInTwoSegments();
+  public void testForceMergeBehaviorWithSnapshot() throws Exception {
+    addFourDocsInTwoSegments();
     commit();
 
     // Correct number of segments and no searchers in the response other than currentSearcher
-    assertStats(segmentsBeforeMerge, List.of());
+    assertStats(segmentsBeforeMerge, java.util.List.of());
 
     doSearch();
 
     // Searcher present in the response after doing a search
-    assertStats(segmentsBeforeMerge, List.of(6L));
+    assertStats(segmentsBeforeMerge, java.util.List.of(6L));
 
     SnapshotId snapshotId = createSnapshot();
 
     // Another searcher opened after the snapshot was created
-    assertStats(segmentsBeforeMerge, List.of(7L, 6L));
+    assertStats(segmentsBeforeMerge, java.util.List.of(7L, 6L));
 
     Set<String> segmentFilesBeforeMerge = getSegmentFiles();
 
     doForceMerge();
 
-    testAddDocs.refresh();
+    server.refresh(TEST_INDEX);
 
     // Only the previous searchers present
-    assertStats(segmentsAfterMerge, List.of(7L, 6L));
+    assertStats(segmentsAfterMerge, java.util.List.of(7L, 6L));
 
     // After merge we have both pre-merge segments and the new merged segments
     Set<String> segmentFilesAfterMerge = getSegmentFiles();
@@ -265,13 +238,13 @@ public class MergeBehaviorTests {
     doSearch();
 
     // After doing another search all previous and current searchers show up under searchers
-    assertStats(segmentsAfterMerge, List.of(9L, 7L, 6L));
+    assertStats(segmentsAfterMerge, java.util.List.of(9L, 7L, 6L));
 
     // Wait for 62 seconds
     sleep(62);
 
     // Searcher cleanup begins after 60 seconds but we still have the searcher opened with snapshot
-    assertStats(segmentsAfterMerge, List.of(9L, 7L));
+    assertStats(segmentsAfterMerge, java.util.List.of(9L, 7L));
     // Also no change in segment files since merge
     assertEquals(segmentFilesAfterMerge, getSegmentFiles());
 
@@ -282,7 +255,7 @@ public class MergeBehaviorTests {
 
     // After releasing the snapshot the snapshot searcher is pruned as the cleanup time has already
     // passed
-    assertStats(segmentsAfterMerge, List.of(9L));
+    assertStats(segmentsAfterMerge, java.util.List.of(9L));
 
     Set<String> segmentFilesAfterMergeAndSnapshotRelease = getSegmentFiles();
 
@@ -313,29 +286,30 @@ public class MergeBehaviorTests {
             .isEmpty());
   }
 
-  private GrpcServer.TestServer addFourDocsInTwoSegments()
-      throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
+  private void addFourDocsInTwoSegments() throws Exception {
     // add 2 docs and create a segment
-    testAddDocs.addDocuments();
+    TestDocumentHelper.addDocuments(
+        server.getClient().getAsyncStub(),
+        TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocs.csv"));
+    server.refresh(TEST_INDEX);
     // add 2 more docs in a different segment
-    testAddDocs.addDocuments();
-    return testAddDocs;
+    TestDocumentHelper.addDocuments(
+        server.getClient().getAsyncStub(),
+        TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocs.csv"));
+    server.refresh(TEST_INDEX);
   }
 
   private void commit() {
-    CommitRequest commitRequest =
-        CommitRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build();
-    grpcServer.getBlockingStub().commit(commitRequest);
+    server.commit(TEST_INDEX);
   }
 
   /** Get and assert the stats. */
-  private void assertStats(int numSegments, List<Long> searcherVersions) {
+  private void assertStats(int numSegments, java.util.List<Long> searcherVersions) {
     StatsResponse stats =
-        grpcServer
+        server
+            .getClient()
             .getBlockingStub()
-            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+            .stats(StatsRequest.newBuilder().setIndexName(TEST_INDEX).build());
     assertEquals(4, stats.getNumDocs());
     assertEquals(numSegments, stats.getCurrentSearcher().getNumSegments());
     assertEquals(searcherVersions.size(), stats.getSearchersList().size());
@@ -355,11 +329,12 @@ public class MergeBehaviorTests {
 
   private void doSearch() {
     SearchResponse searchResponse =
-        grpcServer
+        server
+            .getClient()
             .getBlockingStub()
             .search(
                 SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
+                    .setIndexName(TEST_INDEX)
                     .setStartHit(0)
                     .setTopHits(numDocs + 1)
                     .addAllRetrieveFields(RETRIEVED_VALUES)
@@ -369,11 +344,12 @@ public class MergeBehaviorTests {
 
   private void doForceMerge() {
     ForceMergeResponse response =
-        grpcServer
+        server
+            .getClient()
             .getBlockingStub()
             .forceMerge(
                 ForceMergeRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
+                    .setIndexName(TEST_INDEX)
                     .setMaxNumSegments(segmentsAfterMerge)
                     .setDoWait(true)
                     .build());
@@ -382,13 +358,10 @@ public class MergeBehaviorTests {
 
   private Path getSegmentDirectory() throws IOException {
     return Paths.get(
-        grpcServer.getIndexDir(),
+        server.getGlobalState().getIndexDirBase().toString(),
         BackendGlobalState.getUniqueIndexName(
-            grpcServer.getTestIndex(),
-            grpcServer
-                .getGlobalState()
-                .getIndexStateManagerOrThrow(grpcServer.getTestIndex())
-                .getIndexId()),
+            TEST_INDEX,
+            server.getGlobalState().getIndexStateManagerOrThrow(TEST_INDEX).getIndexId()),
         "shard0",
         "index");
   }
@@ -399,19 +372,16 @@ public class MergeBehaviorTests {
 
   private SnapshotId createSnapshot() {
     CreateSnapshotRequest request =
-        CreateSnapshotRequest.newBuilder()
-            .setIndexName(grpcServer.getTestIndex())
-            .setOpenSearcher(true)
-            .build();
-    return grpcServer.getBlockingStub().createSnapshot(request).getSnapshotId();
+        CreateSnapshotRequest.newBuilder().setIndexName(TEST_INDEX).setOpenSearcher(true).build();
+    return server.getClient().getBlockingStub().createSnapshot(request).getSnapshotId();
   }
 
   private boolean releaseSnapshot(SnapshotId snapshotId) {
     ReleaseSnapshotRequest request =
         ReleaseSnapshotRequest.newBuilder()
-            .setIndexName(grpcServer.getTestIndex())
+            .setIndexName(TEST_INDEX)
             .setSnapshotId(snapshotId)
             .build();
-    return grpcServer.getBlockingStub().releaseSnapshot(request).getSuccess();
+    return server.getClient().getBlockingStub().releaseSnapshot(request).getSuccess();
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/NrtsearchServerIdFieldTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/NrtsearchServerIdFieldTest.java
@@ -15,19 +15,12 @@
  */
 package com.yelp.nrtsearch.server.grpc;
 
-import static com.yelp.nrtsearch.server.grpc.GrpcServer.rmDir;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
-import com.yelp.nrtsearch.server.config.NrtsearchConfig;
-import com.yelp.nrtsearch.server.utils.NrtsearchTestConfigurationFactory;
+import com.yelp.nrtsearch.test_utils.TestDocumentHelper;
+import com.yelp.nrtsearch.test_utils.TestResourceHelper;
 import io.grpc.StatusRuntimeException;
-import io.grpc.testing.GrpcCleanupRule;
-import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
@@ -40,125 +33,90 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class NrtsearchServerIdFieldTest {
 
-  /**
-   * This rule manages automatic graceful shutdown for the registered servers and channels at the
-   * end of test.
-   */
-  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+  private static final String TEST_INDEX = "test_index";
 
-  /**
-   * This rule ensure the temporary folder which maintains indexes are cleaned up after each test
-   */
   @Rule public final TemporaryFolder folder = new TemporaryFolder();
 
-  private GrpcServer grpcServer;
+  private TestServer server;
 
   @After
-  public void tearDown() throws IOException {
-    tearDownGrpcServer();
-  }
-
-  private void tearDownGrpcServer() throws IOException {
-    grpcServer.getGlobalState().close();
-    grpcServer.shutdown();
-    rmDir(Paths.get(grpcServer.getIndexDir()).getParent());
+  public void tearDown() {
+    TestServer.cleanupAll();
   }
 
   @Before
   public void setUp() throws IOException {
-    PrometheusRegistry prometheusRegistry = new PrometheusRegistry();
-    grpcServer = setUpGrpcServer(prometheusRegistry);
-  }
-
-  private GrpcServer setUpGrpcServer(PrometheusRegistry prometheusRegistry) throws IOException {
-    String testIndex = "test_index";
-    NrtsearchConfig configuration =
-        NrtsearchTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
-    return new GrpcServer(
-        prometheusRegistry,
-        grpcCleanup,
-        configuration,
-        folder,
-        null,
-        configuration.getIndexDir(),
-        testIndex,
-        configuration.getPort(),
-        null,
-        Collections.emptyList());
+    server = TestServer.builder(folder).build();
   }
 
   @Test
-  public void testAddUpdateAndSearch() throws IOException, InterruptedException {
-    GrpcServer.TestServer testServer =
-        new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
-    new GrpcServer.IndexAndRoleManager(grpcServer)
-        .createStartIndexAndRegisterFields(
-            Mode.STANDALONE, 0, false, "registerFieldsBasicWithId.json");
+  public void testAddUpdateAndSearch() throws Exception {
+    LuceneServerGrpc.LuceneServerBlockingStub stub = server.getClient().getBlockingStub();
+    stub.createIndex(CreateIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    stub.startIndex(StartIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    stub.registerFields(
+        TestResourceHelper.getFieldsFromResourceFile("/registerFieldsBasicWithId.json").toBuilder()
+            .setIndexName(TEST_INDEX)
+            .build());
+
     // 2 docs addDocuments
-    testServer.addDocuments();
-    assertFalse(testServer.error);
-    assertTrue(testServer.completed);
+    TestDocumentHelper.addDocuments(
+        server.getClient().getAsyncStub(),
+        TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocs.csv"));
+    stub.refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
 
     // add 2 more docs
-    testServer.addDocuments();
-    assertFalse(testServer.error);
-    assertTrue(testServer.completed);
+    TestDocumentHelper.addDocuments(
+        server.getClient().getAsyncStub(),
+        TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocs.csv"));
+    stub.refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
 
-    StatsResponse stats =
-        grpcServer
-            .getBlockingStub()
-            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
-
-    // there are only 2 documents
+    StatsResponse stats = stub.stats(StatsRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    // there are only 2 documents (ID field deduplicates)
     assertEquals(2, stats.getNumDocs());
 
     // update schema: add a new field
-    grpcServer
-        .getBlockingStub()
-        .updateFields(
-            FieldDefRequest.newBuilder()
-                .setIndexName("test_index")
-                .addField(
-                    Field.newBuilder()
-                        .setName("new_text_field")
-                        .setType(FieldType.TEXT)
-                        .setStoreDocValues(true)
-                        .setSearch(true)
-                        .setMultiValued(true)
-                        .build())
-                .build());
-    // 2 docs addDocuments
-    testServer.addDocuments("addDocsUpdated.csv");
-    assertFalse(testServer.error);
-    assertTrue(testServer.completed);
-    stats =
-        grpcServer
-            .getBlockingStub()
-            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+    stub.updateFields(
+        FieldDefRequest.newBuilder()
+            .setIndexName(TEST_INDEX)
+            .addField(
+                Field.newBuilder()
+                    .setName("new_text_field")
+                    .setType(FieldType.TEXT)
+                    .setStoreDocValues(true)
+                    .setSearch(true)
+                    .setMultiValued(true)
+                    .build())
+            .build());
 
+    // 2 docs addDocuments with updated schema
+    TestDocumentHelper.addDocuments(
+        server.getClient().getAsyncStub(),
+        TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocsUpdated.csv"));
+    stub.refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
+
+    stats = stub.stats(StatsRequest.newBuilder().setIndexName(TEST_INDEX).build());
     // there are 4 documents in total
     assertEquals(4, stats.getNumDocs());
 
     // Query for first document
     SearchResponse searchResponse =
-        grpcServer
-            .getBlockingStub()
-            .search(
-                SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
-                    .setStartHit(0)
-                    .setTopHits(10)
-                    .addAllRetrieveFields(List.of("doc_id", "vendor_name"))
-                    .setQuery(
-                        Query.newBuilder()
-                            .setPhraseQuery(
-                                PhraseQuery.newBuilder()
-                                    .setField("vendor_name")
-                                    .addTerms("first")
-                                    .addTerms("vendor")
-                                    .build())
-                            .build())
-                    .build());
+        stub.search(
+            SearchRequest.newBuilder()
+                .setIndexName(TEST_INDEX)
+                .setStartHit(0)
+                .setTopHits(10)
+                .addAllRetrieveFields(List.of("doc_id", "vendor_name"))
+                .setQuery(
+                    Query.newBuilder()
+                        .setPhraseQuery(
+                            PhraseQuery.newBuilder()
+                                .setField("vendor_name")
+                                .addTerms("first")
+                                .addTerms("vendor")
+                                .build())
+                        .build())
+                .build());
     assertEquals(1, searchResponse.getTotalHits().getValue());
     assertEquals(1, searchResponse.getHitsList().size());
     assertEquals(
@@ -167,20 +125,18 @@ public class NrtsearchServerIdFieldTest {
 
     // Term Query for first document
     searchResponse =
-        grpcServer
-            .getBlockingStub()
-            .search(
-                SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
-                    .setStartHit(0)
-                    .setTopHits(10)
-                    .addAllRetrieveFields(List.of("doc_id", "vendor_name"))
-                    .setQuery(
-                        Query.newBuilder()
-                            .setTermQuery(
-                                TermQuery.newBuilder().setField("doc_id").setTextValue("1").build())
-                            .build())
-                    .build());
+        stub.search(
+            SearchRequest.newBuilder()
+                .setIndexName(TEST_INDEX)
+                .setStartHit(0)
+                .setTopHits(10)
+                .addAllRetrieveFields(List.of("doc_id", "vendor_name"))
+                .setQuery(
+                    Query.newBuilder()
+                        .setTermQuery(
+                            TermQuery.newBuilder().setField("doc_id").setTextValue("1").build())
+                        .build())
+                .build());
     assertEquals(1, searchResponse.getTotalHits().getValue());
     assertEquals(1, searchResponse.getHitsList().size());
     assertEquals(
@@ -189,26 +145,24 @@ public class NrtsearchServerIdFieldTest {
 
     // TermInSetQuery for first and third document
     searchResponse =
-        grpcServer
-            .getBlockingStub()
-            .search(
-                SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
-                    .setStartHit(0)
-                    .setTopHits(10)
-                    .addAllRetrieveFields(List.of("doc_id", "vendor_name"))
-                    .setQuery(
-                        Query.newBuilder()
-                            .setTermInSetQuery(
-                                TermInSetQuery.newBuilder()
-                                    .setField("doc_id")
-                                    .setTextTerms(
-                                        TermInSetQuery.TextTerms.newBuilder()
-                                            .addAllTerms(List.of("1", "3"))
-                                            .build())
-                                    .build())
-                            .build())
-                    .build());
+        stub.search(
+            SearchRequest.newBuilder()
+                .setIndexName(TEST_INDEX)
+                .setStartHit(0)
+                .setTopHits(10)
+                .addAllRetrieveFields(List.of("doc_id", "vendor_name"))
+                .setQuery(
+                    Query.newBuilder()
+                        .setTermInSetQuery(
+                            TermInSetQuery.newBuilder()
+                                .setField("doc_id")
+                                .setTextTerms(
+                                    TermInSetQuery.TextTerms.newBuilder()
+                                        .addAllTerms(List.of("1", "3"))
+                                        .build())
+                                .build())
+                        .build())
+                .build());
     assertEquals(2, searchResponse.getTotalHits().getValue());
     assertEquals(2, searchResponse.getHitsList().size());
     assertEquals(
@@ -220,44 +174,43 @@ public class NrtsearchServerIdFieldTest {
   }
 
   @Test(expected = StatusRuntimeException.class)
-  public void testDuplicateIdFieldInIndexState() throws IOException, InterruptedException {
-    GrpcServer.TestServer testServer =
-        new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
-    new GrpcServer.IndexAndRoleManager(grpcServer)
-        .createStartIndexAndRegisterFields(
-            Mode.STANDALONE, 0, false, "registerFieldsBasicWithId.json");
+  public void testDuplicateIdFieldInIndexState() throws Exception {
+    LuceneServerGrpc.LuceneServerBlockingStub stub = server.getClient().getBlockingStub();
+    stub.createIndex(CreateIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    stub.startIndex(StartIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    stub.registerFields(
+        TestResourceHelper.getFieldsFromResourceFile("/registerFieldsBasicWithId.json").toBuilder()
+            .setIndexName(TEST_INDEX)
+            .build());
+
     // 2 docs addDocuments
-    testServer.addDocuments();
-    assertFalse(testServer.error);
-    assertTrue(testServer.completed);
+    TestDocumentHelper.addDocuments(
+        server.getClient().getAsyncStub(),
+        TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocs.csv"));
+    stub.refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
 
     // add 2 more docs
-    testServer.addDocuments();
-    assertFalse(testServer.error);
-    assertTrue(testServer.completed);
+    TestDocumentHelper.addDocuments(
+        server.getClient().getAsyncStub(),
+        TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocs.csv"));
+    stub.refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
 
-    StatsResponse stats =
-        grpcServer
-            .getBlockingStub()
-            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
-
-    // there are only 2 documents
+    StatsResponse stats = stub.stats(StatsRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    // there are only 2 documents (ID field deduplicates)
     assertEquals(2, stats.getNumDocs());
 
     try {
-      // update schema: add a new field
-      grpcServer
-          .getBlockingStub()
-          .updateFields(
-              FieldDefRequest.newBuilder()
-                  .setIndexName("test_index")
-                  .addField(
-                      Field.newBuilder()
-                          .setName("new_text_field")
-                          .setType(FieldType._ID)
-                          .setStore(true)
-                          .build())
-                  .build());
+      // update schema: add a new field with _ID type (duplicate)
+      stub.updateFields(
+          FieldDefRequest.newBuilder()
+              .setIndexName(TEST_INDEX)
+              .addField(
+                  Field.newBuilder()
+                      .setName("new_text_field")
+                      .setType(FieldType._ID)
+                      .setStore(true)
+                      .build())
+              .build());
     } catch (RuntimeException e) {
       String message =
           "INTERNAL: Error handling updateFields request\n"
@@ -331,15 +284,12 @@ public class NrtsearchServerIdFieldTest {
   }
 
   private void registerFields(List<Field> fields) throws IOException {
-    new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
-    String indexName = grpcServer.getTestIndex();
-    grpcServer
-        .getBlockingStub()
-        .createIndex(CreateIndexRequest.newBuilder().setIndexName(indexName).build());
-    FieldDefRequest.Builder builder = FieldDefRequest.newBuilder().setIndexName(indexName);
+    LuceneServerGrpc.LuceneServerBlockingStub stub = server.getClient().getBlockingStub();
+    stub.createIndex(CreateIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    FieldDefRequest.Builder builder = FieldDefRequest.newBuilder().setIndexName(TEST_INDEX);
     for (Field field : fields) {
       builder.addField(field);
     }
-    grpcServer.getBlockingStub().registerFields(builder.build());
+    stub.registerFields(builder.build());
   }
 }

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/NrtsearchServerTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/NrtsearchServerTest.java
@@ -15,7 +15,6 @@
  */
 package com.yelp.nrtsearch.server.grpc;
 
-import static com.yelp.nrtsearch.server.grpc.GrpcServer.rmDir;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -25,7 +24,6 @@ import static org.junit.Assert.fail;
 
 import com.google.api.HttpBody;
 import com.google.protobuf.Empty;
-import com.yelp.nrtsearch.server.concurrent.ExecutorFactory;
 import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.grpc.NrtsearchServer.LuceneServerImpl;
 import com.yelp.nrtsearch.server.grpc.SearchResponse.Hit.CompositeFieldValue;
@@ -34,18 +32,15 @@ import com.yelp.nrtsearch.server.remote.s3.S3Backend;
 import com.yelp.nrtsearch.server.remote.s3.S3Util;
 import com.yelp.nrtsearch.server.search.cache.NrtQueryCache;
 import com.yelp.nrtsearch.server.state.StateUtils;
-import com.yelp.nrtsearch.server.utils.NrtsearchTestConfigurationFactory;
 import com.yelp.nrtsearch.test_utils.AmazonS3Provider;
+import com.yelp.nrtsearch.test_utils.TestDocumentHelper;
+import com.yelp.nrtsearch.test_utils.TestResourceHelper;
 import io.grpc.StatusRuntimeException;
-import io.grpc.testing.GrpcCleanupRule;
-import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -69,7 +64,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 @RunWith(JUnit4.class)
 public class NrtsearchServerTest {
@@ -99,81 +94,52 @@ public class NrtsearchServerTest {
       Arrays.asList(
           "doc_id", "vendor_name", "vendor_name_atom", "license_no", "lat_lon", "lat_lon_multi");
 
-  private final String bucketName = "server-unittest";
+  private static final String TEST_INDEX = "test_index";
+  private static final String TEST_SERVICE_NAME = "TEST_SERVICE_NAME";
 
-  /**
-   * This rule manages automatic graceful shutdown for the registered servers and channels at the
-   * end of test.
-   */
-  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
-
-  /**
-   * This rule ensure the temporary folder which maintains indexes are cleaned up after each test
-   */
   @Rule public final TemporaryFolder folder = new TemporaryFolder();
 
-  @Rule public final AmazonS3Provider s3Provider = new AmazonS3Provider(bucketName);
-
-  private GrpcServer grpcServer;
-  private GrpcServer replicaGrpcServer;
-  private PrometheusRegistry prometheusRegistry;
-  private ExecutorFactory executorFactory;
+  private TestServer primaryServer;
+  private TestServer replicaServer;
   private RemoteBackend remoteBackend;
-  private S3Client s3;
-  private final String TEST_SERVICE_NAME = "TEST_SERVICE_NAME";
 
   @After
-  public void tearDown() throws IOException {
-    tearDownGrpcServer();
-    tearDownReplicaGrpcServer();
-    executorFactory.close();
-  }
-
-  private void tearDownGrpcServer() throws IOException {
-    grpcServer.getGlobalState().close();
-    grpcServer.shutdown();
-    rmDir(Paths.get(grpcServer.getIndexDir()).getParent());
-  }
-
-  private void tearDownReplicaGrpcServer() throws IOException {
-    replicaGrpcServer.getGlobalState().close();
-    replicaGrpcServer.shutdown();
-    rmDir(Paths.get(replicaGrpcServer.getIndexDir()).getParent());
+  public void tearDown() {
+    TestServer.cleanupAll();
   }
 
   @Before
-  public void setUp() throws IOException {
-    NrtsearchConfig configuration =
-        NrtsearchTestConfigurationFactory.getConfig(
-            Mode.STANDALONE, folder.getRoot(), "bucketName: " + bucketName);
-
-    prometheusRegistry = new PrometheusRegistry();
-    executorFactory = new ExecutorFactory(configuration.getThreadPoolConfiguration());
-    remoteBackend = setUpRemoteBackend(configuration, executorFactory);
-    grpcServer = setUpGrpcServer(configuration, prometheusRegistry);
-    replicaGrpcServer = setUpReplicaGrpcServer(prometheusRegistry);
+  public void setUp() throws Exception {
+    primaryServer = TestServer.builder(folder).build();
+    replicaServer =
+        TestServer.builder(folder)
+            .withServiceName(TEST_SERVICE_NAME)
+            .withWarming(10, 1, true)
+            .withAdditionalConfig("syncInitialNrtPoint: false")
+            .build();
+    remoteBackend = createRemoteBackend(replicaServer.getConfiguration());
     setUpWarmer();
   }
 
-  private RemoteBackend setUpRemoteBackend(
-      NrtsearchConfig configuration, ExecutorFactory executorFactory) throws IOException {
-    s3 = s3Provider.getAmazonS3();
+  private RemoteBackend createRemoteBackend(NrtsearchConfig config) {
+    S3AsyncClient s3Async = AmazonS3Provider.createTestS3AsyncClient(TestServer.S3_ENDPOINT);
     return new S3Backend(
-        configuration, new S3Util.S3ClientBundle(s3, s3Provider.getS3AsyncClient()));
+        config,
+        new S3Util.S3ClientBundle(
+            AmazonS3Provider.createTestS3Client(TestServer.S3_ENDPOINT), s3Async));
   }
 
-  private void setUpWarmer() throws IOException {
+  private void setUpWarmer() throws Exception {
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     try (OutputStreamWriter writer =
         new OutputStreamWriter(byteArrayOutputStream, StateUtils.getValidatingUTF8Encoder())) {
-      List<String> testSearchRequestsJson = getTestSearchRequestsAsJsonStrings();
-      for (String line : testSearchRequestsJson) {
+      for (String line : getTestSearchRequestsAsJsonStrings()) {
         writer.write(line);
         writer.write("\n");
       }
     }
-    byte[] warmingQueriesBytes = byteArrayOutputStream.toByteArray();
-    remoteBackend.uploadWarmingQueries(TEST_SERVICE_NAME, "test_index", warmingQueriesBytes);
+    remoteBackend.uploadWarmingQueries(
+        TEST_SERVICE_NAME, TEST_INDEX, byteArrayOutputStream.toByteArray());
   }
 
   private List<String> getTestSearchRequestsAsJsonStrings() {
@@ -182,49 +148,49 @@ public class NrtsearchServerTest {
         "{\"indexName\":\"test_index\",\"query\":{\"termQuery\":{\"field\":\"field1\"}}}");
   }
 
-  private GrpcServer setUpGrpcServer(
-      NrtsearchConfig configuration, PrometheusRegistry prometheusRegistry) throws IOException {
-    String testIndex = "test_index";
-
-    return new GrpcServer(
-        prometheusRegistry,
-        grpcCleanup,
-        configuration,
-        folder,
-        null,
-        configuration.getIndexDir(),
-        testIndex,
-        configuration.getPort(),
-        remoteBackend,
-        Collections.emptyList());
+  private void setupIndex(String registerFieldsFile, String addDocsFile) throws Exception {
+    LuceneServerGrpc.LuceneServerBlockingStub stub = primaryServer.getClient().getBlockingStub();
+    stub.createIndex(CreateIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    stub.startIndex(StartIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    stub.registerFields(
+        TestResourceHelper.getFieldsFromResourceFile("/" + registerFieldsFile).toBuilder()
+            .setIndexName(TEST_INDEX)
+            .build());
+    TestDocumentHelper.addDocuments(
+        primaryServer.getClient().getAsyncStub(),
+        TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/" + addDocsFile));
+    stub.refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
   }
 
-  private GrpcServer setUpReplicaGrpcServer(PrometheusRegistry prometheusRegistry)
-      throws IOException {
-    String testIndex = "test_index";
-    NrtsearchConfig replicaConfiguration =
-        NrtsearchTestConfigurationFactory.getConfig(
-            Mode.REPLICA, folder.getRoot(), getExtraConfig());
-
-    return new GrpcServer(
-        grpcCleanup,
-        replicaConfiguration,
-        folder,
-        null,
-        replicaConfiguration.getIndexDir(),
-        testIndex,
-        replicaConfiguration.getPort(),
-        remoteBackend);
+  private FieldDefResponse setupIndexNoDocuments(String registerFieldsFile) throws Exception {
+    LuceneServerGrpc.LuceneServerBlockingStub stub = primaryServer.getClient().getBlockingStub();
+    stub.createIndex(CreateIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    stub.startIndex(StartIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    return stub.registerFields(
+        TestResourceHelper.getFieldsFromResourceFile("/" + registerFieldsFile).toBuilder()
+            .setIndexName(TEST_INDEX)
+            .build());
   }
 
-  private String getExtraConfig() {
-    return String.join(
-        "\n",
-        "warmer:",
-        "  maxWarmingQueries: 10",
-        "  warmOnStartup: true",
-        "  warmingParallelism: 1",
-        "syncInitialNrtPoint: false");
+  private void setupIndexPrimary() throws Exception {
+    LuceneServerGrpc.LuceneServerBlockingStub stub = primaryServer.getClient().getBlockingStub();
+    stub.createIndex(CreateIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    stub.startIndex(
+        StartIndexRequest.newBuilder()
+            .setIndexName(TEST_INDEX)
+            .setMode(Mode.PRIMARY)
+            .setPrimaryGen(0)
+            .build());
+    stub.registerFields(
+        TestResourceHelper.getFieldsFromResourceFile("/registerFieldsBasic.json").toBuilder()
+            .setIndexName(TEST_INDEX)
+            .build());
+    // Add and commit an initial set of documents so the Lucene gen is at 1 before the
+    // test's own commit calls; the test expects its first explicit commit to produce gen=2.
+    TestDocumentHelper.addDocuments(
+        primaryServer.getClient().getAsyncStub(),
+        TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocs.csv"));
+    stub.commit(CommitRequest.newBuilder().setIndexName(TEST_INDEX).build());
   }
 
   @Test
@@ -233,13 +199,16 @@ public class NrtsearchServerTest {
         List.of("idx", "idx1", "idx_1", "idx-3", "123", "IDX123", "iD1x23", "_");
     List<String> invalidIndexNames = List.of("id@x", "idx,1", "#", "", "(idx)");
 
-    LuceneServerGrpc.LuceneServerBlockingStub blockingStub = grpcServer.getBlockingStub();
+    LuceneServerGrpc.LuceneServerBlockingStub blockingStub =
+        primaryServer.getClient().getBlockingStub();
 
     for (String indexName : validIndexNames) {
       CreateIndexRequest request = CreateIndexRequest.newBuilder().setIndexName(indexName).build();
       CreateIndexResponse reply = blockingStub.createIndex(request);
       assertEquals(
-          String.format("Created Index name: %s", indexName, grpcServer.getIndexDir()),
+          String.format(
+              "Created Index name: %s",
+              indexName, primaryServer.getGlobalState().getIndexDirBase().toString()),
           reply.getResponse());
     }
 
@@ -259,9 +228,10 @@ public class NrtsearchServerTest {
   }
 
   @Test
-  public void testStartShard() throws IOException {
-    String testIndex = grpcServer.getTestIndex();
-    LuceneServerGrpc.LuceneServerBlockingStub blockingStub = grpcServer.getBlockingStub();
+  public void testStartShard() throws Exception {
+    String testIndex = TEST_INDEX;
+    LuceneServerGrpc.LuceneServerBlockingStub blockingStub =
+        primaryServer.getClient().getBlockingStub();
     // create the index
     blockingStub.createIndex(CreateIndexRequest.newBuilder().setIndexName(testIndex).build());
     // start the index
@@ -274,7 +244,8 @@ public class NrtsearchServerTest {
 
   @Test
   public void testStartIndexWithEmptyString() {
-    LuceneServerGrpc.LuceneServerBlockingStub blockingStub = grpcServer.getBlockingStub();
+    LuceneServerGrpc.LuceneServerBlockingStub blockingStub =
+        primaryServer.getClient().getBlockingStub();
     try {
       // start the index
       String emptyTestIndex = "";
@@ -300,9 +271,7 @@ public class NrtsearchServerTest {
 
   @Test
   public void testRegisterFieldsBasic() throws Exception {
-    FieldDefResponse reply =
-        new GrpcServer.IndexAndRoleManager(grpcServer)
-            .createStartIndexAndRegisterFields(Mode.STANDALONE);
+    FieldDefResponse reply = setupIndexNoDocuments("registerFieldsBasic.json");
     assertTrue(reply.getResponse().contains("vendor_name"));
     assertTrue(reply.getResponse().contains("vendor_name_atom"));
     assertTrue(reply.getResponse().contains("license_no"));
@@ -310,14 +279,13 @@ public class NrtsearchServerTest {
 
   @Test
   public void testUpdateFieldsBasic() throws Exception {
-    FieldDefResponse reply =
-        new GrpcServer.IndexAndRoleManager(grpcServer)
-            .createStartIndexAndRegisterFields(Mode.STANDALONE);
+    FieldDefResponse reply = setupIndexNoDocuments("registerFieldsBasic.json");
     assertTrue(reply.getResponse().contains("vendor_name"));
     assertTrue(reply.getResponse().contains("vendor_name_atom"));
     assertTrue(reply.getResponse().contains("license_no"));
     reply =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
             .updateFields(
                 FieldDefRequest.newBuilder()
@@ -336,14 +304,13 @@ public class NrtsearchServerTest {
 
   @Test
   public void testRegisterVirtualFields() throws Exception {
-    FieldDefResponse reply =
-        new GrpcServer.IndexAndRoleManager(grpcServer)
-            .createStartIndexAndRegisterFields(Mode.STANDALONE);
+    FieldDefResponse reply = setupIndexNoDocuments("registerFieldsBasic.json");
     assertTrue(reply.getResponse().contains("vendor_name"));
     assertTrue(reply.getResponse().contains("vendor_name_atom"));
     assertTrue(reply.getResponse().contains("license_no"));
     reply =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
             .updateFields(
                 FieldDefRequest.newBuilder()
@@ -364,14 +331,13 @@ public class NrtsearchServerTest {
 
   @Test
   public void testRegisterVirtualAndNonVirtualFields() throws Exception {
-    FieldDefResponse reply =
-        new GrpcServer.IndexAndRoleManager(grpcServer)
-            .createStartIndexAndRegisterFields(Mode.STANDALONE);
+    FieldDefResponse reply = setupIndexNoDocuments("registerFieldsBasic.json");
     assertTrue(reply.getResponse().contains("vendor_name"));
     assertTrue(reply.getResponse().contains("vendor_name_atom"));
     assertTrue(reply.getResponse().contains("license_no"));
     reply =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
             .updateFields(
                 FieldDefRequest.newBuilder()
@@ -401,14 +367,13 @@ public class NrtsearchServerTest {
 
   @Test
   public void testRegisterVirtualWithDependentField() throws Exception {
-    FieldDefResponse reply =
-        new GrpcServer.IndexAndRoleManager(grpcServer)
-            .createStartIndexAndRegisterFields(Mode.STANDALONE);
+    FieldDefResponse reply = setupIndexNoDocuments("registerFieldsBasic.json");
     assertTrue(reply.getResponse().contains("vendor_name"));
     assertTrue(reply.getResponse().contains("vendor_name_atom"));
     assertTrue(reply.getResponse().contains("license_no"));
     reply =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
             .updateFields(
                 FieldDefRequest.newBuilder()
@@ -436,14 +401,12 @@ public class NrtsearchServerTest {
   }
 
   @Test
-  public void testSearchPostUpdate() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
-    // 2 docs addDocuments
-    testAddDocs.addDocuments();
+  public void testSearchPostUpdate() throws Exception {
+    setupIndex("registerFieldsBasic.json", "addDocs.csv");
 
     // update schema: add a new field
-    grpcServer
+    primaryServer
+        .getClient()
         .getBlockingStub()
         .updateFields(
             FieldDefRequest.newBuilder()
@@ -459,9 +422,13 @@ public class NrtsearchServerTest {
                 .build());
 
     // 2 docs addDocuments
-    AddDocumentResponse addDocumentResponse = testAddDocs.addDocuments("addDocsUpdated.csv");
-    assertEquals(false, testAddDocs.error);
-    assertEquals(true, testAddDocs.completed);
+    TestDocumentHelper.addDocuments(
+        primaryServer.getClient().getAsyncStub(),
+        TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocsUpdated.csv"));
+    primaryServer
+        .getClient()
+        .getBlockingStub()
+        .refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
     List<String> RETRIEVE = Arrays.asList("doc_id", "new_text_field");
 
     Query query =
@@ -470,11 +437,12 @@ public class NrtsearchServerTest {
             .build();
 
     SearchResponse searchResponse =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
             .search(
                 SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
+                    .setIndexName(TEST_INDEX)
                     .setStartHit(0)
                     .setTopHits(10)
                     .setQuery(query)
@@ -500,12 +468,8 @@ public class NrtsearchServerTest {
   }
 
   @Test
-  public void testAddDocumentsBasic() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
-    testAddDocs.addDocuments();
-    assertEquals(false, testAddDocs.error);
-    assertEquals(true, testAddDocs.completed);
+  public void testAddDocumentsBasic() throws Exception {
+    setupIndexNoDocuments("registerFieldsBasic.json");
 
     /* Tricky to check genId for exact match on a standalone node (one that does both indexing and real-time searching.
      *  The ControlledRealTimeReopenThread is running in the background which refreshes the searcher and updates the sequence_number
@@ -516,55 +480,56 @@ public class NrtsearchServerTest {
      *  - once for each invocation of SearcherTaxonomyManager as explained above
      *  - once per commit
      */
-    assert 3 <= Integer.parseInt(testAddDocs.addDocumentResponse.getGenId());
-    testAddDocs.addDocuments();
-    assert 4 <= Integer.parseInt(testAddDocs.addDocumentResponse.getGenId());
+    AddDocumentResponse resp1 =
+        TestDocumentHelper.addDocuments(
+            primaryServer.getClient().getAsyncStub(),
+            TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocs.csv"));
+    assert 3 <= Integer.parseInt(resp1.getGenId());
+    AddDocumentResponse resp2 =
+        TestDocumentHelper.addDocuments(
+            primaryServer.getClient().getAsyncStub(),
+            TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocs.csv"));
+    assert 4 <= Integer.parseInt(resp2.getGenId());
   }
 
   @Test
-  public void testAddDocumentsLatLon() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
-    new GrpcServer.IndexAndRoleManager(grpcServer)
-        .createStartIndexAndRegisterFields(Mode.STANDALONE, 0, false, "registerFieldsLatLon.json");
-    AddDocumentResponse addDocumentResponse = testAddDocs.addDocuments("addDocsLatLon.csv");
-    assertEquals(false, testAddDocs.error);
-    assertEquals(true, testAddDocs.completed);
+  public void testAddDocumentsLatLon() throws Exception {
+    setupIndex("registerFieldsLatLon.json", "addDocsLatLon.csv");
   }
 
   @Test
-  public void testAddNoDocuments() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
-    new GrpcServer.IndexAndRoleManager(grpcServer)
-        .createStartIndexAndRegisterFields(Mode.STANDALONE, 0, false, "registerFieldsLatLon.json");
-
-    testAddDocs.addDocumentsFromStream(Stream.empty());
-    assertFalse(testAddDocs.error);
-    assertTrue(testAddDocs.completed);
+  public void testAddNoDocuments() throws Exception {
+    setupIndexNoDocuments("registerFieldsLatLon.json");
+    // Adding an empty stream should succeed without error
+    TestDocumentHelper.addDocuments(primaryServer.getClient().getAsyncStub(), Stream.empty());
   }
 
   @Test
-  public void testStats() throws IOException, InterruptedException {
-    new GrpcServer.IndexAndRoleManager(grpcServer)
-        .createStartIndexAndRegisterFields(Mode.STANDALONE);
+  public void testStats() throws Exception {
+    setupIndexNoDocuments("registerFieldsBasic.json");
     StatsResponse statsResponse =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
-            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+            .stats(StatsRequest.newBuilder().setIndexName(TEST_INDEX).build());
     assertEquals(0, statsResponse.getNumDocs());
     assertEquals(0, statsResponse.getMaxDoc());
     assertEquals(0, statsResponse.getOrd());
     assertEquals(0, statsResponse.getCurrentSearcher().getNumDocs());
     assertTrue(statsResponse.getDirSize() > 0);
     assertEquals("started", statsResponse.getState());
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
-    testAddDocs.addDocuments();
+    TestDocumentHelper.addDocuments(
+        primaryServer.getClient().getAsyncStub(),
+        TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocs.csv"));
+    primaryServer
+        .getClient()
+        .getBlockingStub()
+        .refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
     statsResponse =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
-            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+            .stats(StatsRequest.newBuilder().setIndexName(TEST_INDEX).build());
     assertEquals(2, statsResponse.getNumDocs());
     assertEquals(2, statsResponse.getMaxDoc());
     assertEquals(0, statsResponse.getOrd());
@@ -575,35 +540,35 @@ public class NrtsearchServerTest {
   }
 
   @Test
-  public void testRefresh() throws IOException, InterruptedException {
-    new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE).addDocuments();
+  public void testRefresh() throws Exception {
+    setupIndex("registerFieldsBasic.json", "addDocs.csv");
     StatsResponse statsResponse =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
-            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+            .stats(StatsRequest.newBuilder().setIndexName(TEST_INDEX).build());
     assertEquals(2, statsResponse.getNumDocs());
     assertEquals(2, statsResponse.getMaxDoc());
     assertEquals(0, statsResponse.getOrd());
     assertEquals(2, statsResponse.getCurrentSearcher().getNumDocs());
     // check status on currentSearchAgain
     statsResponse =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
-            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+            .stats(StatsRequest.newBuilder().setIndexName(TEST_INDEX).build());
     assertEquals(2, statsResponse.getCurrentSearcher().getNumDocs());
   }
 
   @Test
-  public void testDelete() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
-    // add 2 docs
-    testAddDocs.addDocuments();
+  public void testDelete() throws Exception {
+    setupIndex("registerFieldsBasic.json", "addDocs.csv");
     // check stats numDocs for 2 docs
     StatsResponse statsResponse =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
-            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+            .stats(StatsRequest.newBuilder().setIndexName(TEST_INDEX).build());
     assertEquals(2, statsResponse.getNumDocs());
     assertEquals(2, statsResponse.getMaxDoc());
 
@@ -614,35 +579,35 @@ public class NrtsearchServerTest {
         AddDocumentRequest.MultiValuedField.newBuilder();
     addDocumentRequestBuilder.putFields("doc_id", multiValuedFieldsBuilder.addValue("1").build());
     AddDocumentResponse addDocumentResponse =
-        grpcServer.getBlockingStub().delete(addDocumentRequestBuilder.build());
+        primaryServer.getClient().getBlockingStub().delete(addDocumentRequestBuilder.build());
     assertFalse(addDocumentResponse.getPrimaryId().isEmpty());
 
     // manual refresh needed to depict changes in buffered deletes (i.e. not committed yet)
-    grpcServer
+    primaryServer
+        .getClient()
         .getBlockingStub()
-        .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+        .refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
 
     // check stats numDocs for 1 docs
     statsResponse =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
-            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+            .stats(StatsRequest.newBuilder().setIndexName(TEST_INDEX).build());
     assertEquals(1, statsResponse.getNumDocs());
     // the refresh triggers a merge, so there is only one doc in the segment
     assertEquals(1, statsResponse.getMaxDoc());
   }
 
   @Test
-  public void testDeleteByQuery() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
-    // add 2 docs
-    testAddDocs.addDocuments();
+  public void testDeleteByQuery() throws Exception {
+    setupIndex("registerFieldsBasic.json", "addDocs.csv");
     // check stats numDocs for 2 docs
     StatsResponse statsResponse =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
-            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+            .stats(StatsRequest.newBuilder().setIndexName(TEST_INDEX).build());
     assertEquals(2, statsResponse.getNumDocs());
     assertEquals(2, statsResponse.getMaxDoc());
 
@@ -652,13 +617,14 @@ public class NrtsearchServerTest {
             .build();
     SearchRequest searchRequest =
         SearchRequest.newBuilder()
-            .setIndexName(grpcServer.getTestIndex())
+            .setIndexName(TEST_INDEX)
             .setStartHit(0)
             .setTopHits(10)
             .addAllRetrieveFields(RETRIEVED_VALUES)
             .setQuery(query)
             .build();
-    SearchResponse searchResponse = grpcServer.getBlockingStub().search(searchRequest);
+    SearchResponse searchResponse =
+        primaryServer.getClient().getBlockingStub().search(searchRequest);
     assertEquals(searchResponse.getHitsCount(), 1);
 
     // delete 1 doc
@@ -666,38 +632,38 @@ public class NrtsearchServerTest {
     DeleteByQueryRequest deleteByQueryRequest =
         DeleteByQueryRequest.newBuilder().setIndexName("test_index").addQuery(query).build();
     AddDocumentResponse addDocumentResponse =
-        grpcServer.getBlockingStub().deleteByQuery(deleteByQueryRequest);
+        primaryServer.getClient().getBlockingStub().deleteByQuery(deleteByQueryRequest);
     assertFalse(addDocumentResponse.getPrimaryId().isEmpty());
 
     // manual refresh needed to depict changes in buffered deletes (i.e. not committed yet)
-    grpcServer
+    primaryServer
+        .getClient()
         .getBlockingStub()
-        .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+        .refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
 
     // check stats numDocs for 1 docs
     statsResponse =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
-            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+            .stats(StatsRequest.newBuilder().setIndexName(TEST_INDEX).build());
     assertEquals(1, statsResponse.getNumDocs());
     // the refresh triggers a merge, so there is only one doc in the segment
     assertEquals(1, statsResponse.getMaxDoc());
     // deleted document does not show up in search response now
-    searchResponse = grpcServer.getBlockingStub().search(searchRequest);
+    searchResponse = primaryServer.getClient().getBlockingStub().search(searchRequest);
     assertEquals(searchResponse.getHitsCount(), 0);
   }
 
   @Test
-  public void testDeleteAllDocuments() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
-    // add 2 docs
-    testAddDocs.addDocuments();
+  public void testDeleteAllDocuments() throws Exception {
+    setupIndex("registerFieldsBasic.json", "addDocs.csv");
     // check stats numDocs for 2 docs
     StatsResponse statsResponse =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
-            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+            .stats(StatsRequest.newBuilder().setIndexName(TEST_INDEX).build());
     assertEquals(2, statsResponse.getNumDocs());
     assertEquals(2, statsResponse.getMaxDoc());
 
@@ -706,28 +672,27 @@ public class NrtsearchServerTest {
         DeleteAllDocumentsRequest.newBuilder();
     DeleteAllDocumentsRequest deleteAllDocumentsRequest =
         deleteAllDocumentsBuilder.setIndexName("test_index").build();
-    grpcServer.getBlockingStub().deleteAll(deleteAllDocumentsRequest);
+    primaryServer.getClient().getBlockingStub().deleteAll(deleteAllDocumentsRequest);
 
     // check stats numDocs for 1 docs
     statsResponse =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
-            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+            .stats(StatsRequest.newBuilder().setIndexName(TEST_INDEX).build());
     assertEquals(0, statsResponse.getNumDocs());
     assertEquals(0, statsResponse.getMaxDoc());
   }
 
   @Test
-  public void testDeleteIndex() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
-    // add 2 docs
-    testAddDocs.addDocuments();
+  public void testDeleteIndex() throws Exception {
+    setupIndex("registerFieldsBasic.json", "addDocs.csv");
     // check stats numDocs for 2 docs
     StatsResponse statsResponse =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
-            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+            .stats(StatsRequest.newBuilder().setIndexName(TEST_INDEX).build());
     assertEquals(2, statsResponse.getNumDocs());
     assertEquals(2, statsResponse.getMaxDoc());
 
@@ -736,31 +701,30 @@ public class NrtsearchServerTest {
     DeleteIndexRequest deleteIndexRequest =
         DeleteIndexRequest.newBuilder().setIndexName(indexName).build();
     DeleteIndexResponse deleteIndexResponse =
-        grpcServer.getBlockingStub().deleteIndex(deleteIndexRequest);
+        primaryServer.getClient().getBlockingStub().deleteIndex(deleteIndexRequest);
 
-    Path indexRootDir = Paths.get(grpcServer.getIndexDir(), indexName);
+    Path indexRootDir = primaryServer.getGlobalState().getIndexDirBase().resolve(indexName);
     assertEquals(false, Files.exists(indexRootDir));
 
     assertEquals("ok", deleteIndexResponse.getOk());
   }
 
   @Test
-  public void testSearchBasic() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
-    // 2 docs addDocuments
-    testAddDocs.addDocuments();
+  public void testSearchBasic() throws Exception {
+    setupIndex("registerFieldsBasic.json", "addDocs.csv");
     // manual refresh
-    grpcServer
+    primaryServer
+        .getClient()
         .getBlockingStub()
-        .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+        .refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
 
     SearchResponse searchResponse =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
             .search(
                 SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
+                    .setIndexName(TEST_INDEX)
                     .setStartHit(0)
                     .setTopHits(10)
                     .addAllRetrieveFields(RETRIEVED_VALUES)
@@ -775,23 +739,21 @@ public class NrtsearchServerTest {
   }
 
   @Test
-  public void testSearchFetchingAllFieldsWithWildcard() throws IOException, InterruptedException {
-    new GrpcServer.IndexAndRoleManager(grpcServer)
-        .createStartIndexAndRegisterFields(
-            Mode.STANDALONE, 0, false, "registerFieldsWildcardRetrieval.json");
-    new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE)
-        .addDocuments("addDocsWildcardRetrieval.csv");
+  public void testSearchFetchingAllFieldsWithWildcard() throws Exception {
+    setupIndex("registerFieldsWildcardRetrieval.json", "addDocsWildcardRetrieval.csv");
 
-    grpcServer
+    primaryServer
+        .getClient()
         .getBlockingStub()
-        .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+        .refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
 
     SearchResponse searchResponseWithWildcard =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
             .search(
                 SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
+                    .setIndexName(TEST_INDEX)
                     .setStartHit(0)
                     .setTopHits(10)
                     .addRetrieveFields("*")
@@ -804,23 +766,16 @@ public class NrtsearchServerTest {
   }
 
   @Test
-  public void testSearchLatLong() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
-    new GrpcServer.IndexAndRoleManager(grpcServer)
-        .createStartIndexAndRegisterFields(Mode.STANDALONE, 0, false, "registerFieldsLatLon.json");
-    AddDocumentResponse addDocumentResponse = testAddDocs.addDocuments("addDocsLatLon.csv");
-    // manual refresh
-    grpcServer
-        .getBlockingStub()
-        .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+  public void testSearchLatLong() throws Exception {
+    setupIndex("registerFieldsLatLon.json", "addDocsLatLon.csv");
 
     SearchResponse searchResponse =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
             .search(
                 SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
+                    .setIndexName(TEST_INDEX)
                     .setStartHit(0)
                     .setTopHits(10)
                     .addAllRetrieveFields(LAT_LON_VALUES)
@@ -835,26 +790,19 @@ public class NrtsearchServerTest {
   }
 
   @Test
-  public void testSearchIndexVirtualFields() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
-    new GrpcServer.IndexAndRoleManager(grpcServer)
-        .createStartIndexAndRegisterFields(Mode.STANDALONE, 0, false, "registerFieldsVirtual.json");
-    AddDocumentResponse addDocumentResponse = testAddDocs.addDocuments("addDocs.csv");
-    // manual refresh
-    grpcServer
-        .getBlockingStub()
-        .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+  public void testSearchIndexVirtualFields() throws Exception {
+    setupIndex("registerFieldsVirtual.json", "addDocs.csv");
 
     List<String> queryFields = new ArrayList<>(RETRIEVED_VALUES);
     queryFields.addAll(INDEX_VIRTUAL_FIELDS);
 
     SearchResponse searchResponse =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
             .search(
                 SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
+                    .setIndexName(TEST_INDEX)
                     .setStartHit(0)
                     .setTopHits(10)
                     .addAllRetrieveFields(queryFields)
@@ -870,26 +818,19 @@ public class NrtsearchServerTest {
   }
 
   @Test
-  public void testSearchQueryVirtualFields() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
-    new GrpcServer.IndexAndRoleManager(grpcServer)
-        .createStartIndexAndRegisterFields(Mode.STANDALONE, 0, false, "registerFieldsBasic.json");
-    AddDocumentResponse addDocumentResponse = testAddDocs.addDocuments("addDocs.csv");
-    // manual refresh
-    grpcServer
-        .getBlockingStub()
-        .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+  public void testSearchQueryVirtualFields() throws Exception {
+    setupIndex("registerFieldsBasic.json", "addDocs.csv");
 
     List<String> queryFields = new ArrayList<>(RETRIEVED_VALUES);
     queryFields.addAll(QUERY_VIRTUAL_FIELDS);
 
     SearchResponse searchResponse =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
             .search(
                 SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
+                    .setIndexName(TEST_INDEX)
                     .setStartHit(0)
                     .setTopHits(10)
                     .addAllRetrieveFields(queryFields)
@@ -906,27 +847,20 @@ public class NrtsearchServerTest {
   }
 
   @Test
-  public void testSearchBothVirtualFields() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
-    new GrpcServer.IndexAndRoleManager(grpcServer)
-        .createStartIndexAndRegisterFields(Mode.STANDALONE, 0, false, "registerFieldsVirtual.json");
-    AddDocumentResponse addDocumentResponse = testAddDocs.addDocuments("addDocs.csv");
-    // manual refresh
-    grpcServer
-        .getBlockingStub()
-        .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+  public void testSearchBothVirtualFields() throws Exception {
+    setupIndex("registerFieldsVirtual.json", "addDocs.csv");
 
     List<String> queryFields = new ArrayList<>(RETRIEVED_VALUES);
     queryFields.addAll(INDEX_VIRTUAL_FIELDS);
     queryFields.addAll(QUERY_VIRTUAL_FIELDS);
 
     SearchResponse searchResponse =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
             .search(
                 SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
+                    .setIndexName(TEST_INDEX)
                     .setStartHit(0)
                     .setTopHits(10)
                     .addAllRetrieveFields(queryFields)
@@ -943,36 +877,31 @@ public class NrtsearchServerTest {
   }
 
   @Test
-  public void testBackupWarmingQueries() throws IOException, InterruptedException {
-    GrpcServer.TestServer testServerReplica =
-        new GrpcServer.TestServer(replicaGrpcServer, true, Mode.REPLICA);
-    replicaGrpcServer
-        .getGlobalState()
-        .getIndexOrThrow(replicaGrpcServer.getTestIndex())
-        .initWarmer(remoteBackend);
-    assertNotNull(
-        replicaGrpcServer
-            .getGlobalState()
-            .getIndexOrThrow(replicaGrpcServer.getTestIndex())
-            .getWarmer());
+  public void testBackupWarmingQueries() throws Exception {
+    LuceneServerGrpc.LuceneServerBlockingStub replicaStub =
+        replicaServer.getClient().getBlockingStub();
+    replicaStub.createIndex(CreateIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    replicaStub.startIndex(StartIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    replicaStub.registerFields(
+        TestResourceHelper.getFieldsFromResourceFile("/registerFieldsBasic.json").toBuilder()
+            .setIndexName(TEST_INDEX)
+            .build());
+    replicaServer.getGlobalState().getIndexOrThrow(TEST_INDEX).initWarmer(remoteBackend);
+    assertNotNull(replicaServer.getGlobalState().getIndexOrThrow(TEST_INDEX).getWarmer());
     // Average case should pass
-    replicaGrpcServer
-        .getBlockingStub()
-        .backupWarmingQueries(
-            BackupWarmingQueriesRequest.newBuilder()
-                .setIndex(replicaGrpcServer.getTestIndex())
-                .setServiceName(TEST_SERVICE_NAME)
-                .build());
+    replicaStub.backupWarmingQueries(
+        BackupWarmingQueriesRequest.newBuilder()
+            .setIndex(TEST_INDEX)
+            .setServiceName(TEST_SERVICE_NAME)
+            .build());
     // Should fail; does not meet UptimeMinutesThreshold
     try {
-      replicaGrpcServer
-          .getBlockingStub()
-          .backupWarmingQueries(
-              BackupWarmingQueriesRequest.newBuilder()
-                  .setIndex(replicaGrpcServer.getTestIndex())
-                  .setServiceName(TEST_SERVICE_NAME)
-                  .setUptimeMinutesThreshold(1000)
-                  .build());
+      replicaStub.backupWarmingQueries(
+          BackupWarmingQueriesRequest.newBuilder()
+              .setIndex(TEST_INDEX)
+              .setServiceName(TEST_SERVICE_NAME)
+              .setUptimeMinutesThreshold(1000)
+              .build());
       fail("Expecting exception on the previous line");
     } catch (StatusRuntimeException e) {
       Pattern pattern =
@@ -984,14 +913,12 @@ public class NrtsearchServerTest {
 
     // Should fail; does not meet NumQueriesThreshold
     try {
-      replicaGrpcServer
-          .getBlockingStub()
-          .backupWarmingQueries(
-              BackupWarmingQueriesRequest.newBuilder()
-                  .setIndex(replicaGrpcServer.getTestIndex())
-                  .setServiceName(TEST_SERVICE_NAME)
-                  .setNumQueriesThreshold(1000)
-                  .build());
+      replicaStub.backupWarmingQueries(
+          BackupWarmingQueriesRequest.newBuilder()
+              .setIndex(TEST_INDEX)
+              .setServiceName(TEST_SERVICE_NAME)
+              .setNumQueriesThreshold(1000)
+              .build());
       fail("Expecting exception on the previous line");
     } catch (StatusRuntimeException e) {
       assertEquals(
@@ -1003,9 +930,10 @@ public class NrtsearchServerTest {
   @Test
   public void testMetrics() {
     // make rpc calls to populate some metrics
-    grpcServer.getBlockingStub().status(HealthCheckRequest.newBuilder().build());
+    primaryServer.getClient().getBlockingStub().status(HealthCheckRequest.newBuilder().build());
 
-    HttpBody response = grpcServer.getBlockingStub().metrics(Empty.newBuilder().build());
+    HttpBody response =
+        primaryServer.getClient().getBlockingStub().metrics(Empty.newBuilder().build());
     HashSet expectedSampleNames =
         new HashSet(
             Arrays.asList(
@@ -1030,166 +958,182 @@ public class NrtsearchServerTest {
   }
 
   @Test
-  public void testIndexState() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
-    testAddDocs.addDocuments();
+  public void testIndexState() throws Exception {
+    setupIndex("registerFieldsBasic.json", "addDocs.csv");
     IndexStateResponse indexStateResponse =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
-            .indexState(
-                IndexStateRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+            .indexState(IndexStateRequest.newBuilder().setIndexName(TEST_INDEX).build());
     assertEquals(
-        grpcServer.getGlobalState().getIndex(grpcServer.getTestIndex()).getIndexStateInfo(),
+        primaryServer.getGlobalState().getIndex(TEST_INDEX).getIndexStateInfo(),
         indexStateResponse.getIndexState());
   }
 
   @Test
-  public void testForceMerge() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
-    // 2 docs addDocuments
-    testAddDocs.addDocuments();
-    // add more documents to different segment
-    testAddDocs.addDocuments();
+  public void testForceMerge() throws Exception {
+    setupIndex("registerFieldsBasic.json", "addDocs.csv");
+    // add more documents to a different segment
+    TestDocumentHelper.addDocuments(
+        primaryServer.getClient().getAsyncStub(),
+        TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocs.csv"));
+    primaryServer
+        .getClient()
+        .getBlockingStub()
+        .refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
 
     StatsResponse stats =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
-            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+            .stats(StatsRequest.newBuilder().setIndexName(TEST_INDEX).build());
     assertEquals(4, stats.getNumDocs());
     assertEquals(2, stats.getCurrentSearcher().getNumSegments());
 
     ForceMergeResponse response =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
             .forceMerge(
                 ForceMergeRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
+                    .setIndexName(TEST_INDEX)
                     .setMaxNumSegments(1)
                     .setDoWait(true)
                     .build());
     assertEquals(ForceMergeResponse.Status.FORCE_MERGE_COMPLETED, response.getStatus());
 
-    testAddDocs.refresh();
+    primaryServer
+        .getClient()
+        .getBlockingStub()
+        .refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
 
     stats =
-        grpcServer
+        primaryServer
+            .getClient()
             .getBlockingStub()
-            .stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+            .stats(StatsRequest.newBuilder().setIndexName(TEST_INDEX).build());
     assertEquals(4, stats.getNumDocs());
     assertEquals(1, stats.getCurrentSearcher().getNumSegments());
   }
 
   @Test
-  public void testReleaseSnapshotOnPrimary() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs = new GrpcServer.TestServer(grpcServer, true, Mode.PRIMARY);
-    // 2 docs addDocuments
-    testAddDocs.addDocuments();
-    CommitRequest commitRequest =
-        CommitRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build();
-    grpcServer.getBlockingStub().commit(commitRequest);
+  public void testReleaseSnapshotOnPrimary() throws Exception {
+    setupIndexPrimary();
+    CommitRequest commitRequest = CommitRequest.newBuilder().setIndexName(TEST_INDEX).build();
+    primaryServer.getClient().getBlockingStub().commit(commitRequest);
 
     // create a snapshot
     CreateSnapshotRequest createSnapshotRequest =
-        CreateSnapshotRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build();
+        CreateSnapshotRequest.newBuilder().setIndexName(TEST_INDEX).build();
     CreateSnapshotResponse createSnapshotResponse =
-        grpcServer.getBlockingStub().createSnapshot(createSnapshotRequest);
+        primaryServer.getClient().getBlockingStub().createSnapshot(createSnapshotRequest);
     assertEquals(2, createSnapshotResponse.getSnapshotId().getIndexGen());
     assertEquals(-1, createSnapshotResponse.getSnapshotId().getStateGen());
 
     // add more documents and another commit to create another index gen
-    testAddDocs.addDocuments();
-    grpcServer.getBlockingStub().commit(commitRequest);
+    TestDocumentHelper.addDocuments(
+        primaryServer.getClient().getAsyncStub(),
+        TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocs.csv"));
+    primaryServer.getClient().getBlockingStub().commit(commitRequest);
 
     // create another snapshot
-    createSnapshotResponse = grpcServer.getBlockingStub().createSnapshot(createSnapshotRequest);
+    createSnapshotResponse =
+        primaryServer.getClient().getBlockingStub().createSnapshot(createSnapshotRequest);
     assertEquals(3, createSnapshotResponse.getSnapshotId().getIndexGen());
     assertEquals(-1, createSnapshotResponse.getSnapshotId().getStateGen());
 
     // Release the first snapshot with index and state gen
     ReleaseSnapshotRequest releaseSnapshotRequest =
         ReleaseSnapshotRequest.newBuilder()
-            .setIndexName(grpcServer.getTestIndex())
+            .setIndexName(TEST_INDEX)
             .setSnapshotId(SnapshotId.newBuilder().setIndexGen(2).setStateGen(-1))
             .build();
     ReleaseSnapshotResponse releaseSnapshotResponse =
-        grpcServer.getBlockingStub().releaseSnapshot(releaseSnapshotRequest);
+        primaryServer.getClient().getBlockingStub().releaseSnapshot(releaseSnapshotRequest);
     assertTrue(releaseSnapshotResponse.getSuccess());
 
     // Release the second snapshot's index gen and already released state gen
     releaseSnapshotRequest =
         ReleaseSnapshotRequest.newBuilder()
-            .setIndexName(grpcServer.getTestIndex())
+            .setIndexName(TEST_INDEX)
             .setSnapshotId(SnapshotId.newBuilder().setIndexGen(3).setStateGen(-1))
             .build();
-    releaseSnapshotResponse = grpcServer.getBlockingStub().releaseSnapshot(releaseSnapshotRequest);
+    releaseSnapshotResponse =
+        primaryServer.getClient().getBlockingStub().releaseSnapshot(releaseSnapshotRequest);
     assertTrue(releaseSnapshotResponse.getSuccess());
 
     // Verify both index gens released
     GetAllSnapshotGenRequest getAllSnapshotGenRequest =
-        GetAllSnapshotGenRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build();
+        GetAllSnapshotGenRequest.newBuilder().setIndexName(TEST_INDEX).build();
     GetAllSnapshotGenResponse getAllSnapshotGenResponse =
-        grpcServer.getBlockingStub().getAllSnapshotIndexGen(getAllSnapshotGenRequest);
+        primaryServer
+            .getClient()
+            .getBlockingStub()
+            .getAllSnapshotIndexGen(getAllSnapshotGenRequest);
     assertEquals(0, getAllSnapshotGenResponse.getIndexGensCount());
   }
 
   @Test
-  public void testGetAllSnapshotIndexGen() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
-    // 2 docs addDocuments
-    testAddDocs.addDocuments();
-    CommitRequest commitRequest =
-        CommitRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build();
-    grpcServer.getBlockingStub().commit(commitRequest);
+  public void testGetAllSnapshotIndexGen() throws Exception {
+    setupIndex("registerFieldsBasic.json", "addDocs.csv");
+    CommitRequest commitRequest = CommitRequest.newBuilder().setIndexName(TEST_INDEX).build();
+    primaryServer.getClient().getBlockingStub().commit(commitRequest);
 
     // create a snapshot
     CreateSnapshotRequest createSnapshotRequest =
-        CreateSnapshotRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build();
+        CreateSnapshotRequest.newBuilder().setIndexName(TEST_INDEX).build();
     CreateSnapshotResponse createSnapshotResponse =
-        grpcServer.getBlockingStub().createSnapshot(createSnapshotRequest);
+        primaryServer.getClient().getBlockingStub().createSnapshot(createSnapshotRequest);
     assertEquals(2, createSnapshotResponse.getSnapshotId().getIndexGen());
 
     // add more documents and another commit to create another index gen
-    testAddDocs.addDocuments();
-    grpcServer.getBlockingStub().commit(commitRequest);
+    TestDocumentHelper.addDocuments(
+        primaryServer.getClient().getAsyncStub(),
+        TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocs.csv"));
+    primaryServer.getClient().getBlockingStub().commit(commitRequest);
 
     // create another snapshot
-    createSnapshotResponse = grpcServer.getBlockingStub().createSnapshot(createSnapshotRequest);
+    createSnapshotResponse =
+        primaryServer.getClient().getBlockingStub().createSnapshot(createSnapshotRequest);
     assertEquals(3, createSnapshotResponse.getSnapshotId().getIndexGen());
 
     GetAllSnapshotGenRequest getAllSnapshotGenRequest =
-        GetAllSnapshotGenRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build();
+        GetAllSnapshotGenRequest.newBuilder().setIndexName(TEST_INDEX).build();
     GetAllSnapshotGenResponse getAllSnapshotGenResponse =
-        grpcServer.getBlockingStub().getAllSnapshotIndexGen(getAllSnapshotGenRequest);
+        primaryServer
+            .getClient()
+            .getBlockingStub()
+            .getAllSnapshotIndexGen(getAllSnapshotGenRequest);
 
     assertTrue(getAllSnapshotGenResponse.getIndexGensList().contains(2L));
     assertTrue(getAllSnapshotGenResponse.getIndexGensList().contains(3L));
   }
 
   @Test
-  public void testAddDocsHasPrimaryId() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs = new GrpcServer.TestServer(grpcServer, true, Mode.PRIMARY);
-    // 2 docs addDocuments
-    AddDocumentResponse response = testAddDocs.addDocuments();
+  public void testAddDocsHasPrimaryId() throws Exception {
+    setupIndexPrimary();
+    AddDocumentResponse response =
+        TestDocumentHelper.addDocuments(
+            primaryServer.getClient().getAsyncStub(),
+            TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocs.csv"));
     assertFalse(response.getPrimaryId().isEmpty());
   }
 
   @Test
-  public void testCommitHasPrimaryId() throws IOException, InterruptedException {
-    GrpcServer.TestServer testAddDocs = new GrpcServer.TestServer(grpcServer, true, Mode.PRIMARY);
-    // 2 docs addDocuments
-    testAddDocs.addDocuments();
-    CommitRequest commitRequest =
-        CommitRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build();
-    CommitResponse response = grpcServer.getBlockingStub().commit(commitRequest);
+  public void testCommitHasPrimaryId() throws Exception {
+    setupIndexPrimary();
+    TestDocumentHelper.addDocuments(
+        primaryServer.getClient().getAsyncStub(),
+        TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocs.csv"));
+    CommitRequest commitRequest = CommitRequest.newBuilder().setIndexName(TEST_INDEX).build();
+    CommitResponse response = primaryServer.getClient().getBlockingStub().commit(commitRequest);
     assertFalse(response.getPrimaryId().isEmpty());
   }
 
   @Test
-  public void testReady() throws IOException {
-    LuceneServerGrpc.LuceneServerBlockingStub blockingStub = grpcServer.getBlockingStub();
+  public void testReady() throws Exception {
+    LuceneServerGrpc.LuceneServerBlockingStub blockingStub =
+        primaryServer.getClient().getBlockingStub();
     String index1 = "index1";
     String index2 = "index2";
     String index3 = "index3";
@@ -1199,7 +1143,9 @@ public class NrtsearchServerTest {
       CreateIndexResponse createIndexResponse =
           blockingStub.createIndex(CreateIndexRequest.newBuilder().setIndexName(indexName).build());
       String expectedResponse =
-          String.format("Created Index name: %s", indexName, grpcServer.getIndexDir());
+          String.format(
+              "Created Index name: %s",
+              indexName, primaryServer.getGlobalState().getIndexDirBase().toString());
       assertEquals(expectedResponse, createIndexResponse.getResponse());
     }
 
@@ -1211,7 +1157,7 @@ public class NrtsearchServerTest {
       assertEquals(0, startIndexResponse.getNumDocs());
     }
 
-    grpcServer.getGlobalState().getIndexOrThrow(index3).getShard(0).writer.close();
+    primaryServer.getGlobalState().getIndexOrThrow(index3).getShard(0).writer.close();
 
     try {
       blockingStub.ready(ReadyCheckRequest.newBuilder().setIndexNames("").build());

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/QueryTest.java
@@ -20,11 +20,8 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.yelp.nrtsearch.server.config.NrtsearchConfig;
-import com.yelp.nrtsearch.server.utils.NrtsearchTestConfigurationFactory;
-import io.grpc.testing.GrpcCleanupRule;
-import java.io.IOException;
-import java.nio.file.Paths;
+import com.yelp.nrtsearch.test_utils.TestDocumentHelper;
+import com.yelp.nrtsearch.test_utils.TestResourceHelper;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -38,65 +35,42 @@ import org.junit.rules.TemporaryFolder;
 
 public class QueryTest {
 
-  /**
-   * This rule manages automatic graceful shutdown for the registered servers and channels at the
-   * end of test.
-   */
-  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+  private static final String TEST_INDEX = "test_index";
 
-  /**
-   * This rule ensure the temporary folder which maintains indexes are cleaned up after each test
-   */
   @Rule public final TemporaryFolder folder = new TemporaryFolder();
 
-  private GrpcServer grpcServer;
+  private TestServer server;
 
   @After
-  public void tearDown() throws IOException {
-    tearDownGrpcServer();
-  }
-
-  private void tearDownGrpcServer() throws IOException {
-    grpcServer.getGlobalState().close();
-    grpcServer.shutdown();
-    GrpcServer.rmDir(Paths.get(grpcServer.getIndexDir()).getParent());
+  public void tearDown() {
+    TestServer.cleanupAll();
   }
 
   @Before
   public void setUp() throws Exception {
-    grpcServer = setUpGrpcServer();
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
-    // 2 docs addDocuments
-    testAddDocs.addDocuments();
-    // manual refresh
-    grpcServer
-        .getBlockingStub()
-        .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
-  }
-
-  private GrpcServer setUpGrpcServer() throws IOException {
-    String testIndex = "test_index";
-    NrtsearchConfig configuration =
-        NrtsearchTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
-    return new GrpcServer(
-        grpcCleanup,
-        configuration,
-        folder,
-        null,
-        configuration.getIndexDir(),
-        testIndex,
-        configuration.getPort());
+    server = TestServer.builder(folder).build();
+    LuceneServerGrpc.LuceneServerBlockingStub stub = server.getClient().getBlockingStub();
+    stub.createIndex(CreateIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    stub.startIndex(StartIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    stub.registerFields(
+        TestResourceHelper.getFieldsFromResourceFile("/registerFieldsBasic.json").toBuilder()
+            .setIndexName(TEST_INDEX)
+            .build());
+    TestDocumentHelper.addDocuments(
+        server.getClient().getAsyncStub(),
+        TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/addDocs.csv"));
+    stub.refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
   }
 
   @Test
   public void testSearchQueryText() {
     SearchResponse searchResponse =
-        grpcServer
+        server
+            .getClient()
             .getBlockingStub()
             .search(
                 SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
+                    .setIndexName(TEST_INDEX)
                     .setStartHit(0)
                     .setTopHits(10)
                     .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
@@ -114,11 +88,12 @@ public class QueryTest {
   @Test
   public void testSearchV2QueryText() throws InvalidProtocolBufferException {
     Any anyResponse =
-        grpcServer
+        server
+            .getClient()
             .getBlockingStub()
             .searchV2(
                 SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
+                    .setIndexName(TEST_INDEX)
                     .setStartHit(0)
                     .setTopHits(10)
                     .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
@@ -140,11 +115,12 @@ public class QueryTest {
 
     for (String compressionType : compressionTypes) {
       SearchResponse searchResponse =
-          grpcServer
+          server
+              .getClient()
               .getBlockingStub()
               .search(
                   SearchRequest.newBuilder()
-                      .setIndexName(grpcServer.getTestIndex())
+                      .setIndexName(TEST_INDEX)
                       .setStartHit(0)
                       .setTopHits(10)
                       .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
@@ -167,11 +143,12 @@ public class QueryTest {
 
     for (String compressionType : compressionTypes) {
       Any anyResponse =
-          grpcServer
+          server
+              .getClient()
               .getBlockingStub()
               .searchV2(
                   SearchRequest.newBuilder()
-                      .setIndexName(grpcServer.getTestIndex())
+                      .setIndexName(TEST_INDEX)
                       .setStartHit(0)
                       .setTopHits(10)
                       .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
@@ -994,11 +971,12 @@ public class QueryTest {
           assertEquals("2", docId);
           NrtsearchServerTest.checkHits(hit);
         };
-    SearchResponse searchResponse = grpcServer.getBlockingStub().search(buildSearchRequest(query));
+    SearchResponse searchResponse =
+        server.getClient().getBlockingStub().search(buildSearchRequest(query));
     responseTester.accept(searchResponse);
     boolean explain = true;
     SearchResponse searchResponseExplained =
-        grpcServer.getBlockingStub().search(buildSearchRequestWithExplain(query, explain));
+        server.getClient().getBlockingStub().search(buildSearchRequestWithExplain(query, explain));
     responseTester.accept(searchResponseExplained);
     String expectedExplain =
         "0.3979403 = weight(vendor_name:\"second again\"~1 in 1) [], result of:\n"
@@ -1030,7 +1008,8 @@ public class QueryTest {
   @Test
   public void testEmptyBooleanQuery() {
     Query query = Query.newBuilder().setBooleanQuery(BooleanQuery.newBuilder().build()).build();
-    SearchResponse response = grpcServer.getBlockingStub().search(buildSearchRequest(query));
+    SearchResponse response =
+        server.getClient().getBlockingStub().search(buildSearchRequest(query));
     assertEquals(response.getHitsCount(), 2);
     for (SearchResponse.Hit hit : response.getHitsList()) {
       assertEquals(1.0, hit.getScore(), 0.0);
@@ -1049,7 +1028,8 @@ public class QueryTest {
             .build();
     long deadlineMs = 30000;
     SearchResponse searchResponse =
-        grpcServer
+        server
+            .getClient()
             .getBlockingStub()
             .withDeadlineAfter(deadlineMs, TimeUnit.MILLISECONDS)
             .search(buildSearchRequest(query));
@@ -1066,7 +1046,8 @@ public class QueryTest {
                     .setQuery("SECOND again")
                     .setSlop(1))
             .build();
-    SearchResponse searchResponse = grpcServer.getBlockingStub().search(buildSearchRequest(query));
+    SearchResponse searchResponse =
+        server.getClient().getBlockingStub().search(buildSearchRequest(query));
     assertEquals(0, searchResponse.getDiagnostics().getInitialDeadlineMs(), 0);
   }
 
@@ -1078,7 +1059,8 @@ public class QueryTest {
    * @param responseTester {@link Consumer} that tests a {@link SearchResponse}
    */
   private void testQuery(Query query, Consumer<SearchResponse> responseTester) {
-    SearchResponse searchResponse = grpcServer.getBlockingStub().search(buildSearchRequest(query));
+    SearchResponse searchResponse =
+        server.getClient().getBlockingStub().search(buildSearchRequest(query));
     responseTester.accept(searchResponse);
     testWithBoost(query, searchResponse);
   }
@@ -1086,7 +1068,10 @@ public class QueryTest {
   private void testQueryWithRescorers(
       Query query, List<Rescorer> rescorers, Consumer<SearchResponse> responseTester) {
     SearchResponse searchResponse =
-        grpcServer.getBlockingStub().search(buildSearchRequestWithRescorers(query, rescorers));
+        server
+            .getClient()
+            .getBlockingStub()
+            .search(buildSearchRequestWithRescorers(query, rescorers));
     responseTester.accept(searchResponse);
   }
 
@@ -1103,7 +1088,7 @@ public class QueryTest {
 
   private SearchRequest buildSearchRequest(Query query) {
     return SearchRequest.newBuilder()
-        .setIndexName(grpcServer.getTestIndex())
+        .setIndexName(TEST_INDEX)
         .setStartHit(0)
         .setTopHits(10)
         .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
@@ -1113,7 +1098,7 @@ public class QueryTest {
 
   private SearchRequest buildSearchRequestWithExplain(Query query, boolean explain) {
     return SearchRequest.newBuilder()
-        .setIndexName(grpcServer.getTestIndex())
+        .setIndexName(TEST_INDEX)
         .setStartHit(0)
         .setTopHits(10)
         .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
@@ -1124,7 +1109,7 @@ public class QueryTest {
 
   private SearchRequest buildSearchRequestWithRescorers(Query query, List<Rescorer> rescorers) {
     return SearchRequest.newBuilder()
-        .setIndexName(grpcServer.getTestIndex())
+        .setIndexName(TEST_INDEX)
         .setStartHit(0)
         .setTopHits(10)
         .addAllRetrieveFields(NrtsearchServerTest.RETRIEVED_VALUES)
@@ -1137,7 +1122,7 @@ public class QueryTest {
     int boost = 2;
     Query boostedQuery = Query.newBuilder(originalQuery).setBoost(boost).build();
     SearchResponse searchResponseBoosted =
-        grpcServer.getBlockingStub().search(buildSearchRequest(boostedQuery));
+        server.getClient().getBlockingStub().search(buildSearchRequest(boostedQuery));
 
     assertEquals(
         searchResponse.getTotalHits().getValue(), searchResponseBoosted.getTotalHits().getValue());

--- a/src/test/java/com/yelp/nrtsearch/server/grpc/TestServer.java
+++ b/src/test/java/com/yelp/nrtsearch/server/grpc/TestServer.java
@@ -35,6 +35,9 @@ import com.yelp.nrtsearch.server.grpc.SearchResponse.Hit;
 import com.yelp.nrtsearch.server.index.IndexState;
 import com.yelp.nrtsearch.server.index.IndexStateManager;
 import com.yelp.nrtsearch.server.index.ShardState;
+import com.yelp.nrtsearch.server.monitoring.Configuration;
+import com.yelp.nrtsearch.server.monitoring.NrtsearchMonitoringServerInterceptor;
+import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.remote.RemoteBackend;
 import com.yelp.nrtsearch.server.remote.s3.S3Backend;
 import com.yelp.nrtsearch.server.remote.s3.S3Util;
@@ -102,6 +105,7 @@ public class TestServer {
   private final NrtsearchConfig configuration;
   private final boolean writeDiscoveryFile;
   private final Path discoveryFilePath;
+  private final List<Plugin> plugins;
   private Server server;
   private Server replicationServer;
   private NrtsearchClient client;
@@ -140,11 +144,25 @@ public class TestServer {
   public TestServer(
       NrtsearchConfig configuration, boolean writeDiscoveryFile, Path discoveryFilePath)
       throws IOException {
+    this(configuration, writeDiscoveryFile, discoveryFilePath, Collections.emptyList());
+  }
+
+  public TestServer(
+      NrtsearchConfig configuration,
+      boolean writeDiscoveryFile,
+      Path discoveryFilePath,
+      List<Plugin> plugins)
+      throws IOException {
     this.configuration = configuration;
     this.writeDiscoveryFile = writeDiscoveryFile;
     this.discoveryFilePath = discoveryFilePath;
+    this.plugins = plugins;
     createdServers.add(this);
     restart();
+  }
+
+  public NrtsearchConfig getConfiguration() {
+    return configuration;
   }
 
   private RemoteBackend createRemoteBackend() {
@@ -167,13 +185,10 @@ public class TestServer {
       executorFactory = new ExecutorFactory(configuration.getThreadPoolConfiguration());
     }
     remoteBackend = createRemoteBackend();
+    PrometheusRegistry prometheusRegistry = new PrometheusRegistry();
     serverImpl =
         new LuceneServerImpl(
-            configuration,
-            remoteBackend,
-            new PrometheusRegistry(),
-            executorFactory,
-            Collections.emptyList());
+            configuration, remoteBackend, prometheusRegistry, executorFactory, plugins);
 
     replicationServer =
         ServerBuilder.forPort(0)
@@ -188,9 +203,14 @@ public class TestServer {
       writeDiscoveryFile(replicationServer.getPort());
     }
 
+    NrtsearchMonitoringServerInterceptor monitoringInterceptor =
+        NrtsearchMonitoringServerInterceptor.create(
+            Configuration.allMetrics().withPrometheusRegistry(prometheusRegistry));
     server =
         ServerBuilder.forPort(0)
-            .addService(ServerInterceptors.intercept(serverImpl, new NrtsearchHeaderInterceptor()))
+            .addService(
+                ServerInterceptors.intercept(
+                    serverImpl, new NrtsearchHeaderInterceptor(), monitoringInterceptor))
             .build()
             .start();
     client = new NrtsearchClient("localhost", server.getPort());
@@ -594,6 +614,7 @@ public class TestServer {
     private boolean writeDiscoveryFile = false;
 
     private String additionalConfig = "";
+    private List<Plugin> plugins = Collections.emptyList();
 
     Builder(TemporaryFolder folder) {
       this.folder = folder;
@@ -654,6 +675,11 @@ public class TestServer {
       return this;
     }
 
+    public Builder withPlugins(List<Plugin> plugins) {
+      this.plugins = plugins;
+      return this;
+    }
+
     public Builder withWriteDiscoveryFile(boolean writeDiscoveryFile) {
       this.writeDiscoveryFile = writeDiscoveryFile;
       return this;
@@ -673,7 +699,8 @@ public class TestServer {
       return new TestServer(
           new NrtsearchConfig(new ByteArrayInputStream(configFile.getBytes())),
           writeDiscoveryFile,
-          Paths.get(folder.getRoot().toString(), DISCOVERY_FILE));
+          Paths.get(folder.getRoot().toString(), DISCOVERY_FILE),
+          plugins);
     }
 
     private String backendConfig() {

--- a/src/test/java/com/yelp/nrtsearch/server/script/ScoreScriptTest.java
+++ b/src/test/java/com/yelp/nrtsearch/server/script/ScoreScriptTest.java
@@ -15,7 +15,6 @@
  */
 package com.yelp.nrtsearch.server.script;
 
-import static com.yelp.nrtsearch.server.grpc.GrpcServer.rmDir;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -23,28 +22,26 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.common.primitives.Floats;
-import com.yelp.nrtsearch.server.config.NrtsearchConfig;
 import com.yelp.nrtsearch.server.doc.LoadedDocValues;
 import com.yelp.nrtsearch.server.doc.LoadedDocValues.SingleVector;
 import com.yelp.nrtsearch.server.geo.GeoPoint;
-import com.yelp.nrtsearch.server.grpc.AddDocumentResponse;
+import com.yelp.nrtsearch.server.grpc.CreateIndexRequest;
 import com.yelp.nrtsearch.server.grpc.FunctionScoreQuery;
-import com.yelp.nrtsearch.server.grpc.GrpcServer;
+import com.yelp.nrtsearch.server.grpc.LuceneServerGrpc;
 import com.yelp.nrtsearch.server.grpc.MatchQuery;
-import com.yelp.nrtsearch.server.grpc.Mode;
 import com.yelp.nrtsearch.server.grpc.Query;
 import com.yelp.nrtsearch.server.grpc.RefreshRequest;
 import com.yelp.nrtsearch.server.grpc.Script;
 import com.yelp.nrtsearch.server.grpc.SearchRequest;
 import com.yelp.nrtsearch.server.grpc.SearchResponse;
+import com.yelp.nrtsearch.server.grpc.StartIndexRequest;
+import com.yelp.nrtsearch.server.grpc.TestServer;
 import com.yelp.nrtsearch.server.grpc.VirtualField;
 import com.yelp.nrtsearch.server.plugins.Plugin;
 import com.yelp.nrtsearch.server.plugins.ScriptPlugin;
-import com.yelp.nrtsearch.server.utils.NrtsearchTestConfigurationFactory;
-import io.grpc.testing.GrpcCleanupRule;
-import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import com.yelp.nrtsearch.test_utils.TestDocumentHelper;
+import com.yelp.nrtsearch.test_utils.TestResourceHelper;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -64,52 +61,38 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public class ScoreScriptTest {
-  /**
-   * This rule manages automatic graceful shutdown for the registered servers and channels at the
-   * end of test.
-   */
-  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
-  /**
-   * This rule ensure the temporary folder which maintains indexes are cleaned up after each test
-   */
+  private static final String TEST_INDEX = "test_index";
+
   @Rule public final TemporaryFolder folder = new TemporaryFolder();
 
-  private GrpcServer grpcServer;
-  private PrometheusRegistry prometheusRegistry;
+  private TestServer server;
 
   @After
-  public void tearDown() throws IOException {
-    tearDownGrpcServer();
-  }
-
-  private void tearDownGrpcServer() throws IOException {
-    grpcServer.getGlobalState().close();
-    grpcServer.shutdown();
-    rmDir(Paths.get(grpcServer.getIndexDir()).getParent());
+  public void tearDown() {
+    TestServer.cleanupAll();
   }
 
   @Before
   public void setUp() throws IOException {
-    prometheusRegistry = new PrometheusRegistry();
-    grpcServer = setUpGrpcServer(prometheusRegistry);
+    server =
+        TestServer.builder(folder)
+            .withPlugins(Collections.singletonList(new ScoreScriptTestPlugin()))
+            .build();
   }
 
-  private GrpcServer setUpGrpcServer(PrometheusRegistry prometheusRegistry) throws IOException {
-    String testIndex = "test_index";
-    NrtsearchConfig configuration =
-        NrtsearchTestConfigurationFactory.getConfig(Mode.STANDALONE, folder.getRoot());
-    return new GrpcServer(
-        prometheusRegistry,
-        grpcCleanup,
-        configuration,
-        folder,
-        null,
-        configuration.getIndexDir(),
-        testIndex,
-        configuration.getPort(),
-        null,
-        Collections.singletonList(new ScoreScriptTestPlugin()));
+  private void setupIndex(String registerFieldsFile, String addDocsFile) throws Exception {
+    LuceneServerGrpc.LuceneServerBlockingStub stub = server.getClient().getBlockingStub();
+    stub.createIndex(CreateIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    stub.startIndex(StartIndexRequest.newBuilder().setIndexName(TEST_INDEX).build());
+    stub.registerFields(
+        TestResourceHelper.getFieldsFromResourceFile("/" + registerFieldsFile).toBuilder()
+            .setIndexName(TEST_INDEX)
+            .build());
+    TestDocumentHelper.addDocuments(
+        server.getClient().getAsyncStub(),
+        TestResourceHelper.getCsvDocumentStream(TEST_INDEX, "/" + addDocsFile));
+    stub.refresh(RefreshRequest.newBuilder().setIndexName(TEST_INDEX).build());
   }
 
   static class ScoreScriptTestPlugin extends Plugin implements ScriptPlugin {
@@ -684,23 +667,15 @@ public class ScoreScriptTest {
 
   @Test
   public void testScriptDocValuesIndexField() throws Exception {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
-    new GrpcServer.IndexAndRoleManager(grpcServer)
-        .createStartIndexAndRegisterFields(
-            Mode.STANDALONE, 0, false, "registerFieldsScriptTest.json");
-    AddDocumentResponse addDocumentResponse = testAddDocs.addDocuments("addDocs.csv");
-    // manual refresh
-    grpcServer
-        .getBlockingStub()
-        .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+    setupIndex("registerFieldsScriptTest.json", "addDocs.csv");
 
     SearchResponse searchResponse =
-        grpcServer
+        server
+            .getClient()
             .getBlockingStub()
             .search(
                 SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
+                    .setIndexName(TEST_INDEX)
                     .addRetrieveFields("test_doc_values")
                     .setStartHit(0)
                     .setTopHits(10)
@@ -726,14 +701,7 @@ public class ScoreScriptTest {
 
   @Test
   public void testScriptDocValuesScoreQuery() throws Exception {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
-    // 2 docs addDocuments
-    testAddDocs.addDocuments();
-    // manual refresh
-    grpcServer
-        .getBlockingStub()
-        .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+    setupIndex("registerFieldsBasic.json", "addDocs.csv");
 
     SearchResponse searchResponse = doFunctionScoreQuery("verify_doc_values");
     assertEquals(2, searchResponse.getHitsCount());
@@ -771,14 +739,7 @@ public class ScoreScriptTest {
 
   @Test
   public void testScriptUsingScore() throws Exception {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
-    // 2 docs addDocuments
-    testAddDocs.addDocuments();
-    // manual refresh
-    grpcServer
-        .getBlockingStub()
-        .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+    setupIndex("registerFieldsBasic.json", "addDocs.csv");
 
     VirtualField virtualField =
         VirtualField.newBuilder()
@@ -787,11 +748,12 @@ public class ScoreScriptTest {
             .build();
 
     SearchResponse searchResponse =
-        grpcServer
+        server
+            .getClient()
             .getBlockingStub()
             .search(
                 SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
+                    .setIndexName(TEST_INDEX)
                     .setStartHit(0)
                     .setTopHits(10)
                     .addVirtualFields(virtualField)
@@ -811,23 +773,15 @@ public class ScoreScriptTest {
 
   @Test
   public void testScriptUsingScoreInIndexField() throws Exception {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
-    new GrpcServer.IndexAndRoleManager(grpcServer)
-        .createStartIndexAndRegisterFields(
-            Mode.STANDALONE, 0, false, "registerFieldsScriptTest.json");
-    AddDocumentResponse addDocumentResponse = testAddDocs.addDocuments("addDocs.csv");
-    // manual refresh
-    grpcServer
-        .getBlockingStub()
-        .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+    setupIndex("registerFieldsScriptTest.json", "addDocs.csv");
 
     SearchResponse searchResponse =
-        grpcServer
+        server
+            .getClient()
             .getBlockingStub()
             .search(
                 SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
+                    .setIndexName(TEST_INDEX)
                     .addRetrieveFields("test_score")
                     .setStartHit(0)
                     .setTopHits(10)
@@ -846,14 +800,7 @@ public class ScoreScriptTest {
 
   @Test
   public void testScriptUsingScoreInScoreQuery() throws Exception {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
-    // 2 docs addDocuments
-    testAddDocs.addDocuments();
-    // manual refresh
-    grpcServer
-        .getBlockingStub()
-        .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+    setupIndex("registerFieldsBasic.json", "addDocs.csv");
 
     SearchResponse searchResponse = doFunctionScoreQuery("verify_score");
     assertEquals(2, searchResponse.getHitsCount());
@@ -868,14 +815,7 @@ public class ScoreScriptTest {
 
   @Test
   public void testParams() throws Exception {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
-    // 2 docs addDocuments
-    testAddDocs.addDocuments();
-    // manual refresh
-    grpcServer
-        .getBlockingStub()
-        .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+    setupIndex("registerFieldsBasic.json", "addDocs.csv");
 
     VirtualField virtualField =
         VirtualField.newBuilder()
@@ -901,11 +841,12 @@ public class ScoreScriptTest {
             .build();
 
     SearchResponse searchResponse =
-        grpcServer
+        server
+            .getClient()
             .getBlockingStub()
             .search(
                 SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
+                    .setIndexName(TEST_INDEX)
                     .setStartHit(0)
                     .setTopHits(10)
                     .addVirtualFields(virtualField)
@@ -925,15 +866,7 @@ public class ScoreScriptTest {
   private void testQueryFieldScript(
       String source, String registerFieldsFile, String addDocsFile, double expectedScore)
       throws Exception {
-    GrpcServer.TestServer testAddDocs =
-        new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
-    new GrpcServer.IndexAndRoleManager(grpcServer)
-        .createStartIndexAndRegisterFields(Mode.STANDALONE, 0, false, registerFieldsFile);
-    AddDocumentResponse addDocumentResponse = testAddDocs.addDocuments(addDocsFile);
-    // manual refresh
-    grpcServer
-        .getBlockingStub()
-        .refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+    setupIndex(registerFieldsFile, addDocsFile);
 
     VirtualField virtualField =
         VirtualField.newBuilder()
@@ -942,11 +875,12 @@ public class ScoreScriptTest {
             .build();
 
     SearchResponse searchResponse =
-        grpcServer
+        server
+            .getClient()
             .getBlockingStub()
             .search(
                 SearchRequest.newBuilder()
-                    .setIndexName(grpcServer.getTestIndex())
+                    .setIndexName(TEST_INDEX)
                     .setStartHit(0)
                     .setTopHits(10)
                     .addVirtualFields(virtualField)
@@ -964,11 +898,12 @@ public class ScoreScriptTest {
   }
 
   private SearchResponse doFunctionScoreQuery(String scriptSource) {
-    return grpcServer
+    return server
+        .getClient()
         .getBlockingStub()
         .search(
             SearchRequest.newBuilder()
-                .setIndexName(grpcServer.getTestIndex())
+                .setIndexName(TEST_INDEX)
                 .setStartHit(0)
                 .setTopHits(10)
                 .setQuery(

--- a/src/test/java/com/yelp/nrtsearch/test_utils/TestResourceHelper.java
+++ b/src/test/java/com/yelp/nrtsearch/test_utils/TestResourceHelper.java
@@ -17,14 +17,24 @@ package com.yelp.nrtsearch.test_utils;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
+import com.yelp.nrtsearch.server.grpc.AddDocumentRequest;
 import com.yelp.nrtsearch.server.grpc.FieldDefRequest;
+import com.yelp.nrtsearch.server.grpc.NrtsearchClientBuilder;
 import com.yelp.nrtsearch.server.grpc.SearchRequest;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
 
 public class TestResourceHelper {
 
@@ -49,6 +59,17 @@ public class TestResourceHelper {
       throw new RuntimeException(e);
     }
     return fieldDefRequestBuilder.build();
+  }
+
+  public static Stream<AddDocumentRequest> getCsvDocumentStream(
+      String indexName, String resourceFileName) throws IOException, URISyntaxException {
+    Path filePath = Paths.get(TestResourceHelper.class.getResource(resourceFileName).toURI());
+    Reader reader = Files.newBufferedReader(filePath);
+    CSVParser csvParser =
+        new CSVParser(
+            reader, CSVFormat.DEFAULT.builder().setHeader().setSkipHeaderRecord(true).build());
+    return new NrtsearchClientBuilder.AddDocumentsClientBuilder(indexName, csvParser)
+        .buildRequest(filePath);
   }
 
   public static SearchRequest getSearchRequestFromResourceFile(String resourceFileName)

--- a/src/test/java/com/yelp/nrtsearch/tools/cli/ReadyCommandTest.java
+++ b/src/test/java/com/yelp/nrtsearch/tools/cli/ReadyCommandTest.java
@@ -17,13 +17,9 @@ package com.yelp.nrtsearch.tools.cli;
 
 import static org.junit.Assert.assertEquals;
 
-import com.yelp.nrtsearch.server.config.NrtsearchConfig;
-import com.yelp.nrtsearch.server.grpc.CreateIndexRequest;
-import com.yelp.nrtsearch.server.grpc.GrpcServer;
 import com.yelp.nrtsearch.server.grpc.Mode;
 import com.yelp.nrtsearch.server.grpc.StartIndexRequest;
-import com.yelp.nrtsearch.server.utils.NrtsearchTestConfigurationFactory;
-import io.grpc.testing.GrpcCleanupRule;
+import com.yelp.nrtsearch.server.grpc.TestServer;
 import java.io.IOException;
 import org.junit.After;
 import org.junit.Rule;
@@ -33,43 +29,26 @@ import picocli.CommandLine;
 
 public class ReadyCommandTest {
 
-  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
-
   @Rule public final TemporaryFolder folder = new TemporaryFolder();
 
   @After
-  public void cleanup() throws IOException {
-    if (server != null) {
-      server.shutdown();
-      server = null;
-    }
+  public void cleanup() {
+    TestServer.cleanupAll();
   }
 
-  private GrpcServer server;
+  private TestServer server;
 
   private void startServer() throws IOException {
-    NrtsearchConfig configuration =
-        NrtsearchTestConfigurationFactory.getConfig(Mode.PRIMARY, folder.getRoot());
-    server =
-        new GrpcServer(
-            grpcCleanup,
-            configuration,
-            folder,
-            null,
-            configuration.getIndexDir(),
-            "test_index",
-            configuration.getPort(),
-            null);
+    server = TestServer.builder(folder).build();
   }
 
   private void createIndex(String indexName) {
-    server
-        .getBlockingStub()
-        .createIndex(CreateIndexRequest.newBuilder().setIndexName(indexName).build());
+    server.createIndex(indexName);
   }
 
   private void startIndex(String indexName) {
     server
+        .getClient()
         .getBlockingStub()
         .startIndex(
             StartIndexRequest.newBuilder().setIndexName(indexName).setMode(Mode.PRIMARY).build());
@@ -86,8 +65,7 @@ public class ReadyCommandTest {
   public void testNoIndices() throws IOException {
     startServer();
     CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
-    int exitCode =
-        cmd.execute("--hostname=localhost", "--port=" + server.getGlobalState().getPort(), "ready");
+    int exitCode = cmd.execute("--hostname=localhost", "--port=" + server.getPort(), "ready");
     assertEquals(0, exitCode);
   }
 
@@ -125,8 +103,7 @@ public class ReadyCommandTest {
     verifyIndicesReady("test_index,test_index_3", 1);
 
     CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
-    int exitCode =
-        cmd.execute("--hostname=localhost", "--port=" + server.getGlobalState().getPort(), "ready");
+    int exitCode = cmd.execute("--hostname=localhost", "--port=" + server.getPort(), "ready");
     assertEquals(0, exitCode);
   }
 
@@ -145,8 +122,7 @@ public class ReadyCommandTest {
     verifyIndicesReady("test_index,test_index_3", 0);
 
     CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
-    int exitCode =
-        cmd.execute("--hostname=localhost", "--port=" + server.getGlobalState().getPort(), "ready");
+    int exitCode = cmd.execute("--hostname=localhost", "--port=" + server.getPort(), "ready");
     assertEquals(0, exitCode);
   }
 
@@ -154,10 +130,7 @@ public class ReadyCommandTest {
     CommandLine cmd = new CommandLine(new NrtsearchClientCommand());
     int exitCode =
         cmd.execute(
-            "--hostname=localhost",
-            "--port=" + server.getGlobalState().getPort(),
-            "ready",
-            "--indices=" + indices);
+            "--hostname=localhost", "--port=" + server.getPort(), "ready", "--indices=" + indices);
     assertEquals(expectedExitCode, exitCode);
   }
 }


### PR DESCRIPTION
Replace all direct GrpcServer construction with TestServer.builder() in:
- NodeNameResolverAndLoadBalancingTests
- QueryTest, ScoreScriptTest, CustomFieldTypeTest
- MergeBehaviorTests, NrtsearchServerIdFieldTest
- ReadyCommandTest, NrtsearchServerTest

TestServer gains plugin support (withPlugins builder option), a getConfiguration() getter, and a NrtsearchMonitoringServerInterceptor so testMetrics passes. TestResourceHelper gains getCsvDocumentStream().

After this commit GrpcServer is no longer instantiated outside ServerTestCase; GrpcServer.TestServer (inner class) is unused.