### PR TITLE
Upgrade Lucene to v10.5.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ aws-legacy = "1.12.768"
 grpc = "1.81.0"
 jackson = "2.19.1"
 log4j = "2.23.1"
-lucene = "10.4.0"
+lucene = "10.5.1"
 prometheus = "1.3.1"
 protobuf = "3.25.8"
 

--- a/src/main/java/com/yelp/nrtsearch/server/field/VectorFieldDef.java
+++ b/src/main/java/com/yelp/nrtsearch/server/field/VectorFieldDef.java
@@ -46,7 +46,6 @@ import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
 import org.apache.lucene.codecs.lucene104.Lucene104HnswScalarQuantizedVectorsFormat;
-import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
@@ -64,6 +63,7 @@ import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.VectorUtil;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
 
 /**
  * Field class for 'VECTOR' field type.

--- a/src/main/java/com/yelp/nrtsearch/server/handler/AddDocumentHandler.java
+++ b/src/main/java/com/yelp/nrtsearch/server/handler/AddDocumentHandler.java
@@ -38,7 +38,6 @@ import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -651,37 +650,20 @@ public class AddDocumentHandler extends Handler<AddDocumentRequest, AddDocumentR
         throw new IllegalStateException(
             "Adding documents to an index on a replica node is not supported");
       }
-      if (documents != null)
-        IndexingMetrics.addDocumentRequestsReceived.labelValues(indexName).inc(documents.size());
-      long ns_start = System.nanoTime();
-      shardState.writer.addDocuments(
-          (Iterable<Document>)
-              () ->
-                  new Iterator<>() {
-                    private Document nextDoc;
-
-                    @Override
-                    public boolean hasNext() {
-                      if (!documents.isEmpty()) {
-                        nextDoc = documents.poll();
-                        nextDoc = handleFacets(indexState, shardState, nextDoc);
-                        return true;
-                      } else {
-                        nextDoc = null;
-                        return false;
-                      }
-                    }
-
-                    @Override
-                    public Document next() {
-                      return nextDoc;
-                    }
-                  });
-      if (documents != null && documents.size() >= 1) {
-        IndexingMetrics.addDocumentLatency
-            .labelValues(indexName)
-            .observe((System.nanoTime() - ns_start) / ONE_MILLION / documents.size());
+      if (documents == null || documents.isEmpty()) {
+        return;
       }
+      int count = documents.size();
+      IndexingMetrics.addDocumentRequestsReceived.labelValues(indexName).inc(count);
+      long ns_start = System.nanoTime();
+      Document doc;
+      while ((doc = documents.poll()) != null) {
+        doc = handleFacets(indexState, shardState, doc);
+        shardState.writer.addDocument(doc);
+      }
+      IndexingMetrics.addDocumentLatency
+          .labelValues(indexName)
+          .observe((System.nanoTime() - ns_start) / ONE_MILLION / count);
     }
 
     private Document handleFacets(IndexState indexState, ShardState shardState, Document nextDoc) {


### PR DESCRIPTION
Upgrade `development` branch to latest Lucene 10.x release.

## Upgrade Lucene to 10.5.1

 Bumps Lucene from 10.4.0 to 10.5.1 across all 14 modules. 10.5.0 focused on performance improvements (SIMD-accelerated bulk range evaluation for doc-values queries, adaptive HNSW graph traversal, expanded concurrent grouping/collector support). 10.5.1 is a bugfix release on top.

 ## Changes

 - gradle/libs.versions.toml — Single version property change; all 14 Lucene module dependencies update automatically.

 - VectorFieldDef.java — ScalarEncoding was moved from Lucene104ScalarQuantizedVectorsFormat to org.apache.lucene.util.quantization.QuantizedByteVectorValues in 10.5.x. Updated the import; no behavioral change.

 - AddDocumentHandler.java — Fixed a latent bug in DocumentIndexer.addDocuments exposed by a Lucene 10.5.x internal change. The method previously used a side-effecting iterator where hasNext() polled the next document from the queue as a side effect. In Lucene 10.4.0, DocumentsWriterPerThread.updateDocuments only called hasNext() a second time (to determine isLastDoc) when a parent field was configured — which nrtsearch never sets. In 10.5.1, this second hasNext() call was made unconditional, causing every other document in each batch to be silently dropped. Fixed by replacing the side-effecting iterator with individual IndexWriter.addDocument() calls per document, which is also semantically correct since non-nested documents should never be grouped into a block in the first place.

 ## Compatibility

  Rolling upgrades are safe. No new codec classes were introduced in 10.5.x — Lucene104Codec remains the default — so segment files written by either version are readable by the other, and NRT replication between mixed-version nodes is unaffected.